### PR TITLE
Remove redundant req.Slot check in GetAttestationData RPC handler

### DIFF
--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -483,9 +483,6 @@ func (s *Service) GetAttestationData(
 	ctx, span := trace.StartSpan(ctx, "coreService.GetAttestationData")
 	defer span.End()
 
-	if req.Slot != s.GenesisTimeFetcher.CurrentSlot() {
-		return nil, &RpcError{Reason: BadRequest, Err: errors.Errorf("invalid request: slot %d is not the current slot %d", req.Slot, s.GenesisTimeFetcher.CurrentSlot())}
-	}
 	if err := helpers.ValidateAttestationTime(
 		req.Slot,
 		s.GenesisTimeFetcher.GenesisTime(),

--- a/changelog/pvl-rpc-redundant-att-slot-check.md
+++ b/changelog/pvl-rpc-redundant-att-slot-check.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed redundant check for attestation request slot in `GetAttestationData` RPC call.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Not sure we we are checking req.Slot here. In the next line, we call `helpers.ValidateAttestationTime` which validates the req.Slot within the spec tolerance for early or late arrivals.

**Which issues(s) does this PR fix?**

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
