### PR TITLE
Don't downscore block peer on envelope mismatch from different peer

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
@@ -100,9 +100,11 @@ func (f *blocksFetcher) validatePayloadBlockConsistency(r *fetchRequestResponse)
 		env := r.envelopes[pidx]
 		full, err := blocks.BlockBuiltOnEnvelope(env, b.Block)
 		if err != nil || !full {
-			r.err = errors.Wrap(prysmsync.ErrInvalidFetchedData, "envelope does not match block")
 			if r.blocksFrom == r.payloadsFrom {
+				r.err = errors.Wrap(prysmsync.ErrInvalidFetchedData, "envelope does not match block")
 				f.downscorePeer(r.blocksFrom, r.err)
+			} else {
+				r.err = errors.New("envelope does not match block")
 			}
 			return
 		}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
@@ -102,7 +102,6 @@ func (f *blocksFetcher) validatePayloadBlockConsistency(r *fetchRequestResponse)
 		if err != nil || !full {
 			if r.blocksFrom == r.payloadsFrom {
 				r.err = errors.Wrap(prysmsync.ErrInvalidFetchedData, "envelope does not match block")
-				f.downscorePeer(r.blocksFrom, r.err)
 			} else {
 				r.err = errors.New("envelope does not match block")
 			}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_payload_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_payload_test.go
@@ -3,6 +3,7 @@ package initialsync
 import (
 	"testing"
 
+	prysmsync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
@@ -12,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/pkg/errors"
 )
 
 // makeGloasBlock creates a Gloas ROBlock with the given slot, parentRoot, and parentBlockHash in the bid.
@@ -247,7 +249,7 @@ func TestValidatePayloadBlockConsistency(t *testing.T) {
 		require.Equal(t, 1, len(r.envelopes))
 	})
 
-	t.Run("mismatched envelope sets error", func(t *testing.T) {
+	t.Run("mismatched envelope from different peer does not wrap ErrInvalidFetchedData", func(t *testing.T) {
 		wrongEnv := makeEnvelope(t, 10, [32]byte{0xff}, [32]byte{})
 		f := &blocksFetcher{}
 		r := &fetchRequestResponse{
@@ -261,5 +263,7 @@ func TestValidatePayloadBlockConsistency(t *testing.T) {
 		}
 		f.validatePayloadBlockConsistency(r)
 		require.ErrorContains(t, "envelope does not match block", r.err)
+		require.Equal(t, false, errors.Is(r.err, prysmsync.ErrInvalidFetchedData))
 	})
+
 }

--- a/changelog/terence_dont-downscore-block-peer-on-envelope-mismatch.md
+++ b/changelog/terence_dont-downscore-block-peer-on-envelope-mismatch.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Don't downscore the block peer when a different peer served a mismatched envelope.


### PR DESCRIPTION
Follow-up to #16779. Same anti-pattern lived in the non-empty envelope branch of `validatePayloadBlockConsistency`:

- When an envelope doesn't match a block, the old code set `r.err = errors.Wrap(prysmsync.ErrInvalidFetchedData, ...)`.
- The inline downscore is correctly gated on `r.blocksFrom == r.payloadsFrom`, but `ErrInvalidFetchedData` propagates up to `blocks_queue.go:347-349` which unconditionally fires `q.downscorePeer(response.blocksFrom, "invalidBlocks")`, penalizing the block peer for a bad envelope served by a different peer