### PR TITLE
Make sync completion slot-precise and remove the initial-sync to regular-sync handoff gap

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
@@ -338,8 +338,28 @@ func (f *blocksFetcher) bestFinalizedSlot() primitives.Slot {
 // bestNonFinalizedSlot returns the highest non-finalized slot of enough number of connected peers.
 func (f *blocksFetcher) bestNonFinalizedSlot() primitives.Slot {
 	headEpoch := slots.ToEpoch(f.chain.HeadSlot())
-	targetEpoch, _ := f.p2p.Peers().BestNonFinalized(flags.Get().MinimumSyncPeers*2, headEpoch)
-	return params.BeaconConfig().SlotsPerEpoch.Mul(uint64(targetEpoch))
+	targetEpoch, peers := f.p2p.Peers().BestNonFinalized(flags.Get().MinimumSyncPeers*2, headEpoch)
+	if targetEpoch == 0 {
+		return 0
+	}
+
+	// Preserve slot precision within the quorum-backed target epoch so the queue does
+	// not stop early after converting peer progress to an epoch boundary.
+	targetSlot := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(targetEpoch))
+	for _, pid := range peers {
+		peerChainState, err := f.p2p.Peers().ChainState(pid)
+		if err != nil || peerChainState == nil {
+			continue
+		}
+		if slots.ToEpoch(peerChainState.HeadSlot) != targetEpoch {
+			continue
+		}
+		if peerChainState.HeadSlot > targetSlot {
+			targetSlot = peerChainState.HeadSlot
+		}
+	}
+
+	return targetSlot
 }
 
 // calculateHeadAndTargetEpochs return node's current head epoch, along with the best known target

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils_test.go
@@ -643,3 +643,31 @@ func TestBlocksFetcher_currentHeadAndTargetEpochs(t *testing.T) {
 		})
 	}
 }
+
+// TestBlocksFetcher_bestNonFinalizedSlot_PreservesPeerHeadWithinEpoch verifies non-finalized targets keep intra-epoch slot precision.
+func TestBlocksFetcher_bestNonFinalizedSlot_PreservesPeerHeadWithinEpoch(t *testing.T) {
+	useMinimalInitialSyncConfig(t)
+
+	const (
+		ourHeadSlot  = primitives.Slot(90)
+		peerHeadSlot = primitives.Slot(92)
+	)
+
+	mc, p2p, _ := initializeTestServices(t, []primitives.Slot{}, []*peerData{
+		{blocks: makeSequence(1, peerHeadSlot), finalizedEpoch: 8, headSlot: peerHeadSlot},
+		{blocks: makeSequence(1, peerHeadSlot), finalizedEpoch: 8, headSlot: peerHeadSlot},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	fetcher := newBlocksFetcher(ctx, &blocksFetcherConfig{
+		chain: mc,
+		p2p:   p2p,
+	})
+	fetcher.mode = modeNonConstrained
+	require.NoError(t, mc.State.SetSlot(ourHeadSlot))
+
+	got := fetcher.bestNonFinalizedSlot()
+	require.Equal(t, peerHeadSlot, got, "bestNonFinalizedSlot should keep slot precision within the current epoch")
+}

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -1350,3 +1350,49 @@ func TestBlocksQueue_stuckWhenHeadIsSetToOrphanedBlock(t *testing.T) {
 		require.Equal(t, true, beaconDB.HasBlock(ctx, blkRoot) || mc.HasBlock(ctx, blkRoot), "slot %d", blk.Block.Slot)
 	}
 }
+
+// TestBlocksQueue_waitHighestExpectedSlot_ExtendsTargetWithinCurrentEpoch verifies the queue extends its target when peers are ahead in the same epoch.
+func TestBlocksQueue_waitHighestExpectedSlot_ExtendsTargetWithinCurrentEpoch(t *testing.T) {
+	useMinimalInitialSyncConfig(t)
+
+	const (
+		ourHeadSlot    = primitives.Slot(90)
+		initialTarget  = primitives.Slot(90)
+		latestPeerHead = primitives.Slot(92)
+	)
+
+	mc, p2p, _ := initializeTestServices(t, []primitives.Slot{}, []*peerData{
+		{blocks: makeSequence(1, latestPeerHead), finalizedEpoch: 8, headSlot: latestPeerHead},
+		{blocks: makeSequence(1, latestPeerHead), finalizedEpoch: 8, headSlot: latestPeerHead},
+	})
+	require.NoError(t, mc.State.SetSlot(ourHeadSlot))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	fetcher := newBlocksFetcher(ctx, &blocksFetcherConfig{
+		chain: mc,
+		p2p:   p2p,
+	})
+	fetcher.mode = modeNonConstrained
+
+	queueCtx, queueCancel := context.WithCancel(ctx)
+	q := &blocksQueue{
+		ctx:                 queueCtx,
+		cancel:              queueCancel,
+		blocksFetcher:       fetcher,
+		chain:               mc,
+		highestExpectedSlot: initialTarget,
+		mode:                modeNonConstrained,
+	}
+
+	extended := waitHighestExpectedSlot(q)
+
+	require.Equal(t, true, extended, "queue should extend the target when peers are ahead within the same epoch")
+	require.Equal(t, latestPeerHead, q.highestExpectedSlot, "queue should extend to the peer head slot, not the epoch start slot")
+	select {
+	case <-queueCtx.Done():
+		t.Fatal("queue canceled even though peers were still ahead within the same epoch")
+	default:
+	}
+}

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -197,8 +197,9 @@ func (s *Service) Start() {
 	s.chainStarted.Set()
 	log.Info("Starting initial chain sync...")
 
-	// Are we already in sync, or close to it?
-	if slots.ToEpoch(s.cfg.Chain.HeadSlot()) == slots.ToEpoch(currentSlot) {
+	// Initial sync completion must be slot-precise. Being in the same epoch can still
+	// leave the node several slots behind the current head.
+	if s.cfg.Chain.HeadSlot() >= currentSlot {
 		log.Info("Already synced to the current chain head")
 		s.markSynced()
 		return

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -201,6 +201,102 @@ func TestService_InitStartStop(t *testing.T) {
 	}
 }
 
+func useMinimalInitialSyncConfig(t *testing.T) {
+	t.Helper()
+
+	params.SetupTestConfigCleanup(t)
+	cfg := params.MinimalSpecConfig().Copy()
+	params.OverrideBeaconConfig(cfg)
+
+	prev := *flags.Get()
+	next := prev
+	next.MinimumSyncPeers = 1
+	if next.BlockBatchLimit == 0 {
+		next.BlockBatchLimit = 64
+	}
+	if next.BlockBatchLimitBurstFactor == 0 {
+		next.BlockBatchLimitBurstFactor = 10
+	}
+	flags.Init(&next)
+	t.Cleanup(func() {
+		prevCopy := prev
+		flags.Init(&prevCopy)
+	})
+}
+
+func newClockAtSlot(slot primitives.Slot) (*startup.Clock, time.Time) {
+	genesisTime := time.Unix(1_700_000_000, 0)
+	var validatorsRoot [32]byte
+	return startup.NewClock(genesisTime, validatorsRoot, startup.WithSlotAsNow(slot)), genesisTime
+}
+
+// TestService_Start_DoesNotMarkSyncedWhenStillBehindInSameEpoch verifies startup does not skip sync when head and current slot share an epoch but differ by slots.
+func TestService_Start_DoesNotMarkSyncedWhenStillBehindInSameEpoch(t *testing.T) {
+	useMinimalInitialSyncConfig(t)
+
+	headSlot := primitives.Slot(88)
+	currentSlot := primitives.Slot(95)
+
+	st, err := util.NewBeaconState()
+	require.NoError(t, err)
+	require.NoError(t, st.SetSlot(headSlot))
+
+	clock, genesisTime := newClockAtSlot(currentSlot)
+	gs := startup.NewClockSynchronizer()
+	require.NoError(t, gs.SetClock(clock))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	initialSyncComplete := make(chan struct{})
+	mc := &mock.ChainService{
+		State: st,
+		FinalizedCheckPoint: &ethpb.Checkpoint{
+			Epoch: 0,
+		},
+		Genesis:        genesisTime,
+		ValidatorsRoot: [32]byte{},
+	}
+
+	s := NewService(ctx, &Config{
+		P2P:                 p2ptest.NewTestP2P(t),
+		Chain:               mc,
+		ClockWaiter:         gs,
+		StateNotifier:       &mock.MockStateNotifier{},
+		InitialSyncComplete: initialSyncComplete,
+	})
+	s.verifierWaiter = verification.NewInitializerWaiter(gs, nil, nil, nil)
+	s.blobRetentionChecker = func(primitives.Slot) bool { return true }
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.Start()
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	select {
+	case <-done:
+		t.Fatal("initial sync exited early while the node was still seven slots behind in the current epoch")
+	default:
+	}
+	require.Equal(t, true, s.Syncing(), "service should still be syncing while behind in the current epoch")
+	require.Equal(t, false, s.Synced(), "service should not report synced while behind in the current epoch")
+	select {
+	case <-initialSyncComplete:
+		t.Fatal("service closed InitialSyncComplete while still behind in the current epoch")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(6 * time.Second):
+		t.Fatal("initial sync did not stop after context cancellation")
+	}
+}
+
 func TestService_waitForStateInitialization(t *testing.T) {
 	hook := logTest.NewGlobal()
 	newService := func(ctx context.Context, mc *mock.ChainService) (*Service, *startup.ClockSynchronizer) {

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -69,6 +69,7 @@ func TestSyncHandlers_WaitToSync(t *testing.T) {
 			initialSync: &mockSync.Sync{IsSyncing: false},
 		},
 		chainStarted:                    abool.New(),
+		subHandler:                      newSubTopicHandler(),
 		clockWaiter:                     gs,
 		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
 		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -389,13 +389,10 @@ func (s *Service) subscribeLogFields(topic string, nse params.NetworkScheduleEnt
 // subscribe to a given topic with a given validator and subscription handler.
 // The base protobuf message is used to initialize new messages for decoding.
 func (s *Service) subscribe(topic string, validator wrappedVal, handle subHandler, nse params.NetworkScheduleEntry) {
-	if err := s.waitForInitialSync(s.ctx); err != nil {
-		log.WithFields(s.subscribeLogFields(topic, nse)).WithError(err).Debug("Context cancelled while waiting for initial sync, not subscribing to topic")
-		return
-	}
-	// Check if this subscribe request is still valid - we may have crossed another fork epoch while waiting for initial sync.
+	// Subscriptions need to come up before initial sync completes so the node can
+	// follow new gossip immediately after the synced flag flips. Validators already
+	// ignore messages while initial sync is still active.
 	if s.subscriptionRequestExpired(nse) {
-		// If we are already past the next fork epoch, do not subscribe to this topic.
 		log.WithFields(s.subscribeLogFields(topic, nse)).Debug("Not subscribing to topic as we are already past the next fork epoch")
 		return
 	}
@@ -584,10 +581,6 @@ func (s *Service) subscribeWithParameters(p subscribeParameters) {
 	go s.ensurePeers(ctx, tracker)
 	go s.logMinimumPeersPerSubnet(ctx, p)
 
-	if err := s.waitForInitialSync(ctx); err != nil {
-		log.WithFields(p.logFields()).WithError(err).Debug("Could not subscribe to subnets as initial sync failed")
-		return
-	}
 	s.trySubscribeSubnets(tracker)
 	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
 	defer slotTicker.Done()
@@ -613,7 +606,7 @@ func (s *Service) subscribeWithParameters(p subscribeParameters) {
 }
 
 // trySubscribeSubnets attempts to subscribe to any missing subnets that we should be subscribed to.
-// Only if initial sync is complete.
+// Validators gate message processing while initial sync is active, so subscriptions can come up early.
 func (s *Service) trySubscribeSubnets(t *subnetTracker) {
 	subnetsToJoin := t.getSubnetsToJoin(s.cfg.clock.CurrentSlot())
 	s.pruneNotWanted(t, subnetsToJoin)

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -82,6 +82,51 @@ func TestSubscribe_ReceivesValidMessage(t *testing.T) {
 	}
 }
 
+// TestSubscribe_DoesNotWaitForInitialSyncToRegisterTopic verifies regular-sync topics are registered before initial sync completes.
+func TestSubscribe_DoesNotWaitForInitialSyncToRegisterTopic(t *testing.T) {
+	p2pService := p2ptest.NewTestP2P(t)
+	gt := time.Now()
+	vr := [32]byte{'A'}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	r := Service{
+		ctx: ctx,
+		cfg: &config{
+			p2p:         p2pService,
+			initialSync: &mockSync.Sync{IsSyncing: true},
+			chain: &mockChain.ChainService{
+				ValidatorsRoot: vr,
+				Genesis:        gt,
+			},
+			clock: startup.NewClock(gt, vr),
+		},
+		subHandler:          newSubTopicHandler(),
+		chainStarted:        abool.New(),
+		initialSyncComplete: make(chan struct{}),
+	}
+	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+	p2pService.Digest = nse.ForkDigest
+	topic := "/eth2/%x/voluntary_exit"
+
+	done := make(chan struct{})
+	go func() {
+		r.subscribe(topic, r.noopValidator, func(_ context.Context, _ proto.Message) error {
+			return nil
+		}, nse)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("the node reported sync complete before it was ready to follow new gossip blocks")
+	}
+
+	fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
+	assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
+	r.unSubscribeFromTopic(fullTopic)
+}
+
 func markInitSyncComplete(_ *testing.T, s *Service) {
 	s.initialSyncComplete = make(chan struct{})
 	close(s.initialSyncComplete)

--- a/changelog/satushh_sync-completion-handoff.md
+++ b/changelog/satushh_sync-completion-handoff.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Make initial sync completion slot-precise and register gossip subscriptions before sync is marked complete.


### PR DESCRIPTION
**TLDR**: Go over `TestBlocksFetcher_bestNonFinalizedSlot_PreservesPeerHeadWithinEpoch` test to quickly know what bug is being discussed. This test fails on develop. 

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

**Problem**                                                                                                                                                                                                        
                                                            
  In e2e presubmits, checkpoint-sync nodes intermittently fail with:

  _`received conflicting head epochs on node 2, expected 12, received 11`_
                                                                                                                                                                                                                 
  This is a real sync issue exposed by e2e, not just an evaluator artifact.
                                                                                                                                                                                                                 
  How initial sync is supposed to work:                      

 Start() → roundRobinSync() → markSynced()                                                                                                                                                                      
                                                                                                                                                                                                                 
  Start() (beacon-chain/sync/initial-sync/service.go):                                                                                                                                                                                       
  - Compares head vs current slot                                                                                                                                                                              
  - Skips sync if already caught up                                                                                                                                                                              

 roundRobinSync()  (beacon-chain/sync/initial-sync/round_robin.go)
                                                                                                                                                                                                               
  In its non-finalized phase, roundRobinSync() uses a block queue that calls:
  - bestNonFinalizedSlot() (blocks_fetcher_utils.go)                                                                                                                                                         
    "What is the highest slot enough peers agree on?"                                                                                                                                                            
  - waitHighestExpectedSlot() (blocks_queue.go)
    "Should the queue keep going or declare sync done?"                                                                                                                                                          
                                                                                                                                                                                                                 
  markSynced() (beacon-chain/sync/initial-sync/service.go)                                                                                                                                                                                  
  - Sets Syncing()=false                                                                                                                                                                                         
  - Closes InitialSyncComplete channel                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                    
                                                            
  In a perfect world:                                                                                                                                                                                            
   
    Peers at slot 92                                                                                                                                                                                             
           │                                                
           ▼
    bestNonFinalizedSlot() returns 92
           │
           ▼
    waitHighestExpectedSlot() sees target=92, keeps queue running
           │
           ▼
    Node reaches slot 92, sync queue ends                                                                                                                                                                        
           │
           ▼                                                                                                                                                                                                     
    Gossip subscriptions already active by the time markSynced() runs       
           │
           ▼
    Node can immediately follow new head blocks, with no handoff gap

  Three things break this flow.                                                                                                                                                                                  
   
  **1. Slot precision loss in sync target**                                                                                                                                                                          
                                                            
  bestNonFinalizedSlot() asks peers for their head slots, but converts them through an epoch round-trip that truncates intra-epoch progress:

    What peers report:    HeadSlot = 92
                                                                                                                                                                                                                 
    What bestNonFinalizedSlot() did:
                                                                                                                                                                                                                 
      slot 92 → ToEpoch → epoch 11 → epoch 11 × 8 → slot 88 
                                                      ▲
                                                      lost 4 slots
                                                                                                                                                                                                                 
    ┌─── Epoch 11 (slots 88─95) ─────────────────────────┐
    │                                                     │                                                                                                                                                      
    │  88    89    90    91    92    93    94    95        │
    │  ▲                       ▲                          │
    │  │                       └── peers are here         │                                                                                                                                                      
    │  └── sync target (truncated to epoch start)         │
    │                                                     │                                                                                                                                                      
    └─────────────────────────────────────────────────────┘ 
                                                                                                                                                                                                                 
    blocks_fetcher_utils.go ── bestNonFinalizedSlot()
    blocks_queue.go         ── waitHighestExpectedSlot() uses this to decide if sync is done  

  waitHighestExpectedSlot() re-checks the target when the node catches up. With the truncated value, it sees no further target and cancels the sync queue.                                                       
   
  **2. Same-epoch fast path skips sync entirely**                                                                                                                                                                    
                                                            
  Start() had a shortcut: if the node's head epoch matches the current epoch, skip initial sync. But "same epoch" can mean up to 7 slots behind (minimal config) or 31 slots behind (mainnet):                   
   
    beacon-chain/sync/initial-sync/service.go (old):                                                                                                                                                                                        
      if ToEpoch(HeadSlot) == ToEpoch(currentSlot) → markSynced()
                                                                                                                                                                                                                 
    ┌─── Epoch 11 ───────────────────────────────────────┐
    │                                                     │                                                                                                                                                      
    │  88    89    90    91    92    93    94    95        │
    │  ▲                                          ▲       │                                                                                                                                                      
    │  HeadSlot                             currentSlot   │
    │                                                     │                                                                                                                                                      
    │  ToEpoch(88) == ToEpoch(95) == 11                   │ 
    │  → "already synced!" (7 slots behind)               │                                                                                                                                                      
    └─────────────────────────────────────────────────────┘
                                                                                                                                                                                                                 
  **3. Before this change, the node could report sync complete before it was ready to follow new gossip blocks**                                                                                                                                                  
   
  markSynced() immediately sets Syncing()=false and closes InitialSyncComplete. Before this change, the regular-sync subscribe paths in subscriber.go were still waiting on InitialSyncComplete, so topic validators and subscriptions were only registered after the node already reported sync complete.                                                 

    BEFORE (handoff gap):
                                                                                                                                                                                                                 
    markSynced()
      ├─ synced.Set()                    ← Syncing()=false instantly                                                                                                                                             
      └─ close(InitialSyncComplete)      ← subscriber goroutines start waking
                                            RegisterTopicValidator()...                                                                                                                                          
                                            SubscribeToTopic()...
           ◄──── GAP ────►                  ← node may not yet be subscribed                                                                                                                                     
                                              to gossip; new head blocks can
                                              be delayed during the handoff                                                                                                                                      
   
    If an epoch boundary block lands in the gap:                                                                                                                                                                 
      The node can remain at epoch 11 while peers advance to epoch 12.    
      resyncIfBehind() requires >1 epoch behind to trigger (rpc_status.go),                                                                                                                                  
      so being exactly 1 epoch behind does not trigger automatic resync, which lets the lag persist long enough for the evaluator to observe it.
                                                                                                                                                                                                                 
  **Why it's a flake**                                                                                                                                                                                               
   
  The handoff gap duration varies with goroutine scheduling and CI machine load. With minimal config (4-second slots, 32-second epochs), the window is narrow but non-trivial relative to slot time. An epoch boundary that lands in the gap can cause the failure; if it does not, the test usually passes. On mainnet, the much longer slot and epoch durations plus gossip redundancy from thousands of peers make this much less likely to surface.                                                                                                                                                                                         
                                                            
  **Fix**

  **1. Slot-precise sync target** (blocks_fetcher_utils.go)                                                                                                                                                          
   
  After BestNonFinalized() returns the quorum-backed target epoch + supporting peers, scan those peers for the highest actual HeadSlot within that epoch:                                                        
                                                            
    AFTER:
      slot 92 → BestNonFinalized → epoch 11 + peers [A, B]
      scan peers: A.HeadSlot=92, B.HeadSlot=92                                                                                                                                                                   
      return max(92, 92) = 92        ← slot-precise
                                                                                                                                                                                                                 
  **2. Slot-precise startup check** (beacon-chain/sync/initial-sync/service.go)                                                                                                                                                                     
   
    OLD:  if ToEpoch(HeadSlot) == ToEpoch(currentSlot) → markSynced()                                                                                                                                            
    NEW:  if HeadSlot >= currentSlot                    → markSynced()

  **3. Subscriptions active before markSynced()** (subscriber.go)                                                                                                                                                    
   
  Remove waitForInitialSync() from subscribe() and subscribeWithParameters(). Gossip validators already ignore messages while initialSync.Syncing() is true (e.g., validate_beacon_blocks.go), so subscriptions can safely be live before sync completes:   
                                                                                                                                                                                                                 
    AFTER (no gap):                                         

    Subscriptions registered at startup
      ├─ topics active, validators reject while syncing
      │
    ... initial sync runs ...
      │                                                                                                                                                                                                          
    markSynced()
      ├─ synced.Set()                    ← Syncing()=false                                                                                                                                                       
      └─ validators start accepting      ← gossip already subscribed
                                         ← NO GAP

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
