### PR TITLE
Stop downscoring peers for hitting our serving rate limit

### DIFF
--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/trailofbits/go-mutexasserts"
@@ -139,7 +138,6 @@ func (l *limiter) validateRequest(stream network.Stream, amt uint64) error {
 		amt = 1
 	}
 	if amt > uint64(remaining) {
-		l.downscorePeer(remotePeer, topic, "rateLimitExceeded")
 		writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrRateLimited.Error(), stream, l.p2p)
 		return p2ptypes.ErrRateLimited
 	}
@@ -151,7 +149,6 @@ func (l *limiter) validateRawRpcRequest(stream network.Stream, amt uint64) error
 	l.RLock()
 	defer l.RUnlock()
 
-	remotePeer := stream.Conn().RemotePeer()
 	collector, err := l.retrieveCollector(rpcLimiterTopic)
 	if err != nil {
 		return err
@@ -160,7 +157,6 @@ func (l *limiter) validateRawRpcRequest(stream network.Stream, amt uint64) error
 	remaining := collector.Remaining(key)
 
 	if amt > uint64(remaining) {
-		l.downscorePeer(remotePeer, rpcLimiterTopic, "rawRateLimitExceeded")
 		writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrRateLimited.Error(), stream, l.p2p)
 		return p2ptypes.ErrRateLimited
 	}
@@ -238,14 +234,4 @@ func (l *limiter) retrieveCollector(topic string) (*leakybucket.Collector, error
 
 func (_ *limiter) topicLogger(topic string) *logrus.Entry {
 	return log.WithField("rateLimiter", topic)
-}
-
-func (l *limiter) downscorePeer(peerID peer.ID, topic, reason string) {
-	newScore := l.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-	log.WithFields(logrus.Fields{
-		"peerID":   peerID.String(),
-		"reason":   reason,
-		"newScore": newScore,
-		"topic":    topic,
-	}).Debug("Downscore peer")
 }

--- a/beacon-chain/sync/rate_limiter_test.go
+++ b/beacon-chain/sync/rate_limiter_test.go
@@ -93,11 +93,10 @@ func TestRateLimiter_ExceedRawCapacity(t *testing.T) {
 	// Triggers rate limit error on burst.
 	assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream, 1))
 
-	// Make Peer bad.
 	for range defaultBurstLimit {
 		assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream, 1))
 	}
-	assert.NotNil(t, p1.Peers().IsBad(p2.PeerID()), "peer is not marked as a bad peer")
+	assert.NoError(t, p1.Peers().IsBad(p2.PeerID()), "rate limit must not mark peer bad")
 	require.NoError(t, stream.Close(), "could not close stream")
 
 	if util.WaitTimeout(&wg, 1*time.Second) {

--- a/changelog/terence_drop-downscore-on-rate-limit.md
+++ b/changelog/terence_drop-downscore-on-rate-limit.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Stop downscoring peers that hit our serving rate limit.


### PR DESCRIPTION
this PR removes the two `downscorePeer` calls in `validateRequest` and `validateRawRpcRequest`, and deletes the now-unused helper. Peers still receive `ErrRateLimited` and back off, they just no longer accumulate strikes toward the 5-strike bad-responses threshold that triggers auto-disconnect. we have seen more often peers often accumulate 5 strikes within minutes of connecting and get auto disconnected via `disconnectBadPeer`

  | client | downscore on rate-limit hit | response |
  |---|---|---|
  | Lighthouse | no | sends `RpcErrorResponse::RateLimited`, no score impact |
  | Lodestar | no (with explicit comment: *"could come from ourself, not the peer so we should not penalize them"*) | sends rate-limited error |
  | Nimbus | no | queues the request internally; doesn't even surface an error to the peer |