### PR TITLE
fix(e2e): add configurable timeout to WaitForTextInFile

### DIFF
--- a/changelog/pvl-waitfortextinfile-timeout.md
+++ b/changelog/pvl-waitfortextinfile-timeout.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Added `WaitForTextInFileWithTimeout` to allow e2e test components to specify custom timeouts when polling log files for expected text, instead of being limited to the default 60-second timeout.

--- a/testing/endtoend/helpers/BUILD.bazel
+++ b/testing/endtoend/helpers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -25,4 +25,11 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//testing/require:go_default_library"],
 )

--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -71,9 +71,9 @@ func DeleteAndCreatePath(fp string) (*os.File, error) {
 	return os.Create(filepath.Clean(fp))
 }
 
-// WaitForTextInFile checks a file every polling interval for the text requested.
-func WaitForTextInFile(src *os.File, match string) error {
-	d := time.Now().Add(maxPollingWaitTime)
+// WaitForTextInFileWithTimeout checks a file every polling interval for the text requested with a configurable timeout.
+func WaitForTextInFileWithTimeout(src *os.File, match string, timeout time.Duration) error {
+	d := time.Now().Add(timeout)
 	ctx, cancel := context.WithDeadline(context.Background(), d)
 	defer cancel()
 
@@ -138,6 +138,11 @@ func WaitForTextInFile(src *os.File, match string) error {
 	case err = <-errChan:
 		return errors.Wrapf(err, "received error while scanning %s for %s", f.Name(), match)
 	}
+}
+
+// WaitForTextInFile checks a file every polling interval for the text requested.
+func WaitForTextInFile(src *os.File, match string) error {
+	return WaitForTextInFileWithTimeout(src, match, maxPollingWaitTime)
 }
 
 // FindFollowingTextInFile checks a file every polling interval for the  following text requested.

--- a/testing/endtoend/helpers/helpers_test.go
+++ b/testing/endtoend/helpers/helpers_test.go
@@ -1,0 +1,69 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func TestWaitForTextInFileWithTimeout_Found(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "test.log")
+	f, err := os.Create(tmp)
+	require.NoError(t, err)
+
+	// Write the match text before calling the function.
+	_, err = f.WriteString("line one\nRunning bootnode\nline three\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Sync())
+
+	err = WaitForTextInFileWithTimeout(f, "Running bootnode", 5*time.Second)
+	require.NoError(t, err)
+}
+
+func TestWaitForTextInFileWithTimeout_Timeout(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "test.log")
+	f, err := os.Create(tmp)
+	require.NoError(t, err)
+
+	// Write text that does NOT match.
+	_, err = f.WriteString("nothing relevant here\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Sync())
+
+	err = WaitForTextInFileWithTimeout(f, "will never appear", 1*time.Second)
+	require.ErrorContains(t, "could not find requested text", err)
+}
+
+func TestWaitForTextInFileWithTimeout_DelayedWrite(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "test.log")
+	f, err := os.Create(tmp)
+	require.NoError(t, err)
+
+	// Write the match text after a short delay — exercises the polling loop.
+	go func() {
+		time.Sleep(600 * time.Millisecond) // Just over one polling interval.
+		_, _ = f.WriteString("beacon started\n")
+		_ = f.Sync()
+	}()
+
+	err = WaitForTextInFileWithTimeout(f, "beacon started", 5*time.Second)
+	require.NoError(t, err)
+}
+
+func TestWaitForTextInFile_UsesDefaultTimeout(t *testing.T) {
+	// WaitForTextInFile delegates to WaitForTextInFileWithTimeout with maxPollingWaitTime (60s).
+	// We verify it works by checking a file with existing content.
+	tmp := filepath.Join(t.TempDir(), "test.log")
+	f, err := os.Create(tmp)
+	require.NoError(t, err)
+
+	_, err = f.WriteString("Chain started in sync service\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Sync())
+
+	err = WaitForTextInFile(f, "Chain started in sync service")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Extracts `WaitForTextInFileWithTimeout(src, match, timeout)` from `WaitForTextInFile`, allowing e2e test components to specify custom timeouts when polling log files for expected text
- Keeps `WaitForTextInFile` as a backward-compatible wrapper using the existing 60-second default (`maxPollingWaitTime`)
- Adds 4 unit tests (first test coverage for `helpers.go`): text found, timeout, delayed write (polling loop), and default-timeout delegation

## Motivation

Several e2e components (bootnode, beacon node) need longer startup timeouts than the hardcoded 60s, especially under CI load. Rather than changing the global constant (which would slow down failure detection for all callers), this provides a per-call configurable timeout.

## Changes

- `testing/endtoend/helpers/helpers.go` — new `WaitForTextInFileWithTimeout` function, `WaitForTextInFile` refactored as thin wrapper
- `testing/endtoend/helpers/helpers_test.go` — 4 unit tests (new file)
- `testing/endtoend/helpers/BUILD.bazel` — added `go_test` target
- `changelog/pvl-waitfortextinfile-timeout.md` — changelog fragment

## Testing

All 4 unit tests pass. Zero behavioral change for existing 8 callers of `WaitForTextInFile`.