### PR TITLE
sync: Use multiset counting to reject duplicate blob/datacolumn responses

### DIFF
--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -50,10 +50,12 @@ var (
 	errMaxResponseDataColumnSidecarsExceeded = errors.New("peer returned more data column sidecars than requested")
 
 	errSidecarRPCValidation     = errors.Wrap(ErrInvalidFetchedData, "DataColumnSidecar")
-	errSidecarSlotsUnordered    = errors.Wrap(errSidecarRPCValidation, "slots not in ascending order")
-	errSidecarIndicesUnordered  = errors.Wrap(errSidecarRPCValidation, "sidecar indices not in ascending order")
-	errSidecarSlotNotRequested  = errors.Wrap(errSidecarRPCValidation, "sidecar slot not in range")
-	errSidecarIndexNotRequested = errors.Wrap(errSidecarRPCValidation, "sidecar index not requested")
+	errSidecarSlotsUnordered     = errors.Wrap(errSidecarRPCValidation, "slots not in ascending order")
+	errSidecarIndicesUnordered   = errors.Wrap(errSidecarRPCValidation, "sidecar indices not in ascending order")
+	errSidecarSlotNotRequested   = errors.Wrap(errSidecarRPCValidation, "sidecar slot not in range")
+	errSidecarIndexNotRequested  = errors.Wrap(errSidecarRPCValidation, "sidecar index not requested")
+	errSidecarDuplicate          = errors.Wrap(errSidecarRPCValidation, "duplicate sidecar received")
+	errBlobDuplicateOrUnexpected = errors.Wrap(verification.ErrBlobInvalid, "received duplicate or unexpected BlobSidecar")
 )
 
 // ------
@@ -363,23 +365,24 @@ func newSequentialBlobValidator() BlobResponseValidation {
 }
 
 func blobValidatorFromRootReq(req *p2ptypes.BlobSidecarsByRootReq) BlobResponseValidation {
-	blobIds := make(map[[32]byte]map[uint64]bool)
+	pendingBlobs := make(map[[32]byte]map[uint64]int)
 	for _, sc := range *req {
 		blockRoot := bytesutil.ToBytes32(sc.BlockRoot)
-		if blobIds[blockRoot] == nil {
-			blobIds[blockRoot] = make(map[uint64]bool)
+		if pendingBlobs[blockRoot] == nil {
+			pendingBlobs[blockRoot] = make(map[uint64]int)
 		}
-		blobIds[blockRoot][sc.Index] = true
+		pendingBlobs[blockRoot][sc.Index]++
 	}
 	return func(sc blocks.ROBlob) error {
-		blobIndices := blobIds[sc.BlockRoot()]
+		blobIndices := pendingBlobs[sc.BlockRoot()]
 		if blobIndices == nil {
 			return errors.Wrapf(errUnrequested, "root=%#x", sc.BlockRoot())
 		}
-		requested := blobIndices[sc.Index]
-		if !requested {
-			return errors.Wrapf(errUnrequested, "root=%#x index=%d", sc.BlockRoot(), sc.Index)
+		remaining := blobIndices[sc.Index]
+		if remaining <= 0 {
+			return errors.Wrapf(errBlobDuplicateOrUnexpected, "root=%#x index=%d", sc.BlockRoot(), sc.Index)
 		}
+		blobIndices[sc.Index] = remaining - 1
 		return nil
 	}
 }
@@ -621,12 +624,19 @@ func areSidecarsOrdered() DataColumnResponseValidation {
 	}
 }
 
-// isSidecarIndexRequested verifies that the index of the data column sidecar is found in the requested indices.
+type slotColumnKey struct {
+	slot  primitives.Slot
+	index uint64
+}
+
+// isSidecarIndexRequested verifies that the index of the data column sidecar is found in the requested indices
+// and has not already been received for the same slot.
 func isSidecarIndexRequested(request *ethpb.DataColumnSidecarsByRangeRequest) DataColumnResponseValidation {
 	requestedIndices := make(map[uint64]bool)
 	for _, col := range request.Columns {
 		requestedIndices[col] = true
 	}
+	receivedPairs := make(map[slotColumnKey]bool)
 
 	return func(sidecar blocks.RODataColumn) error {
 		columnIndex := sidecar.Index()
@@ -634,6 +644,12 @@ func isSidecarIndexRequested(request *ethpb.DataColumnSidecarsByRangeRequest) Da
 			requested := helpers.SortedPrettySliceFromMap(requestedIndices)
 			return errors.Wrapf(errSidecarIndexNotRequested, "%d not in %v", columnIndex, requested)
 		}
+
+		key := slotColumnKey{slot: sidecar.Slot(), index: columnIndex}
+		if receivedPairs[key] {
+			return errors.Wrapf(errSidecarDuplicate, "slot=%d index=%d", sidecar.Slot(), columnIndex)
+		}
+		receivedPairs[key] = true
 
 		return nil
 	}
@@ -719,30 +735,32 @@ func SendDataColumnSidecarsByRootRequest(p DataColumnSidecarsParams, peer goPeer
 }
 
 func isSidecarIndexRootRequested(request p2ptypes.DataColumnsByRootIdentifiers) DataColumnResponseValidation {
-	columnsIndexFromRoot := make(map[[fieldparams.RootLength]byte]map[uint64]bool)
+	pendingColumns := make(map[[fieldparams.RootLength]byte]map[uint64]int)
 
 	for _, sidecar := range request {
 		blockRoot := bytesutil.ToBytes32(sidecar.BlockRoot)
-		if columnsIndexFromRoot[blockRoot] == nil {
-			columnsIndexFromRoot[blockRoot] = make(map[uint64]bool)
+		if pendingColumns[blockRoot] == nil {
+			pendingColumns[blockRoot] = make(map[uint64]int)
 		}
 
 		for _, column := range sidecar.Columns {
-			columnsIndexFromRoot[blockRoot][column] = true
+			pendingColumns[blockRoot][column]++
 		}
 	}
 
 	return func(sidecar blocks.RODataColumn) error {
 		root, index := sidecar.BlockRoot(), sidecar.Index()
-		indices, ok := columnsIndexFromRoot[root]
+		indices, ok := pendingColumns[root]
 
 		if !ok {
 			return errors.Errorf("root %#x returned by peer but not requested", root)
 		}
 
-		if !indices[index] {
-			return errors.Errorf("index %d for root %#x returned by peer but not requested", index, root)
+		remaining := indices[index]
+		if remaining <= 0 {
+			return errors.Wrapf(errSidecarDuplicate, "root=%#x index=%d", root, index)
 		}
+		indices[index] = remaining - 1
 
 		return nil
 	}

--- a/beacon-chain/sync/rpc_send_request_test.go
+++ b/beacon-chain/sync/rpc_send_request_test.go
@@ -500,6 +500,7 @@ func TestBlobValidatorFromRootReq(t *testing.T) {
 		ids      []*ethpb.BlobIdentifier
 		response []blocks.ROBlob
 		err      error
+		errAt    int
 	}{
 		{
 			name:     "expected",
@@ -516,16 +517,28 @@ func TestBlobValidatorFromRootReq(t *testing.T) {
 			name:     "wrong index",
 			ids:      []*ethpb.BlobIdentifier{{BlockRoot: rootA, Index: 0}},
 			response: []blocks.ROBlob{blobSidecarA1},
-			err:      errUnrequested,
+			err:      errBlobDuplicateOrUnexpected,
+		},
+		{
+			name:     "duplicate blob rejected",
+			ids:      []*ethpb.BlobIdentifier{{BlockRoot: rootA, Index: 0}, {BlockRoot: rootA, Index: 1}},
+			response: []blocks.ROBlob{blobSidecarA0, blobSidecarA0},
+			err:      errBlobDuplicateOrUnexpected,
+			errAt:    1,
+		},
+		{
+			name:     "multiple blobs valid",
+			ids:      []*ethpb.BlobIdentifier{{BlockRoot: rootA, Index: 0}, {BlockRoot: rootA, Index: 1}},
+			response: []blocks.ROBlob{blobSidecarA0, blobSidecarA1},
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			r := p2pTypes.BlobSidecarsByRootReq(c.ids)
 			vf := blobValidatorFromRootReq(&r)
-			for _, sc := range c.response {
+			for i, sc := range c.response {
 				err := vf(sc)
-				if c.err != nil {
+				if c.err != nil && i == c.errAt {
 					require.ErrorIs(t, err, c.err)
 					return
 				}
@@ -1135,63 +1148,66 @@ func TestIsSidecarSlotWithinBounds(t *testing.T) {
 }
 
 func TestIsSidecarIndexRequested(t *testing.T) {
-	request := &ethpb.DataColumnSidecarsByRangeRequest{
-		Columns: []uint64{2, 9, 4},
-	}
+	createSidecar := func(slot primitives.Slot, index uint64) blocks.RODataColumn {
+		const count = 4
+		kzgCommitmentsInclusionProof := make([][]byte, 0, count)
+		for range count {
+			kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
+		}
 
-	validator := isSidecarIndexRequested(request)
-
-	testCases := []struct {
-		name            string
-		index           uint64
-		isErrorExpected bool
-	}{
-		{
-			name:            "not requested",
-			index:           1,
-			isErrorExpected: true,
-		},
-		{
-			name:            "requested",
-			index:           9,
-			isErrorExpected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			const count = 4
-			kzgCommitmentsInclusionProof := make([][]byte, 0, count)
-			for range count {
-				kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
-			}
-
-			sidecarPb := &ethpb.DataColumnSidecar{
-				SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
-					Header: &ethpb.BeaconBlockHeader{
-						Slot:       0,
-						ParentRoot: make([]byte, fieldparams.RootLength),
-						StateRoot:  make([]byte, fieldparams.RootLength),
-						BodyRoot:   make([]byte, fieldparams.RootLength),
-					},
-					Signature: make([]byte, fieldparams.BLSSignatureLength),
+		sidecarPb := &ethpb.DataColumnSidecar{
+			SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
+				Header: &ethpb.BeaconBlockHeader{
+					Slot:       slot,
+					ParentRoot: make([]byte, fieldparams.RootLength),
+					StateRoot:  make([]byte, fieldparams.RootLength),
+					BodyRoot:   make([]byte, fieldparams.RootLength),
 				},
-				KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
-				Index:                        tc.index,
-			}
+				Signature: make([]byte, fieldparams.BLSSignatureLength),
+			},
+			KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
+			Index:                        index,
+		}
 
-			sidecar, err := blocks.NewRODataColumn(sidecarPb)
-			require.NoError(t, err)
-
-			err = validator(sidecar)
-			if tc.isErrorExpected {
-				require.NotNil(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-		})
+		sidecar, _ := blocks.NewRODataColumn(sidecarPb)
+		return sidecar
 	}
+
+	t.Run("not requested index", func(t *testing.T) {
+		request := &ethpb.DataColumnSidecarsByRangeRequest{Columns: []uint64{2, 9, 4}}
+		validator := isSidecarIndexRequested(request)
+		err := validator(createSidecar(0, 1))
+		require.ErrorIs(t, err, errSidecarIndexNotRequested)
+	})
+
+	t.Run("requested index", func(t *testing.T) {
+		request := &ethpb.DataColumnSidecarsByRangeRequest{Columns: []uint64{2, 9, 4}}
+		validator := isSidecarIndexRequested(request)
+		err := validator(createSidecar(0, 9))
+		require.NoError(t, err)
+	})
+
+	t.Run("duplicate sidecar same slot rejected", func(t *testing.T) {
+		request := &ethpb.DataColumnSidecarsByRangeRequest{Columns: []uint64{2, 9, 4}}
+		validator := isSidecarIndexRequested(request)
+
+		err := validator(createSidecar(0, 2))
+		require.NoError(t, err)
+
+		err = validator(createSidecar(0, 2))
+		require.ErrorIs(t, err, errSidecarDuplicate)
+	})
+
+	t.Run("same index different slots allowed", func(t *testing.T) {
+		request := &ethpb.DataColumnSidecarsByRangeRequest{Columns: []uint64{2, 9, 4}}
+		validator := isSidecarIndexRequested(request)
+
+		err := validator(createSidecar(0, 2))
+		require.NoError(t, err)
+
+		err = validator(createSidecar(1, 2))
+		require.NoError(t, err)
+	})
 }
 
 func TestSendDataColumnSidecarsByRootRequest(t *testing.T) {
@@ -1381,72 +1397,82 @@ func TestSendDataColumnSidecarsByRootRequest(t *testing.T) {
 }
 
 func TestIsSidecarIndexRootRequested(t *testing.T) {
-	testCases := []struct {
-		name            string
-		root            [fieldparams.RootLength]byte
-		index           uint64
-		isErrorExpected bool
-	}{
-		{
-			name:            "non requested root",
-			root:            [fieldparams.RootLength]byte{2},
-			isErrorExpected: true,
-		},
-		{
-			name:            "non requested index",
-			root:            [fieldparams.RootLength]byte{1},
-			index:           3,
-			isErrorExpected: true,
-		},
-		{
-			name:            "nominal",
-			root:            [fieldparams.RootLength]byte{1},
-			index:           2,
-			isErrorExpected: false,
-		},
-	}
+	createSidecar := func(root [fieldparams.RootLength]byte, index uint64) blocks.RODataColumn {
+		const count = 4
+		kzgCommitmentsInclusionProof := make([][]byte, 0, count)
+		for range count {
+			kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
+		}
 
-	request := types.DataColumnsByRootIdentifiers{
-		{BlockRoot: []byte{1}, Columns: []uint64{1, 2}},
-	}
-
-	validator := isSidecarIndexRootRequested(request)
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			const count = 4
-			kzgCommitmentsInclusionProof := make([][]byte, 0, count)
-			for range count {
-				kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
-			}
-
-			sidecarPb := &ethpb.DataColumnSidecar{
-				SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
-					Header: &ethpb.BeaconBlockHeader{
-						ParentRoot: make([]byte, fieldparams.RootLength),
-						StateRoot:  make([]byte, fieldparams.RootLength),
-						BodyRoot:   make([]byte, fieldparams.RootLength),
-					},
-					Signature: make([]byte, fieldparams.BLSSignatureLength),
+		sidecarPb := &ethpb.DataColumnSidecar{
+			SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
+				Header: &ethpb.BeaconBlockHeader{
+					ParentRoot: make([]byte, fieldparams.RootLength),
+					StateRoot:  make([]byte, fieldparams.RootLength),
+					BodyRoot:   make([]byte, fieldparams.RootLength),
 				},
-				KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
-				Index:                        tc.index,
-			}
+				Signature: make([]byte, fieldparams.BLSSignatureLength),
+			},
+			KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
+			Index:                        index,
+		}
 
-			// There is a discrepancy between `tc.root` and the real root,
-			// but we don't care about it here.
-			sidecar, err := blocks.NewRODataColumnWithRoot(sidecarPb, tc.root)
-			require.NoError(t, err)
-
-			err = validator(sidecar)
-			if tc.isErrorExpected {
-				require.NotNil(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-		})
+		sidecar, _ := blocks.NewRODataColumnWithRoot(sidecarPb, root)
+		return sidecar
 	}
+
+	t.Run("non requested root", func(t *testing.T) {
+		request := types.DataColumnsByRootIdentifiers{
+			{BlockRoot: []byte{1}, Columns: []uint64{1, 2}},
+		}
+		validator := isSidecarIndexRootRequested(request)
+		err := validator(createSidecar([fieldparams.RootLength]byte{2}, 1))
+		require.ErrorContains(t, "not requested", err)
+	})
+
+	t.Run("non requested index", func(t *testing.T) {
+		request := types.DataColumnsByRootIdentifiers{
+			{BlockRoot: []byte{1}, Columns: []uint64{1, 2}},
+		}
+		validator := isSidecarIndexRootRequested(request)
+		err := validator(createSidecar([fieldparams.RootLength]byte{1}, 3))
+		require.ErrorIs(t, err, errSidecarDuplicate)
+	})
+
+	t.Run("nominal", func(t *testing.T) {
+		request := types.DataColumnsByRootIdentifiers{
+			{BlockRoot: []byte{1}, Columns: []uint64{1, 2}},
+		}
+		validator := isSidecarIndexRootRequested(request)
+		err := validator(createSidecar([fieldparams.RootLength]byte{1}, 2))
+		require.NoError(t, err)
+	})
+
+	t.Run("duplicate sidecar rejected", func(t *testing.T) {
+		request := types.DataColumnsByRootIdentifiers{
+			{BlockRoot: []byte{1}, Columns: []uint64{1, 2}},
+		}
+		validator := isSidecarIndexRootRequested(request)
+
+		err := validator(createSidecar([fieldparams.RootLength]byte{1}, 1))
+		require.NoError(t, err)
+
+		err = validator(createSidecar([fieldparams.RootLength]byte{1}, 1))
+		require.ErrorIs(t, err, errSidecarDuplicate)
+	})
+
+	t.Run("multiple valid sidecars", func(t *testing.T) {
+		request := types.DataColumnsByRootIdentifiers{
+			{BlockRoot: []byte{1}, Columns: []uint64{1, 2}},
+		}
+		validator := isSidecarIndexRootRequested(request)
+
+		err := validator(createSidecar([fieldparams.RootLength]byte{1}, 1))
+		require.NoError(t, err)
+
+		err = validator(createSidecar([fieldparams.RootLength]byte{1}, 2))
+		require.NoError(t, err)
+	})
 }
 
 func TestReadChunkedDataColumnSidecar(t *testing.T) {


### PR DESCRIPTION
Blob/DataColumn by-root and by-range validators were using bool sets to track requested items, allowing peers to fill responses with duplicates while omitting others. Switched to multiset counting (same pattern as `ExecutionPayloadEnvelopesByRootRequest`) so each item is consumed on receipt and duplicates are rejected.