### PR TITLE
Use head aware state for payload attestation processing

### DIFF
--- a/beacon-chain/blockchain/receive_payload_attestation_message.go
+++ b/beacon-chain/blockchain/receive_payload_attestation_message.go
@@ -1,10 +1,15 @@
 package blockchain
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -14,6 +19,7 @@ import (
 // validated payload attestation messages.
 type PayloadAttestationReceiver interface {
 	ReceivePayloadAttestationMessage(context.Context, *ethpb.PayloadAttestationMessage) error
+	PtcLookupState(ctx context.Context, blockRoot [32]byte, blockSlot primitives.Slot) (state.ReadOnlyBeaconState, error)
 }
 
 // ReceivePayloadAttestationMessage accepts a payload attestation message and updates the
@@ -24,9 +30,12 @@ func (s *Service) ReceivePayloadAttestationMessage(ctx context.Context, a *ethpb
 	}
 	root := bytesutil.ToBytes32(a.Data.BeaconBlockRoot)
 
-	st, err := s.HeadStateReadOnly(ctx)
+	st, err := s.PtcLookupState(ctx, root, a.Data.Slot)
 	if err != nil {
 		return err
+	}
+	if st == nil {
+		return errors.New("unable to find state for payload attestation")
 	}
 	idx, err := gloas.PayloadCommitteeIndex(ctx, st, a.Data.Slot, a.ValidatorIndex)
 	if err != nil {
@@ -36,4 +45,42 @@ func (s *Service) ReceivePayloadAttestationMessage(ctx context.Context, a *ethpb
 	defer s.cfg.ForkChoiceStore.Unlock()
 	s.cfg.ForkChoiceStore.SetPTCVote(root, idx, a.Data.PayloadPresent, a.Data.BlobDataAvailable)
 	return nil
+}
+
+func (s *Service) PtcLookupState(ctx context.Context, blockRoot [32]byte, blockSlot primitives.Slot) (state.ReadOnlyBeaconState, error) {
+	blockEpoch := slots.ToEpoch(blockSlot)
+	headEpoch := slots.ToEpoch(s.HeadSlot())
+	headRoot, err := s.HeadRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	blockDependent, err := s.DependentRootForEpoch(blockRoot, blockEpoch)
+	if err != nil {
+		return nil, err
+	}
+
+	if blockEpoch == headEpoch {
+		if bytes.Equal(blockRoot[:], headRoot) {
+			return s.HeadStateReadOnly(ctx)
+		}
+		headDependent, err := s.DependentRootForEpoch(bytesutil.ToBytes32(headRoot), blockEpoch)
+		if err != nil {
+			return nil, err
+		}
+		if bytes.Equal(headDependent[:], blockDependent[:]) {
+			return s.HeadStateReadOnly(ctx)
+		}
+	}
+	if bytes.Equal(blockDependent[:], headRoot) {
+		headState, err := s.HeadState(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, blockSlot)
+	}
+	if st := s.cfg.StateGen.StateByRootIfCachedNoCopy(blockRoot); st != nil && slots.ToEpoch(st.Slot()) == blockEpoch {
+		return st, nil
+	}
+	return nil, nil
 }

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -851,6 +851,14 @@ func (c *ChainService) ReceivePayloadAttestationMessage(_ context.Context, _ *et
 	return nil
 }
 
+// PtcLookupState implements the same method in the chain service.
+func (c *ChainService) PtcLookupState(_ context.Context, _ [32]byte, _ primitives.Slot) (state.ReadOnlyBeaconState, error) {
+	if c.State == nil {
+		return nil, nil
+	}
+	return c.State, nil
+}
+
 // ReceiveExecutionPayloadEnvelope implements the same method in the chain service.
 func (c *ChainService) ReceiveExecutionPayloadEnvelope(_ context.Context, _ interfaces.ROSignedExecutionPayloadEnvelope) error {
 	return nil

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation.go
@@ -7,6 +7,7 @@ import (
 	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
@@ -118,9 +119,13 @@ func (vs *Server) SubmitPayloadAttestation(
 }
 
 func (vs *Server) payloadAttestationCommitteeIndex(ctx context.Context, msg *ethpb.PayloadAttestationMessage) (uint64, error) {
-	st, err := vs.HeadFetcher.HeadStateReadOnly(ctx)
+	root := bytesutil.ToBytes32(msg.Data.BeaconBlockRoot)
+	st, err := vs.PayloadAttestationReceiver.PtcLookupState(ctx, root, msg.Data.Slot)
 	if err != nil {
 		return 0, err
+	}
+	if st == nil {
+		return 0, status.Errorf(codes.Unavailable, "unable to find state for payload attestation")
 	}
 	return gloas.PayloadCommitteeIndex(ctx, st, msg.Data.Slot, msg.ValidatorIndex)
 }

--- a/beacon-chain/sync/validate_payload_attestation.go
+++ b/beacon-chain/sync/validate_payload_attestation.go
@@ -1,15 +1,11 @@
 package sync
 
 import (
-	"bytes"
 	"context"
 
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	payloadattestation "github.com/OffchainLabs/prysm/v7/consensus-types/payload-attestation"
-	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	prysmTime "github.com/OffchainLabs/prysm/v7/time"
@@ -75,9 +71,12 @@ func (s *Service) validatePayloadAttestation(ctx context.Context, pid peer.ID, m
 		return pubsub.ValidationReject, err
 	}
 
-	st, err := s.getPtcState(ctx, pa)
+	st, err := s.cfg.chain.PtcLookupState(ctx, pa.BeaconBlockRoot(), pa.Slot())
 	if err != nil {
 		return pubsub.ValidationIgnore, err
+	}
+	if st == nil {
+		return pubsub.ValidationIgnore, errors.New("unable to find state for payload attestation")
 	}
 
 	// [REJECT] The message's validator index is within the payload committee in get_ptc(state, data.slot).
@@ -100,40 +99,4 @@ func (s *Service) validatePayloadAttestation(ctx context.Context, pid peer.ID, m
 	}
 
 	return pubsub.ValidationAccept, nil
-}
-
-func (s *Service) getPtcState(ctx context.Context, pa payloadattestation.ROMessage) (state.ReadOnlyBeaconState, error) {
-	blockRoot := pa.BeaconBlockRoot()
-	blockSlot := pa.Slot()
-	blockEpoch := slots.ToEpoch(blockSlot)
-	headSlot := s.cfg.chain.HeadSlot()
-	headEpoch := slots.ToEpoch(headSlot)
-	headRoot, err := s.cfg.chain.HeadRoot(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if blockEpoch == headEpoch {
-		if bytes.Equal(blockRoot[:], headRoot) {
-			return s.cfg.chain.HeadStateReadOnly(ctx)
-		}
-
-		headDependent, err := s.cfg.chain.DependentRootForEpoch(bytesutil.ToBytes32(headRoot), blockEpoch)
-		if err != nil {
-			return nil, err
-		}
-		blockDependent, err := s.cfg.chain.DependentRootForEpoch(blockRoot, blockEpoch)
-		if err != nil {
-			return nil, err
-		}
-		if bytes.Equal(headDependent[:], blockDependent[:]) {
-			return s.cfg.chain.HeadStateReadOnly(ctx)
-		}
-	}
-
-	headState, err := s.cfg.chain.HeadState(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, blockSlot)
 }

--- a/beacon-chain/sync/validate_payload_attestation_test.go
+++ b/beacon-chain/sync/validate_payload_attestation_test.go
@@ -98,7 +98,9 @@ func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
 		t.Run(tt.error.Error(), func(t *testing.T) {
 			ctx := context.Background()
 			p := p2ptest.NewTestP2P(t)
-			chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+			st, err := util.NewBeaconState()
+			require.NoError(t, err)
+			chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
 			s := &Service{
 				payloadAttestationCache: &cache.PayloadAttestationCache{},
 				cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
@@ -106,7 +108,7 @@ func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
 
 			msg := newPayloadAttestationMessage()
 			buf := new(bytes.Buffer)
-			_, err := p.Encoding().EncodeGossip(buf, msg)
+			_, err = p.Encoding().EncodeGossip(buf, msg)
 			require.NoError(t, err)
 
 			topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
@@ -129,7 +131,9 @@ func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
 func TestValidatePayloadAttestationMessage_Accept(t *testing.T) {
 	ctx := context.Background()
 	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+	st, err := util.NewBeaconState()
+	require.NoError(t, err)
+	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
 	s := &Service{
 		payloadAttestationCache: &cache.PayloadAttestationCache{},
 		cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
@@ -139,7 +143,7 @@ func TestValidatePayloadAttestationMessage_Accept(t *testing.T) {
 
 	msg := newPayloadAttestationMessage()
 	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
+	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]

--- a/changelog/terence_ptc-state-cache-fallback.md
+++ b/changelog/terence_ptc-state-cache-fallback.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use the right state for payload attestation processing, with a no-copy hot-cache fallback for cross-fork blocks.


### PR DESCRIPTION
- Add `PtcLookupState` so PTC verification, forkchoice votes, and `SubmitPayloadAttestation` use a state correct for the attested block, not just head
- Fall back to no-copy hot-cache state-by-root (same-epoch guard) when head can't resolve
