### PR TITLE
fix: inherit fork time from input genesis config

### DIFF
--- a/changelog/inherit-fork-time-from-input-genesis.md
+++ b/changelog/inherit-fork-time-from-input-genesis.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Inherit fork activation times (Shanghai, Cancun, Prague, Osaka) from input genesis file during chain initialization.

--- a/cmd/prysmctl/testnet/generate_genesis.go
+++ b/cmd/prysmctl/testnet/generate_genesis.go
@@ -261,10 +261,18 @@ func generateGenesis(ctx context.Context) (state.BeaconState, error) {
 		// set timestamps for genesis and shanghai fork
 		gen.Timestamp = f.GenesisTime
 		genesis := time.Unix(int64(f.GenesisTime), 0)
-		gen.Config.ShanghaiTime = interop.GethShanghaiTime(genesis, params.BeaconConfig())
-		gen.Config.CancunTime = interop.GethCancunTime(genesis, params.BeaconConfig())
-		gen.Config.PragueTime = interop.GethPragueTime(genesis, params.BeaconConfig())
-		gen.Config.OsakaTime = interop.GethOsakaTime(genesis, params.BeaconConfig())
+		if gen.Config.ShanghaiTime == nil {
+			gen.Config.ShanghaiTime = interop.GethShanghaiTime(genesis, params.BeaconConfig())
+		}
+		if gen.Config.CancunTime == nil {
+			gen.Config.CancunTime = interop.GethCancunTime(genesis, params.BeaconConfig())
+		}
+		if gen.Config.PragueTime == nil {
+			gen.Config.PragueTime = interop.GethPragueTime(genesis, params.BeaconConfig())
+		}
+		if gen.Config.OsakaTime == nil {
+			gen.Config.OsakaTime = interop.GethOsakaTime(genesis, params.BeaconConfig())
+		}
 
 		fields := logrus.Fields{}
 		if gen.Config.ShanghaiTime != nil {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix

**What does this PR do? Why is it needed?**
If fork time like ShangHaiTime exist in input genesis file, we better use it directly, not overwrite it.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
