### PR TITLE
statediff logs cleanup

### DIFF
--- a/beacon-chain/db/kv/state_diff_helpers.go
+++ b/beacon-chain/db/kv/state_diff_helpers.go
@@ -264,7 +264,7 @@ func (s *Store) initializeStateDiff(slot primitives.Slot, initialState state.Rea
 	// Only reinitialize if the offset is different
 	if s.stateDiffCache != nil {
 		if s.stateDiffCache.getOffset() == uint64(slot) {
-			log.WithField("offset", slot).Warning("Ignoring state diff cache reinitialization")
+			log.WithField("offset", slot).Debug("Ignoring state diff cache reinitialization")
 			return nil
 		}
 	}
@@ -303,7 +303,7 @@ func (s *Store) initializeStateDiff(slot primitives.Slot, initialState state.Rea
 		return pkgerrors.Wrap(err, "failed to save initial snapshot")
 	}
 
-	log.WithField("offset", slot).Info("Initialized state-diff cache")
+	log.WithField("offset", slot).Debug("Initialized state-diff cache")
 	return nil
 }
 

--- a/changelog/bastin_statediff-logs-cleanup.md
+++ b/changelog/bastin_statediff-logs-cleanup.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Moved some state diff logs to debug level.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Moves two state diff logs to Debug instead of Warning/Info.

- the "ignoring reinitializitation" log: this is a no op. user doesn't care.
- the "Initialized cache" log: this one gets printed twice when doing checkpoint sync, and is confusing. Also, it is not an information that the user needs to know on Info level.