### PR TITLE
perf(random): reduce allocations in deterministic randomness helpers

### DIFF
--- a/changelog/sahil4555_optimize_deterministic_random_helpers.md
+++ b/changelog/sahil4555_optimize_deterministic_random_helpers.md
@@ -1,3 +1,3 @@
 ### Changed
 
-Optimize deterministic randomness helpers to reduce runtime overhead and allocations in `crypto/random`.
+- Optimize deterministic randomness helpers to reduce runtime overhead and allocations in `crypto/random`.

--- a/changelog/sahil4555_optimize_deterministic_random_helpers.md
+++ b/changelog/sahil4555_optimize_deterministic_random_helpers.md
@@ -1,0 +1,3 @@
+### Changed
+
+Optimize deterministic randomness helpers to reduce runtime overhead and allocations in `crypto/random`.

--- a/crypto/random/random.go
+++ b/crypto/random/random.go
@@ -1,27 +1,18 @@
 package random
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	GoKZG "github.com/crate-crypto/go-kzg-4844"
-	"github.com/sirupsen/logrus"
 )
 
 // DeterministicRandomness creates a deterministic 32 byte array from a seed
 func DeterministicRandomness(seed int64) [32]byte {
-	// Converts an int64 to a byte slice
-	buf := new(bytes.Buffer)
-	err := binary.Write(buf, binary.BigEndian, seed)
-	if err != nil {
-		logrus.WithError(err).Error("Failed to write int64 to bytes buffer")
-		return [32]byte{}
-	}
-	bytes := buf.Bytes()
-
-	return sha256.Sum256(bytes)
+	var seedBytes [8]byte
+	binary.BigEndian.PutUint64(seedBytes[:], uint64(seed))
+	return sha256.Sum256(seedBytes[:])
 }
 
 // GetRandFieldElement returns a serialized random field element in big-endian


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Other


**What does this PR do? Why is it needed?**

This PR optimizes the deterministic randomness helpers in `crypto/random/random.go` by replacing the previous `bytes.Buffer` and `binary.Write` based seed encoding path with direct fixed-size big-endian encoding into an 8-byte stack buffer. This removes unnecessary heap allocations, avoids buffer construction overhead, and eliminates dead error-handling logic from the deterministic seed encoding path.

**Which issues(s) does this PR fix?**
N/A

**Other notes for review**
Benchmark code used:
```go
package random

import "testing"

func BenchmarkDeterministicRandomness(b *testing.B) {
	for b.Loop() {
		_ = DeterministicRandomness(123)
	}
}

func BenchmarkGetRandFieldElement(b *testing.B) {
	for b.Loop() {
		_ = GetRandFieldElement(123)
	}
}

func BenchmarkGetRandBlob(b *testing.B) {
	for b.Loop() {
		_ = GetRandBlob(123)
	}
}
```
Result:
```
goos: linux
goarch: amd64
pkg: github.com/OffchainLabs/prysm/v7/crypto/random
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                        │ old_bench.txt │            new_bench.txt            │
                        │    sec/op     │   sec/op     vs base                │
DeterministicRandomness     317.3n ± 4%   202.9n ± 2%  -36.04% (p=0.000 n=10)
GetRandFieldElement         385.7n ± 7%   258.2n ± 2%  -33.04% (p=0.000 n=10)
GetRandBlob                 2.153m ± 2%   1.701m ± 2%  -20.99% (p=0.000 n=10)
geomean                     6.411µ        4.467µ       -30.32%

                        │ old_bench.txt │               new_bench.txt               │
                        │     B/op      │     B/op      vs base                     │
DeterministicRandomness      120.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
GetRandFieldElement          120.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
GetRandBlob               497.61Ki ± 0%   17.54Ki ± 0%   -96.47% (p=0.000 n=10)
geomean                    1.898Ki                      ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                        │ old_bench.txt │              new_bench.txt               │
                        │   allocs/op   │  allocs/op   vs base                     │
DeterministicRandomness      3.000 ± 0%    0.000 ± 0%  -100.00% (p=0.000 n=10)
GetRandFieldElement          3.000 ± 0%    0.000 ± 0%  -100.00% (p=0.000 n=10)
GetRandBlob                14.533k ± 0%   2.245k ± 0%   -84.55% (p=0.000 n=10)
geomean                      50.76                     ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
