### PR TITLE
Move SaveState() timing metric

### DIFF
--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -120,14 +120,16 @@ func (s *Store) LegacyGenesisState(ctx context.Context) (state.BeaconState, erro
 }
 
 // SaveState stores a state to the db using block's signing root which was used to generate the state.
-func (s *Store) SaveState(ctx context.Context, st state.ReadOnlyBeaconState, blockRoot [32]byte) error {
+func (s *Store) SaveState(ctx context.Context, st state.ReadOnlyBeaconState, blockRoot [32]byte) (err error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveState")
 	defer span.End()
 
 	startTime := time.Now()
 
 	defer func() {
-		stateSavingTime.Observe(float64(time.Since(startTime).Milliseconds()))
+		if err == nil {
+			stateSavingTime.Observe(float64(time.Since(startTime).Milliseconds()))
+		}
 	}()
 
 	if features.Get().EnableStateDiff && s.stateDiffCache != nil {

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -124,6 +124,12 @@ func (s *Store) SaveState(ctx context.Context, st state.ReadOnlyBeaconState, blo
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveState")
 	defer span.End()
 
+	startTime := time.Now()
+
+	defer func() {
+		stateSavingTime.Observe(float64(time.Since(startTime).Milliseconds()))
+	}()
+
 	if features.Get().EnableStateDiff && s.stateDiffCache != nil {
 		return s.saveStateByDiff(ctx, st)
 	}
@@ -145,7 +151,6 @@ func (s *Store) SaveStates(ctx context.Context, states []state.ReadOnlyBeaconSta
 	if states == nil {
 		return errors.New("nil state")
 	}
-	startTime := time.Now()
 	multipleEncs := make([][]byte, len(states))
 	for i, st := range states {
 		stateBytes, err := marshalState(ctx, st)
@@ -170,7 +175,6 @@ func (s *Store) SaveStates(ctx context.Context, states []state.ReadOnlyBeaconSta
 	}); err != nil {
 		return err
 	}
-	stateSavingTime.Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 

--- a/changelog/bastin_save-state-metric.md
+++ b/changelog/bastin_save-state-metric.md
@@ -1,0 +1,3 @@
+### Changed
+
+- moved metric for timing beaconDB.saveState() to cover every path.


### PR DESCRIPTION
moved metric for timing `beaconDB.saveState()` to cover every path. it was previously only counting one of the paths.