### PR TITLE
Preserve injected highest bid cache in sync service

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -401,7 +401,9 @@ func (s *Service) initCaches() {
 	s.seenBlockCache = lruwrpr.New(seenBlockSize)
 	s.seenPayloadEnvelopeCache = lruwrpr.New(seenPayloadEnvelopeSize)
 	s.seenExecutionPayloadBidCache = newSlotAwareCache(seenExecutionPayloadBidSize)
-	s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
+	if s.highestExecutionPayloadBidCache == nil {
+		s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
+	}
 	s.seenBlobCache = lruwrpr.New(seenBlockSize * params.BeaconConfig().DeprecatedMaxBlobsPerBlockElectra)
 	s.seenDataColumnCache = newSlotAwareCache(seenDataColumnSize)
 	s.seenAggregatedAttestationCache = lruwrpr.New(seenAggregatedAttSize)

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -54,6 +54,19 @@ func TestService_StatusZeroEpoch(t *testing.T) {
 	assert.NoError(t, r.Status(), "Wanted non failing status")
 }
 
+func TestNewService_PreservesInjectedHighestExecutionPayloadBidCache(t *testing.T) {
+	p2p := p2ptest.NewTestP2P(t)
+	injected := cache.NewHighestExecutionPayloadBidCache()
+
+	s := NewService(
+		t.Context(),
+		WithP2P(p2p),
+		WithHighestExecutionPayloadBidCache(injected),
+	)
+	require.NotNil(t, s)
+	require.Equal(t, injected, s.highestExecutionPayloadBidCache)
+}
+
 func TestSyncHandlers_WaitToSync(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
 	chainService := &mockChain.ChainService{


### PR DESCRIPTION
• **What type of PR is this?**                                                                                                                                                        
                                                                                                                                                                                      
  Bug fix                                                                                                                                                                             
                                                                                                                                                                                      
  **What does this PR do? Why is it needed?**                                                                                                                                         
                                                                                                                                                                                      
  `node` injects one shared `HighestExecutionPayloadBidCache` into both sync and validator RPC, but `sync.NewService` later called `initCaches` and unconditionally created a new cache instance.                                                                                                                                                                     
  That broke cross-layer sharing: sync wrote highest P2P bids into one cache while proposer read from another.                                                                        
  This PR preserves injected cache instances by only creating `HighestExecutionPayloadBidCache` when it is `nil`, and adds a regression test (`TestNewService_PreservesInjectedHighestExecutionPayloadBidCache`) to lock this contract.                                                                                          
                                                                                                                                                                                      
  **Which issues(s) does this PR fix?**                                                                                                                                               
                                                                                                                                                                                      
  Fixes #<issue-number>                                                                                                                                                               
                                                                                                                                                                                      
  **Other notes for review**                                                                                                                                                          
                                                                                                                                                                                      
  - Minimal functional scope:                                                                                                                                                         
    - `beacon-chain/sync/service.go`: guard cache initialization with a nil check.                                                                                                    
    - `beacon-chain/sync/service_test.go`: add constructor-level regression test for injected cache preservation.                                                                     
  - Suggested validation commands:                                                                                                                                                    
    - `go test ./beacon-chain/sync -run TestNewService_PreservesInjectedHighestExecutionPayloadBidCache -count=1`                                                                     
    - `go test ./beacon-chain/sync -count=1`                                                                                                                                          

  **Acknowledgements**                                                                                                                                                                
                                                                                                                                                                                      
  - [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).                                                                           
  - [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).                      
  - [x] I have added a description with sufficient context for reviewers to understand this PR.                                                                                       
  - [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).   