### PR TITLE
Clean up redundant boolean checks in LRU tests

### DIFF
--- a/cache/nonblocking/lru_test.go
+++ b/cache/nonblocking/lru_test.go
@@ -64,10 +64,10 @@ func TestLRU_Add(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if l.Add(1, 1) == true || evictCounter != 0 {
+	if l.Add(1, 1) || evictCounter != 0 {
 		t.Errorf("should not have an eviction")
 	}
-	if l.Add(2, 2) == false || evictCounter != 1 {
+	if !l.Add(2, 2) || evictCounter != 1 {
 		t.Errorf("should have an eviction")
 	}
 }

--- a/changelog/0xLogicalx_redundant-boolean.md
+++ b/changelog/0xLogicalx_redundant-boolean.md
@@ -1,0 +1,1 @@
+strip the extra == true/== false comparisons in TestLRU_Add, keep the eviction assertions readable without any behavior change


### PR DESCRIPTION
strip the extra == true/== false comparisons in TestLRU_Add, keep the eviction assertions readable without any behavior change