### PR TITLE
Refresh sync RPC timeouts after chain config override

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -3,6 +3,7 @@ package node
 import (
 	"fmt"
 
+	regularsync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync"
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -26,8 +27,11 @@ func configureTracing(cliCtx *cli.Context) error {
 func configureChainConfig(cliCtx *cli.Context) error {
 	if cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
 		chainConfigFileName := cliCtx.String(cmd.ChainConfigFileFlag.Name)
-		return params.LoadChainConfigFile(chainConfigFileName, nil)
+		if err := params.LoadChainConfigFile(chainConfigFileName, nil); err != nil {
+			return err
+		}
 	}
+	regularsync.RefreshRPCTimeoutsFromConfig()
 	return nil
 }
 

--- a/beacon-chain/sync/deadlines.go
+++ b/beacon-chain/sync/deadlines.go
@@ -4,13 +4,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/sirupsen/logrus"
 )
 
 var defaultReadDuration = ttfbTimeout
-var defaultWriteDuration = params.BeaconConfig().RespTimeoutDuration() // RESP_TIMEOUT
+var defaultWriteDuration = respTimeout
 
 // SetRPCStreamDeadlines sets read and write deadlines for libp2p-based connection streams.
 func SetRPCStreamDeadlines(stream network.Stream) {

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -31,6 +31,18 @@ var (
 	respTimeout = params.BeaconConfig().RespTimeoutDuration()
 )
 
+// RefreshRPCTimeoutsFromConfig refreshes package-level RPC timeout values from
+// the current active beacon config.
+//
+// This should be called after runtime config overrides (for example
+// --chain-config-file) are applied.
+func RefreshRPCTimeoutsFromConfig() {
+	ttfbTimeout = params.BeaconConfig().TtfbTimeoutDuration()
+	respTimeout = params.BeaconConfig().RespTimeoutDuration()
+	defaultReadDuration = ttfbTimeout
+	defaultWriteDuration = respTimeout
+}
+
 // rpcHandler is responsible for handling and responding to any incoming message.
 // This method may return an error to internal monitoring, but the error will
 // not be relayed to the peer.


### PR DESCRIPTION
  **What type of PR is this?**
                                                                                                                                                                                      
  Bug fix                                                                                                                                                                             
                                                                                                                                                                                      
  **What does this PR do? Why is it needed?**                                                                                                                                         
                                                                                                                                                                                      
  This PR fixes sync RPC timeout values not being refreshed after runtime chain-config overrides.                                                                                     
                                                                                                                                                                                      
  Before this change, `ttfbTimeout`, `respTimeout`, and `defaultWriteDuration` were initialized from package-level values, so `--chain-config-file` updates to `TTFB_TIMEOUT`/ `RESP_TIMEOUT` could be ignored by sync RPC behavior in the running node.                                                                                                           
                                                                                                                                                                                      
  This PR:                                                                                                                                                                            
  - adds `RefreshRPCTimeoutsFromConfig()` in `beacon-chain/sync/rpc.go`,                                                                                                              
  - calls it after `configureChainConfig` loads chain config in `beacon-chain/node/config.go`,                                                                                        
  - aligns `defaultWriteDuration` with `respTimeout` in `beacon-chain/sync/deadlines.go`,                                                                                             
  - adds `TestRefreshRPCTimeoutsFromConfig` in `beacon-chain/sync/timeouts_test.go`.                                                                                                  
                                                                                                                                                                                      
  Result: timeout settings from runtime chain config are applied consistently and predictably.                                                                                        
                                                                                                                                                                                      
  **Which issues(s) does this PR fix?**                                                                                                                                               
                                                                                                                                                                                      
  Fixes #<issue-number>                                                                                                                                                               
                                                                                                                                                                                      
  **Other notes for review**                                                                                                                                                          
                                                                                                                                                                                      
  Testing plan:                                                                                                                                                                       
  - `gofmt -l beacon-chain/node/config.go beacon-chain/sync/deadlines.go beacon-chain/sync/rpc.go beacon-chain/sync/timeouts_test.go`                                                 
  - `go build ./beacon-chain/sync ./beacon-chain/node`                                                                                                                                
  - `go test -c ./beacon-chain/sync`                                                                                                                                                  
  - `go test -c ./beacon-chain/node`                                                                                                                                                  
  - `go test ./beacon-chain/sync ./beacon-chain/node -run "TestRefreshRPCTimeoutsFromConfig" -count=1`
                                                                                                                                                                                      
  Note: runtime `go test` is blocked in this local environment by BLS init (`panic: ERR Init curve=5`) and config parsing noise (`invalid byte: U+000D`), so CI is needed for full runtime confirmation.                                                                                                                                                               
                                                                                                                                                                                      
  **Acknowledgements**                                                                                                                                                                
                                                                                                                                                                                      
  - [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
  - [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).                      
  - [x] I have added a description with sufficient context for reviewers to understand this PR.                                                                                       
  - [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 