### PR TITLE
fix(engine): unmarshal slotNumber in ExecutionBundleGloas

### DIFF
--- a/changelog/barnabasbusa_fix-gloas-unmarshal-slot-number.md
+++ b/changelog/barnabasbusa_fix-gloas-unmarshal-slot-number.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed `ExecutionBundleGloas.UnmarshalJSON` dropping the EIP-7843 `slotNumber` field returned by `engine_getPayloadV6`. Self-build execution payload envelopes were cached with `SlotNumber=0`, causing `GetExecutionPayloadEnvelope(slot)` to return `NotFound` and stalling the execution chain at the Gloas fork boundary.

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -1693,6 +1693,11 @@ func (e *ExecutionBundleGloas) UnmarshalJSON(enc []byte) error {
 	e.Payload.BlockAccessList = *dec.ExecutionPayload.BlockAccessList
 	e.Payload.SlotNumber = primitives.Slot(*dec.ExecutionPayload.SlotNumber)
 
+	if dec.ExecutionPayload.SlotNumber == nil {
+		return errors.New("missing required field 'slotNumber' for ExecutionPayload")
+	}
+	e.Payload.SlotNumber = primitives.Slot(*dec.ExecutionPayload.SlotNumber)
+
 	v, err := hexutil.DecodeBig(dec.BlockValue)
 	if err != nil {
 		return err

--- a/proto/engine/v1/json_marshal_unmarshal_test.go
+++ b/proto/engine/v1/json_marshal_unmarshal_test.go
@@ -776,3 +776,80 @@ func TestBlsSig(t *testing.T) {
 	require.NoError(t, json.Unmarshal(b, um))
 	require.Equal(t, *tm.V, *um.V)
 }
+
+// TestExecutionBundleGloas_UnmarshalJSON_PreservesSlotNumber guards against a
+// regression where engine_getPayloadV6 responses lost the EIP-7843 slotNumber
+// field during JSON decoding, causing self-build execution payload envelopes
+// to be rejected by the beacon node's cache lookup
+// (envelope.Payload.SlotNumber != request.Slot) and preventing the execution
+// chain from advancing past the Gloas fork boundary.
+func TestExecutionBundleGloas_UnmarshalJSON_PreservesSlotNumber(t *testing.T) {
+	const wantSlot primitives.Slot = 42
+	raw := fmt.Sprintf(`{
+		"executionPayload": {
+			"parentHash": "0x%064x",
+			"feeRecipient": "0x%040x",
+			"stateRoot": "0x%064x",
+			"receiptsRoot": "0x%064x",
+			"logsBloom": "0x%0512x",
+			"prevRandao": "0x%064x",
+			"blockNumber": "0x1",
+			"gasLimit": "0x1c9c380",
+			"gasUsed": "0x0",
+			"timestamp": "0x64",
+			"extraData": "0x",
+			"baseFeePerGas": "0x7",
+			"blockHash": "0x%064x",
+			"transactions": [],
+			"withdrawals": [],
+			"blobGasUsed": "0x0",
+			"excessBlobGas": "0x0",
+			"blockAccessList": "0x",
+			"slotNumber": "0x%x"
+		},
+		"blockValue": "0x0",
+		"blobsBundle": null,
+		"shouldOverrideBuilder": false,
+		"executionRequests": []
+	}`, 1, 2, 3, 4, 5, 6, 7, uint64(wantSlot))
+
+	bundle := &enginev1.ExecutionBundleGloas{}
+	require.NoError(t, json.Unmarshal([]byte(raw), bundle))
+	require.NotNil(t, bundle.Payload)
+	require.Equal(t, wantSlot, bundle.Payload.SlotNumber)
+}
+
+// TestExecutionBundleGloas_UnmarshalJSON_RequiresSlotNumber ensures the
+// required-field guard fires when slotNumber is absent.
+func TestExecutionBundleGloas_UnmarshalJSON_RequiresSlotNumber(t *testing.T) {
+	raw := fmt.Sprintf(`{
+		"executionPayload": {
+			"parentHash": "0x%064x",
+			"feeRecipient": "0x%040x",
+			"stateRoot": "0x%064x",
+			"receiptsRoot": "0x%064x",
+			"logsBloom": "0x%0512x",
+			"prevRandao": "0x%064x",
+			"blockNumber": "0x1",
+			"gasLimit": "0x1c9c380",
+			"gasUsed": "0x0",
+			"timestamp": "0x64",
+			"extraData": "0x",
+			"baseFeePerGas": "0x7",
+			"blockHash": "0x%064x",
+			"transactions": [],
+			"withdrawals": [],
+			"blobGasUsed": "0x0",
+			"excessBlobGas": "0x0",
+			"blockAccessList": "0x"
+		},
+		"blockValue": "0x0",
+		"blobsBundle": null,
+		"shouldOverrideBuilder": false,
+		"executionRequests": []
+	}`, 1, 2, 3, 4, 5, 6, 7)
+
+	bundle := &enginev1.ExecutionBundleGloas{}
+	err := json.Unmarshal([]byte(raw), bundle)
+	require.ErrorContains(t, "missing required field 'slotNumber'", err)
+}


### PR DESCRIPTION
Before: 

<img width="1951" height="1395" alt="Screenshot_2026-04-21_at_10 15 16" src="https://github.com/user-attachments/assets/292162b1-c418-44bb-a408-5977f94c9314" />


After:

<img width="3870" height="1668" alt="image" src="https://github.com/user-attachments/assets/a01af3b6-1c6d-419e-93ad-481c069062f4" />

Also with mainnet preset: 

<img width="1510" height="1100" alt="image" src="https://github.com/user-attachments/assets/806f925e-fb14-4e75-a72d-ab7d4275717f" />


## Summary

`ExecutionBundleGloas.UnmarshalJSON` drops the EIP-7843 `slotNumber` field when decoding `engine_getPayloadV6` responses. Every other field of `ExecutionPayloadGloasJSON` is copied into `e.Payload`, but `SlotNumber` is silently skipped, so the cached payload always has `SlotNumber == 0`.

That zero value then fails the cache guard in `getExecutionPayloadEnvelope`:

https://github.com/OffchainLabs/prysm/blob/v1.7.0-alpha.5/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go#L84-L95

```go
if envelope.Payload == nil || primitives.Slot(envelope.Payload.SlotNumber) != slot {
    return nil, false
}
```

Because the stored `SlotNumber` is `0` and the validator asks for slot N, the BN returns `codes.NotFound`, the self-build reveal step never runs, the payload is never gossiped, the PTC votes `payloadPresent=false`, and the EL head stays frozen at the last pre-Gloas block while the beacon chain happily advances on a stale parent hash.

### Observed on a local ePBS devnet (prysm + geth)

After the Gloas fork transition:

- `snooper-engine`: EL gets repeated `forkchoiceUpdatedV4` + `getPayloadV6` every slot and returns VALID payloads, but **no `engine_newPayloadV4` ever follows**.
- `el-geth`: "Chain head was updated" stops at the last pre-fork block.
- `cl-prysm`: beacon chain advances (even finalizes), but every `Synced new block` carries the same `parentHash` (pre-fork EL block) and `builderIndex=18446744073709551615` (self-build sentinel).
- `vc-prysm`: every proposer slot logs
  ```
  ERROR Failed to propose self-build envelope
    error=failed to get execution payload envelope for self-build:
    GetExecutionPayloadEnvelope: rpc error: code = NotFound
    desc = execution payload envelope not found for slot N: could not connect
  ```
- `dora`: `{"message":"execution payload envelope not found","code":404}` for every finalised slot.

### Why existing tests didn't catch it

`TestStoreExecutionPayloadEnvelope` builds the `ExecutionPayloadGloas` proto directly in Go (so `SlotNumber = 0`) and uses a beacon block whose slot is also `0`, so the cache lookup happens to succeed. The bug only manifests on the real JSON path from the EL at slot ≥ 1.

## Change

- `ExecutionBundleGloas.UnmarshalJSON`: copy `dec.ExecutionPayload.SlotNumber` into `e.Payload.SlotNumber`, and return an error when the field is missing (mirroring the existing required-field guards for `blockAccessList`, `blockNumber`, etc.).
- Two regression tests that exercise the real JSON path end-to-end.
- Changelog entry.

`MarshalJSON`/`marshalGloasJSON` already emits `slotNumber`, so marshal/unmarshal are now symmetric.

## Test plan

- [x] `go test ./proto/engine/v1/... -run 'TestExecutionBundleGloas' -count=1`
- [x] `go test ./proto/engine/v1/... -count=1`
- [x] `go test ./beacon-chain/rpc/prysm/v1alpha1/validator/... -run 'ExecutionPayloadEnvelope|StoreExecutionPayloadEnvelope|ExtractExecutionPayloadGloas' -count=1`
- [ ] Local ePBS devnet: verify EL head advances past the Gloas fork boundary and payload attestations carry `payloadPresent=true`.