### PR TITLE
Initialise ExecutionRequestsRoot and ParentExecutionRequests in gloasGenesisBlock

### DIFF
--- a/beacon-chain/core/blocks/genesis.go
+++ b/beacon-chain/core/blocks/genesis.go
@@ -219,16 +219,18 @@ func gloasGenesisBlock(root [fieldparams.RootLength]byte) *ethpb.BeaconBlockGloa
 			},
 			SignedExecutionPayloadBid: &ethpb.SignedExecutionPayloadBid{
 				Message: &ethpb.ExecutionPayloadBid{
-					ParentBlockHash:    make([]byte, 32),
-					ParentBlockRoot:    make([]byte, 32),
-					BlockHash:          make([]byte, 32),
-					PrevRandao:         make([]byte, 32),
-					FeeRecipient:       make([]byte, 20),
-					BlobKzgCommitments: make([][]byte, 0),
+					ParentBlockHash:       make([]byte, 32),
+					ParentBlockRoot:       make([]byte, 32),
+					BlockHash:             make([]byte, 32),
+					PrevRandao:            make([]byte, 32),
+					FeeRecipient:          make([]byte, 20),
+					BlobKzgCommitments:    make([][]byte, 0),
+					ExecutionRequestsRoot: make([]byte, 32),
 				},
 				Signature: make([]byte, fieldparams.BLSSignatureLength),
 			},
-			PayloadAttestations: make([]*ethpb.PayloadAttestation, 0),
+			PayloadAttestations:     make([]*ethpb.PayloadAttestation, 0),
+			ParentExecutionRequests: &enginev1.ExecutionRequests{},
 		},
 	}
 }

--- a/changelog/bbusa_gloas-genesis-bid-execution-requests.md
+++ b/changelog/bbusa_gloas-genesis-bid-execution-requests.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Initialise `ExecutionRequestsRoot` on the Gloas genesis block's execution payload bid and `ParentExecutionRequests` on the block body so `NewGenesisBlockForState` can compute the genesis block root without hitting "bytes array does not have the correct length: expected 32 and 0 found".


### PR DESCRIPTION
## Problem

When a network has `GLOAS_FORK_EPOCH: 0`, `beacon-chain/db/kv/(*Store).SaveGenesisData` calls `blocks.NewGenesisBlockForState`, which returns a genesis block built by `gloasGenesisBlock(root)`. On this branch that helper omits two fields that were added to the gloas schema in consensus-specs v1.7.0-alpha.5:

- `ExecutionRequestsRoot` on `ExecutionPayloadBid` — new via consensus-specs #5113 (swap of `latest_block_hash` / `latest_execution_payload_bid`, which also introduced `execution_requests_root` on the bid).
- `ParentExecutionRequests` on `BeaconBlockBodyGloas` — new via consensus-specs #5117 (merge of EIP-7928 specs into Gloas).

Because `ExecutionRequestsRoot` is declared as `[]byte` with `ssz-size:"32"`, leaving it as the proto zero value (`nil`, `len=0`) makes the SSZ hasher fail when `SaveGenesisData` then calls `wsb.Block().HashTreeRoot()`:

```
FATAL main: unable to start beacon node: could not start modules: could not start DB:
  could not ensure embedded genesis: could not get genesis block root:
  --.ExecutionRequestsRoot (bytes array does not have the correct length): expected 32 and 0 found
```

Reproduced by running a devnet with `gloas_fork_epoch: 0` against `ethpandaops/prysm-beacon-chain:v1.7.0-alpha.5` and a gloas-capable EL (geth `glamsterdam-devnet-0` with ethereum/go-ethereum#34774 to fix a sibling RLP bug). Geth comes up and exposes its engine RPC; `beacon-chain` crashes on startup before it even attempts to connect.

## Fix

Initialise `ExecutionRequestsRoot` to a 32-byte zero slice and `ParentExecutionRequests` to an empty `enginev1.ExecutionRequests{}` in `gloasGenesisBlock`, so the block round-trips through `HashTreeRoot`.

This is the same pattern `electraGenesisBlock`/`fuluGenesisBlock` already use for their post-Electra fields.

## Test plan

- [x] `go build ./beacon-chain/core/blocks/...`
- [x] `go test ./beacon-chain/core/blocks/ -run TestGenesisBlock -count=1`
- [ ] Bring up a devnet with `gloas_fork_epoch: 0` + this build — `beacon-chain` should start cleanly past the `SaveGenesisData` step.