### PR TITLE
Support context cancellation in PartialColumnBroadcaster

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -493,7 +493,7 @@ func (s *Service) broadcastDataColumnSidecars(ctx context.Context, forkDigest [f
 	var partialsWithPeers atomic.Int64
 	// Publish partial columns that already have peers.
 	if s.partialColumnBroadcaster != nil {
-		if err := s.partialColumnBroadcaster.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+		if err := s.partialColumnBroadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 			for _, item := range itemsWithPeers {
 				if item.partialColumn == nil {
 					continue
@@ -542,7 +542,7 @@ func (s *Service) broadcastDataColumnSidecars(ctx context.Context, forkDigest [f
 			if item.partialColumn != nil && s.partialColumnBroadcaster != nil {
 				pc := *item.partialColumn
 				fullTopicStr := item.topic + s.Encoding().ProtocolSuffix()
-				if err := s.partialColumnBroadcaster.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+				if err := s.partialColumnBroadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 					yield(fullTopicStr, pc)
 				}); err != nil {
 					log.WithError(err).Error("Cannot publish partial data column")

--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -490,10 +490,10 @@ func (s *Service) broadcastDataColumnSidecars(ctx context.Context, forkDigest [f
 		close(batchDone)
 	}()
 
-	var partialsWithPeers atomic.Int64
 	// Publish partial columns that already have peers.
 	if s.partialColumnBroadcaster != nil {
-		if err := s.partialColumnBroadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
+		var partialsWithPeers atomic.Int64
+		iterFunc := func(yield func(string, blocks.PartialDataColumn) bool) {
 			for _, item := range itemsWithPeers {
 				if item.partialColumn == nil {
 					continue
@@ -504,7 +504,8 @@ func (s *Service) broadcastDataColumnSidecars(ctx context.Context, forkDigest [f
 					return
 				}
 			}
-		}); err != nil {
+		}
+		if err := s.partialColumnBroadcaster.Publish(ctx, iterFunc); err != nil {
 			log.WithError(err).Error("Cannot publish partial data columns")
 		} else {
 			partialDataColumnBroadcasts.Add(float64(partialsWithPeers.Load()))

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/BUILD.bazel
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "config_test.go",
         "gossip_logger_test.go",
         "partial_test.go",
+        "publish_blocking_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/two_node_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/two_node_test.go
@@ -221,9 +221,9 @@ func TestTwoNodePartialColumnExchange(t *testing.T) {
 		go broadcaster1.Start(newTestCallbacks(node1Complete, "Node 1"))
 		go broadcaster2.Start(newTestCallbacks(node2Complete, "Node 2"))
 
-		err = broadcaster1.Subscribe(topic1)
+		err = broadcaster1.Subscribe(ctx, topic1)
 		require.NoError(t, err)
-		err = broadcaster2.Subscribe(topic2)
+		err = broadcaster2.Subscribe(ctx, topic2)
 		require.NoError(t, err)
 
 		// Wait for mesh to form
@@ -231,7 +231,7 @@ func TestTwoNodePartialColumnExchange(t *testing.T) {
 
 		// Publish
 		t.Log("Publishing from Node 1")
-		err = broadcaster1.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+		err = broadcaster1.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 			yield(topicStr, pc1)
 		})
 		require.NoError(t, err)
@@ -239,7 +239,7 @@ func TestTwoNodePartialColumnExchange(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 
 		t.Log("Publishing from Node 2")
-		err = broadcaster2.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+		err = broadcaster2.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 			yield(topicStr, pc2)
 		})
 		require.NoError(t, err)

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -150,14 +150,6 @@ func (r request) finish(err error) {
 // A nil ctx is permitted for fire-and-forget requests that have no cancellation.
 func (p *PartialColumnBroadcaster) enqueue(ctx context.Context, kind requestKind, v requestValues) (request, error) {
 	req := newRequest(ctx, kind, v)
-	if ctx == nil {
-		select {
-		case p.incomingReq <- req:
-			return req, nil
-		case <-p.stop:
-			return req, errPartialBroadcasterStopped
-		}
-	}
 	select {
 	case p.incomingReq <- req:
 		return req, nil
@@ -170,8 +162,8 @@ func (p *PartialColumnBroadcaster) enqueue(ctx context.Context, kind requestKind
 
 // tryEnqueue creates and enqueues a request without blocking.
 // Returns false if the request channel is full.
-func (p *PartialColumnBroadcaster) tryEnqueue(ctx context.Context, kind requestKind, v requestValues) (request, bool) {
-	req := newRequest(ctx, kind, v)
+func (p *PartialColumnBroadcaster) tryEnqueue(kind requestKind, v requestValues) (request, bool) {
+	req := newRequest(context.Background(), kind, v)
 	select {
 	case p.incomingReq <- req:
 		return req, true
@@ -183,9 +175,6 @@ func (p *PartialColumnBroadcaster) tryEnqueue(ctx context.Context, kind requestK
 // waitForResponse blocks until the request has been processed and returns the result.
 // If the request's context is cancelled before a response arrives, it returns the context error.
 func (r request) waitForResponse() error {
-	if r.ctx == nil {
-		return <-r.response
-	}
 	select {
 	case err := <-r.response:
 		return err
@@ -264,7 +253,7 @@ func NewBroadcaster(logger *logrus.Logger) *PartialColumnBroadcaster {
 // onEmitGossip enqueues a gossip request for the broadcaster's event loop.
 func (p *PartialColumnBroadcaster) onEmitGossip(topic string, groupID []byte, _ []peer.ID, _ map[peer.ID]blocks.PartialDataColumnPeerState) {
 	// Drop gossip emission if we have too many pending requests.
-	p.tryEnqueue(nil, requestKindGossip, requestValues{
+	p.tryEnqueue(requestKindGossip, requestValues{
 		gossip: gossip{
 			topic:   topic,
 			groupID: groupID,
@@ -294,7 +283,7 @@ func (p *PartialColumnBroadcaster) onIncomingRPC(from peer.ID, peerStates map[pe
 	if err != nil {
 		return err
 	}
-	_, ok := p.tryEnqueue(nil, requestKindHandleIncomingRPC, requestValues{
+	_, ok := p.tryEnqueue(requestKindHandleIncomingRPC, requestValues{
 		incomingRPC: incomingPartialRPC{rpc, from, message},
 	})
 	if !ok {
@@ -348,7 +337,7 @@ func (p *PartialColumnBroadcaster) loop() {
 		select {
 		case req := <-p.incomingReq:
 			// This check enables the requester to cancel the request by cancelling the given context.
-			if req.ctx != nil && req.ctx.Err() != nil {
+			if req.ctx.Err() != nil {
 				p.logger.WithError(req.ctx.Err()).WithField("kind", req.kind.String()).
 					Debug("Context canceled for PartialColumnBroadcaster event.") // Debug log level to avoid log storm at node shutdown.
 				req.finish(req.ctx.Err())
@@ -715,7 +704,7 @@ func (p *PartialColumnBroadcaster) handlePartialCells(ourDataColumn *blocks.Part
 				return
 			}
 			_ = p.peerFeedback(topicId, rpc.from, pubsub.PeerFeedbackUsefulMessage)
-			_, _ = p.enqueue(nil, requestKindCellsValidated, requestValues{
+			_, _ = p.enqueue(context.Background(), requestKindCellsValidated, requestValues{
 				cellsValidated: &cellsValidated{
 					validationTook: time.Since(start),
 					topic:          topicId,

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -2,6 +2,7 @@ package partialdatacolumnbroadcaster
 
 import (
 	"bytes"
+	"context"
 	stderrors "errors"
 	"iter"
 	"log/slog"
@@ -95,15 +96,102 @@ const (
 	requestKindCellsValidated
 )
 
-type request struct {
-	kind           requestKind
+func (k requestKind) String() string {
+	switch k {
+	case requestKindPublish:
+		return "publish"
+	case requestKindSubscribe:
+		return "subscribe"
+	case requestKindUnsubscribe:
+		return "unsubscribe"
+	case requestKindGossip:
+		return "gossip"
+	case requestKindHandleIncomingRPC:
+		return "handle_incoming_rpc"
+	case requestKindCellsValidated:
+		return "cells_validated"
+	default:
+		return "unknown"
+	}
+}
+
+type requestValues struct {
 	cellsValidated *cellsValidated
-	response       chan error
 	unsub          unsubscribe
 	incomingRPC    incomingPartialRPC
 	sub            subscribe
 	publish        publish
 	gossip         gossip
+}
+
+type request struct {
+	requestValues
+	ctx      context.Context
+	kind     requestKind
+	response chan error
+}
+
+func newRequest(ctx context.Context, kind requestKind, v requestValues) request {
+	return request{
+		requestValues: v,
+		ctx:           ctx,
+		kind:          kind,
+		response:      make(chan error, 1),
+	}
+}
+
+// finish sends the result to the caller waiting on the response channel.
+func (r request) finish(err error) {
+	r.response <- err
+}
+
+// enqueue creates and enqueues a request, blocking until it is accepted.
+// Returns an error if the broadcaster has stopped or the context has been cancelled.
+// A nil ctx is permitted for fire-and-forget requests that have no cancellation.
+func (p *PartialColumnBroadcaster) enqueue(ctx context.Context, kind requestKind, v requestValues) (request, error) {
+	req := newRequest(ctx, kind, v)
+	if ctx == nil {
+		select {
+		case p.incomingReq <- req:
+			return req, nil
+		case <-p.stop:
+			return req, errPartialBroadcasterStopped
+		}
+	}
+	select {
+	case p.incomingReq <- req:
+		return req, nil
+	case <-p.stop:
+		return req, errPartialBroadcasterStopped
+	case <-ctx.Done():
+		return req, ctx.Err()
+	}
+}
+
+// tryEnqueue creates and enqueues a request without blocking.
+// Returns false if the request channel is full.
+func (p *PartialColumnBroadcaster) tryEnqueue(ctx context.Context, kind requestKind, v requestValues) (request, bool) {
+	req := newRequest(ctx, kind, v)
+	select {
+	case p.incomingReq <- req:
+		return req, true
+	default:
+		return req, false
+	}
+}
+
+// waitForResponse blocks until the request has been processed and returns the result.
+// If the request's context is cancelled before a response arrives, it returns the context error.
+func (r request) waitForResponse() error {
+	if r.ctx == nil {
+		return <-r.response
+	}
+	select {
+	case err := <-r.response:
+		return err
+	case <-r.ctx.Done():
+		return r.ctx.Err()
+	}
 }
 
 type publish struct {
@@ -175,17 +263,13 @@ func NewBroadcaster(logger *logrus.Logger) *PartialColumnBroadcaster {
 
 // onEmitGossip enqueues a gossip request for the broadcaster's event loop.
 func (p *PartialColumnBroadcaster) onEmitGossip(topic string, groupID []byte, _ []peer.ID, _ map[peer.ID]blocks.PartialDataColumnPeerState) {
-	select {
-	case p.incomingReq <- request{
-		kind: requestKindGossip,
+	// Drop gossip emission if we have too many pending requests.
+	p.tryEnqueue(nil, requestKindGossip, requestValues{
 		gossip: gossip{
 			topic:   topic,
 			groupID: groupID,
 		},
-	}:
-	default:
-		// Drop gossip emission if we have too many pending requests
-	}
+	})
 }
 
 // onIncomingRPC processes an incoming partial message RPC by updating peer state
@@ -210,12 +294,10 @@ func (p *PartialColumnBroadcaster) onIncomingRPC(from peer.ID, peerStates map[pe
 	if err != nil {
 		return err
 	}
-	select {
-	case p.incomingReq <- request{
-		kind:        requestKindHandleIncomingRPC,
+	_, ok := p.tryEnqueue(nil, requestKindHandleIncomingRPC, requestValues{
 		incomingRPC: incomingPartialRPC{rpc, from, message},
-	}:
-	default:
+	})
+	if !ok {
 		p.logger.Warn("Dropping incoming partial RPC", "rpc", rpc)
 		return errors.New("incomingReq channel is full, dropping RPC")
 	}
@@ -254,13 +336,57 @@ func (p *PartialColumnBroadcaster) Start(callbacks ColumnCallbacks) {
 	p.loop()
 }
 
+var (
+	errPartialBroadcasterStopped = errors.New("partial column broadcaster stopped")
+	errUnknownRequestKind        = errors.New("unknown request kind")
+)
+
 func (p *PartialColumnBroadcaster) loop() {
 	cleanup := time.NewTicker(time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot))
 	defer cleanup.Stop()
 	for {
 		select {
+		case req := <-p.incomingReq:
+			// This check enables the requester to cancel the request by cancelling the given context.
+			if req.ctx != nil && req.ctx.Err() != nil {
+				p.logger.WithError(req.ctx.Err()).WithField("kind", req.kind.String()).
+					Debug("Context canceled for PartialColumnBroadcaster event.") // Debug log level to avoid log storm at node shutdown.
+				req.finish(req.ctx.Err())
+				continue
+			}
+			var err error
+			switch req.kind {
+			case requestKindPublish:
+				err = p.publish(req.publish.topicsAndColumns)
+			case requestKindSubscribe:
+				err = p.subscribe(req.sub.t)
+			case requestKindUnsubscribe:
+				err = p.unsubscribe(req.unsub.topic)
+			case requestKindGossip:
+				p.gossip(req.gossip.topic, req.gossip.groupID)
+			case requestKindHandleIncomingRPC:
+				err = p.handleIncomingRPC(req.incomingRPC)
+			case requestKindCellsValidated:
+				err = p.handleCellsValidated(req.cellsValidated)
+			default:
+				err = errUnknownRequestKind
+			}
+			if err != nil {
+				p.logger.WithField("kind", req.kind.String()).WithError(err).
+					Error("Failure handling PartialColumnBroadcaster event.")
+				err = errors.Wrap(err, "partial column broadcaster "+req.kind.String()+" event")
+			}
+			req.finish(err)
 		case <-p.stop:
-			return
+			// Drain remaining requests before exiting the loop.
+			for {
+				select {
+				case req := <-p.incomingReq:
+					req.finish(errPartialBroadcasterStopped)
+				default:
+					return
+				}
+			}
 		case <-cleanup.C:
 			for groupID, ttl := range p.groupTTL {
 				if ttl > 0 {
@@ -277,29 +403,6 @@ func (p *PartialColumnBroadcaster) loop() {
 						delete(p.partialMsgStore, topic)
 					}
 				}
-			}
-		case req := <-p.incomingReq:
-			switch req.kind {
-			case requestKindPublish:
-				req.response <- p.publish(req.publish.topicsAndColumns)
-			case requestKindSubscribe:
-				req.response <- p.subscribe(req.sub.t)
-			case requestKindUnsubscribe:
-				req.response <- p.unsubscribe(req.unsub.topic)
-			case requestKindGossip:
-				p.gossip(req.gossip.topic, req.gossip.groupID)
-			case requestKindHandleIncomingRPC:
-				err := p.handleIncomingRPC(req.incomingRPC)
-				if err != nil {
-					p.logger.Error("Failed to handle incoming partial RPC", "err", err)
-				}
-			case requestKindCellsValidated:
-				err := p.handleCellsValidated(req.cellsValidated)
-				if err != nil {
-					p.logger.Error("Failed to handle cells validated", "err", err)
-				}
-			default:
-				p.logger.Error("Unknown request kind", "kind", req.kind)
 			}
 		}
 	}
@@ -612,8 +715,7 @@ func (p *PartialColumnBroadcaster) handlePartialCells(ourDataColumn *blocks.Part
 				return
 			}
 			_ = p.peerFeedback(topicId, rpc.from, pubsub.PeerFeedbackUsefulMessage)
-			p.incomingReq <- request{
-				kind: requestKindCellsValidated,
+			_, _ = p.enqueue(nil, requestKindCellsValidated, requestValues{
 				cellsValidated: &cellsValidated{
 					validationTook: time.Since(start),
 					topic:          topicId,
@@ -621,7 +723,7 @@ func (p *PartialColumnBroadcaster) handlePartialCells(ourDataColumn *blocks.Part
 					cells:          cellsToVerify,
 					cellIndices:    cellIndices,
 				},
-			}
+			})
 		}()
 	}
 	return nil
@@ -699,25 +801,19 @@ func (p *PartialColumnBroadcaster) Stop() {
 }
 
 // Publish publishes partial columns for the given topics.
-func (p *PartialColumnBroadcaster) Publish(topicsAndColumns iter.Seq2[string, blocks.PartialDataColumn]) error {
+func (p *PartialColumnBroadcaster) Publish(ctx context.Context, topicsAndColumns iter.Seq2[string, blocks.PartialDataColumn]) error {
 	if p.peerFeedback == nil || p.publishPartialCol == nil {
 		return errors.New("pubsub not initialized")
 	}
-	respCh := make(chan error)
-
-	select {
-	case p.incomingReq <- request{
-		kind: requestKindPublish,
+	req, err := p.enqueue(ctx, requestKindPublish, requestValues{
 		publish: publish{
 			topicsAndColumns: topicsAndColumns,
 		},
-		response: respCh,
-	}:
-	case <-p.stop:
-		return errors.New("broadcaster has stopped")
+	})
+	if err != nil {
+		return err
 	}
-
-	return <-respCh
+	return req.waitForResponse()
 }
 
 func (p *PartialColumnBroadcaster) gossip(topic string, groupID []byte) {
@@ -786,20 +882,16 @@ func (p *PartialColumnBroadcaster) publish(topicsAndColumns iter.Seq2[string, bl
 	return aggErr
 }
 
-func (p *PartialColumnBroadcaster) Subscribe(t *pubsub.Topic) error {
-	respCh := make(chan error)
-	select {
-	case <-p.stop:
-		return errors.New("broadcaster stopped")
-	case p.incomingReq <- request{
-		kind: requestKindSubscribe,
+func (p *PartialColumnBroadcaster) Subscribe(ctx context.Context, t *pubsub.Topic) error {
+	req, err := p.enqueue(ctx, requestKindSubscribe, requestValues{
 		sub: subscribe{
 			t: t,
 		},
-		response: respCh,
-	}:
+	})
+	if err != nil {
+		return err
 	}
-	return <-respCh
+	return req.waitForResponse()
 }
 
 func (p *PartialColumnBroadcaster) subscribe(t *pubsub.Topic) error {
@@ -812,20 +904,16 @@ func (p *PartialColumnBroadcaster) subscribe(t *pubsub.Topic) error {
 	return nil
 }
 
-func (p *PartialColumnBroadcaster) Unsubscribe(topic string) error {
-	respCh := make(chan error)
-	select {
-	case <-p.stop:
-		return errors.New("broadcaster stopped")
-	case p.incomingReq <- request{
-		kind: requestKindUnsubscribe,
+func (p *PartialColumnBroadcaster) Unsubscribe(ctx context.Context, topic string) error {
+	req, err := p.enqueue(ctx, requestKindUnsubscribe, requestValues{
 		unsub: unsubscribe{
 			topic: topic,
 		},
-		response: respCh,
-	}:
+	})
+	if err != nil {
+		return err
 	}
-	return <-respCh
+	return req.waitForResponse()
 }
 func (p *PartialColumnBroadcaster) unsubscribe(topic string) error {
 	t, ok := p.topics[topic]

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
@@ -1345,7 +1345,7 @@ func TestPartialColumnBroadcaster_Publish(t *testing.T) {
 			h.start(recorder)
 			defer h.Stop()
 
-			err := h.broadcaster.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+			err := h.broadcaster.Publish(t.Context(), func(yield func(string, blocks.PartialDataColumn) bool) {
 				yield(topic, *column)
 			})
 			if tt.expectedErrContains != "" {
@@ -1423,7 +1423,7 @@ func TestPartialColumnBroadcaster_Subscribe(t *testing.T) {
 			h.start(recorder)
 			defer h.Stop()
 
-			err := h.broadcaster.Subscribe(topic)
+			err := h.broadcaster.Subscribe(t.Context(), topic)
 			if tt.expectedErr != "" {
 				require.ErrorContains(t, tt.expectedErr, err)
 			} else {
@@ -1488,7 +1488,7 @@ func TestPartialColumnBroadcaster_Unsubscribe(t *testing.T) {
 			h.start(recorder)
 			defer h.Stop()
 
-			err := h.broadcaster.Unsubscribe(topicName)
+			err := h.broadcaster.Unsubscribe(t.Context(), topicName)
 			if tt.expectedErr != "" {
 				require.ErrorContains(t, tt.expectedErr, err)
 			} else {

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/publish_blocking_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/publish_blocking_test.go
@@ -1,0 +1,31 @@
+package partialdatacolumnbroadcaster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/sirupsen/logrus"
+)
+
+// TestPublishReturnsOnContextDeadline verifies that Publish returns a
+// context error when the event loop is not processing requests, rather
+// than blocking indefinitely.
+func TestPublishReturnsOnContextDeadline(t *testing.T) {
+	b := NewBroadcaster(logrus.New())
+	b.peerFeedback = func(_ string, _ peer.ID, _ pubsub.PeerFeedbackKind) error { return nil }
+	b.publishPartialCol = func(_ string, _ []byte, _ *blocks.PartialDataColumn) error { return nil }
+
+	// Deliberately do NOT start the event loop. This simulates loop() being
+	// busy with another request — the effect is the same: respCh never gets a response.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := b.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -101,7 +101,7 @@ func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Contex
 					if err != nil {
 						log.Error("Failed to get current fork digest")
 					} else {
-						err := broadcaster.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+						err := broadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 							for _, sc := range reconstructedSidecars {
 								if !unseenIndices[sc.Index] {
 									continue

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -568,7 +568,7 @@ func (s *Service) pruneNotWanted(t *subnetTracker, wantedSubnets map[uint64]bool
 		t.cancelSubscription(subnet)
 		topic := t.fullTopic(subnet, s.cfg.p2p.Encoding().ProtocolSuffix())
 		if t.partial != nil {
-			_ = t.partial.broadcaster.Unsubscribe(topic)
+			_ = t.partial.broadcaster.Unsubscribe(s.ctx, topic)
 		}
 		s.unSubscribeFromTopic(topic)
 	}
@@ -634,7 +634,7 @@ func (s *Service) trySubscribeSubnets(t *subnetTracker) {
 
 		if requestPartial {
 			log.Info("Subscribing to partial columns on", topicStr)
-			err = t.partial.broadcaster.Subscribe(topic)
+			err = t.partial.broadcaster.Subscribe(s.ctx, topic)
 
 			if err != nil {
 				log.WithError(err).Error("Failed to subscribe to partial column")

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -250,7 +250,7 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, so
 				// Publish the partial column. This is idempotent if we republish the same data twice.
 				// Note, the "partial column" may indeed be complete. We still
 				// should publish to help our peers.
-				err = partialBroadcaster.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+				err = partialBroadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 					for i := range uint64(len(partialColumns)) {
 						if !columnIndicesToSample[i] {
 							continue

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -38,7 +38,7 @@ func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) e
 			if err != nil {
 				log.Error("Failed to get current fork digest")
 			} else {
-				err := broadcaster.Publish(func(yield func(string, blocks.PartialDataColumn) bool) {
+				err := broadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 					subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index)
 					topic := fmt.Sprintf(p2p.DataColumnSubnetTopicFormat, digest, subnet) + s.cfg.p2p.Encoding().ProtocolSuffix()
 					yield(topic, blocks.NewPartialDataColumnFromVerifiedRODataColumn(sidecar))

--- a/changelog/kasey_partial-cells-context-in-loop.md
+++ b/changelog/kasey_partial-cells-context-in-loop.md
@@ -1,0 +1,2 @@
+### Ignored
+- Changing `PartialColumnBroadcaster` to allow callers to cancel requests via context cancellation.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The main goal of this PR is to lightly refactor the `loop()` method in `PartialColumnBroadcaster` to support context cancellation. Along the way I made a number of changes to harden the event loop against edge cases:
- Consistently deal with context cancellation and the `stop` channel.
- Always use buffered channels for the request's response channel, preventing `loop` from blocking on misbehaving callers.
- Some surface level refactoring to consolidate boilerplate: instead of interacting directly with the channel, methods were added to `PartialColumnBroadcaster` (`enqueue` and `tryEnqueue`) and `request` (`waitForResponse`, `finish`) and a constructor for `request` objects was added (`newRequest`).

These new methods encapsulate the different ways existing code interacted with the request and response channels in an attempt to make sure such cases are consistent and safe.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
