### PR TITLE
Use forwarding peer ID when queuing deferred Gloas data columns

### DIFF
--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -86,7 +86,7 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 
 	var verifiedRODataColumn blocks.VerifiedRODataColumn
 	if slots.ToEpoch(roDataColumn.Slot()) >= params.BeaconConfig().GloasForkEpoch {
-		verifiedRODataColumn, err = s.validateDataColumnGloas(ctx, msg, roDataColumn, dataColumnSidecarSubTopic)
+		verifiedRODataColumn, err = s.validateDataColumnGloas(ctx, pid, msg, roDataColumn, dataColumnSidecarSubTopic)
 		if err != nil {
 			return validationResultFromError(err), baseValidationErr(err)
 		}

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -37,6 +37,7 @@ type pendingGloasEntry struct {
 
 func (s *Service) validateDataColumnGloas(
 	ctx context.Context,
+	pid peer.ID,
 	msg *pubsub.Message,
 	roDataColumn blocks.RODataColumn,
 	dataColumnSidecarSubTopic string,
@@ -53,7 +54,7 @@ func (s *Service) validateDataColumnGloas(
 		if msg.Topic == nil || !strings.Contains(*msg.Topic+"/", expectedSubTopic) {
 			return blocks.VerifiedRODataColumn{}, errors.New("gloas data column on wrong subnet")
 		}
-		s.queuePendingGloasColumn(roDataColumn, peer.ID(msg.GetFrom()))
+		s.queuePendingGloasColumn(roDataColumn, pid)
 		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.New("gloas data column block not yet seen"))
 	}
 

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -121,6 +121,14 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		result, err := service.validateDataColumn(ctx, "aDummyPID", message)
 		require.ErrorContains(t, "gloas data column block not yet seen", err)
 		require.Equal(t, pubsub.ValidationIgnore, result)
+
+		// The queued entry must record the forwarding peer (`pid`), not msg.From which
+		// is empty under StrictNoSign/WithNoAuthor and would no-op the bad-response scorer.
+		blockRoot := bytesutil.ToBytes32(sidecar.BeaconBlockRoot)
+		entry := service.pendingGloasColumns[blockRoot]
+		require.NotNil(t, entry)
+		require.NotNil(t, entry.columns[sidecar.Index])
+		require.Equal(t, peer.ID("aDummyPID"), entry.columns[sidecar.Index].peer)
 	})
 
 	t.Run("validates against bid commitments", func(t *testing.T) {
@@ -186,7 +194,7 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		topic := service.addDigestAndIndexToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.DataColumnSidecarGloas]()], digest, peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index))
 		msg := &pubsub.Message{Message: &pb.Message{Topic: &topic}}
 
-		_, err = service.validateDataColumnGloas(ctx, msg, roDataColumn, "/data_column_sidecar_%d/")
+		_, err = service.validateDataColumnGloas(ctx, "aDummyPID", msg, roDataColumn, "/data_column_sidecar_%d/")
 		require.ErrorContains(t, "slot does not match block slot", err)
 	})
 }

--- a/changelog/satushh_fix-gloas-pending-column-peer-id.md
+++ b/changelog/satushh_fix-gloas-pending-column-peer-id.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Pass the forwarding peer ID into `queuePendingGloasColumn` so deferred Gloas data column failures actually downscore the sender. `msg.GetFrom()` is empty under Prysm's `StrictNoSign`/`WithNoAuthor` pubsub config, which made the bad-response increment a no-op.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Pass the forwarding peer ID into `queuePendingGloasColumn` so deferred Gloas data column failures actually downscore the sender. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
