### PR TITLE
Reduce chain service processing time at epoch transition

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -182,15 +182,8 @@ func (s *Service) updateCheckpoints(
 	preState, postState state.BeaconState,
 	blockRoot [32]byte,
 ) error {
-	if coreTime.CurrentEpoch(postState) > cp.c && s.cfg.ForkChoiceStore.IsCanonical(blockRoot) {
-		headSt, err := s.HeadState(ctx)
-		if err != nil {
-			return errors.Wrap(err, "could not get head state")
-		}
-		if err := reportEpochMetrics(ctx, postState, headSt); err != nil {
-			log.WithError(err).Error("Could not report epoch metrics")
-		}
-	}
+	s.reportEpochMetrics(postState, cp.c, blockRoot)
+
 	if err := s.updateJustificationOnBlock(ctx, preState, postState, cp.j); err != nil {
 		return errors.Wrap(err, "could not update justified checkpoint")
 	}
@@ -205,6 +198,24 @@ func (s *Service) updateCheckpoints(
 		s.executePostFinalizationTasks(ctx, postState)
 	}
 	return nil
+}
+
+func (s *Service) reportEpochMetrics(postState state.BeaconState, prevEpoch primitives.Epoch, blockRoot [32]byte) {
+	if coreTime.CurrentEpoch(postState) <= prevEpoch || !s.cfg.ForkChoiceStore.IsCanonical(blockRoot) {
+		return
+	}
+
+	go func() {
+		headSt, err := s.HeadState(s.ctx)
+		if err != nil {
+			log.WithError(err).Error("Could not get head state for epoch metrics")
+			return
+		}
+
+		if err := reportEpochMetrics(s.ctx, postState, headSt); err != nil {
+			log.WithError(err).Error("Could not report epoch metrics")
+		}
+	}()
 }
 
 func (s *Service) validateExecutionAndConsensus(

--- a/changelog/manu_report_epoch_metrics_async.md
+++ b/changelog/manu_report_epoch_metrics_async.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `reportEpochMetrics`: run asynchronously on the epoch boundary.


### PR DESCRIPTION
**What type of PR is this?**
Optimisation

**What does this PR do? Why is it needed?**
During epoch transition, reporting epoch metrics is done in the critical path.
Until these metrics are reported, the block cannot be imported.
Any validator client asking for an attestation won't get the processed block until epoch metrics are reported.

The issue is epoch metrics reporting function iterates all over the validator set (2.4M validators on mainnet), which takes time.
==> This epoch metrics reporting can cause the block to be imported **after** the 4 seconds into the slot limit.
As a consequence, the validator won't vote for the correct head, and won't get the head reward.

This pull request runs the epoch metrics reporting function async.

**Before:** See the corresponding issue.
**After:**

<img width="956" height="307" alt="image" src="https://github.com/user-attachments/assets/8efa3d85-f717-47c2-9eea-04eb6e9bf083" />

In the 37 epochs during the 4H that are represented, 3 of them have a block synced more than 4 seconds into the slot (8%), which is quite a nice improvement compared to before this PR (see the corresponding issue).


**Chain service processing time comparison:**
- Before: yellow
- After: green

<img width="948" height="305" alt="image" src="https://github.com/user-attachments/assets/50d99699-072d-4fcf-a83e-17795f7516f7" />


Peaks at epoch transitions are considerably reduced.

**Which issues(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/16730

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
