### PR TITLE
Async dynamic run intervals

### DIFF
--- a/async/every.go
+++ b/async/every.go
@@ -29,3 +29,24 @@ func RunEvery(ctx context.Context, period time.Duration, f func()) {
 		}
 	}()
 }
+
+// RunEveryDynamic runs the provided command periodically with a dynamic interval.
+// The interval is determined by calling the intervalFunc before each execution.
+// It runs in a goroutine, and can be cancelled by finishing the supplied context.
+func RunEveryDynamic(ctx context.Context, intervalFunc func() time.Duration, f func()) {
+	go func() {
+		for {
+			// Get the next interval duration
+			interval := intervalFunc()
+			timer := time.NewTimer(interval)
+
+			select {
+			case <-timer.C:
+				f()
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
+		}
+	}()
+}

--- a/async/every_test.go
+++ b/async/every_test.go
@@ -38,3 +38,51 @@ func TestEveryRuns(t *testing.T) {
 		t.Error("Counter incremented after stop")
 	}
 }
+
+func TestEveryDynamicRuns(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	i := int32(0)
+	intervalCount := int32(0)
+
+	// Start with 50ms intervals, then increase to 100ms after 2 calls
+	async.RunEveryDynamic(ctx, func() time.Duration {
+		count := atomic.LoadInt32(&intervalCount)
+		atomic.AddInt32(&intervalCount, 1)
+		if count < 2 {
+			return 50 * time.Millisecond
+		}
+		return 100 * time.Millisecond
+	}, func() {
+		atomic.AddInt32(&i, 1)
+	})
+
+	// After 150ms, should have run at least 2 times (at 50ms and 100ms)
+	time.Sleep(150 * time.Millisecond)
+	count1 := atomic.LoadInt32(&i)
+	if count1 < 2 {
+		t.Errorf("Expected at least 2 runs after 150ms, got %d", count1)
+	}
+
+	// After another 150ms (total 300ms), should have run at least 3 times
+	// (50ms, 100ms, 150ms, 250ms)
+	time.Sleep(150 * time.Millisecond)
+	count2 := atomic.LoadInt32(&i)
+	if count2 < 3 {
+		t.Errorf("Expected at least 3 runs after 300ms, got %d", count2)
+	}
+
+	cancel()
+
+	// Sleep for a bit to let the cancel take place.
+	time.Sleep(100 * time.Millisecond)
+
+	last := atomic.LoadInt32(&i)
+
+	// Sleep for a bit and ensure the value has not increased.
+	time.Sleep(200 * time.Millisecond)
+
+	if atomic.LoadInt32(&i) != last {
+		t.Error("Counter incremented after stop")
+	}
+}

--- a/changelog/pvl-async-dynamic-run-every.md
+++ b/changelog/pvl-async-dynamic-run-every.md
@@ -1,0 +1,3 @@
+### Added
+
+- async: Added a method for periodic execution with dynamic intervals. This is useful for a future progressive slot schedule.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

We need a run interval method in which we can change the interval at runtime. The other run interval methods use a constant argument value to run every `$interval`. With progressive slot times, the `$interval` value is the slot time which changes from 12s to 6s and maybe even lower in the future.

**Which issues(s) does this PR fix?**


**Other notes for review**

This method is not currently used (yet), but it is a necessary feature for progressive slot times. 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
