### PR TITLE
Prysm Version Upgrade Script

### DIFF
--- a/changelog/bastin_version-upgrade-script.md
+++ b/changelog/bastin_version-upgrade-script.md
@@ -1,0 +1,3 @@
+### Added
+
+- Bash script for automating the version upgrade process.

--- a/hack/upgrade-version.sh
+++ b/hack/upgrade-version.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ====== config ======
+OLD="OffchainLabs/prysm/v6"
+NEW="OffchainLabs/prysm/v7"
+
+# files by extension (recursive)
+EXTENSIONS=("bazel" "go" "proto")
+
+# explicit files (relative to project root)
+EXPLICIT_FILES=(
+  "hack/update-mockgen.sh"
+  "hack/update-go-pbs.sh"
+  "go.mod"
+  ".deepsource.toml"
+)
+
+# commands to run at the end, in order
+COMMANDS=(
+  'bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%prysm_deps -prune=true'
+  'go mod tidy && go get ./...'
+  './hack/update-go-pbs.sh'
+  'go build ./... && bazel build //cmd/beacon-chain'
+)
+# ====================
+
+# Detect BSD vs GNU sed (macOS vs Linux)
+if sed --version >/dev/null 2>&1; then
+  SED_INPLACE=("sed" "-i")
+else
+  # macOS / BSD sed needs an empty string after -i
+  SED_INPLACE=("sed" "-i" "")
+fi
+
+escape_sed() {
+  # escape / in pattern and replacement so sed doesn't choke
+  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
+}
+
+OLD_ESCAPED=$(escape_sed "$OLD")
+NEW_ESCAPED=$(escape_sed "$NEW")
+
+############################################
+# 1) walk directory by extensions
+############################################
+for ext in "${EXTENSIONS[@]}"; do
+  while IFS= read -r -d '' file; do
+    "${SED_INPLACE[@]}" "s/${OLD_ESCAPED}/${NEW_ESCAPED}/g" "$file"
+    echo "updated (by ext): $file"
+  done < <(find . -type f -name "*.${ext}" -print0)
+done
+
+############################################
+# 2) specific files
+############################################
+for f in "${EXPLICIT_FILES[@]}"; do
+  if [[ -f "$f" ]]; then
+    "${SED_INPLACE[@]}" "s/${OLD_ESCAPED}/${NEW_ESCAPED}/g" "$f"
+    echo "updated (explicit): $f"
+  else
+    echo "warn: explicit file not found: $f" >&2
+  fi
+done
+
+############################################
+# 3) run commands in order
+############################################
+for cmd in "${COMMANDS[@]}"; do
+  echo "==> running: $cmd"
+  # use bash -c so we can have && in commands
+  bash -c "$cmd"
+  echo "==> done: $cmd"
+done
+
+echo
+echo "✅ version upgrade was successful."

--- a/hack/upgrade-version.sh
+++ b/hack/upgrade-version.sh
@@ -21,6 +21,8 @@ COMMANDS=(
   'bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%prysm_deps -prune=true'
   'go mod tidy && go get ./...'
   './hack/update-go-pbs.sh'
+  'bazel clean --expunge --async'
+  './hack/update-go-ssz.sh'
   'go build ./... && bazel build //cmd/beacon-chain'
 )
 # ====================

--- a/hack/upgrade-version.sh
+++ b/hack/upgrade-version.sh
@@ -20,10 +20,10 @@ EXPLICIT_FILES=(
 COMMANDS=(
   'bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%prysm_deps -prune=true'
   'go mod tidy && go get ./...'
-  './hack/update-go-pbs.sh'
   'bazel clean --expunge --async'
+  './hack/update-go-pbs.sh'
   './hack/update-go-ssz.sh'
-  'go build ./... && bazel build //cmd/beacon-chain'
+  'go build ./... && bazel build //cmd/beacon-chain //cmd/validator'
 )
 # ====================
 

--- a/hack/upgrade-version.sh
+++ b/hack/upgrade-version.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ====== config ======
+OLD="OffchainLabs/prysm/v6"
+NEW="OffchainLabs/prysm/v7"
+
+# files by extension (recursive, excluding Git-ignored paths)
+EXTENSIONS=("bazel" "go" "proto")
+
+# explicit files (relative to project root)
+EXPLICIT_FILES=(
+  "go.mod"
+  ".deepsource.toml"
+)
+
+# commands to run at the end, in order
+COMMANDS=(
+  'bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%prysm_deps -prune=true'
+  'go mod tidy && go get ./...'
+  'bazel clean --expunge --async'
+  'make gen'
+  'go build ./... && bazel build //cmd/beacon-chain //cmd/validator'
+)
+# ====================
+
+# Detect BSD vs GNU sed (macOS vs Linux)
+if sed --version >/dev/null 2>&1; then
+  SED_INPLACE=("sed" "-i")
+else
+  # macOS / BSD sed needs an empty string after -i
+  SED_INPLACE=("sed" "-i" "")
+fi
+
+escape_sed() {
+  # escape / in pattern and replacement so sed doesn't choke
+  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
+}
+
+OLD_ESCAPED=$(escape_sed "$OLD")
+NEW_ESCAPED=$(escape_sed "$NEW")
+
+############################################
+# 1) walk directory by extensions
+############################################
+for ext in "${EXTENSIONS[@]}"; do
+  while IFS= read -r -d '' file; do
+    "${SED_INPLACE[@]}" "s/${OLD_ESCAPED}/${NEW_ESCAPED}/g" "$file"
+    echo "updated (by ext): $file"
+  done < <(git ls-files --cached --others --exclude-standard -z -- "*.${ext}")
+done
+
+############################################
+# 2) specific files
+############################################
+for f in "${EXPLICIT_FILES[@]}"; do
+  if git check-ignore --quiet -- "$f"; then
+    echo "skipped (ignored): $f"
+    continue
+  fi
+
+  if [[ -f "$f" ]]; then
+    "${SED_INPLACE[@]}" "s/${OLD_ESCAPED}/${NEW_ESCAPED}/g" "$f"
+    echo "updated (explicit): $f"
+  else
+    echo "warn: explicit file not found: $f" >&2
+  fi
+done
+
+############################################
+# 3) run commands in order
+############################################
+for cmd in "${COMMANDS[@]}"; do
+  echo "==> running: $cmd"
+  # use bash -c so we can have && in commands
+  bash -c "$cmd"
+  echo "==> done: $cmd"
+done
+
+echo
+echo "✅ version upgrade was successful."


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR adds a bash script to automate the prysm version upgrade process. 

**This is the process that the script is automating:**

Migrates the Prysm dependency from `OffchainLabs/prysm/vX` to `OffchainLabs/prysm/vY` across the entire codebase.

##### File Modifications
- Replaces import paths in all `*.bazel`, `*.go`, `*.proto` files

##### File Updates
- Manually updates references in `go.mod`, `.deepsource.toml`

##### Command Updates
- Regenerates Bazel deps:  
  `bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%prysm_deps -prune=true`
- Cleans and fetches Go deps:  
  `go mod tidy && go get ./...`
- Cleans bazel files:
  `bazel clean --expunge --async`
- Regenerates protobufs and ssz and mock files:  
  `make gen`
- Verifies builds:  
  `go build ./... && bazel build //cmd/beacon-chain //cmd/validator`


