### PR TITLE
compress state diff anchor cache

### DIFF
--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -69,6 +69,10 @@ var (
 		Name: "db_beacon_state_saving_milliseconds",
 		Help: "Milliseconds it takes to save a beacon state to the DB",
 	})
+	stateDiffAnchorCacheBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "state_diff_anchor_cache_bytes",
+		Help: "The size in bytes of each state diff anchor cache level.",
+	}, []string{"level"})
 )
 
 // BlockCacheSize specifies 1000 slots worth of blocks cached, which

--- a/beacon-chain/db/kv/state_diff_cache.go
+++ b/beacon-chain/db/kv/state_diff_cache.go
@@ -4,25 +4,27 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"strconv"
 	"sync"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/golang/snappy"
 	pkgerrors "github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
 
 type stateDiffCache struct {
 	sync.RWMutex
-	anchors        []state.ReadOnlyBeaconState
+	anchors        [][]byte
 	levelsWithData []bool
 	offset         uint64
 }
 
 func populateStateDiffCacheFromDB(s *Store, offset uint64) (*stateDiffCache, error) {
 	cache := &stateDiffCache{
-		anchors:        make([]state.ReadOnlyBeaconState, len(flags.Get().StateDiffExponents)-1),
+		anchors:        make([][]byte, len(flags.Get().StateDiffExponents)-1),
 		levelsWithData: make([]bool, len(flags.Get().StateDiffExponents)),
 		offset:         offset,
 	}
@@ -74,7 +76,10 @@ func populateStateDiffCacheFromDB(s *Store, offset uint64) (*stateDiffCache, err
 	// Only cache anchor if there are higher levels that need it.
 	// With a single exponent, len(anchors)==0 and no caching is needed.
 	if len(cache.anchors) > 0 {
-		cache.anchors[0] = anchor0
+		err := cache.setAnchor(0, anchor0)
+		if err != nil {
+			return nil, err
+		}
 	}
 	cache.levelsWithData[0] = true
 
@@ -171,7 +176,7 @@ func newStateDiffCache(s *Store) (*stateDiffCache, error) {
 	}
 
 	return &stateDiffCache{
-		anchors:        make([]state.ReadOnlyBeaconState, len(flags.Get().StateDiffExponents)-1), // -1 because last level doesn't need to be cached
+		anchors:        make([][]byte, len(flags.Get().StateDiffExponents)-1), // -1 because last level doesn't need to be cached
 		levelsWithData: make([]bool, len(flags.Get().StateDiffExponents)),
 		offset:         offset,
 	}, nil
@@ -180,7 +185,24 @@ func newStateDiffCache(s *Store) (*stateDiffCache, error) {
 func (c *stateDiffCache) getAnchor(level int) state.ReadOnlyBeaconState {
 	c.RLock()
 	defer c.RUnlock()
-	return c.anchors[level]
+
+	compressed := c.anchors[level]
+
+	if len(compressed) == 0 {
+		return nil
+	}
+
+	uncompressed, err := snappy.Decode(nil, compressed)
+	if err != nil {
+		return nil
+	}
+
+	st, err := decodeStateSnapshot(uncompressed)
+	if err != nil {
+		return nil
+	}
+
+	return st
 }
 
 func (c *stateDiffCache) setAnchor(level int, anchor state.ReadOnlyBeaconState) error {
@@ -189,7 +211,22 @@ func (c *stateDiffCache) setAnchor(level int, anchor state.ReadOnlyBeaconState) 
 	if level >= len(c.anchors) || level < 0 {
 		return errors.New("state diff cache: anchor level out of range")
 	}
-	c.anchors[level] = anchor
+	if anchor == nil {
+		return errors.New("state diff cache: anchor cannot be nil")
+	}
+
+	anchorSSZ, err := anchor.MarshalSSZ()
+	if err != nil {
+		return err
+	}
+	versionedAnchorBytes, err := addKey(anchor.Version(), anchorSSZ)
+	if err != nil {
+		return err
+	}
+	compressed := snappy.Encode(nil, versionedAnchorBytes)
+
+	c.anchors[level] = compressed
+	stateDiffAnchorCacheBytes.WithLabelValues(strconv.Itoa(level)).Set(float64(len(compressed)))
 	return nil
 }
 
@@ -227,5 +264,8 @@ func (c *stateDiffCache) setOffset(offset uint64) {
 func (c *stateDiffCache) clearAnchors() {
 	c.Lock()
 	defer c.Unlock()
-	c.anchors = make([]state.ReadOnlyBeaconState, len(flags.Get().StateDiffExponents)-1) // -1 because last level doesn't need to be cached
+	c.anchors = make([][]byte, len(flags.Get().StateDiffExponents)-1) // -1 because last level doesn't need to be cached
+	for level := range len(c.anchors) {
+		stateDiffAnchorCacheBytes.WithLabelValues(strconv.Itoa(level)).Set(0)
+	}
 }

--- a/beacon-chain/db/kv/state_diff_test.go
+++ b/beacon-chain/db/kv/state_diff_test.go
@@ -779,7 +779,11 @@ func TestStateDiff_AnchorCache(t *testing.T) {
 			localCache[0] = st
 
 			// level 0 should be the same
-			require.DeepEqual(t, localCache[0], db.stateDiffCache.getAnchor(0))
+			localSSZ, err := localCache[0].MarshalSSZ()
+			require.NoError(t, err)
+			cachedSSZ, err := db.stateDiffCache.getAnchor(0).MarshalSSZ()
+			require.NoError(t, err)
+			require.DeepSSZEqual(t, localSSZ, cachedSSZ)
 
 			// rest of the cache should be nil
 			for i := 1; i < len(exponents)-1; i++ {
@@ -818,7 +822,11 @@ func TestStateDiff_AnchorCache(t *testing.T) {
 			localCache[0] = st
 
 			// level 0 should be the same
-			require.DeepEqual(t, localCache[0], db.stateDiffCache.getAnchor(0))
+			localSSZ, err = localCache[0].MarshalSSZ()
+			require.NoError(t, err)
+			cachedSSZ, err = db.stateDiffCache.getAnchor(0).MarshalSSZ()
+			require.NoError(t, err)
+			require.DeepSSZEqual(t, localSSZ, cachedSSZ)
 
 			// rest of the cache should be nil
 			for i := 1; i < len(exponents)-1; i++ {

--- a/changelog/bastin_compress-anchors.md
+++ b/changelog/bastin_compress-anchors.md
@@ -1,0 +1,3 @@
+### Added
+
+- snappy compression for the anchor states in state diff cache.


### PR DESCRIPTION
This PR adds snappy compression for states in the state diff cache's anchors list. 

this change will cut the cache size approximately in half. the cost of this is the marshalling and compressing the state while saving the anchors, and uncompressing and unmarshalling the states when reading them. 

this will add around 500ms to the time that it takes to save a state to DB. (mainnet)