### PR TITLE
Fixed missed first attestation for newly-activated validators when the validator client runs with `--enable-beacon-rest-api`.

### DIFF
--- a/changelog/nalepa_fix-rest-api-first-attestation.md
+++ b/changelog/nalepa_fix-rest-api-first-attestation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed missed first attestation for newly-activated validators when the validator client runs with `--enable-beacon-rest-api`.

--- a/validator/client/beacon-api/duties.go
+++ b/validator/client/beacon-api/duties.go
@@ -13,7 +13,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
-	"github.com/OffchainLabs/prysm/v7/consensus-types/validator"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
@@ -366,8 +365,7 @@ func (c *beaconApiValidatorClient) validatorsForDuties(ctx context.Context, pubk
 		stringPubkeys[i] = stringPk
 	}
 
-	statusesWithDuties := []string{validator.ActiveOngoing.String(), validator.ActiveExiting.String()}
-	stateValidatorsResponse, err := c.stateValidatorsProvider.StateValidators(ctx, stringPubkeys, nil, statusesWithDuties)
+	stateValidatorsResponse, err := c.stateValidatorsProvider.StateValidators(ctx, stringPubkeys, nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get state validators")
 	}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**Which issues(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/16723
- https://github.com/OffchainLabs/prysm/issues/16759 (issue added **after** the fix was already done)

**Other notes for review**
The reproduction steps are in the linked issue.

After the fix:
<img width="1524" height="766" alt="image" src="https://github.com/user-attachments/assets/1b3ee2e3-c257-4d48-ba56-82e8791ee9b5" />

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
