### PR TITLE
remove saving states to hotStateDB in stateDiff mode

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -508,8 +508,14 @@ func (s *Service) markIncludedBlockBLSToExecChanges(headBlock interfaces.ReadOnl
 
 // This checks whether it's time to start saving hot state to DB.
 // It's time when there's `epochsSinceFinalitySaveHotStateDB` epochs of non-finality.
+//
+//	If state-diff is enabled, we will not save hot states to DB regardless of finality status.
+//
 // Requires a read lock on forkchoice
 func (s *Service) checkSaveHotStateDB(ctx context.Context) error {
+	if features.Get().EnableStateDiff {
+		return s.cfg.StateGen.DisableSaveHotStateToDB(ctx)
+	}
 	currentEpoch := slots.ToEpoch(s.CurrentSlot())
 	// Prevent `sinceFinality` going underflow.
 	var sinceFinality primitives.Epoch

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
-	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -48,22 +47,10 @@ func (s *State) ForceCheckpoint(ctx context.Context, blockRoot []byte) error {
 
 // This saves a post beacon state. On the epoch boundary,
 // it saves a full state. On an intermediate slot, it saves a back pointer to the
-// nearest epoch boundary state.
+// nearest epoch boundary state. If state-diff mode is enabled, it skips saving to hot state db.
 func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, st state.BeaconState) error {
 	ctx, span := trace.StartSpan(ctx, "stateGen.saveStateByRoot")
 	defer span.End()
-
-	// When state-diff is enabled, persist states that land on diff-tree
-	// boundaries unconditionally. The DB's SaveState dispatches to
-	// saveStateByDiff which no-ops for non-boundary slots, so this is
-	// safe to call on every slot. This bounds restart replay to the
-	// finest diff-tree granularity (~32 slots) instead of the entire
-	// finalized-to-head gap.
-	if features.Get().EnableStateDiff {
-		if err := s.beaconDB.SaveState(ctx, st, blockRoot); err != nil {
-			return err
-		}
-	}
 
 	// Duration can't be 0 to prevent panic for division.
 	duration := uint64(max(float64(s.saveHotStateDB.duration), 1))

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -3,11 +3,8 @@ package stategen
 import (
 	"testing"
 
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/kv"
 	testDB "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
-	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
-	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -232,63 +229,4 @@ func TestEnableSaveHotStateToDB_AlreadyDisabled(t *testing.T) {
 	require.NoError(t, service.DisableSaveHotStateToDB(ctx))
 	require.LogsDoNotContain(t, hook, "Exiting mode to save hot states in DB")
 	require.Equal(t, false, service.saveHotStateDB.enabled)
-}
-
-// TestSaveState_StateDiff_SavesAtDiffTreeBoundary verifies that when
-// --enable-state-diff is active, saveStateByRoot persists hot states at
-// diff-tree boundary slots to the DB even when saveHotStateDB is disabled.
-// This caps the worst-case replay on restart to the finest diff-tree
-// granularity (2^5 = 32 slots by default) instead of the entire
-// finalized-to-head gap.
-func TestSaveState_StateDiff_SavesAtDiffTreeBoundary(t *testing.T) {
-	ctx := t.Context()
-	// Use small exponents [6, 5] => level 0 every 64 slots, level 1 every 32 slots.
-	globalFlags := flags.GlobalFlags{StateDiffExponents: []int{6, 5}}
-	flags.Init(&globalFlags)
-
-	beaconDB := testDB.SetupDB(t)
-	require.NoError(t, beaconDB.(*kv.Store).InitStateDiffCacheForTesting(t, 0))
-	resetCfg := features.InitWithReset(&features.Flags{EnableStateDiff: true})
-	defer resetCfg()
-
-	service := New(beaconDB, doublylinkedtree.New())
-	// Explicitly verify saveHotStateDB is NOT enabled — this is the normal
-	// initial-sync condition. The point is that diff-tree saves should happen
-	// regardless.
-	require.Equal(t, false, service.saveHotStateDB.enabled)
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	// Slot 64 lands on a level-0 boundary (2^6 = 64). It should be saved.
-	require.NoError(t, beaconState.SetSlot(64))
-	r := [32]byte{'D'}
-	require.NoError(t, service.saveStateByRoot(ctx, r, beaconState))
-
-	assert.Equal(t, true, beaconDB.HasState(ctx, r),
-		"State at diff-tree boundary slot should be persisted to DB when state-diff is enabled")
-}
-
-// TestSaveState_StateDiff_SkipsNonBoundary verifies that when
-// --enable-state-diff is active, saveStateByRoot does NOT persist states
-// at slots that are not on any diff-tree boundary.
-func TestSaveState_StateDiff_SkipsNonBoundary(t *testing.T) {
-	ctx := t.Context()
-	globalFlags := flags.GlobalFlags{StateDiffExponents: []int{6, 5}}
-	flags.Init(&globalFlags)
-
-	beaconDB := testDB.SetupDB(t)
-	require.NoError(t, beaconDB.(*kv.Store).InitStateDiffCacheForTesting(t, 0))
-	resetCfg := features.InitWithReset(&features.Flags{EnableStateDiff: true})
-	defer resetCfg()
-
-	service := New(beaconDB, doublylinkedtree.New())
-	require.Equal(t, false, service.saveHotStateDB.enabled)
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	// Slot 50 is NOT on any diff-tree boundary (not divisible by 32 or 64).
-	require.NoError(t, beaconState.SetSlot(50))
-	r := [32]byte{'E'}
-	require.NoError(t, service.saveStateByRoot(ctx, r, beaconState))
-
-	assert.Equal(t, false, beaconDB.HasState(ctx, r),
-		"State at non-boundary slot should NOT be persisted to DB")
 }

--- a/changelog/bastin_state-diff-no-hotstate-db.md
+++ b/changelog/bastin_state-diff-no-hotstate-db.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- remove the call to save states in hotStateDB when in state diff mode.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
There was a bug in state-diff code path that calls `stateGen.SaveState()` (which calls `beaconDB.SaveState()`) on every received block. This was done to act as the state-diff version of saving to hot state DB. So the idea was that instead of every n slots, we should just call `SaveState` and it will only save the states that fall in the tree. 

This is problematic, specially since it was being done not only after 100 epochs of non finality, but without condition. so we would save every newly received (non finalized) state to db. which in itself is not a good thing.

The bigger problem it creates is this:
when a slot that falls in the tree is missed, the `SaveState` is never called so we don't save it in db. but when the next eligible slot comes, and we want to save it, it's anchor doesn't exist and we throw errors.

look at this kurtosis run:

normal kurtosis run with these changes:
- add `--enable-state-diff` and `--state-diff-exponents=6,5` to `cl_extra_params`.
- make your validator miss slot 64: add this: `|| slot == 64` to the if check in `validator/client/propose.go:L46`

when slot 64 is missed, nothing special happens in the beacon node. 
<img width="660" height="47" alt="Screenshot 2026-04-30 at 6 32 39 PM" src="https://github.com/user-attachments/assets/50bb2355-5699-45d0-8d9b-84098d3311b3" />
the problem comes when we get to slot 96, which needs slot 64 as its anchor in the diff tree. we get a cache mismatch, because anchorCache hasn't been updated, because we didn't save slot 64.

```
[2026-04-30 16:20:21.09]  WARN db: Cached state-diff anchor slot mismatch; reloading anchor from database cachedSlot=0 expectedSlot=64 level=0
[2026-04-30 16:20:21.09]  WARN blockchain: Rolling back insertion of block with root 0xc14bc92c7febbb2c548ab639915f8df563d691ee27540b9c0e5a421c150908f8 due to processing error
```
and slot 96 is counted as missed:
<img width="676" height="45" alt="Screenshot 2026-04-30 at 6 39 23 PM" src="https://github.com/user-attachments/assets/ae0e5cfd-2776-4de9-ac83-18b93219b81e" />


This will happen for every slot that depends on 64 or 96 as its anchor, or any subsequent slot. and depending on the state diff exponents, this could hurt the beacon node.

 ---

The fix:

We need to remove the call to `SaveState()` for every newly received slot. we should only have `migrateToCold` have control of saving states, because that's the place that can reconstruct the missing nodes in the tree. 

I also changed `checkSaveHotStateDB()` to return early if state diff is enabled and disable `hotStateDB`. because this won't help, and it makes things complicated like the example above. and we should fix the unfinalized part of state diff in a future attempt. 