### PR TITLE
fix(genesis): validate genesis file by checking network genesis validator root

### DIFF
--- a/changelog/samcm_fix-genesis-validation.md
+++ b/changelog/samcm_fix-genesis-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed genesis file validation by checking BeaconConfig genesis validators root to ensure correct genesis state is loaded.

--- a/genesis/initialize.go
+++ b/genesis/initialize.go
@@ -78,7 +78,10 @@ func findGenesisFile(dir string) (GenesisData, error) {
 		if err != nil {
 			continue
 		}
-		return gd, nil
+		// Only return genesis file if it matches the expected network GVR
+		if gd.ValidatorsRoot == params.BeaconConfig().GenesisValidatorsRoot {
+			return gd, nil
+		}
 	}
 	return GenesisData{}, ErrGenesisFileNotFound
 }

--- a/genesis/initialize.go
+++ b/genesis/initialize.go
@@ -78,7 +78,6 @@ func findGenesisFile(dir string) (GenesisData, error) {
 		if err != nil {
 			continue
 		}
-		// Only return genesis file if it matches the expected network GVR
 		if gd.ValidatorsRoot == params.BeaconConfig().GenesisValidatorsRoot {
 			return gd, nil
 		}
@@ -91,7 +90,7 @@ func tryParseFname(dir string, f os.DirEntry) (GenesisData, error) {
 	if f.IsDir() {
 		return gd, ErrNotGenesisStateFile
 	}
-	extParts := strings.Split(f.Name(), ".")
+	extParts := strings.Split(f.Name(), ".")ß
 	if len(extParts) != 2 || extParts[1] != "ssz" {
 		return gd, ErrNotGenesisStateFile
 	}

--- a/genesis/initialize.go
+++ b/genesis/initialize.go
@@ -90,7 +90,7 @@ func tryParseFname(dir string, f os.DirEntry) (GenesisData, error) {
 	if f.IsDir() {
 		return gd, ErrNotGenesisStateFile
 	}
-	extParts := strings.Split(f.Name(), ".")ß
+	extParts := strings.Split(f.Name(), ".")
 	if len(extParts) != 2 || extParts[1] != "ssz" {
 		return gd, ErrNotGenesisStateFile
 	}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Prysm will load the first cached genesis state file that it sees, which can be problematic if you have multiple different networks cached. E.g. if you've previously run on Hoodi, then swap to Sepolia, the Hoodi genesis state would be loaded over the top of the Sepolia config.

**Which issues(s) does this PR fix?**
Fixes https://github.com/OffchainLabs/prysm/issues/15874

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
