### PR TITLE
Re-broadcast pending payload envelopes after processing

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -68,6 +68,7 @@ type ChainService struct {
 	Genesis                     time.Time
 	ForkChoiceStore             forkchoice.ForkChoicer
 	ReceiveBlockMockErr         error
+	ReceivePayloadEnvelopeErr   error
 	OptimisticCheckRootReceived [32]byte
 	FinalizedRoots              map[[32]byte]bool
 	OptimisticRoots             map[[32]byte]bool
@@ -853,7 +854,7 @@ func (c *ChainService) ReceivePayloadAttestationMessage(_ context.Context, _ *et
 
 // ReceiveExecutionPayloadEnvelope implements the same method in the chain service.
 func (c *ChainService) ReceiveExecutionPayloadEnvelope(_ context.Context, _ interfaces.ROSignedExecutionPayloadEnvelope) error {
-	return nil
+	return c.ReceivePayloadEnvelopeErr
 }
 
 // ParentPayloadReady mocks the same method in the chain service.

--- a/beacon-chain/sync/pending_payload_envelope.go
+++ b/beacon-chain/sync/pending_payload_envelope.go
@@ -58,8 +58,13 @@ func (s *Service) processPendingPayloadEnvelope(ctx context.Context, root [32]by
 			continue
 		}
 		s.setSeenPayloadEnvelope(root, env.BuilderIndex())
+
 		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(ctx, e); err != nil {
 			log.WithError(err).Debug("Could not process pending payload envelope")
+			continue
+		}
+		if err := s.cfg.p2p.Broadcast(ctx, signedEnvelope); err != nil {
+			log.WithError(err).Warn("Could not broadcast pending payload envelope")
 		}
 	}
 }

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -9,6 +9,7 @@ import (
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
+	p2ptesting "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stategen"
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
@@ -78,6 +79,7 @@ func TestProcessPendingPayloadEnvelope_HappyPath(t *testing.T) {
 		DB:                  db,
 	}
 	stateGen := stategen.New(db, doublylinkedtree.New())
+	broadcaster := p2ptesting.NewTestP2P(t)
 	s := &Service{
 		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
 		seenPayloadEnvelopeCache: lruwrpr.New(10),
@@ -87,6 +89,7 @@ func TestProcessPendingPayloadEnvelope_HappyPath(t *testing.T) {
 			beaconDB: db,
 			stateGen: stateGen,
 			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			p2p:      broadcaster,
 		},
 	}
 
@@ -113,6 +116,49 @@ func TestProcessPendingPayloadEnvelope_HappyPath(t *testing.T) {
 	s.processPendingPayloadEnvelope(ctx, root)
 	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
 	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
+}
+
+func TestProcessPendingPayloadEnvelope_DoesNotBroadcastOnReceiveError(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.SetupDB(t)
+	chainService := &mock.ChainService{
+		Genesis:                   time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+		FinalizedCheckPoint:       &ethpb.Checkpoint{},
+		DB:                        db,
+		ReceivePayloadEnvelopeErr: errors.New("receive failed"),
+	}
+	stateGen := stategen.New(db, doublylinkedtree.New())
+	broadcaster := p2ptesting.NewTestP2P(t)
+	s := &Service{
+		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+		seenPayloadEnvelopeCache: lruwrpr.New(10),
+		badBlockCache:            lruwrpr.New(10),
+		cfg: &config{
+			chain:    chainService,
+			beaconDB: db,
+			stateGen: stateGen,
+			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			p2p:      broadcaster,
+		},
+	}
+
+	bid := util.GenerateTestSignedExecutionPayloadBid(1)
+	sb := util.NewBeaconBlockGloas()
+	sb.Block.Slot = 1
+	sb.Block.Body.SignedExecutionPayloadBid = bid
+	signedBlock, err := blocks.NewSignedBeaconBlock(sb)
+	require.NoError(t, err)
+	root, err := signedBlock.Block().HashTreeRoot()
+	require.NoError(t, err)
+
+	builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
+	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
+	env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
+	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
+
+	s.processPendingPayloadEnvelope(ctx, root)
+	require.Equal(t, false, broadcaster.BroadcastCalled.Load())
 }
 
 func TestProcessPendingPayloadEnvelopes_Sweep(t *testing.T) {
@@ -133,6 +179,7 @@ func TestProcessPendingPayloadEnvelopes_Sweep(t *testing.T) {
 			beaconDB: db,
 			stateGen: stateGen,
 			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			p2p:      p2ptesting.NewTestP2P(t),
 		},
 	}
 

--- a/changelog/terence_broadcast-pending-payload-envelope.md
+++ b/changelog/terence_broadcast-pending-payload-envelope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Re-broadcast pending payload envelopes after they are successfully processed.


### PR DESCRIPTION
When finishing with the pending payload envelope queue, broadcast each envelope after `ReceiveExecutionPayloadEnvelope` succeeds so peers that missed the original gossip can still receive it