### PR TITLE
fix(forkchoice): skip slot-start check for tree root node

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/node.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/node.go
@@ -38,6 +38,13 @@ func (n *Node) leadsToViableHead(justifiedEpoch, currentEpoch primitives.Epoch) 
 // inequality < here. For example a block that arrives 3.9999 seconds into the
 // slot will have secs = 3 below.
 func (n *PayloadNode) arrivedEarly(genesis time.Time) (bool, error) {
+	// The tree root node (genesis or the finalized checkpoint on checkpoint-sync)
+	// carries an insertion timestamp sourced from time.Now() at process startup,
+	// not actual network arrival time. It can never be a reorg target anyway, so
+	// treat it as always having arrived early.
+	if n.node.parent == nil {
+		return true, nil
+	}
 	sss, err := slots.SinceSlotStart(n.node.slot, genesis, n.timestamp.Truncate(time.Second)) // Truncate such that 3.9999 seconds will have a value of 3.
 	votingWindow := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().AttestationDueBPS)
 	return sss < votingWindow, err
@@ -49,6 +56,10 @@ func (n *PayloadNode) arrivedEarly(genesis time.Time) (bool, error) {
 // inequality >= here. For example a block that arrives 10.00001 seconds into the
 // slot will have secs = 10 below.
 func (n *PayloadNode) arrivedAfterOrphanCheck(genesis time.Time) (bool, error) {
+	// See arrivedEarly: the tree root's timestamp is not meaningful here.
+	if n.node.parent == nil {
+		return false, nil
+	}
 	secs, err := slots.SinceSlotStart(n.node.slot, genesis, n.timestamp.Truncate(time.Second)) // Truncate such that 10.00001 seconds will have a value of 10.
 	return secs >= ProcessAttestationsThreshold, err
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/node_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/node_test.go
@@ -330,3 +330,27 @@ func TestNode_TimeStampsChecks(t *testing.T) {
 	require.ErrorContains(t, "invalid timestamp", err)
 	require.Equal(t, false, late)
 }
+
+// TestNode_TimeStampsChecks_TreeRoot verifies that arrivedEarly and
+// arrivedAfterOrphanCheck do not error when called on the tree root node, even
+// if the node was inserted with a timestamp before the slot start time. This
+// can happen on a fresh beacon node that starts up before MIN_GENESIS_TIME: the
+// genesis node's timestamp field is sourced from time.Now() at insertion rather
+// than the real arrival time, and can land before genesis time.
+func TestNode_TimeStampsChecks_TreeRoot(t *testing.T) {
+	f := setup(0, 0)
+
+	// Simulate a beacon node that started before genesis by setting the tree
+	// root's timestamp earlier than the forkchoice genesis time.
+	f.store.genesisTime = time.Now()
+	treeRoot := f.store.choosePayloadContent(f.store.treeRootNode)
+	require.NotNil(t, treeRoot)
+	treeRoot.timestamp = f.store.genesisTime.Add(-24 * time.Second)
+
+	early, err := treeRoot.arrivedEarly(f.store.genesisTime)
+	require.NoError(t, err)
+	require.Equal(t, true, early)
+	late, err := treeRoot.arrivedAfterOrphanCheck(f.store.genesisTime)
+	require.NoError(t, err)
+	require.Equal(t, false, late)
+}

--- a/changelog/barnabasbusa_fix-forkchoice-genesis-timestamp.md
+++ b/changelog/barnabasbusa_fix-forkchoice-genesis-timestamp.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Forkchoice no longer logs `could not check if block arrived early: invalid timestamp` on beacon nodes that start before `MIN_GENESIS_TIME`. The tree root node (genesis or checkpoint-sync finalized block) is never a reorg candidate, so `arrivedEarly` and `arrivedAfterOrphanCheck` now short-circuit for it instead of comparing its process-startup insertion timestamp against the slot start.


### PR DESCRIPTION
## Summary

Fixes spurious `could not check if block arrived early error=could not compute seconds since slot 0 start: invalid timestamp` errors from the forkchoice package on beacon nodes that start before `MIN_GENESIS_TIME` — reproducible on Gloas genesis testnets (`gloas_fork_epoch: 0`) where, absent the fix, the chain sometimes stalls at slot 1 while the proposer path repeatedly hits this error.

Rebased onto `v1.7.0-alpha.5` so it can land independently of the other Gloas fixes in my stack.

## Root cause

`PayloadNode.timestamp` is stamped with `time.Now()` at insertion (`beacon-chain/forkchoice/doubly-linked-tree/store.go:141/151`, `forkchoice.go:547`, `gloas.go:393`). For the tree root — i.e. the genesis block on a fresh chain, or the finalized checkpoint block on checkpoint-sync startup — insertion happens during process startup via `Service.initializeChainInfo`, *before* `SetGenesisTime` is called. If the beacon node starts before `MIN_GENESIS_TIME`, that timestamp lands before slot 0's start.

Later, at slot 1 the validator calls `GetProposerHead` (`beacon-chain/forkchoice/doubly-linked-tree/reorg_late_blocks.go:109`) while the head is still genesis. The `arrivedEarly` path passes the stale timestamp into `slots.SinceSlotStart(0, genesis, timestamp)`, which rejects `timestamp < genesis` with the "invalid timestamp" error.

## Fix

Short-circuit `arrivedEarly` (`true`) and `arrivedAfterOrphanCheck` (`false`) when `n.node.parent == nil`, i.e. the tree root. The tree root is never a reorg candidate — `GetProposerHead` already bails out at the `parent == nil` guard (`reorg_late_blocks.go:140-142`) — so its timestamp should not gate anything, and the stored process-startup value is not a meaningful arrival time.

## Test plan

- [x] `go test ./beacon-chain/forkchoice/doubly-linked-tree/... -run TestNode_TimeStampsChecks -count=1` passes on this branch, including the new `TestNode_TimeStampsChecks_TreeRoot` case that directly reproduces the scenario (genesis node timestamp set 24s before `genesisTime`) and asserts both checks return without error.
- [x] Reproduced on a Kurtosis `gloas_fork_epoch: 0` devnet: without the fix the error spams every slot and the chain stalls at slot 1; with the fix the error is gone (chain then progresses once the upstream genesis-tooling mismatch unrelated to this PR is resolved).