### PR TITLE
boundary slot check for state diff cache

### DIFF
--- a/beacon-chain/db/kv/state_diff_helpers.go
+++ b/beacon-chain/db/kv/state_diff_helpers.go
@@ -261,6 +261,11 @@ func (s *Store) initializeStateDiff(slot primitives.Slot, initialState state.Rea
 	if !features.Get().EnableStateDiff {
 		return nil
 	}
+
+	if slot%32 != 0 {
+		return errors.New("cannot initialize state diff with a non epoch boundary offset")
+	}
+
 	// Only reinitialize if the offset is different
 	if s.stateDiffCache != nil {
 		if s.stateDiffCache.getOffset() == uint64(slot) {

--- a/beacon-chain/db/kv/wss_test.go
+++ b/beacon-chain/db/kv/wss_test.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/genesis"
@@ -47,4 +48,38 @@ func TestSaveOrigin(t *testing.T) {
 	broot, err := scb.Block().HashTreeRoot()
 	require.NoError(t, err)
 	require.Equal(t, true, db.IsFinalizedBlock(ctx, broot))
+}
+
+func TestSaveOrigin_StateDiffNonEpochBoundarySlot(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	params.OverrideBeaconConfig(params.MainnetConfig())
+	resetCfg := features.InitWithReset(&features.Flags{EnableStateDiff: true})
+	defer resetCfg()
+	setDefaultStateDiffExponents()
+
+	ctx := t.Context()
+	db := setupDB(t)
+
+	require.NoError(t, genesis.Initialize(ctx, t.TempDir()))
+
+	st, err := genesis.State()
+	require.NoError(t, err)
+
+	sb, err := st.MarshalSSZ()
+	require.NoError(t, err)
+	require.NoError(t, db.LoadGenesis(ctx, sb))
+	require.NoError(t, db.EnsureEmbeddedGenesis(ctx))
+
+	cst, err := util.NewBeaconState()
+	require.NoError(t, err)
+	require.NoError(t, cst.SetSlot(31))
+	csb, err := cst.MarshalSSZ()
+	require.NoError(t, err)
+	cb := util.NewBeaconBlock()
+	cb.Block.Slot = 31
+	scb, err := blocks.NewSignedBeaconBlock(cb)
+	require.NoError(t, err)
+	cbb, err := scb.MarshalSSZ()
+	require.NoError(t, err)
+	require.ErrorContains(t, "non epoch boundary offset", db.SaveOrigin(ctx, csb, cbb))
 }

--- a/changelog/bastin_statediff-offset-boundary.md
+++ b/changelog/bastin_statediff-offset-boundary.md
@@ -1,0 +1,3 @@
+### Changed
+
+- state diff cache won't be initialized with a non epoch boundary offset.


### PR DESCRIPTION
Adding a check that prevents state diff cache to be initialized with an offset that is not divisible by 32. 
This prevents problems and complications that arise between the state diff db and the epoch boundary cache.