### PR TITLE
Strip stack trace from Downscore peer log reason field

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -556,7 +556,7 @@ func dedupPeers(peers []peer.ID) []peer.ID {
 // downscorePeer increments the bad responses score for the peer and logs the event.
 func (f *blocksFetcher) downscorePeer(peerID peer.ID, reason error) {
 	newScore := f.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason, "newScore": newScore}).Debug("Downscore peer")
+	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason.Error(), "newScore": newScore}).Debug("Downscore peer")
 }
 
 // findFirstForkIndex returns the index of the first block with a version >= v.

--- a/changelog/terence_fix-downscore-log-stacktrace.md
+++ b/changelog/terence_fix-downscore-log-stacktrace.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Strip pkg/errors stack traces from the `reason` field of initial-sync `Downscore peer` debug logs.


### PR DESCRIPTION
## Summary

- The `reason` argument to `(*blocksFetcher).downscorePeer` is an `error`, and logrus's `WithFields` ends up formatting it via pkg/errors' `Format` method, which dumps the full call stack on `%+v`.
- Result: the `reason` field in the `Downscore peer` debug log gets polluted with a multi-line goroutine stack trace concatenated after the actual reason string, making logs nearly unreadable.
- One-line fix: pass `reason.Error()` to keep just the message.

Before:
```
DEBUG initial-sync: Downscore peer newScore=7 peerID=... reason=invalid data returned from peergithub.com/OffchainLabs/prysm/v7/beacon-chain/sync.init<autogenerated>:1runtime.doInit1GOROOT/src/runtime/proc.go:7656runtime.doInitGOROOT/src/runtime/proc.go:7623...
```

After:
```
DEBUG initial-sync: Downscore peer newScore=7 peerID=... reason="invalid data returned from peer"
```