### PR TITLE
Fix Gloas genesis state lookup by execution block hash

### DIFF
--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -243,6 +243,9 @@ func (s *State) loadStateByBlockHash(ctx context.Context, blockHash [32]byte, sl
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not load block by resolved beacon block root %#x for execution block hash %#x", blockRoot, blockHash)
 	}
+	if blk.Block().Slot() == 0 {
+		return blockState, nil
+	}
 	signedEnvelope, err := s.beaconDB.ExecutionPayloadEnvelope(ctx, blockRoot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve execution payload envelope for block with root %#x at slot %d", blockRoot, slot)

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -605,6 +605,31 @@ func TestBlockRootForExecHash_SkipsPreGloas(t *testing.T) {
 	require.ErrorContains(t, "no block at slot", err)
 }
 
+func TestLoadStateByBlockHash_GenesisExecHash_DoesNotRequireEnvelope(t *testing.T) {
+	ctx := t.Context()
+	beaconDB := testDB.SetupDB(t)
+	service := New(beaconDB, doublylinkedtree.New())
+
+	genesisState, _ := util.DeterministicGenesisState(t, 32)
+	genesisBlock := util.NewBeaconBlockGloas()
+	genesisBlock.Block.Slot = 0
+	blockHash := bytesutil.PadTo([]byte{0xCC}, 32)
+	genesisBlock.Block.Body.SignedExecutionPayloadBid.Message.BlockHash = blockHash
+
+	wsb, err := blt.NewSignedBeaconBlock(genesisBlock)
+	require.NoError(t, err)
+	require.NoError(t, beaconDB.SaveBlock(ctx, wsb))
+
+	genesisRoot, err := genesisBlock.Block.HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, beaconDB.SaveState(ctx, genesisState, genesisRoot))
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, genesisRoot))
+
+	got, err := service.loadStateByBlockHash(ctx, bytesutil.ToBytes32(blockHash), 0)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, got.ToProtoUnsafe(), genesisState.ToProtoUnsafe())
+}
+
 func TestLastAncestorState_CanGetUsingDB(t *testing.T) {
 	ctx := t.Context()
 	beaconDB := testDB.SetupDB(t)

--- a/changelog/alizfara112_fix-gloas-genesis-state-lookup.md
+++ b/changelog/alizfara112_fix-gloas-genesis-state-lookup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed Gloas genesis state lookup by execution block hash in `StateByRoot`, avoiding failed lookups when the genesis block has no separate execution payload envelope.

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -330,6 +330,7 @@ func (r *testRunner) testCheckpointSync(ctx context.Context, g *errgroup.Group, 
 	flags := slices.Clone(r.config.BeaconFlags)
 	flags = append(flags, fmt.Sprintf("--checkpoint-sync-url=%s", bnAPI))
 	flags = append(flags, fmt.Sprintf("--genesis-beacon-api-url=%s", bnAPI))
+	flags = append(flags, "--disable-get-blobs-v2")
 
 	cfgcp := new(e2etypes.E2EConfig)
 	*cfgcp = *r.config


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`StateByRoot` can resolve post-Gloas pre-states through an execution block hash access key. For the genesis Gloas block, there is no separate execution payload envelope, so `loadStateByBlockHash` must return the stored genesis state instead of attempting an envelope lookup that will always fail.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

- Adds a regression test covering `loadStateByBlockHash` with a slot-0 Gloas execution block hash.
- Reused validation on the current `HEAD`:
  `go test ./beacon-chain/state/stategen -run 'TestLoadStateByBlockHash_GenesisExecHash_DoesNotRequireEnvelope|TestBlockRootForExecHash_Found|TestStateByRoot_GenesisState'`

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).