### PR TITLE
Cache random_bytes in compute_balance_weighted_selection

### DIFF
--- a/beacon-chain/core/gloas/payload_attestation.go
+++ b/beacon-chain/core/gloas/payload_attestation.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	stderrors "errors"
 	"fmt"
+	"math"
 	"slices"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
@@ -231,10 +232,8 @@ func selectByBalanceFill(
 	copy(buf[:], seed[:])
 	maxBalance := params.BeaconConfig().MaxEffectiveBalanceElectra
 
-	// Cache the hash and only refresh on a 16-round boundary -
-	// see consensus-specs PR#5079.
 	var randomBytes [32]byte
-	cachedBlock := ^uint64(0)
+	cachedBlock := uint64(math.MaxUint64)
 
 	for _, idx := range candidates {
 		if ctx.Err() != nil {
@@ -247,11 +246,14 @@ func selectByBalanceFill(
 			cachedBlock = block
 		}
 
-		ok, err := acceptByBalance(st, idx, randomBytes, maxBalance, i)
+		offset := (i % 16) * 2
+		randomValue := uint64(binary.LittleEndian.Uint16(randomBytes[offset : offset+2]))
+
+		val, err := st.ValidatorAtIndexReadOnly(idx)
 		if err != nil {
-			return nil, i, err
+			return nil, i, errors.Wrapf(err, "validator %d", idx)
 		}
-		if ok {
+		if val.EffectiveBalance()*fieldparams.MaxRandomValueElectra >= maxBalance*randomValue {
 			selected = append(selected, idx)
 		}
 		if uint64(len(selected)) == fieldparams.PTCSize {
@@ -261,35 +263,6 @@ func selectByBalanceFill(
 	}
 
 	return selected, i, nil
-}
-
-// acceptByBalance determines if a validator is accepted based on its effective balance.
-//
-//	<spec fn="compute_balance_weighted_acceptance" fork="gloas" hash="9954dcd0">
-//	def compute_balance_weighted_acceptance(
-//	    state: BeaconState, index: ValidatorIndex, seed: Bytes32, i: uint64
-//	) -> bool:
-//	    """
-//	    Return whether to accept the selection of the validator ``index``, with probability
-//	    proportional to its ``effective_balance``, and randomness given by ``seed`` and ``i``.
-//	    """
-//	    MAX_RANDOM_VALUE = 2**16 - 1
-//	    random_bytes = hash(seed + uint_to_bytes(i // 16))
-//	    offset = i % 16 * 2
-//	    random_value = bytes_to_uint64(random_bytes[offset : offset + 2])
-//	    effective_balance = state.validators[index].effective_balance
-//	    return effective_balance * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_ELECTRA * random_value
-//	</spec>
-func acceptByBalance(st state.ReadOnlyBeaconState, idx primitives.ValidatorIndex, random [32]byte, maxBalance uint64, round uint64) (bool, error) {
-	offset := (round % 16) * 2
-	randomValue := uint64(binary.LittleEndian.Uint16(random[offset : offset+2])) // 16-bit draw per spec
-
-	val, err := st.ValidatorAtIndexReadOnly(idx)
-	if err != nil {
-		return false, errors.Wrapf(err, "validator %d", idx)
-	}
-
-	return val.EffectiveBalance()*fieldparams.MaxRandomValueElectra >= maxBalance*randomValue, nil
 }
 
 // validIndexedPayloadAttestation verifies the signature of an indexed payload attestation.

--- a/beacon-chain/core/gloas/payload_attestation.go
+++ b/beacon-chain/core/gloas/payload_attestation.go
@@ -231,7 +231,7 @@ func selectByBalanceFill(
 	copy(buf[:], seed[:])
 	maxBalance := params.BeaconConfig().MaxEffectiveBalanceElectra
 
-	// Cache the hash and only refresh on a 16-round boundary 
+	// Cache the hash and only refresh on a 16-round boundary -
 	// see consensus-specs PR#5079.
 	var randomBytes [32]byte
 	cachedBlock := ^uint64(0)

--- a/beacon-chain/core/gloas/payload_attestation.go
+++ b/beacon-chain/core/gloas/payload_attestation.go
@@ -231,12 +231,23 @@ func selectByBalanceFill(
 	copy(buf[:], seed[:])
 	maxBalance := params.BeaconConfig().MaxEffectiveBalanceElectra
 
+	// Cache the hash and only refresh on a 16-round boundary 
+	// see consensus-specs PR#5079.
+	var randomBytes [32]byte
+	cachedBlock := ^uint64(0)
+
 	for _, idx := range candidates {
 		if ctx.Err() != nil {
 			return nil, i, ctx.Err()
 		}
 
-		ok, err := acceptByBalance(st, idx, buf[:], hashFunc, maxBalance, i)
+		if block := i / 16; block != cachedBlock {
+			binary.LittleEndian.PutUint64(buf[len(buf)-8:], block)
+			randomBytes = hashFunc(buf[:])
+			cachedBlock = block
+		}
+
+		ok, err := acceptByBalance(st, idx, randomBytes, maxBalance, i)
 		if err != nil {
 			return nil, i, err
 		}
@@ -269,10 +280,7 @@ func selectByBalanceFill(
 //	    effective_balance = state.validators[index].effective_balance
 //	    return effective_balance * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_ELECTRA * random_value
 //	</spec>
-func acceptByBalance(st state.ReadOnlyBeaconState, idx primitives.ValidatorIndex, seedBuf []byte, hashFunc func([]byte) [32]byte, maxBalance uint64, round uint64) (bool, error) {
-	// Reuse the seed buffer by overwriting the last 8 bytes with the round counter.
-	binary.LittleEndian.PutUint64(seedBuf[len(seedBuf)-8:], round/16)
-	random := hashFunc(seedBuf)
+func acceptByBalance(st state.ReadOnlyBeaconState, idx primitives.ValidatorIndex, random [32]byte, maxBalance uint64, round uint64) (bool, error) {
 	offset := (round % 16) * 2
 	randomValue := uint64(binary.LittleEndian.Uint16(random[offset : offset+2])) // 16-bit draw per spec
 

--- a/beacon-chain/core/gloas/payload_attestation_test.go
+++ b/beacon-chain/core/gloas/payload_attestation_test.go
@@ -390,7 +390,7 @@ func TestProcessPTCWindow_GoldenVector(t *testing.T) {
 	lastStart := len(window) - slotsPerEpoch
 	h := sha256.New()
 	var buf [8]byte
-	for i := 0; i < slotsPerEpoch; i++ {
+	for i := range slotsPerEpoch {
 		for _, idx := range window[lastStart+i].ValidatorIndices {
 			binary.LittleEndian.PutUint64(buf[:], uint64(idx))
 			h.Write(buf[:])

--- a/beacon-chain/core/gloas/payload_attestation_test.go
+++ b/beacon-chain/core/gloas/payload_attestation_test.go
@@ -2,6 +2,9 @@ package gloas_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"slices"
 	"testing"
 
@@ -368,6 +371,35 @@ func TestProcessPTCWindow(t *testing.T) {
 	}
 }
 
+// TestProcessPTCWindow_GoldenVector pins a fingerprint of the validator
+// indices produced by the balance-weighted PTC selection for a deterministic
+// state, guarding against unintended behavioral drift.
+func TestProcessPTCWindow_GoldenVector(t *testing.T) {
+	fuluSt, _ := testutil.DeterministicGenesisStateFulu(t, 256)
+	st, err := gloas.UpgradeToGloas(fuluSt)
+	require.NoError(t, err)
+	require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch))
+	require.NoError(t, gloas.ProcessPTCWindow(t.Context(), st))
+
+	window, err := st.PTCWindow()
+	require.NoError(t, err)
+
+	// Fingerprint the newly-computed (last) epoch by sha256'ing the little-endian
+	// encoding of every validator index, slot-by-slot.
+	slotsPerEpoch := int(params.BeaconConfig().SlotsPerEpoch)
+	lastStart := len(window) - slotsPerEpoch
+	h := sha256.New()
+	var buf [8]byte
+	for i := 0; i < slotsPerEpoch; i++ {
+		for _, idx := range window[lastStart+i].ValidatorIndices {
+			binary.LittleEndian.PutUint64(buf[:], uint64(idx))
+			h.Write(buf[:])
+		}
+	}
+	const expected = "bfdb357dbb3f2abe4bba9a0d5d0d6d8ae9e19335e83f64f21b5a2f727a0f3ee9"
+	require.Equal(t, expected, hex.EncodeToString(h.Sum(nil)))
+}
+
 type validatorLookupErrState struct {
 	state.BeaconState
 	errIndex primitives.ValidatorIndex
@@ -379,4 +411,30 @@ func (s *validatorLookupErrState) ValidatorAtIndexReadOnly(idx primitives.Valida
 		return nil, state.ErrNilValidatorsInState
 	}
 	return s.BeaconState.ValidatorAtIndexReadOnly(idx)
+}
+
+// BenchmarkProcessPTCWindow measures end-to-end PTC window rotation, which
+// is dominated by the balance-weighted selection loop.
+//
+// Apple M4 Pro, mainnet config, 2048 validators:
+//
+//	before caching: 87.64 ms/op   136.9 MiB/op   1.230M allocs/op
+//	with caching:   47.20 ms/op   136.9 MiB/op   1.230M allocs/op
+//
+// The caching optimization (hash(seed || i/16) reused across 16 rounds)
+// cuts wall time by ~46% with no change to allocation profile — exactly
+// what's expected: we skipped SHA256 work, not memory traffic.
+func BenchmarkProcessPTCWindow(b *testing.B) {
+	fuluSt, _ := testutil.DeterministicGenesisStateFulu(b, 2048)
+	st, err := gloas.UpgradeToGloas(fuluSt)
+	require.NoError(b, err)
+	require.NoError(b, st.SetSlot(params.BeaconConfig().SlotsPerEpoch))
+
+	ctx := b.Context()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := gloas.ProcessPTCWindow(ctx, st); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/changelog/satushh_perf-ptc-balance-weighted-hash-cache.md
+++ b/changelog/satushh_perf-ptc-balance-weighted-hash-cache.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Cache random_bytes across 16 rounds of `compute_balance_weighted_selection`, mirroring consensus-specs PR#5079. Cuts `ProcessPTCWindow` wall time.


### PR DESCRIPTION
**What type of PR is this?**

Optimisation

**What does this PR do? Why is it needed?**

Implements https://github.com/ethereum/consensus-specs/pull/5079

Performance optimisation: the PTC balance-weighted selection now computes `hash(seed || i/16)` once per 16 rounds instead of once per candidate.

**Which issues(s) does this PR fix?**



**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
