### PR TITLE
Request payload envelope when pending block's parent payload mi…

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -143,6 +143,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 				continue
 			}
 			if !s.cfg.chain.ParentPayloadReady(b.Block()) {
+				go s.requestPayloadEnvelope(parentRoot)
 				continue
 			}
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -193,6 +193,7 @@ type Service struct {
 	newExecutionPayloadBidVerifier       verification.NewExecutionPayloadBidVerifier
 	columnSidecarsExecSingleFlight       singleflight.Group
 	reconstructionSingleFlight           singleflight.Group
+	payloadEnvelopeRequestSingleFlight   singleflight.Group
 	availableBlocker                     coverage.AvailableBlocker
 	reconstructionRandGen                *rand.Rand
 	trackedValidatorsCache               *cache.TrackedValidatorsCache

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain"
 	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
@@ -73,39 +74,64 @@ func (s *Service) validateExecutionPayloadBidParentValid(_ context.Context, blk 
 	return pubsub.ValidationAccept, nil
 }
 
-// requestPayloadEnvelope asks a random peer for the execution payload
-// envelope identified by root and feeds any response through
-// ReceiveExecutionPayloadEnvelope.
 func (s *Service) requestPayloadEnvelope(root [32]byte) {
+	if s.cfg.chain.HasFullNode(root) || s.hasBadPayload(root) {
+		return
+	}
+	key := fmt.Sprintf("%#x", root)
+	_, _, _ = s.payloadEnvelopeRequestSingleFlight.Do(key, func() (any, error) {
+		s.fetchPayloadEnvelope(root)
+		return nil, nil
+	})
+}
+
+const maxPayloadEnvelopeFetchAttempts = 3
+
+func (s *Service) fetchPayloadEnvelope(root [32]byte) {
 	bestPeers := s.getBestPeers()
 	if len(bestPeers) == 0 {
 		return
 	}
-	pid := bestPeers[rand.NewGenerator().Int()%len(bestPeers)]
+	gen := rand.NewGenerator()
+	gen.Shuffle(len(bestPeers), func(i, j int) { bestPeers[i], bestPeers[j] = bestPeers[j], bestPeers[i] })
+	if len(bestPeers) > maxPayloadEnvelopeFetchAttempts {
+		bestPeers = bestPeers[:maxPayloadEnvelopeFetchAttempts]
+	}
 	req := p2ptypes.ExecutionPayloadEnvelopesByRootReq{root}
-	envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(s.ctx, s.cfg.clock, s.cfg.p2p, pid, s.ctxMap, &req)
-	if err != nil {
-		log.WithError(err).Debug("Could not request payload envelope by root")
-		return
-	}
-	if len(envelopes) == 0 {
-		log.Debug("No payload envelopes returned by peer")
-		return
-	}
-	if len(envelopes) > 1 {
-		log.Warn("Multiple payload envelopes returned by peer, expected at most one")
-	}
-	for _, env := range envelopes {
-		wrapped, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(env)
+	for _, pid := range bestPeers {
+		if s.cfg.chain.HasFullNode(root) {
+			return
+		}
+		envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(s.ctx, s.cfg.clock, s.cfg.p2p, pid, s.ctxMap, &req)
 		if err != nil {
-			log.WithError(err).Debug("Could not wrap requested payload envelope")
+			log.WithError(err).WithField("peer", pid).Debug("Could not request payload envelope by root")
 			continue
 		}
-		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(s.ctx, wrapped); err != nil {
-			if blockchain.IsInvalidBlock(err) {
-				s.setBadPayload(s.ctx, root)
+		if len(envelopes) == 0 {
+			continue
+		}
+		if len(envelopes) > 1 {
+			log.Warn("Multiple payload envelopes returned by peer, expected at most one")
+		}
+		processed := false
+		for _, env := range envelopes {
+			wrapped, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(env)
+			if err != nil {
+				log.WithError(err).Debug("Could not wrap requested payload envelope")
+				continue
 			}
-			log.WithError(err).Debug("Could not process requested payload envelope")
+			if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(s.ctx, wrapped); err != nil {
+				if blockchain.IsInvalidBlock(err) {
+					s.setBadPayload(s.ctx, root)
+					return
+				}
+				log.WithError(err).Debug("Could not process requested payload envelope")
+				continue
+			}
+			processed = true
+		}
+		if processed {
+			return
 		}
 	}
 }

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -110,28 +110,19 @@ func (s *Service) fetchPayloadEnvelope(root [32]byte) {
 		if len(envelopes) == 0 {
 			continue
 		}
-		if len(envelopes) > 1 {
-			log.Warn("Multiple payload envelopes returned by peer, expected at most one")
+		wrapped, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(envelopes[0])
+		if err != nil {
+			log.WithError(err).Debug("Could not wrap requested payload envelope")
+			continue
 		}
-		processed := false
-		for _, env := range envelopes {
-			wrapped, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(env)
-			if err != nil {
-				log.WithError(err).Debug("Could not wrap requested payload envelope")
-				continue
+		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(s.ctx, wrapped); err != nil {
+			if blockchain.IsInvalidBlock(err) {
+				s.setBadPayload(s.ctx, root)
+				return
 			}
-			if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(s.ctx, wrapped); err != nil {
-				if blockchain.IsInvalidBlock(err) {
-					s.setBadPayload(s.ctx, root)
-					return
-				}
-				log.WithError(err).Debug("Could not process requested payload envelope")
-				continue
-			}
-			processed = true
+			log.WithError(err).Debug("Could not process requested payload envelope")
+			continue
 		}
-		if processed {
-			return
-		}
+		return
 	}
 }

--- a/beacon-chain/sync/validate_beacon_block_gloas_test.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas_test.go
@@ -164,3 +164,37 @@ func TestValidateExecutionPayloadBidParentValid_Reject(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, pubsub.ValidationReject, res)
 }
+
+func TestRequestPayloadEnvelope_SkipsWhenAlreadyResolved(t *testing.T) {
+	root := [32]byte{0x42}
+
+	tests := []struct {
+		name  string
+		setup func(*Service)
+	}{
+		{
+			name: "already have full node",
+			setup: func(s *Service) {
+				s.cfg.chain = &mock.ChainService{ForkchoiceRoots: map[[32]byte]bool{root: true}}
+			},
+		},
+		{
+			name: "payload marked bad",
+			setup: func(s *Service) {
+				s.cfg.chain = &mock.ChainService{}
+				s.badPayloadCache.Add(string(root[:]), true)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// p2p is nil — getBestPeers would panic if the guards don't short-circuit.
+			s := &Service{
+				cfg:             &config{},
+				badPayloadCache: lruwrpr.New(10),
+			}
+			tt.setup(s)
+			require.NotPanics(t, func() { s.requestPayloadEnvelope(root) })
+		})
+	}
+}

--- a/changelog/terence_request-pending-payload-envelope.md
+++ b/changelog/terence_request-pending-payload-envelope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Request execution payload envelope from peers when a pending block's parent payload is not ready.


### PR DESCRIPTION
Request payload over pending block queue so if we miss it original, we dont get stuck
As for request we added a singleflight dedupes, up to 3 shuffled peers; skip if already have full node or bad payload.