### PR TITLE
Fix monitor log loop truncation

### DIFF
--- a/beacon-chain/monitor/process_block.go
+++ b/beacon-chain/monitor/process_block.go
@@ -148,11 +148,11 @@ func (s *Service) logAggregatedPerformance() {
 
 	for idx, p := range s.aggregatedPerformance {
 		if p.totalAttestedCount == 0 || p.totalRequestedCount == 0 || p.startBalance == 0 {
-			break
+			continue
 		}
 		l, ok := s.latestPerformance[idx]
 		if !ok {
-			break
+			continue
 		}
 		percentAtt := float64(p.totalAttestedCount) / float64(p.totalRequestedCount)
 		percentBal := float64(l.balance-p.startBalance) / float64(p.startBalance)

--- a/beacon-chain/monitor/process_block_test.go
+++ b/beacon-chain/monitor/process_block_test.go
@@ -284,3 +284,52 @@ func TestLogAggregatedPerformance(t *testing.T) {
 		"validatorIndex=1"
 	require.LogsContain(t, hook, wanted)
 }
+
+func TestLogAggregatedPerformance_SkipsInvalidEntries(t *testing.T) {
+	hook := logTest.NewGlobal()
+
+	const runs = 32
+	for i := 0; i < runs; i++ {
+		hook.Reset()
+
+		validIndex := primitives.ValidatorIndex(100 + i)
+		latestPerformance := map[primitives.ValidatorIndex]ValidatorLatestPerformance{
+			validIndex: {
+				balance: 32000000000,
+			},
+		}
+		aggregatedPerformance := map[primitives.ValidatorIndex]ValidatorAggregatedPerformance{
+			validIndex: {
+				startEpoch:          0,
+				startBalance:        31700000000,
+				totalAttestedCount:  12,
+				totalRequestedCount: 15,
+				totalDistance:       14,
+				totalCorrectHead:    8,
+				totalCorrectSource:  11,
+				totalCorrectTarget:  12,
+			},
+		}
+
+		for j := 0; j < 20; j++ {
+			invalidIndex := primitives.ValidatorIndex(1000 + (i * 20) + j)
+			aggregatedPerformance[invalidIndex] = ValidatorAggregatedPerformance{}
+		}
+
+		s := &Service{
+			latestPerformance:     latestPerformance,
+			aggregatedPerformance: aggregatedPerformance,
+		}
+		s.logAggregatedPerformance()
+
+		logCount := 0
+		for _, entry := range hook.AllEntries() {
+			if entry.Message != "Aggregated performance since launch" {
+				continue
+			}
+			require.Equal(t, fmt.Sprintf("%d", validIndex), fmt.Sprintf("%v", entry.Data["validatorIndex"]))
+			logCount++
+		}
+		require.Equal(t, 1, logCount)
+	}
+}


### PR DESCRIPTION
  **What type of PR is this?**
                                                                                                                                                                                      
  Bug fix                                                                                                                                                                             
                                                                                                                                                                                      
  **What does this PR do? Why is it needed?**
                                                                                                                                                                                      
  `logAggregatedPerformance` was using `break` when a single validator entry was incomplete (zero counters or missing latest data).                                                   
  Because iteration is over a map, that behavior could randomly stop the whole loop and silently drop logs for later valid validators.                                                
  This PR switches those exits to `continue`, so invalid entries are skipped while valid validator stats are still reported.                                                          
                                                                                                                                                                                      
  To prove correctness, this PR adds `TestLogAggregatedPerformance_SkipsInvalidEntries`, which repeatedly mixes many invalid entries with one valid entry and asserts the valid       
  aggregated log is still emitted.                                                                                                                                                    

  **Which issues(s) does this PR fix?**                                                                                                                                               
                                                                                                                                                                                      
  Fixes #<issue-number>                                                                                                                                                               
                                                                                                                                                                                      
  **Other notes for review**                                                                                                                                                          
                                                                                                                                                                                      
  - Minimal change in `beacon-chain/monitor/process_block.go` (two `break` -> `continue` updates).                                                                                    
  - Added targeted regression coverage in `beacon-chain/monitor/process_block_test.go`.                                                                                               
  - Added changelog fragment: `changelog/codex_fix-monitor-aggregated-performance-loop.md`.
                                                                                                                                                                                      
  **Acknowledgements**                                                                                                                                                                
                                                                                                                                                                                      
  - [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).                                                                           
  - [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).                      
  - [x] I have added a description with sufficient context for reviewers to understand this PR.                                                                                       
  - [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).    