### PR TITLE
enable the partial message extension during a fanout if the partial messages feature flag is enabled

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -492,6 +492,10 @@ func (s *Service) broadcastDataColumnSidecars(ctx context.Context, forkDigest [f
 
 	// Publish partial columns that already have peers.
 	if s.partialColumnBroadcaster != nil {
+		_, span := trace.StartSpan(ctx, "p2p.broadcastDataColumnSidecars")
+		ctx := trace.NewContext(s.ctx, span)
+		defer span.End()
+
 		var partialsWithPeers atomic.Int64
 		iterFunc := func(yield func(string, blocks.PartialDataColumn) bool) {
 			for _, item := range itemsWithPeers {

--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -510,6 +510,7 @@ func (s *Service) broadcastDataColumnSidecars(ctx context.Context, forkDigest [f
 			}
 		}
 		if err := s.partialColumnBroadcaster.Publish(ctx, iterFunc); err != nil {
+			tracing.AnnotateError(span, err)
 			log.WithError(err).Error("Cannot publish partial data columns")
 		} else {
 			partialDataColumnBroadcasts.Add(float64(partialsWithPeers.Load()))

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -52,6 +52,10 @@ func (s *Service) JoinTopic(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topi
 	s.joinedTopicsLock.Lock()
 	defer s.joinedTopicsLock.Unlock()
 
+	if strings.Contains(topic, DataColumnSubnetTopicFormat) && s.partialColumnBroadcaster != nil {
+		opts = append(opts, pubsub.RequestPartialMessages())
+	}
+
 	if _, ok := s.joinedTopics[topic]; !ok {
 		topicHandle, err := s.pubsub.Join(topic, opts...)
 		if err != nil {

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -52,11 +52,12 @@ func (s *Service) JoinTopic(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topi
 	s.joinedTopicsLock.Lock()
 	defer s.joinedTopicsLock.Unlock()
 
-	if strings.Contains(topic, DataColumnSubnetTopicFormat) && s.partialColumnBroadcaster != nil {
-		opts = append(opts, pubsub.RequestPartialMessages())
-	}
-
 	if _, ok := s.joinedTopics[topic]; !ok {
+		if strings.Contains(topic, GossipDataColumnSidecarMessage) && s.partialColumnBroadcaster != nil {
+			opts = append(opts, pubsub.RequestPartialMessages())
+			log.Info("Joining data column sidecar topic with partial messages", "topic", topic)
+		}
+
 		topicHandle, err := s.pubsub.Join(topic, opts...)
 		if err != nil {
 			return nil, err

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -55,7 +55,7 @@ func (s *Service) JoinTopic(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topi
 	if _, ok := s.joinedTopics[topic]; !ok {
 		if strings.Contains(topic, GossipDataColumnSidecarMessage) && s.partialColumnBroadcaster != nil {
 			opts = append(opts, pubsub.RequestPartialMessages())
-			log.Info("Joining data column sidecar topic with partial messages", "topic", topic)
+			log.Debugf("Joining data column sidecar topic %s with partial messages enabled", topic)
 		}
 
 		topicHandle, err := s.pubsub.Join(topic, opts...)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR fixes the bug where we weren't using the partial message extension when publishing a fanout message for data columns even when the partial messages feature flag was enabled. This caused the proposer to publish full columns instead of partial columns during fanout.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
