### PR TITLE
API: Limit HTTP request max size and batch large RegisterValidator payloads

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -35,6 +35,7 @@ const (
 	postBlindedBeaconBlockPath   = "/eth/v1/builder/blinded_blocks"
 	postBlindedBeaconBlockV2Path = "/eth/v2/builder/blinded_blocks"
 	postRegisterValidatorPath    = "/eth/v1/builder/validators"
+	registerValidatorBatchSize   = 10_000
 )
 
 var (
@@ -383,40 +384,55 @@ func (c *Client) RegisterValidator(ctx context.Context, svr []*ethpb.SignedValid
 		return err
 	}
 
-	var (
-		body     []byte
-		err      error
-		postOpts reqOption
-	)
-	if c.sszEnabled {
-		postOpts = func(r *http.Request) {
-			r.Header.Set("Content-Type", api.OctetStreamMediaType)
-			r.Header.Set("Accept", api.OctetStreamMediaType)
+	for _, batch := range chunkSignedValidatorRegistrationV1(svr, registerValidatorBatchSize) {
+		var (
+			body     []byte
+			err      error
+			postOpts reqOption
+		)
+		if c.sszEnabled {
+			postOpts = func(r *http.Request) {
+				r.Header.Set("Content-Type", api.OctetStreamMediaType)
+				r.Header.Set("Accept", api.OctetStreamMediaType)
+			}
+			body, err = sszValidatorRegisterRequest(batch)
+			if err != nil {
+				err := errors.Wrap(err, "error ssz encoding the SignedValidatorRegistration value body in RegisterValidator")
+				tracing.AnnotateError(span, err)
+				return err
+			}
+		} else {
+			postOpts = func(r *http.Request) {
+				r.Header.Set("Content-Type", api.JsonMediaType)
+				r.Header.Set("Accept", api.JsonMediaType)
+			}
+			body, err = jsonValidatorRegisterRequest(batch)
+			if err != nil {
+				err := errors.Wrap(err, "error json encoding the SignedValidatorRegistration value body in RegisterValidator")
+				tracing.AnnotateError(span, err)
+				return err
+			}
 		}
-		body, err = sszValidatorRegisterRequest(svr)
-		if err != nil {
-			err := errors.Wrap(err, "error ssz encoding the SignedValidatorRegistration value body in RegisterValidator")
-			tracing.AnnotateError(span, err)
-			return err
-		}
-	} else {
-		postOpts = func(r *http.Request) {
-			r.Header.Set("Content-Type", api.JsonMediaType)
-			r.Header.Set("Accept", api.JsonMediaType)
-		}
-		body, err = jsonValidatorRegisterRequest(svr)
-		if err != nil {
-			err := errors.Wrap(err, "error json encoding the SignedValidatorRegistration value body in RegisterValidator")
-			tracing.AnnotateError(span, err)
-			return err
-		}
-	}
 
-	if _, _, err = c.do(ctx, http.MethodPost, postRegisterValidatorPath, bytes.NewBuffer(body), http.StatusOK, postOpts); err != nil {
-		return errors.Wrap(err, "do")
+		if _, _, err = c.do(ctx, http.MethodPost, postRegisterValidatorPath, bytes.NewBuffer(body), http.StatusOK, postOpts); err != nil {
+			return errors.Wrap(err, "do")
+		}
 	}
 	log.WithField("registrationCount", len(svr)).Debug("Successfully registered validator(s) on builder")
 	return nil
+}
+
+func chunkSignedValidatorRegistrationV1(regs []*ethpb.SignedValidatorRegistrationV1, chunkSize int) [][]*ethpb.SignedValidatorRegistrationV1 {
+	if chunkSize <= 0 || len(regs) <= chunkSize {
+		return [][]*ethpb.SignedValidatorRegistrationV1{regs}
+	}
+	chunksCount := (len(regs) + chunkSize - 1) / chunkSize
+	chunks := make([][]*ethpb.SignedValidatorRegistrationV1, 0, chunksCount)
+	for start := 0; start < len(regs); start += chunkSize {
+		end := min(start+chunkSize, len(regs))
+		chunks = append(chunks, regs[start:end])
+	}
+	return chunks
 }
 
 func jsonValidatorRegisterRequest(svr []*ethpb.SignedValidatorRegistrationV1) ([]byte, error) {

--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -168,6 +168,91 @@ func TestClient_RegisterValidator(t *testing.T) {
 	})
 }
 
+func TestJSONValidatorRegisterRequest_BatchSizeUnderMaxPayloadSize(t *testing.T) {
+	registrations := fullyPopulatedRegistrations(registerValidatorBatchSize)
+	body, err := jsonValidatorRegisterRequest(registrations)
+	require.NoError(t, err)
+	assert.Equal(t, true, len(body) < int(params.BeaconConfig().MaxPayloadSize))
+}
+
+func TestClient_RegisterValidator_BatchesJSON(t *testing.T) {
+	ctx := t.Context()
+	registrations := fullyPopulatedRegistrations(registerValidatorBatchSize*2 + 1234)
+	var batchSizes []int
+	hc := &http.Client{
+		Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
+			require.Equal(t, api.JsonMediaType, r.Header.Get("Content-Type"))
+			require.Equal(t, api.JsonMediaType, r.Header.Get("Accept"))
+			body, err := io.ReadAll(r.Body)
+			defer func() {
+				require.NoError(t, r.Body.Close())
+			}()
+			require.NoError(t, err)
+			var request []*structs.SignedValidatorRegistration
+			require.NoError(t, json.Unmarshal(body, &request))
+			batchSizes = append(batchSizes, len(request))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBuffer(nil)),
+				Request:    r.Clone(ctx),
+			}, nil
+		}),
+	}
+	c := &Client{hc: hc, baseURL: &url.URL{Host: "localhost:3500", Scheme: "http"}}
+	require.NoError(t, c.RegisterValidator(ctx, registrations))
+	require.DeepEqual(t, []int{registerValidatorBatchSize, registerValidatorBatchSize, 1234}, batchSizes)
+}
+
+func TestClient_RegisterValidator_BatchesSSZ(t *testing.T) {
+	ctx := t.Context()
+	registrations := fullyPopulatedRegistrations(registerValidatorBatchSize + 321)
+	var batchSizes []int
+	hc := &http.Client{
+		Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
+			require.Equal(t, api.OctetStreamMediaType, r.Header.Get("Content-Type"))
+			require.Equal(t, api.OctetStreamMediaType, r.Header.Get("Accept"))
+			body, err := io.ReadAll(r.Body)
+			defer func() {
+				require.NoError(t, r.Body.Close())
+			}()
+			require.NoError(t, err)
+			require.Equal(t, 0, len(body)%vrSize)
+			batchSizes = append(batchSizes, len(body)/vrSize)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBuffer(nil)),
+				Request:    r.Clone(ctx),
+			}, nil
+		}),
+	}
+	c := &Client{hc: hc, baseURL: &url.URL{Host: "localhost:3500", Scheme: "http"}, sszEnabled: true}
+	require.NoError(t, c.RegisterValidator(ctx, registrations))
+	require.DeepEqual(t, []int{registerValidatorBatchSize, 321}, batchSizes)
+}
+
+func fullyPopulatedRegistrations(count int) []*eth.SignedValidatorRegistrationV1 {
+	registrations := make([]*eth.SignedValidatorRegistrationV1, count)
+	for i := range count {
+		feeRecipient := bytes.Repeat([]byte{0x11}, 20)
+		pubkey := bytes.Repeat([]byte{0x22}, 48)
+		signature := bytes.Repeat([]byte{0x33}, 96)
+		pubkey[0] = byte(i)
+		pubkey[1] = byte(i >> 8)
+		signature[0] = byte(i)
+		signature[1] = byte(i >> 8)
+		registrations[i] = &eth.SignedValidatorRegistrationV1{
+			Message: &eth.ValidatorRegistrationV1{
+				FeeRecipient: feeRecipient,
+				GasLimit:     ^uint64(0),
+				Timestamp:    ^uint64(0),
+				Pubkey:       pubkey,
+			},
+			Signature: signature,
+		}
+	}
+	return registrations
+}
+
 func TestClient_GetHeader(t *testing.T) {
 	ctx := t.Context()
 	ds := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)

--- a/api/server/middleware/middleware.go
+++ b/api/server/middleware/middleware.go
@@ -136,6 +136,21 @@ func (g *gzipResponseWriter) Write(b []byte) (int, error) {
 	return g.ResponseWriter.Write(b)
 }
 
+// MaxBodySizeHandler limits the size of incoming request bodies to prevent
+// memory exhaustion from oversized POST requests. When the limit is exceeded,
+// http.MaxBytesReader causes subsequent reads to return an error, which
+// downstream handlers translate into appropriate HTTP error responses.
+func MaxBodySizeHandler(maxBytes int64) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != nil && r.Body != http.NoBody {
+				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func MiddlewareChain(h http.Handler, mw []Middleware) http.Handler {
 	if len(mw) < 1 {
 		return h

--- a/api/server/middleware/middleware_test.go
+++ b/api/server/middleware/middleware_test.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/api"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
 
@@ -226,6 +228,52 @@ func TestAcceptEncodingHeaderHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMaxBodySizeHandler(t *testing.T) {
+	const limit int64 = 128
+
+	echoHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	handler := MaxBodySizeHandler(limit)(echoHandler)
+
+	t.Run("request within limit is accepted", func(t *testing.T) {
+		body := strings.NewReader("small body")
+		req := httptest.NewRequest(http.MethodPost, "/", body)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "small body", rr.Body.String())
+	})
+	t.Run("request exceeding limit is rejected", func(t *testing.T) {
+		oversized := strings.Repeat("x", int(limit)+1)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(oversized))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	})
+	t.Run("request at exact limit is accepted", func(t *testing.T) {
+		exact := strings.Repeat("x", int(limit))
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(exact))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, int(limit), rr.Body.Len())
+	})
+	t.Run("GET request is not limited", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
 }
 
 func TestAcceptHeaderHandler(t *testing.T) {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -1073,7 +1073,9 @@ func (b *BeaconNode) registerHTTPService(router *http.ServeMux) error {
 		allowedOrigins = strings.Split(flags.HTTPServerCorsDomain.Value, ",")
 	}
 
+	maxHTTPBodySize := int64(2 * params.BeaconConfig().MaxPayloadSize)
 	middlewares := []middleware.Middleware{
+		middleware.MaxBodySizeHandler(maxHTTPBodySize),
 		middleware.NormalizeQueryValuesHandler,
 		middleware.CorsHandler(allowedOrigins),
 	}

--- a/changelog/pvl-max-http-size.md
+++ b/changelog/pvl-max-http-size.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Beacon chain REST API request payloads limited to 20mb
+- Validator now batches RegisterValidator requests containing more than 10,000 items

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -528,7 +528,9 @@ func (c *ValidatorClient) registerRPCService(cliCtx *cli.Context) error {
 		allowedOrigins = strings.Split(flags.HTTPServerCorsDomain.Value, ",")
 	}
 
+	maxHTTPBodySize := int64(2 * params.BeaconConfig().MaxPayloadSize)
 	middlewares := []middleware.Middleware{
+		middleware.MaxBodySizeHandler(maxHTTPBodySize),
 		middleware.NormalizeQueryValuesHandler,
 		middleware.CorsHandler(allowedOrigins),
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR introduces a middleware to limit the max payload size of HTTP requests. Some analysis shows that validator clients running more than 40k keys would bust the 20Mb limit when calling RegisterValidator. This PR allows for validators to run large number of keys with batching for any request more than 10k keys.

The 20Mb value is selected by using double of the p2p max payload size. This accounts for JSON inflation mostly.

**Which issues(s) does this PR fix?**

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
