### PR TITLE
fix: process timely flags for forks >= Altair

### DIFF
--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -99,7 +99,7 @@ func (s *Service) processIncludedAttestation(ctx context.Context, state state.Be
 			inclusionSlotGauge.WithLabelValues(fmt.Sprintf("%d", idx)).Set(float64(latestPerf.inclusionSlot))
 			aggregatedPerf.totalDistance += uint64(latestPerf.inclusionSlot - latestPerf.attestedSlot)
 
-			if state.Version() == version.Altair {
+			if state.Version() >= version.Altair {
 				targetIdx := params.BeaconConfig().TimelyTargetFlagIndex
 				sourceIdx := params.BeaconConfig().TimelySourceFlagIndex
 				headIdx := params.BeaconConfig().TimelyHeadFlagIndex

--- a/beacon-chain/monitor/process_attestation_test.go
+++ b/beacon-chain/monitor/process_attestation_test.go
@@ -245,3 +245,34 @@ func TestProcessAttestations(t *testing.T) {
 	require.LogsContain(t, hook, wanted2)
 
 }
+
+func TestProcessIncludedAttestation_Bellatrix(t *testing.T) {
+	hook := logTest.NewGlobal()
+	s := setupService(t)
+	state, _ := util.DeterministicGenesisStateBellatrix(t, 256)
+	require.NoError(t, state.SetSlot(2))
+	require.NoError(t, state.SetCurrentParticipationBits(bytes.Repeat([]byte{0xff}, 13)))
+
+	att := &ethpb.Attestation{
+		Data: &ethpb.AttestationData{
+			Slot:            1,
+			CommitteeIndex:  0,
+			BeaconBlockRoot: bytesutil.PadTo([]byte("hello-world"), 32),
+			Source: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  bytesutil.PadTo([]byte("hello-world"), 32),
+			},
+			Target: &ethpb.Checkpoint{
+				Epoch: 1,
+				Root:  bytesutil.PadTo([]byte("hello-world"), 32),
+			},
+		},
+		AggregationBits: bitfield.Bitlist{0b11, 0b1},
+	}
+
+	s.processIncludedAttestation(t.Context(), state, att)
+	wanted1 := "\"Attestation included\" balanceChange=0 correctHead=true correctSource=true correctTarget=true head=0x68656c6c6f2d inclusionSlot=2 newBalance=32000000000 prefix=monitor slot=1 source=0x68656c6c6f2d target=0x68656c6c6f2d validatorIndex=2"
+	wanted2 := "\"Attestation included\" balanceChange=100000000 correctHead=true correctSource=true correctTarget=true head=0x68656c6c6f2d inclusionSlot=2 newBalance=32000000000 prefix=monitor slot=1 source=0x68656c6c6f2d target=0x68656c6c6f2d validatorIndex=12"
+	require.LogsContain(t, hook, wanted1)
+	require.LogsContain(t, hook, wanted2)
+}


### PR DESCRIPTION
Problem: processIncludedAttestation() gated timely-flag handling by state.Version() == version.Altair, which disables processing on all forks after Altair (Bellatrix, Capella, Deneb, Electra, Fulu). This causes missing timely flag updates and metrics beyond Altair despite participation bits and flag indices existing in later forks.

Fix: Change the gate to state.Version() >= version.Altair so the logic runs on all post-Altair versions.

Tests: Added TestProcessIncludedAttestation_Bellatrix to ensure timely flags are processed in Bellatrix using a deterministic Bellatrix genesis and participation bits; asserts the same “Attestation included” logs and timely flags as the Altair test.