### PR TITLE
Drain pending blocks when payload envelope arrives

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -248,6 +248,13 @@ func (s *Service) executionPayloadEnvelopeSubscriber(ctx context.Context, msg pr
 		}
 		return err
 	}
+	if s.chainIsStarted() {
+		go func() {
+			if err := s.processPendingBlocks(s.ctx); err != nil {
+				log.WithError(err).Debug("Could not process pending blocks after envelope receipt")
+			}
+		}()
+	}
 	return nil
 }
 

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/async/abool"
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
@@ -140,7 +141,8 @@ func TestExecutionPayloadEnvelopeSubscriber_WrongMessage(t *testing.T) {
 
 func TestExecutionPayloadEnvelopeSubscriber_HappyPath(t *testing.T) {
 	s := &Service{
-		cfg: &config{chain: &mock.ChainService{}},
+		cfg:          &config{chain: &mock.ChainService{}},
+		chainStarted: abool.New(),
 	}
 	root := [32]byte{0x01}
 	blockHash := [32]byte{0x02}

--- a/changelog/terence_drain-pending-on-payload-envelope.md
+++ b/changelog/terence_drain-pending-on-payload-envelope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Drain pending blocks immediately after a payload envelope is received.


### PR DESCRIPTION
When an execution payload envelope arrives, kick the existing pending-blocks drain instead of waiting up to ~1/3 slot for the next ticker. Children whose `ParentPayloadReady` gate just flipped now process immediately