### PR TITLE
Raise MIN_BUILDER_WITHDRAWABILITY_DELAY to 8192 epochs

### DIFF
--- a/changelog/terence_raise-builder-withdrawal-delay.md
+++ b/changelog/terence_raise-builder-withdrawal-delay.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Raise mainnet `MIN_BUILDER_WITHDRAWABILITY_DELAY` to 8192 epochs.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -111,7 +111,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	EpochsPerEth1VotingPeriod:        64,
 	SlotsPerHistoricalRoot:           8192,
 	MinValidatorWithdrawabilityDelay: 256,
-	MinBuilderWithdrawabilityDelay:   64,
+	MinBuilderWithdrawabilityDelay:   8192,
 	ShardCommitteePeriod:             256,
 	MinEpochsToInactivityPenalty:     4,
 	Eth1FollowDistance:               2048,


### PR DESCRIPTION
- Mirror https://github.com/ethereum/consensus-specs/pull/5223: raise mainnet `MIN_BUILDER_WITHDRAWABILITY_DELAY` from 64 → 8192 epochs (~1 month).
- Minimal preset stays at 2 (unchanged upstream)