### PR TITLE
Race condition while reading from sync committee priority queue

### DIFF
--- a/beacon-chain/operations/synccommittee/message_test.go
+++ b/beacon-chain/operations/synccommittee/message_test.go
@@ -34,76 +34,84 @@ func TestSyncCommitteeSignatureCache_RoundTrip(t *testing.T) {
 		require.NoError(t, store.SaveSyncCommitteeMessage(msg))
 	}
 
-	msgs, err := store.SyncCommitteeMessages(1)
+	msgs, unlock, err := store.SyncCommitteeMessages(1)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage(nil), msgs)
 
-	msgs, err = store.SyncCommitteeMessages(2)
+	msgs, unlock, err = store.SyncCommitteeMessages(2)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage(nil), msgs)
 
-	msgs, err = store.SyncCommitteeMessages(3)
+	msgs, unlock, err = store.SyncCommitteeMessages(3)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'e'}},
 		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'f'}},
 	}, msgs)
 
-	msgs, err = store.SyncCommitteeMessages(4)
+	msgs, unlock, err = store.SyncCommitteeMessages(4)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 4, ValidatorIndex: 0, Signature: []byte{'g'}},
 		{Slot: 4, ValidatorIndex: 1, Signature: []byte{'h'}},
 	}, msgs)
 
-	msgs, err = store.SyncCommitteeMessages(5)
+	msgs, unlock, err = store.SyncCommitteeMessages(5)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 5, ValidatorIndex: 0, Signature: []byte{'i'}},
 		{Slot: 5, ValidatorIndex: 1, Signature: []byte{'j'}},
 	}, msgs)
 
-	msgs, err = store.SyncCommitteeMessages(6)
+	msgs, unlock, err = store.SyncCommitteeMessages(6)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 6, ValidatorIndex: 0, Signature: []byte{'k'}},
 		{Slot: 6, ValidatorIndex: 1, Signature: []byte{'l'}},
 	}, msgs)
+	unlock()
 
 	// Messages should persist after retrieval.
-	msgs, err = store.SyncCommitteeMessages(1)
+	msgs, unlock, err = store.SyncCommitteeMessages(1)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage(nil), msgs)
+	unlock()
 
-	msgs, err = store.SyncCommitteeMessages(2)
+	msgs, unlock, err = store.SyncCommitteeMessages(2)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage(nil), msgs)
+	unlock()
 
-	msgs, err = store.SyncCommitteeMessages(3)
+	msgs, unlock, err = store.SyncCommitteeMessages(3)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'e'}},
 		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'f'}},
 	}, msgs)
+	unlock()
 
-	msgs, err = store.SyncCommitteeMessages(4)
+	msgs, unlock, err = store.SyncCommitteeMessages(4)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 4, ValidatorIndex: 0, Signature: []byte{'g'}},
 		{Slot: 4, ValidatorIndex: 1, Signature: []byte{'h'}},
 	}, msgs)
+	unlock()
 
-	msgs, err = store.SyncCommitteeMessages(5)
+	msgs, unlock, err = store.SyncCommitteeMessages(5)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 5, ValidatorIndex: 0, Signature: []byte{'i'}},
 		{Slot: 5, ValidatorIndex: 1, Signature: []byte{'j'}},
 	}, msgs)
+	unlock()
 
-	msgs, err = store.SyncCommitteeMessages(6)
+	msgs, unlock, err = store.SyncCommitteeMessages(6)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*ethpb.SyncCommitteeMessage{
 		{Slot: 6, ValidatorIndex: 0, Signature: []byte{'k'}},
 		{Slot: 6, ValidatorIndex: 1, Signature: []byte{'l'}},
 	}, msgs)
+	unlock()
+
 }

--- a/beacon-chain/operations/synccommittee/pool.go
+++ b/beacon-chain/operations/synccommittee/pool.go
@@ -18,7 +18,7 @@ type Pool interface {
 
 	// Methods for Sync Committee Messages.
 	SaveSyncCommitteeMessage(sig *ethpb.SyncCommitteeMessage) error
-	SyncCommitteeMessages(slot primitives.Slot) ([]*ethpb.SyncCommitteeMessage, error)
+	SyncCommitteeMessages(slot primitives.Slot) ([]*ethpb.SyncCommitteeMessage, func(), error)
 }
 
 // NewPool returns the sync committee store fulfilling the pool interface.

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -529,7 +529,7 @@ func TestSubmitSyncCommitteeSignatures(t *testing.T) {
 		s.SubmitSyncCommitteeSignatures(writer, request)
 		assert.Equal(t, http.StatusOK, writer.Code)
 		require.NoError(t, err)
-		msgsInPool, err := s.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
+		msgsInPool, unlock, err := s.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(msgsInPool))
 		assert.Equal(t, primitives.Slot(1), msgsInPool[0].Slot)
@@ -537,6 +537,7 @@ func TestSubmitSyncCommitteeSignatures(t *testing.T) {
 		assert.Equal(t, primitives.ValidatorIndex(1), msgsInPool[0].ValidatorIndex)
 		assert.Equal(t, "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505", hexutil.Encode(msgsInPool[0].Signature))
 		assert.Equal(t, true, broadcaster.BroadcastCalled.Load())
+		unlock()
 	})
 	t.Run("multiple", func(t *testing.T) {
 		broadcaster := &p2pMock.MockBroadcaster{}
@@ -561,13 +562,15 @@ func TestSubmitSyncCommitteeSignatures(t *testing.T) {
 		s.SubmitSyncCommitteeSignatures(writer, request)
 		assert.Equal(t, http.StatusOK, writer.Code)
 		require.NoError(t, err)
-		msgsInPool, err := s.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
+		msgsInPool, unlock, err := s.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(msgsInPool))
-		msgsInPool, err = s.CoreService.SyncCommitteePool.SyncCommitteeMessages(2)
+		unlock()
+		msgsInPool, unlock, err = s.CoreService.SyncCommitteePool.SyncCommitteeMessages(2)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(msgsInPool))
 		assert.Equal(t, true, broadcaster.BroadcastCalled.Load())
+		unlock()
 	})
 	t.Run("invalid", func(t *testing.T) {
 		broadcaster := &p2pMock.MockBroadcaster{}
@@ -594,10 +597,11 @@ func TestSubmitSyncCommitteeSignatures(t *testing.T) {
 		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
-		msgsInPool, err := s.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
+		msgsInPool, unlock, err := s.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(msgsInPool))
 		assert.Equal(t, false, broadcaster.BroadcastCalled.Load())
+		unlock()
 	})
 	t.Run("empty", func(t *testing.T) {
 		s := &Server{}

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -477,7 +477,8 @@ func (s *Server) produceSyncCommitteeContribution(
 	index uint64,
 	blockRoot []byte,
 ) (*structs.SyncCommitteeContribution, bool) {
-	msgs, err := s.SyncCommitteePool.SyncCommitteeMessages(slot)
+	msgs, unlock, err := s.SyncCommitteePool.SyncCommitteeMessages(slot)
+	defer unlock()
 	if err != nil {
 		httputil.HandleError(w, "Could not get sync subcommittee messages: "+err.Error(), http.StatusInternalServerError)
 		return nil, false

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee.go
@@ -67,8 +67,8 @@ func (vs *Server) GetSyncCommitteeContribution(
 	if err := vs.optimisticStatus(ctx); err != nil {
 		return nil, err
 	}
-
-	msgs, err := vs.SyncCommitteePool.SyncCommitteeMessages(req.Slot)
+	msgs, unlock, err := vs.SyncCommitteePool.SyncCommitteeMessages(req.Slot)
+	defer unlock()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get sync subcommittee messages: %v", err)
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee_test.go
@@ -79,9 +79,10 @@ func TestSubmitSyncMessage_OK(t *testing.T) {
 	}
 	_, err := server.SubmitSyncMessage(context.Background(), msg)
 	require.NoError(t, err)
-	savedMsgs, err := server.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
+	savedMsgs, unlock, err := server.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
 	require.NoError(t, err)
 	require.DeepEqual(t, []*ethpb.SyncCommitteeMessage{msg}, savedMsgs)
+	unlock()
 }
 
 func TestGetSyncSubcommitteeIndex_Ok(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix found using [Antithesis](https://antithesis.com)

**What does this PR do? Why is it needed?**

This PR is a potential solution to a race condition where the underlying messages priority queue is changed while simultaneously being read from without proper locking. Locking is currently terminated when the function `SyncCommitteeMessages` is done reading from the queue. However, the messages returned are pointers to memory locations that are not protected by the lock after returning them to the caller.

**Which issues(s) does this PR fix?**
```
WARNING: DATA RACE
Read at #HEX by go routine: #DIG:
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc/core.(*Service).AggregatedSigAndAggregationBits()
      beacon-chain/rpc/core/validator.go:297 +0x284
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc/prysm/v1alpha1/validator.(*Server).GetSyncCommitteeContribution()
      beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee.go:79 +0x469
  github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1._BeaconNodeValidator_GetSyncCommitteeContribution_Handler.func1()
      bazel-out/k8-opt-ST-308a12fde6ad/bin/proto/prysm/v1alpha1/go_proto_/github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1/validator.pb.go:5596 +0x82
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc.(*Service).validatorUnaryConnectionInterceptor()
      beacon-chain/rpc/service.go:644 +0x74
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc.(*Service).validatorUnaryConnectionInterceptor-fm()
      <autogenerated>:1 +0x8f
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc.NewService.ChainUnaryServer.func6.1.1()
      external/com_github_grpc_ecosystem_go_grpc_middleware/chain.go:25 +0x88
  github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing.UnaryServerInterceptor.func1()
      external/com_github_grpc_ecosystem_go_grpc_middleware/tracing/opentracing/server_interceptors.go:34 +0x23c
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc.NewService.ChainUnaryServer.func6.1.1()
      external/com_github_grpc_ecosystem_go_grpc_middleware/chain.go:25 +0x88
  github.com/grpc-ecosystem/go-grpc-prometheus.init.(*ServerMetrics).UnaryServerInterceptor.func3()
      external/com_github_grpc_ecosystem_go_grpc_prometheus/server_metrics.go:107 +0xbb
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc.NewService.ChainUnaryServer.func6.1.1()
      external/com_github_grpc_ecosystem_go_grpc_middleware/chain.go:25 +0x88
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      external/com_github_grpc_ecosystem_go_grpc_middleware/recovery/interceptors.go:33 +0x171
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc.NewService.ChainUnaryServer.func6.1.1()
      external/com_github_grpc_ecosystem_go_grpc_middleware/chain.go:25 +0x88
  github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc.NewService.ChainUnaryServer.func6()
      external/com_github_grpc_ecosystem_go_grpc_middleware/chain.go:34 +0x133
  github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1._BeaconNodeValidator_GetSyncCommitteeContribution_Handler()
      bazel-out/k8-opt-ST-308a12fde6ad/bin/proto/prysm/v1alpha1/go_proto_/github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1/validator.pb.go:5598 +0x1c3
  google.golang.org/grpc.(*Server).processUnaryRPC()
      external/org_golang_google_grpc/server.go:1335 +0x17c2
  google.golang.org/grpc.(*Server).handleStream()
      external/org_golang_google_grpc/server.go:1712 +0x1012
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
      external/org_golang_google_grpc/server.go:947 +0x17a
Previous write at #HEX by go routine: #DIG:
  github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1.CopySyncCommitteeMessage()
      proto/prysm/v1alpha1/cloners.go:348 +0x22a
  github.com/prysmaticlabs/prysm/v5/beacon-chain/operations/synccommittee.(*Store).SaveSyncCommitteeMessage()
      beacon-chain/operations/synccommittee/message.go:25 +0x168
  github.com/prysmaticlabs/prysm/v5/beacon-chain/sync.(*Service).syncCommitteeMessageSubscriber()
      beacon-chain/sync/subscriber_sync_committee_message.go:23 +0x161
  github.com/prysmaticlabs/prysm/v5/beacon-chain/sync.(*Service).syncCommitteeMessageSubscriber-fm()
      <autogenerated>:1 +0x64
  github.com/prysmaticlabs/prysm/v5/beacon-chain/sync.(*Service).subscribeWithBase.func1()
      beacon-chain/sync/subscriber.go:219 +0x345
  github.com/prysmaticlabs/prysm/v5/beacon-chain/sync.(*Service).subscribeWithBase.func2.1()
      beacon-chain/sync/subscriber.go:246 +0x41
go routine: #DIG (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func1()
      external/org_golang_google_grpc/server.go:958 +0x264
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      external/org_golang_google_grpc/internal/transport/http2_server.go:626 +0x4fc1
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      external/org_golang_google_grpc/internal/transport/http2_server.go:668 +0x29e
  google.golang.org/grpc.(*Server).serveStreams()
      external/org_golang_google_grpc/server.go:940 +0x37d
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      external/org_golang_google_grpc/server.go:882 +0x58
go routine: #DIG (finished) created at:
  github.com/prysmaticlabs/prysm/v5/beacon-chain/sync.(*Service).subscribeWithBase.func2()
      beacon-chain/sync/subscriber.go:246 +
```

Fixes

* One solution that I propose here is to return the lock to the caller in order for them to release it when they are done reading.
