### PR TITLE
Update fastssz to 7a6eb71

### DIFF
--- a/changelog/terence_update-fastssz.md
+++ b/changelog/terence_update-fastssz.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Updated fastssz to commit [7a6eb71](https://github.com/OffchainLabs/fastssz/commit/7a6eb71e6e45e6fa9e6d01d9f023575da3f46fae).

--- a/deps.bzl
+++ b/deps.bzl
@@ -2841,8 +2841,8 @@ def prysm_deps():
     go_repository(
         name = "com_github_prysmaticlabs_fastssz",
         importpath = "github.com/prysmaticlabs/fastssz",
-        sum = "h1:by+quGludklRjZWzNJHPpp5Xwfzk41e85F7w0aWICb8=",
-        version = "v0.0.0-20260401175048-c57e478b88da",
+        sum = "h1:UkcU1rqEBOInBQdP1mCE4Smo90Eux82VEOyBhEK9TA0=",
+        version = "v0.0.0-20260421202104-7a6eb71e6e45",
     )
     go_repository(
         name = "com_github_prysmaticlabs_go_bitfield",

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/prom2json v1.3.0
-	github.com/prysmaticlabs/fastssz v0.0.0-20260401175048-c57e478b88da
+	github.com/prysmaticlabs/fastssz v0.0.0-20260421202104-7a6eb71e6e45
 	github.com/prysmaticlabs/prombbolt v0.0.0-20210126082820-9b7adba6db7c
 	github.com/prysmaticlabs/protoc-gen-go-cast v0.0.0-20230228205207-28762a7b9294
 	github.com/r3labs/sse/v2 v2.10.0

--- a/go.sum
+++ b/go.sum
@@ -900,8 +900,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/prometheus/prom2json v1.3.0 h1:BlqrtbT9lLH3ZsOVhXPsHzFrApCTKRifB7gjJuypu6Y=
 github.com/prometheus/prom2json v1.3.0/go.mod h1:rMN7m0ApCowcoDlypBHlkNbp5eJQf/+1isKykIP5ZnM=
-github.com/prysmaticlabs/fastssz v0.0.0-20260401175048-c57e478b88da h1:by+quGludklRjZWzNJHPpp5Xwfzk41e85F7w0aWICb8=
-github.com/prysmaticlabs/fastssz v0.0.0-20260401175048-c57e478b88da/go.mod h1:6lF+KRHYePGWv4zcbdfmq+EoCy1rch1Ew/oyZmi6AZ0=
+github.com/prysmaticlabs/fastssz v0.0.0-20260421202104-7a6eb71e6e45 h1:UkcU1rqEBOInBQdP1mCE4Smo90Eux82VEOyBhEK9TA0=
+github.com/prysmaticlabs/fastssz v0.0.0-20260421202104-7a6eb71e6e45/go.mod h1:6lF+KRHYePGWv4zcbdfmq+EoCy1rch1Ew/oyZmi6AZ0=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20210108222456-8e92c3709aa0/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
 github.com/prysmaticlabs/gohashtree v0.0.5-beta h1:ct41mg7HyIZd7uoSM/ud23f+3DxQG9tlMlQG+BVX23c=
 github.com/prysmaticlabs/gohashtree v0.0.5-beta/go.mod h1:HRuvtXLZ4WkaB1MItToVH2e8ZwKwZPY5/Rcby+CvvLY=

--- a/proto/engine/v1/engine.ssz.go
+++ b/proto/engine/v1/engine.ssz.go
@@ -868,7 +868,7 @@ func (e *ExecutionPayload) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(e.ExtraData)
+		hh.AppendBytes32(e.ExtraData)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (32+31)/32)
 	}
 
@@ -1282,7 +1282,7 @@ func (e *ExecutionPayloadCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(e.ExtraData)
+		hh.AppendBytes32(e.ExtraData)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (32+31)/32)
 	}
 
@@ -1724,7 +1724,7 @@ func (e *ExecutionPayloadDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(e.ExtraData)
+		hh.AppendBytes32(e.ExtraData)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (32+31)/32)
 	}
 
@@ -2327,7 +2327,7 @@ func (e *ExecutionPayloadHeader) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(e.ExtraData)
+		hh.AppendBytes32(e.ExtraData)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (32+31)/32)
 	}
 
@@ -2649,7 +2649,7 @@ func (e *ExecutionPayloadHeaderCapella) HashTreeRootWith(hh *ssz.Hasher) (err er
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(e.ExtraData)
+		hh.AppendBytes32(e.ExtraData)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (32+31)/32)
 	}
 
@@ -2990,7 +2990,7 @@ func (e *ExecutionPayloadHeaderDeneb) HashTreeRootWith(hh *ssz.Hasher) (err erro
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(e.ExtraData)
+		hh.AppendBytes32(e.ExtraData)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (32+31)/32)
 	}
 

--- a/proto/prysm/v1alpha1/altair.ssz.go
+++ b/proto/prysm/v1alpha1/altair.ssz.go
@@ -1618,7 +1618,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.PreviousEpochParticipation)
+		hh.AppendBytes32(b.PreviousEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 
@@ -1630,7 +1630,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.CurrentEpochParticipation)
+		hh.AppendBytes32(b.CurrentEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 

--- a/proto/prysm/v1alpha1/bellatrix.ssz.go
+++ b/proto/prysm/v1alpha1/bellatrix.ssz.go
@@ -2255,7 +2255,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.PreviousEpochParticipation)
+		hh.AppendBytes32(b.PreviousEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 
@@ -2267,7 +2267,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.CurrentEpochParticipation)
+		hh.AppendBytes32(b.CurrentEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 

--- a/proto/prysm/v1alpha1/capella.ssz.go
+++ b/proto/prysm/v1alpha1/capella.ssz.go
@@ -2742,7 +2742,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.PreviousEpochParticipation)
+		hh.AppendBytes32(b.PreviousEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 
@@ -2754,7 +2754,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.CurrentEpochParticipation)
+		hh.AppendBytes32(b.CurrentEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 

--- a/proto/prysm/v1alpha1/deneb.ssz.go
+++ b/proto/prysm/v1alpha1/deneb.ssz.go
@@ -3536,7 +3536,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.PreviousEpochParticipation)
+		hh.AppendBytes32(b.PreviousEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 
@@ -3548,7 +3548,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.CurrentEpochParticipation)
+		hh.AppendBytes32(b.CurrentEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 

--- a/proto/prysm/v1alpha1/electra.ssz.go
+++ b/proto/prysm/v1alpha1/electra.ssz.go
@@ -4280,7 +4280,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.PreviousEpochParticipation)
+		hh.AppendBytes32(b.PreviousEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 
@@ -4292,7 +4292,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.CurrentEpochParticipation)
+		hh.AppendBytes32(b.CurrentEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 

--- a/proto/prysm/v1alpha1/fulu.ssz.go
+++ b/proto/prysm/v1alpha1/fulu.ssz.go
@@ -1773,7 +1773,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.PreviousEpochParticipation)
+		hh.AppendBytes32(b.PreviousEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 
@@ -1785,7 +1785,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.CurrentEpochParticipation)
+		hh.AppendBytes32(b.CurrentEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 

--- a/proto/prysm/v1alpha1/gloas.ssz.go
+++ b/proto/prysm/v1alpha1/gloas.ssz.go
@@ -2875,7 +2875,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.PreviousEpochParticipation)
+		hh.AppendBytes32(b.PreviousEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 
@@ -2887,7 +2887,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(b.CurrentEpochParticipation)
+		hh.AppendBytes32(b.CurrentEpochParticipation)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1099511627776+31)/32)
 	}
 

--- a/proto/ssz_query/response.ssz.go
+++ b/proto/ssz_query/response.ssz.go
@@ -249,7 +249,7 @@ func (s *SSZQueryResponse) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(s.Result)
+		hh.AppendBytes32(s.Result)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1073741824+31)/32)
 	}
 
@@ -396,7 +396,7 @@ func (s *SSZQueryResponseWithProof) HashTreeRootWith(hh *ssz.Hasher) (err error)
 			err = ssz.ErrIncorrectListSize
 			return
 		}
-		hh.PutBytes(s.Result)
+		hh.AppendBytes32(s.Result)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1073741824+31)/32)
 	}
 


### PR DESCRIPTION
## Summary
- Pins `github.com/prysmaticlabs/fastssz` to OffchainLabs/fastssz@[7a6eb71](https://github.com/OffchainLabs/fastssz/commit/7a6eb71e6e45e6fa9e6d01d9f023575da3f46fae).
- Regenerates ssz.go files; `HashTreeRootWith` for `ExtraData` fields now uses `AppendBytes32` instead of `PutBytes`.