### PR TITLE
Double the global per peer rpc rate limit

### DIFF
--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -108,7 +108,7 @@ func newRateLimiter(p2pProvider p2p.P2P) *limiter {
 	topicMap[addEncoding(p2p.RPCExecutionPayloadEnvelopesByRangeTopicV1)] = envelopeCollector
 
 	// General topic for all rpc requests.
-	topicMap[rpcLimiterTopic] = leakybucket.NewCollector(5, defaultBurstLimit*2, leakyBucketPeriod, false /* deleteEmptyBuckets */)
+	topicMap[rpcLimiterTopic] = leakybucket.NewCollector(10, defaultBurstLimit*4, leakyBucketPeriod, false /* deleteEmptyBuckets */)
 
 	return &limiter{limiterMap: topicMap, p2p: p2pProvider}
 }

--- a/beacon-chain/sync/rate_limiter_test.go
+++ b/beacon-chain/sync/rate_limiter_test.go
@@ -85,7 +85,7 @@ func TestRateLimiter_ExceedRawCapacity(t *testing.T) {
 	stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), protocol.ID(topic))
 	require.NoError(t, err, "could not create stream")
 
-	for range 2 * defaultBurstLimit {
+	for range 4 * defaultBurstLimit {
 		err = rlimiter.validateRawRpcRequest(stream, 1)
 		rlimiter.addRawStream(stream)
 		require.NoError(t, err, "could not validate incoming request")

--- a/changelog/terence_raise-rpc-global-rate-limit.md
+++ b/changelog/terence_raise-rpc-global-rate-limit.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Double the global per-peer RPC rate limit (5 → 10 req/s, burst 10 → 20).


### PR DESCRIPTION
  #### Summary

  The `rpcLimiterTopic` collector caps total RPC requests per peer across all topics combined. Every incoming req/resp message hits this limiter in addition to its per-protocol cap. The current 5 req/s, burst 10 was set when Prysm's rate limiter was first introduced and never revisited, it is the strictest global per-peer cap in the ecosystem across all the clients. This PR doubles it to 10 req/s, burst 20. Per-protocol limits 

  #### Why
  In practice a peer's normal sync traffic, status + ping + metadata + a couple of range requests in the same second, easily exceeds 10 requests, even before considering bursty block-by-range or envelope-by-range traffic. The result is constant `ErrRateLimited` responses to spec compliant peers

  The cap was unjustifiably tight relative to the rest of the implementations:
  | client | global per-peer cap | per-protocol notes |
  |---|---|---|
  | Lighthouse | **none** (per-protocol only) | BlocksByRange: 128 tokens / 10s |
  | Lodestar | **none** (per-protocol only, design copied from Lighthouse) | BlocksByRange: `MAX_REQUEST_BLOCKS_DENEB` / 10s |
  | Nimbus | ~8 req/s sustained, 40 burst (single global bucket) | no separate per-protocol limits |
  | **Prysm (today)** | **5 req/s, burst 10** | per-protocol limits also enforced |
  | **Prysm (after the pr)** | **10 req/s, burst 20** | per-protocol limits also enforced |

  Doubling keeps the cap conservative but still stricter than Nimbus
