### PR TITLE
`getFCUArgs`: Add early return for forkchoice update arguments in non-regular sync.

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -42,11 +42,15 @@ func (s *Service) CurrentSlot() primitives.Slot {
 // getFCUArgs returns the arguments to call forkchoice update
 // this function is only called pre-gloas hence we pass in full to getPayloadAttribute
 func (s *Service) getFCUArgs(cfg *postBlockProcessConfig) (*fcuConfig, error) {
-
 	fcuArgs, err := s.getFCUArgsEarlyBlock(cfg)
 	if err != nil {
 		return nil, err
 	}
+
+	if !s.inRegularSync() {
+		return fcuArgs, nil
+	}
+
 	fcuArgs.attributes = s.getPayloadAttribute(cfg.ctx, fcuArgs.headState, fcuArgs.proposingSlot, cfg.headRoot[:], true)
 	return fcuArgs, nil
 }

--- a/changelog/manu_fcu_args_skip_attributes_non_regular_sync.md
+++ b/changelog/manu_fcu_args_skip_attributes_non_regular_sync.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `getFCUArgs`: skip payload attribute computation when not in regular sync, since the FCU is never sent to the engine in that case.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
We skip payload attribute computation during initial sync, since the FCU is never sent to the engine in that case, and because payload attribute computation can take a lot of time.

**Which issues(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/16714

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
