### PR TITLE
Add automatic IP detection for P2P host configuration

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//genesis:go_default_library",
         "//monitoring/prometheus:go_default_library",
         "//monitoring/tracing:go_default_library",
+        "//network:go_default_library",
         "//runtime:go_default_library",
         "//runtime/prereqs:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -65,6 +65,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/container/slice"
 	"github.com/OffchainLabs/prysm/v7/genesis"
 	"github.com/OffchainLabs/prysm/v7/monitoring/prometheus"
+	prysmnetwork "github.com/OffchainLabs/prysm/v7/network"
 	"github.com/OffchainLabs/prysm/v7/runtime"
 	"github.com/OffchainLabs/prysm/v7/runtime/prereqs"
 	"github.com/ethereum/go-ethereum/common"
@@ -73,7 +74,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const testSkipPowFlag = "test-skip-pow"
+const (
+	testSkipPowFlag = "test-skip-pow"
+	autoIPFlag      = "auto"
+)
 
 // Used as a struct to keep cli flag options for configuring services
 // for the beacon node. We keep this as a separate struct to not pollute the actual BeaconNode
@@ -656,6 +660,16 @@ func (b *BeaconNode) registerP2P(cliCtx *cli.Context) error {
 		return fmt.Errorf("failed to register p2p service: %w", err)
 	}
 
+	hostAddress := cliCtx.String(cmd.P2PHost.Name)
+	if hostAddress == autoIPFlag {
+		hostAddress, err = prysmnetwork.ExternalPublicIP()
+		if err != nil {
+			return fmt.Errorf("failed to auto-detect IP address: %w", err)
+		}
+
+		logHostAddress(hostAddress)
+	}
+
 	svc, err := p2p.NewService(b.ctx, &p2p.Config{
 		NoDiscovery:           cliCtx.Bool(cmd.NoDiscovery.Name),
 		StaticPeers:           slice.SplitCommaSeparated(cliCtx.StringSlice(cmd.StaticPeers.Name)),
@@ -664,7 +678,7 @@ func (b *BeaconNode) registerP2P(cliCtx *cli.Context) error {
 		DataDir:               dataDir,
 		DiscoveryDir:          filepath.Join(dataDir, "discovery"),
 		LocalIP:               cliCtx.String(cmd.P2PIP.Name),
-		HostAddress:           cliCtx.String(cmd.P2PHost.Name),
+		HostAddress:           hostAddress,
 		HostDNS:               cliCtx.String(cmd.P2PHostDNS.Name),
 		PrivateKey:            cliCtx.String(cmd.P2PPrivKey.Name),
 		StaticPeerID:          cliCtx.Bool(cmd.P2PStaticID.Name),
@@ -1174,4 +1188,15 @@ func hasNetworkFlag(cliCtx *cli.Context) bool {
 		}
 	}
 	return false
+}
+
+func logHostAddress(address string) {
+	parsedIP := net.ParseIP(address)
+
+	if parsedIP == nil || !parsedIP.IsPrivate() {
+		log.WithField("address", address).Info("Automatically detected host IP address")
+		return
+	}
+
+	log.WithField("address", address).Warning("No public IP address found, falling back to private address which may not be reachable from the internet")
 }

--- a/changelog/manu-auto-external-ip.md
+++ b/changelog/manu-auto-external-ip.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support `--p2p-host-ip=auto` to automatically detect and advertise the node's external IP address.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -142,8 +142,9 @@ var (
 	}
 	// P2PHost defines the host IP to be used by libp2p.
 	P2PHost = &cli.StringFlag{
-		Name:  "p2p-host-ip",
-		Usage: "The IP address advertised by libp2p. This may be used to advertise an external IP.",
+		Name: "p2p-host-ip",
+		Usage: "The IP address advertised by libp2p. This may be used to advertise an external IP. " +
+			"Set to 'auto' to automatically detect the IP from local network interfaces. (Won't work behind a NAT or within a containerized environment.)",
 		Value: "",
 	}
 	// P2PHostDNS defines the host DNS to be used by libp2p.

--- a/network/external_ip.go
+++ b/network/external_ip.go
@@ -2,9 +2,12 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"sort"
 )
+
+const defaultIP = "127.0.0.1"
 
 // IPAddr gets the external ipv4 address and converts into a libp2p formatted value.
 func IPAddr() net.IP {
@@ -22,7 +25,7 @@ func ExternalIPv4() (string, error) {
 		return "", err
 	}
 	if len(ips) == 0 {
-		return "127.0.0.1", nil
+		return defaultIP, nil
 	}
 	for _, ip := range ips {
 		ip = ip.To4()
@@ -31,7 +34,7 @@ func ExternalIPv4() (string, error) {
 		}
 		return ip.String(), nil
 	}
-	return "127.0.0.1", nil
+	return defaultIP, nil
 }
 
 // ExternalIP returns the first IPv4/IPv6 available.
@@ -41,8 +44,31 @@ func ExternalIP() (string, error) {
 		return "", err
 	}
 	if len(ips) == 0 {
-		return "127.0.0.1", nil
+		return defaultIP, nil
 	}
+	return ips[0].String(), nil
+}
+
+// ExternalPublicIP returns the first public (non-private) IP available,
+// preferring IPv4 over IPv6. If no public IP is found, it falls back to the
+// first private IP. Returns "127.0.0.1" if no addresses are available at all.
+func ExternalPublicIP() (string, error) {
+	ips, err := ipAddrs()
+	if err != nil {
+		return "", fmt.Errorf("failed to get IP addresses: %w", err)
+	}
+
+	if len(ips) == 0 {
+		return defaultIP, nil
+	}
+
+	for _, ip := range ips {
+		if !ip.IsPrivate() {
+			return ip.String(), nil
+		}
+	}
+
+	// No public IP found, fall back to first available (private) IP.
 	return ips[0].String(), nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
When users want to get inbound peers, they have to:
1. Retrieve their external IP address
2. Start the beacon node with the `--p2p-host-ip=<public-ip>` flag.

**This PR adds a new feature:**
When using the `--p2p-host-ip=auto` flag, the beacon node now enumerates all the available IP addresses and uses the first public one.

If at least one public IP address is found, the following log is displayed:
```
[2026-03-16 17:39:56.53]  INFO node: Automatically detected host IP address address=<xxx>
```

In the contrary case, the following log is displayed:
```
[2026-03-16 17:39:56.53] No public IP address found, falling back to private address which may not be reachable from the internet address=<xxx>
```

> [!WARNING]
> This feature will work only if the external IP address can be seen from the node (for example when running `ip a`).
> If, for example, the node runs behind a NAT or in docker (with the default networking configuration), no public address will be available, thus fall backing on a private address.  

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
