### PR TITLE
Harden execution payload envelope nil checks

### DIFF
--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -374,6 +374,29 @@ func TestQueuePendingPayloadEnvelope_DoesNotOverwrite(t *testing.T) {
 	require.Equal(t, first, s.pendingPayloadEnvelopes[root][1])
 }
 
+func TestQueuePendingPayloadEnvelope_PrunesMalformedExistingEnvelope(t *testing.T) {
+	ctx := context.Background()
+	s, _, _, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
+
+	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{
+		1: {Signature: bytes.Repeat([]byte{0xAA}, 96)},
+	}
+
+	blockHash := [32]byte{0x02}
+	next := testSignedExecutionPayloadEnvelope(t, 1, 1, root, blockHash)
+	e, err := blocks.WrappedROSignedExecutionPayloadEnvelope(next)
+	require.NoError(t, err)
+	env, err := e.Envelope()
+	require.NoError(t, err)
+
+	v := &mockExecutionPayloadEnvelopeVerifier{}
+	result, err := s.queuePendingPayloadEnvelope(ctx, v, env, next)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+	require.Equal(t, 1, len(s.pendingPayloadEnvelopes[root]))
+	require.Equal(t, next, s.pendingPayloadEnvelopes[root][1])
+}
+
 func TestQueuePendingPayloadEnvelope_RootCountBound(t *testing.T) {
 	ctx := context.Background()
 	s, _, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
@@ -134,6 +134,28 @@ func TestValidateEnvelopesByRange(t *testing.T) {
 	}
 }
 
+func TestValidateExecutionPayloadEnvelopeByRangeResponseRejectsMalformedEnvelope(t *testing.T) {
+	req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 5, Count: 1}
+
+	t.Run("nil message", func(t *testing.T) {
+		env := testSignedEnvelope(5, make([]byte, 32))
+		env.Message = nil
+
+		_, _, err := validateExecutionPayloadEnvelopeByRangeResponse(env, req, 0, nil, false)
+		require.NotNil(t, err)
+		assert.ErrorContains(t, "invalid execution payload envelope", err)
+	})
+
+	t.Run("nil payload", func(t *testing.T) {
+		env := testSignedEnvelope(5, make([]byte, 32))
+		env.Message.Payload = nil
+
+		_, _, err := validateExecutionPayloadEnvelopeByRangeResponse(env, req, 0, nil, false)
+		require.NotNil(t, err)
+		assert.ErrorContains(t, "invalid execution payload envelope", err)
+	})
+}
+
 // ---------------------------------------------------------------------------
 // executionPayloadEnvelopesByRangeRPCHandler (server handler)
 // ---------------------------------------------------------------------------

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -968,26 +968,39 @@ func SendExecutionPayloadEnvelopesByRangeRequest(
 		if i == max {
 			return nil, errMaxRequestEnvelopesExceeded
 		}
-		// Validate slot is within requested range.
-		envSlot := primitives.Slot(env.Message.Payload.SlotNumber)
-		endSlot := req.StartSlot.Add(req.Count)
-		if envSlot < req.StartSlot || envSlot >= endSlot {
-			return nil, errors.Wrapf(ErrInvalidFetchedData, "envelope slot %d outside requested range [%d, %d)", envSlot, req.StartSlot, endSlot)
+		envSlot, blockHash, err := validateExecutionPayloadEnvelopeByRangeResponse(env, req, prevSlot, prevHash, i > 0)
+		if err != nil {
+			return nil, err
 		}
-		// Validate slots are strictly increasing.
-		if i > 0 && envSlot <= prevSlot {
-			return nil, errors.Wrapf(ErrInvalidFetchedData, "envelope slot %d not greater than previous slot %d", envSlot, prevSlot)
-		}
-		// Validate the hash chain
-		if len(prevHash) != 0 {
-			if !bytes.Equal(env.Message.Payload.ParentHash, prevHash) {
-				return nil, errors.Wrapf(ErrInvalidFetchedData, "envelope parent hash %x does not match previous hash %x", env.Message.Payload.ParentHash, prevHash)
-			}
-		}
-		prevHash = env.Message.Payload.BlockHash
+		prevHash = blockHash
 		prevSlot = envSlot
 		envelopes = append(envelopes, env)
 	}
 
 	return envelopes, nil
+}
+
+func validateExecutionPayloadEnvelopeByRangeResponse(
+	env *ethpb.SignedExecutionPayloadEnvelope,
+	req *ethpb.ExecutionPayloadEnvelopesByRangeRequest,
+	prevSlot primitives.Slot,
+	prevHash []byte,
+	hasPrevious bool,
+) (primitives.Slot, []byte, error) {
+	if _, err := blocks.WrappedROSignedExecutionPayloadEnvelope(env); err != nil {
+		return 0, nil, errors.Wrap(ErrInvalidFetchedData, "invalid execution payload envelope")
+	}
+
+	envSlot := primitives.Slot(env.Message.Payload.SlotNumber)
+	endSlot := req.StartSlot.Add(req.Count)
+	if envSlot < req.StartSlot || envSlot >= endSlot {
+		return 0, nil, errors.Wrapf(ErrInvalidFetchedData, "envelope slot %d outside requested range [%d, %d)", envSlot, req.StartSlot, endSlot)
+	}
+	if hasPrevious && envSlot <= prevSlot {
+		return 0, nil, errors.Wrapf(ErrInvalidFetchedData, "envelope slot %d not greater than previous slot %d", envSlot, prevSlot)
+	}
+	if len(prevHash) != 0 && !bytes.Equal(env.Message.Payload.ParentHash, prevHash) {
+		return 0, nil, errors.Wrapf(ErrInvalidFetchedData, "envelope parent hash %x does not match previous hash %x", env.Message.Payload.ParentHash, prevHash)
+	}
+	return envSlot, env.Message.Payload.BlockHash, nil
 }

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -162,6 +162,9 @@ func (s *Service) queuePendingPayloadEnvelope(
 	builderIdx := uint64(env.BuilderIndex())
 	isSelfBuild := builderIdx == uint64(params.BeaconConfig().BuilderIndexSelfBuild)
 	root := env.BeaconBlockRoot()
+	if signedEnvelope == nil || signedEnvelope.Message == nil || signedEnvelope.Message.Payload == nil {
+		return pubsub.ValidationIgnore, errNilMessage
+	}
 	s.pendingEnvelopeLock.Lock()
 	defer s.pendingEnvelopeLock.Unlock()
 	inner, rootExists := s.pendingPayloadEnvelopes[root]
@@ -197,7 +200,12 @@ func (s *Service) queuePendingPayloadEnvelope(
 		inner = make(map[uint64]*ethpb.SignedExecutionPayloadEnvelope)
 		s.pendingPayloadEnvelopes[root] = inner
 	} else {
-		for _, existing := range inner {
+		for existingBuilderIdx, existing := range inner {
+			if existing == nil || existing.Message == nil || existing.Message.Payload == nil {
+				delete(inner, existingBuilderIdx)
+				log.Debug("Removed malformed pending payload envelope")
+				continue
+			}
 			if existing.Message.Payload.SlotNumber != signedEnvelope.Message.Payload.SlotNumber {
 				log.Debug("Ignoring payload envelope with mismatched slot")
 				return pubsub.ValidationIgnore, nil

--- a/changelog/terence_execution-payload-envelope-nil-checks.md
+++ b/changelog/terence_execution-payload-envelope-nil-checks.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Harden execution payload envelope nil checks in gossip and RPC handling.

--- a/consensus-types/blocks/execution_payload_envelope.go
+++ b/consensus-types/blocks/execution_payload_envelope.go
@@ -57,6 +57,9 @@ func (s signedExecutionPayloadEnvelope) IsNil() bool {
 	if len(s.s.Signature) != field_params.BLSSignatureLength {
 		return true
 	}
+	if s.s.Message == nil {
+		return true
+	}
 	if len(s.s.Message.BeaconBlockRoot) != field_params.RootLength {
 		return true
 	}

--- a/consensus-types/blocks/execution_payload_envelope_test.go
+++ b/consensus-types/blocks/execution_payload_envelope_test.go
@@ -107,6 +107,14 @@ func TestWrappedROSignedExecutionPayloadEnvelope(t *testing.T) {
 		require.Equal(t, consensus_types.ErrNilObjectWrapped, err)
 	})
 
+	t.Run("returns error on nil message", func(t *testing.T) {
+		signed := &ethpb.SignedExecutionPayloadEnvelope{
+			Signature: bytes.Repeat([]byte{0xAA}, 96),
+		}
+		_, err := blocks.WrappedROSignedExecutionPayloadEnvelope(signed)
+		require.Equal(t, consensus_types.ErrNilObjectWrapped, err)
+	})
+
 	t.Run("wraps and provides envelope/signing data", func(t *testing.T) {
 		sig := bytes.Repeat([]byte{0xAB}, 96)
 		signed := &ethpb.SignedExecutionPayloadEnvelope{


### PR DESCRIPTION
Added nil checks to sync/rpc paths for payload envelope that were previously missed