### PR TITLE
Apply parent execution payload before building block

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -198,54 +198,58 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 		}
 	}
 
-	// Set eth1 data.
-	eth1Data, err := vs.eth1DataMajorityVote(ctx, head)
-	if err != nil {
-		eth1Data = &ethpb.Eth1Data{DepositRoot: params.BeaconConfig().ZeroHash[:], BlockHash: params.BeaconConfig().ZeroHash[:]}
-		log.WithError(err).Error("Could not get eth1data")
-	}
-	sBlk.SetEth1Data(eth1Data)
-
-	// Set deposit and attestation.
-	deposits, atts, err := vs.packDepositsAndAttestations(ctx, head, sBlk.Block().Slot(), eth1Data) // TODO: split attestations and deposits
-	if err != nil {
-		sBlk.SetDeposits([]*ethpb.Deposit{})
-		if err := sBlk.SetAttestations([]ethpb.Att{}); err != nil {
-			log.WithError(err).Error("Could not set attestations on block")
+	// Build consensus fields in background
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		// Set eth1 data.
+		eth1Data, err := vs.eth1DataMajorityVote(ctx, head)
+		if err != nil {
+			eth1Data = &ethpb.Eth1Data{DepositRoot: params.BeaconConfig().ZeroHash[:], BlockHash: params.BeaconConfig().ZeroHash[:]}
+			log.WithError(err).Error("Could not get eth1data")
 		}
-		log.WithError(err).Error("Could not pack deposits and attestations")
-	} else {
-		sBlk.SetDeposits(deposits)
-		if err := sBlk.SetAttestations(atts); err != nil {
-			log.WithError(err).Error("Could not set attestations on block")
+		sBlk.SetEth1Data(eth1Data)
+
+		// Set deposit and attestation.
+		deposits, atts, err := vs.packDepositsAndAttestations(ctx, head, sBlk.Block().Slot(), eth1Data) // TODO: split attestations and deposits
+		if err != nil {
+			sBlk.SetDeposits([]*ethpb.Deposit{})
+			if err := sBlk.SetAttestations([]ethpb.Att{}); err != nil {
+				log.WithError(err).Error("Could not set attestations on block")
+			}
+			log.WithError(err).Error("Could not pack deposits and attestations")
+		} else {
+			sBlk.SetDeposits(deposits)
+			if err := sBlk.SetAttestations(atts); err != nil {
+				log.WithError(err).Error("Could not set attestations on block")
+			}
 		}
-	}
 
-	// Set slashings.
-	validProposerSlashings, validAttSlashings := vs.getSlashings(ctx, head)
-	sBlk.SetProposerSlashings(validProposerSlashings)
-	if err := sBlk.SetAttesterSlashings(validAttSlashings); err != nil {
-		log.WithError(err).Error("Could not set attester slashings on block")
-	}
-
-	// Set exits.
-	sBlk.SetVoluntaryExits(vs.getExits(head, sBlk.Block().Slot()))
-
-	// Set sync aggregate. New in Altair.
-	vs.setSyncAggregate(ctx, sBlk, head)
-
-	// Set bls to execution change. New in Capella.
-	vs.setBlsToExecData(sBlk, head)
-
-	// Set payload attestations. New in Gloas.
-	if sBlk.Version() >= version.Gloas {
-		if err := sBlk.SetPayloadAttestations(vs.getPayloadAttestations(ctx, head, sBlk.Block().ParentRoot())); err != nil {
-			log.WithError(err).Error("Could not set payload attestations")
+		// Set slashings.
+		validProposerSlashings, validAttSlashings := vs.getSlashings(ctx, head)
+		sBlk.SetProposerSlashings(validProposerSlashings)
+		if err := sBlk.SetAttesterSlashings(validAttSlashings); err != nil {
+			log.WithError(err).Error("Could not set attester slashings on block")
 		}
-		if err := vs.setParentExecutionRequests(ctx, sBlk, head, parentFull); err != nil {
-			log.WithError(err).Error("Could not set parent execution requests")
+
+		// Set exits.
+		sBlk.SetVoluntaryExits(vs.getExits(head, sBlk.Block().Slot()))
+
+		// Set sync aggregate. New in Altair.
+		vs.setSyncAggregate(ctx, sBlk, head)
+
+		// Set bls to execution change. New in Capella.
+		vs.setBlsToExecData(sBlk, head)
+
+		// Set payload attestations. New in Gloas.
+		if sBlk.Version() >= version.Gloas {
+			if err := sBlk.SetPayloadAttestations(vs.getPayloadAttestations(ctx, head, sBlk.Block().ParentRoot())); err != nil {
+				log.WithError(err).Error("Could not set payload attestations")
+			}
+			if err := vs.setParentExecutionRequests(ctx, sBlk, head, parentFull); err != nil {
+				log.WithError(err).Error("Could not set parent execution requests")
+			}
 		}
-	}
+	})
 
 	winningBid := primitives.ZeroWei()
 	selfBuildEnvelope := true
@@ -286,6 +290,8 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 			}
 		}
 	}
+
+	wg.Wait()
 
 	sr, _, err := vs.computePostBlockStateAndRoot(ctx, sBlk)
 	if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -192,58 +192,60 @@ func (vs *Server) getParentState(ctx context.Context, slot primitives.Slot) (sta
 }
 
 func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, skipMevBoost bool, builderBoostFactor primitives.Gwei, parentFull bool) (*ethpb.GenericBeaconBlock, error) {
-	// Build consensus fields in background
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		// Set eth1 data.
-		eth1Data, err := vs.eth1DataMajorityVote(ctx, head)
-		if err != nil {
-			eth1Data = &ethpb.Eth1Data{DepositRoot: params.BeaconConfig().ZeroHash[:], BlockHash: params.BeaconConfig().ZeroHash[:]}
-			log.WithError(err).Error("Could not get eth1data")
+	if sBlk.Version() >= version.Gloas && parentFull {
+		if err := vs.applyParentExecutionPayloadToHead(ctx, head, sBlk.Block().ParentRoot()); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not apply parent execution payload: %v", err)
 		}
-		sBlk.SetEth1Data(eth1Data)
+	}
 
-		// Set deposit and attestation.
-		deposits, atts, err := vs.packDepositsAndAttestations(ctx, head, sBlk.Block().Slot(), eth1Data) // TODO: split attestations and deposits
-		if err != nil {
-			sBlk.SetDeposits([]*ethpb.Deposit{})
-			if err := sBlk.SetAttestations([]ethpb.Att{}); err != nil {
-				log.WithError(err).Error("Could not set attestations on block")
-			}
-			log.WithError(err).Error("Could not pack deposits and attestations")
-		} else {
-			sBlk.SetDeposits(deposits)
-			if err := sBlk.SetAttestations(atts); err != nil {
-				log.WithError(err).Error("Could not set attestations on block")
-			}
+	// Set eth1 data.
+	eth1Data, err := vs.eth1DataMajorityVote(ctx, head)
+	if err != nil {
+		eth1Data = &ethpb.Eth1Data{DepositRoot: params.BeaconConfig().ZeroHash[:], BlockHash: params.BeaconConfig().ZeroHash[:]}
+		log.WithError(err).Error("Could not get eth1data")
+	}
+	sBlk.SetEth1Data(eth1Data)
+
+	// Set deposit and attestation.
+	deposits, atts, err := vs.packDepositsAndAttestations(ctx, head, sBlk.Block().Slot(), eth1Data) // TODO: split attestations and deposits
+	if err != nil {
+		sBlk.SetDeposits([]*ethpb.Deposit{})
+		if err := sBlk.SetAttestations([]ethpb.Att{}); err != nil {
+			log.WithError(err).Error("Could not set attestations on block")
 		}
-
-		// Set slashings.
-		validProposerSlashings, validAttSlashings := vs.getSlashings(ctx, head)
-		sBlk.SetProposerSlashings(validProposerSlashings)
-		if err := sBlk.SetAttesterSlashings(validAttSlashings); err != nil {
-			log.WithError(err).Error("Could not set attester slashings on block")
+		log.WithError(err).Error("Could not pack deposits and attestations")
+	} else {
+		sBlk.SetDeposits(deposits)
+		if err := sBlk.SetAttestations(atts); err != nil {
+			log.WithError(err).Error("Could not set attestations on block")
 		}
+	}
 
-		// Set exits.
-		sBlk.SetVoluntaryExits(vs.getExits(head, sBlk.Block().Slot()))
+	// Set slashings.
+	validProposerSlashings, validAttSlashings := vs.getSlashings(ctx, head)
+	sBlk.SetProposerSlashings(validProposerSlashings)
+	if err := sBlk.SetAttesterSlashings(validAttSlashings); err != nil {
+		log.WithError(err).Error("Could not set attester slashings on block")
+	}
 
-		// Set sync aggregate. New in Altair.
-		vs.setSyncAggregate(ctx, sBlk, head)
+	// Set exits.
+	sBlk.SetVoluntaryExits(vs.getExits(head, sBlk.Block().Slot()))
 
-		// Set bls to execution change. New in Capella.
-		vs.setBlsToExecData(sBlk, head)
+	// Set sync aggregate. New in Altair.
+	vs.setSyncAggregate(ctx, sBlk, head)
 
-		// Set payload attestations. New in Gloas.
-		if sBlk.Version() >= version.Gloas {
-			if err := sBlk.SetPayloadAttestations(vs.getPayloadAttestations(ctx, head, sBlk.Block().ParentRoot())); err != nil {
-				log.WithError(err).Error("Could not set payload attestations")
-			}
-			if err := vs.setParentExecutionRequests(ctx, sBlk, head, parentFull); err != nil {
-				log.WithError(err).Error("Could not set parent execution requests")
-			}
+	// Set bls to execution change. New in Capella.
+	vs.setBlsToExecData(sBlk, head)
+
+	// Set payload attestations. New in Gloas.
+	if sBlk.Version() >= version.Gloas {
+		if err := sBlk.SetPayloadAttestations(vs.getPayloadAttestations(ctx, head, sBlk.Block().ParentRoot())); err != nil {
+			log.WithError(err).Error("Could not set payload attestations")
 		}
-	})
+		if err := vs.setParentExecutionRequests(ctx, sBlk, head, parentFull); err != nil {
+			log.WithError(err).Error("Could not set parent execution requests")
+		}
+	}
 
 	winningBid := primitives.ZeroWei()
 	selfBuildEnvelope := true
@@ -284,8 +286,6 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 			}
 		}
 	}
-
-	wg.Wait()
 
 	sr, _, err := vs.computePostBlockStateAndRoot(ctx, sBlk)
 	if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -140,7 +140,7 @@ func (vs *Server) getLocalPayloadFromEngine(
 	var attr payloadattribute.Attributer
 	switch {
 	case st.Version() >= version.Gloas:
-		withdrawals, err := vs.computePayloadWithdrawals(ctx, st, parentRoot, parentFull)
+		withdrawals, err := vs.computePayloadWithdrawals(st, parentFull)
 		if err != nil {
 			return nil, err
 		}
@@ -285,29 +285,34 @@ var (
 )
 
 // computePayloadWithdrawals returns the withdrawals for the next payload.
-func (vs *Server) computePayloadWithdrawals(ctx context.Context, st state.BeaconState, parentRoot [32]byte, parentFull bool) ([]*enginev1.Withdrawal, error) {
+func (vs *Server) computePayloadWithdrawals(st state.BeaconState, parentFull bool) ([]*enginev1.Withdrawal, error) {
 	if !parentFull {
 		return st.PayloadExpectedWithdrawals()
-	}
-	parentSlot, err := vs.ForkchoiceFetcher.RecentBlockSlot(parentRoot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get parent block slot")
-	}
-	if slots.ToEpoch(parentSlot) >= params.BeaconConfig().GloasForkEpoch {
-		// TODO: replace DB lookup with a single-entry cache (blockroot → envelope).
-		envelope, err := vs.BeaconDB.ExecutionPayloadEnvelope(ctx, parentRoot)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get parent execution payload envelope")
-		}
-		if err := coregloas.ApplyParentExecutionPayload(ctx, st, envelope.Message.ExecutionRequests); err != nil {
-			return nil, errors.Wrap(err, "could not apply parent execution payload")
-		}
 	}
 	result, err := st.ExpectedWithdrawalsGloas()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compute expected withdrawals")
 	}
 	return result.Withdrawals, nil
+}
+
+func (vs *Server) applyParentExecutionPayloadToHead(ctx context.Context, head state.BeaconState, parentRoot [32]byte) error {
+	parentSlot, err := vs.ForkchoiceFetcher.RecentBlockSlot(parentRoot)
+	if err != nil {
+		return errors.Wrap(err, "could not get parent block slot")
+	}
+	if slots.ToEpoch(parentSlot) < params.BeaconConfig().GloasForkEpoch {
+		return nil
+	}
+	// TODO: replace DB lookup with a single-entry cache (blockroot → envelope).
+	envelope, err := vs.BeaconDB.ExecutionPayloadEnvelope(ctx, parentRoot)
+	if err != nil {
+		return errors.Wrap(err, "could not get parent execution payload envelope")
+	}
+	if err := coregloas.ApplyParentExecutionPayload(ctx, head, envelope.Message.ExecutionRequests); err != nil {
+		return errors.Wrap(err, "could not apply parent execution payload")
+	}
+	return nil
 }
 
 // getParentBlockHash retrieves the parent block hash of the block at the given slot.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
@@ -228,6 +228,20 @@ func TestServer_getParentBlockHash_Gloas_Empty(t *testing.T) {
 	require.DeepEqual(t, parentBlockHash[:], got)
 }
 
+func TestServer_applyParentExecutionPayloadToHead_PreGloas(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 1
+	params.OverrideBeaconConfig(cfg)
+
+	st, err := util.NewBeaconStateGloas()
+	require.NoError(t, err)
+
+	chain := &chainMock.ChainService{BlockSlot: 0}
+	vs := &Server{ForkchoiceFetcher: chain}
+	require.NoError(t, vs.applyParentExecutionPayloadToHead(context.Background(), st, [32]byte{}))
+}
+
 func TestServer_getExecutionPayloadContextTimeout(t *testing.T) {
 	beaconDB := dbTest.SetupDB(t)
 	nonTransitionSt, _ := util.DeterministicGenesisStateBellatrix(t, 1)

--- a/changelog/terence_apply-parent-payload-before-block-build.md
+++ b/changelog/terence_apply-parent-payload-before-block-build.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Apply parent execution payload to head state before building consensus fields in the proposer.


### PR DESCRIPTION
- Move `ApplyParentExecutionPayload` out of `computePayloadWithdrawals` into a new `applyParentExecutionPayloadToHead` step that runs at the start of `BuildBlockParallel` for Gloas blocks with a full parent, sequencing the head-state mutation before consensus construction reads it
- Drop the parallel `WaitGroup` in `BuildBlockParallel` so consensus fields (eth1, deposits, attestations, slashings, exits, sync aggregate, BLS-to-exec, payload attestations, parent execution requests) are built sequentially
