### PR TITLE
Fix highest execution payload bid cache sharing between sync and RPC

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -88,52 +88,51 @@ type serviceFlagOpts struct {
 // full PoS node. It handles the lifecycle of the entire system and registers
 // services to a service registry.
 type BeaconNode struct {
-	cliCtx                          *cli.Context
-	ctx                             context.Context
-	cancel                          context.CancelFunc
-	services                        *runtime.ServiceRegistry
-	lock                            sync.RWMutex
-	stop                            chan struct{} // Channel to wait for termination notifications.
-	db                              db.Database
-	slasherDB                       db.SlasherDatabase
-	attestationCache                *cache.AttestationCache
-	attestationPool                 attestations.Pool
-	payloadAttestationPool          payloadattestation.PoolManager
-	exitPool                        voluntaryexits.PoolManager
-	slashingsPool                   slashings.PoolManager
-	syncCommitteePool               synccommittee.Pool
-	blsToExecPool                   blstoexec.PoolManager
-	depositCache                    cache.DepositCache
-	trackedValidatorsCache          *cache.TrackedValidatorsCache
-	proposerPreferencesCache        *cache.ProposerPreferencesCache
-	highestExecutionPayloadBidCache *cache.HighestExecutionPayloadBidCache
-	payloadIDCache                  *cache.PayloadIDCache
-	stateFeed                       *event.Feed
-	blockFeed                       *event.Feed
-	opFeed                          *event.Feed
-	stateGen                        *stategen.State
-	collector                       *bcnodeCollector
-	slasherBlockHeadersFeed         *event.Feed
-	slasherAttestationsFeed         *event.Feed
-	finalizedStateAtStartUp         state.BeaconState
-	serviceFlagOpts                 *serviceFlagOpts
-	GenesisProviders                []genesis.Provider
-	CheckpointInitializer           checkpoint.Initializer
-	forkChoicer                     forkchoice.ForkChoicer
-	ClockWaiter                     startup.ClockWaiter
-	BackfillOpts                    []backfill.ServiceOption
-	initialSyncComplete             chan struct{}
-	BlobStorage                     *filesystem.BlobStorage
-	BlobStorageOptions              []filesystem.BlobStorageOption
-	DataColumnStorage               *filesystem.DataColumnStorage
-	DataColumnStorageOptions        []filesystem.DataColumnStorageOption
-	verifyInitWaiter                *verification.InitializerWaiter
-	lhsp                            *verification.LazyHeadStateProvider
-	syncChecker                     *initialsync.SyncChecker
-	slasherEnabled                  bool
-	lcStore                         *lightclient.Store
-	ConfigOptions                   []params.Option
-	SyncNeedsWaiter                 func() (das.SyncNeeds, error)
+	cliCtx                   *cli.Context
+	ctx                      context.Context
+	cancel                   context.CancelFunc
+	services                 *runtime.ServiceRegistry
+	lock                     sync.RWMutex
+	stop                     chan struct{} // Channel to wait for termination notifications.
+	db                       db.Database
+	slasherDB                db.SlasherDatabase
+	attestationCache         *cache.AttestationCache
+	attestationPool          attestations.Pool
+	payloadAttestationPool   payloadattestation.PoolManager
+	exitPool                 voluntaryexits.PoolManager
+	slashingsPool            slashings.PoolManager
+	syncCommitteePool        synccommittee.Pool
+	blsToExecPool            blstoexec.PoolManager
+	depositCache             cache.DepositCache
+	trackedValidatorsCache   *cache.TrackedValidatorsCache
+	proposerPreferencesCache *cache.ProposerPreferencesCache
+	payloadIDCache           *cache.PayloadIDCache
+	stateFeed                *event.Feed
+	blockFeed                *event.Feed
+	opFeed                   *event.Feed
+	stateGen                 *stategen.State
+	collector                *bcnodeCollector
+	slasherBlockHeadersFeed  *event.Feed
+	slasherAttestationsFeed  *event.Feed
+	finalizedStateAtStartUp  state.BeaconState
+	serviceFlagOpts          *serviceFlagOpts
+	GenesisProviders         []genesis.Provider
+	CheckpointInitializer    checkpoint.Initializer
+	forkChoicer              forkchoice.ForkChoicer
+	ClockWaiter              startup.ClockWaiter
+	BackfillOpts             []backfill.ServiceOption
+	initialSyncComplete      chan struct{}
+	BlobStorage              *filesystem.BlobStorage
+	BlobStorageOptions       []filesystem.BlobStorageOption
+	DataColumnStorage        *filesystem.DataColumnStorage
+	DataColumnStorageOptions []filesystem.DataColumnStorageOption
+	verifyInitWaiter         *verification.InitializerWaiter
+	lhsp                     *verification.LazyHeadStateProvider
+	syncChecker              *initialsync.SyncChecker
+	slasherEnabled           bool
+	lcStore                  *lightclient.Store
+	ConfigOptions            []params.Option
+	SyncNeedsWaiter          func() (das.SyncNeeds, error)
 }
 
 // New creates a new node instance, sets up configuration options, and registers
@@ -175,15 +174,14 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, optFuncs []func(*cli.Co
 		// proposerPreferencesCache should remain separate. The tracked
 		// validators cache is local-node specific, while proposer preferences
 		// are global and include proposers we do not own.
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-		payloadIDCache:                  cache.NewPayloadIDCache(),
-		slasherBlockHeadersFeed:         new(event.Feed),
-		slasherAttestationsFeed:         new(event.Feed),
-		serviceFlagOpts:                 &serviceFlagOpts{},
-		initialSyncComplete:             make(chan struct{}),
-		syncChecker:                     &initialsync.SyncChecker{},
-		slasherEnabled:                  cliCtx.Bool(flags.SlasherFlag.Name),
+		proposerPreferencesCache: cache.NewProposerPreferencesCache(),
+		payloadIDCache:           cache.NewPayloadIDCache(),
+		slasherBlockHeadersFeed:  new(event.Feed),
+		slasherAttestationsFeed:  new(event.Feed),
+		serviceFlagOpts:          &serviceFlagOpts{},
+		initialSyncComplete:      make(chan struct{}),
+		syncChecker:              &initialsync.SyncChecker{},
+		slasherEnabled:           cliCtx.Bool(flags.SlasherFlag.Name),
 	}
 
 	for _, opt := range opts {
@@ -872,7 +870,6 @@ func (b *BeaconNode) registerSyncService(initialSyncComplete chan struct{}, bFil
 		regularsync.WithAvailableBlocker(bFillStore),
 		regularsync.WithTrackedValidatorsCache(b.trackedValidatorsCache),
 		regularsync.WithProposerPreferencesCache(b.proposerPreferencesCache),
-		regularsync.WithHighestExecutionPayloadBidCache(b.highestExecutionPayloadBidCache),
 		regularsync.WithSlasherEnabled(b.slasherEnabled),
 		regularsync.WithLightClientStore(b.lcStore),
 		regularsync.WithBatchVerifierLimit(b.cliCtx.Int(flags.BatchVerifierLimit.Name)),
@@ -953,6 +950,11 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		return err
 	}
 
+	var regularSyncService *regularsync.Service
+	if err := b.services.FetchService(&regularSyncService); err != nil {
+		return err
+	}
+
 	var slasherService *slasher.Service
 	if b.slasherEnabled {
 		if err := b.services.FetchService(&slasherService); err != nil {
@@ -1030,7 +1032,7 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		DataColumnStorage:                b.DataColumnStorage,
 		TrackedValidatorsCache:           b.trackedValidatorsCache,
 		ProposerPreferencesCache:         b.proposerPreferencesCache,
-		HighestBidCache:                  b.highestExecutionPayloadBidCache,
+		HighestBidCache:                  regularSyncService.HighestExecutionPayloadBidCache(),
 		PayloadIDCache:                   b.payloadIDCache,
 		LCStore:                          b.lcStore,
 		GraffitiInfo:                     web3Service.GraffitiInfo(),

--- a/beacon-chain/sync/options.go
+++ b/beacon-chain/sync/options.go
@@ -222,13 +222,6 @@ func WithProposerPreferencesCache(c *cache.ProposerPreferencesCache) Option {
 	}
 }
 
-func WithHighestExecutionPayloadBidCache(c *cache.HighestExecutionPayloadBidCache) Option {
-	return func(s *Service) error {
-		s.highestExecutionPayloadBidCache = c
-		return nil
-	}
-}
-
 func WithPayloadAttestationPool(pool payloadattestation.PoolManager) Option {
 	return func(s *Service) error {
 		s.cfg.payloadAttestationPool = pool

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -395,6 +395,12 @@ func (s *Service) Status() error {
 	return nil
 }
 
+// HighestExecutionPayloadBidCache exposes sync's cache to the proposer RPC.
+// Sync is the sole writer (gossip); the proposer is a reader.
+func (s *Service) HighestExecutionPayloadBidCache() *cache.HighestExecutionPayloadBidCache {
+	return s.highestExecutionPayloadBidCache
+}
+
 // This initializes the caches to update seen beacon objects coming in from the wire
 // and prevent DoS.
 func (s *Service) initCaches() {

--- a/changelog/terence_fix-sync-highest-bid-cache-sharing.md
+++ b/changelog/terence_fix-sync-highest-bid-cache-sharing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Make sync own the highest execution payload bid cache and expose it to the proposer RPC so gossip writes and proposer reads hit the same instance.


### PR DESCRIPTION
  - Sync now owns the highest execution payload bid cache and exposes it via an accessor. RPC reads from the running sync service.
  - Removes the duplicate cache field on BeaconNode and the WithHighestExecutionPayloadBidCache option so gossip writes and proposer reads can't desync.
