### PR TITLE
Reuse deposit trie root in `ProcessDepositLog`

### DIFF
--- a/beacon-chain/execution/log_processing.go
+++ b/beacon-chain/execution/log_processing.go
@@ -174,10 +174,6 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog *gethtypes.L
 	validData := true
 	if !s.chainStartData.Chainstarted {
 		s.chainStartData.ChainstartDeposits = append(s.chainStartData.ChainstartDeposits, deposit)
-		root, err := s.depositTrie.HashTreeRoot()
-		if err != nil {
-			return errors.Wrap(err, "unable to determine root of deposit trie")
-		}
 		eth1Data := &ethpb.Eth1Data{
 			DepositRoot:  root[:],
 			DepositCount: uint64(len(s.chainStartData.ChainstartDeposits)),
@@ -187,10 +183,6 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog *gethtypes.L
 			validData = false
 		}
 	} else {
-		root, err := s.depositTrie.HashTreeRoot()
-		if err != nil {
-			return errors.Wrap(err, "unable to determine root of deposit trie")
-		}
 		s.cfg.depositCache.InsertPendingDeposit(ctx, deposit, depositLog.BlockNumber, index, root)
 	}
 	if validData {


### PR DESCRIPTION
Was looking at deposit log processing and noticed `ProcessDepositLog` calls `HashTreeRoot()` twice on the same unchanged trie state — once before `InsertDeposit`, then again in the chainstart/pending branch. `getRoot` walks the tree recursively, so we pay that hash cost twice per log for no reason. Just keep the `root` from the first call and use it in both branches.