### PR TITLE
Add `target_gas_limit` to gloas `PayloadAttributes`

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -378,7 +378,7 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 			log.WithError(err).Error("Could not get withdrawals for payload attribute")
 			return emptyAttri
 		}
-		return payloadAttributesGloas(uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot, withdrawals, slot)
+		return payloadAttributesGloas(uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot, withdrawals, slot, val.GasLimit)
 	case v >= version.Deneb:
 		return payloadAttributesDeneb(st, uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot)
 	case v >= version.Capella:
@@ -391,7 +391,7 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 	}
 }
 
-func payloadAttributesGloas(timestamp uint64, prevRandao, feeRecipient, parentBeaconBlockRoot []byte, withdrawals []*enginev1.Withdrawal, slot primitives.Slot) payloadattribute.Attributer {
+func payloadAttributesGloas(timestamp uint64, prevRandao, feeRecipient, parentBeaconBlockRoot []byte, withdrawals []*enginev1.Withdrawal, slot primitives.Slot, targetGasLimit uint64) payloadattribute.Attributer {
 	attr, err := payloadattribute.New(&enginev1.PayloadAttributesV4{
 		Timestamp:             timestamp,
 		PrevRandao:            prevRandao,
@@ -399,6 +399,7 @@ func payloadAttributesGloas(timestamp uint64, prevRandao, feeRecipient, parentBe
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: parentBeaconBlockRoot,
 		SlotNumber:            uint64(slot),
+		TargetGasLimit:        targetGasLimit,
 	})
 	if err != nil {
 		log.WithError(err).Error("Could not get payload attribute")

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -378,7 +378,11 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 			log.WithError(err).Error("Could not get withdrawals for payload attribute")
 			return emptyAttri
 		}
-		return payloadAttributesGloas(uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot, withdrawals, slot, val.GasLimit)
+		targetGasLimit := val.GasLimit
+		if targetGasLimit == 0 {
+			targetGasLimit = params.BeaconConfig().DefaultBuilderGasLimit
+		}
+		return payloadAttributesGloas(uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot, withdrawals, slot, targetGasLimit)
 	case v >= version.Deneb:
 		return payloadAttributesDeneb(st, uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot)
 	case v >= version.Capella:

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -151,6 +151,7 @@ func (s *Service) getLatePayloadAttribute(ctx context.Context, st state.ReadOnly
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: headRoot,
 		SlotNumber:            uint64(slot),
+		TargetGasLimit:        val.GasLimit,
 	})
 	if err != nil {
 		log.WithError(err).Error("Could not get payload attribute")

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -681,9 +681,11 @@ func (s *Server) computePayloadAttributes(ctx context.Context, st state.ReadOnly
 	}
 
 	feeRecpt := params.BeaconConfig().DefaultFeeRecipient.Bytes()
+	gasLimit := params.BeaconConfig().DefaultBuilderGasLimit
 	tValidator, exists := s.TrackedValidatorsCache.Validator(proposer)
 	if exists {
 		feeRecpt = tValidator.FeeRecipient[:]
+		gasLimit = tValidator.GasLimit
 	}
 
 	if v == version.Bellatrix {
@@ -732,6 +734,7 @@ func (s *Server) computePayloadAttributes(ctx context.Context, st state.ReadOnly
 		Withdrawals:           w,
 		ParentBeaconBlockRoot: root[:],
 		SlotNumber:            uint64(slot),
+		TargetGasLimit:        gasLimit,
 	})
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -151,6 +151,7 @@ func (vs *Server) getLocalPayloadFromEngine(
 			Withdrawals:           withdrawals,
 			ParentBeaconBlockRoot: parentRoot[:],
 			SlotNumber:            uint64(slot),
+			TargetGasLimit:        val.GasLimit,
 		})
 		if err != nil {
 			return nil, err

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -144,6 +144,10 @@ func (vs *Server) getLocalPayloadFromEngine(
 		if err != nil {
 			return nil, err
 		}
+		targetGasLimit := val.GasLimit
+		if targetGasLimit == 0 {
+			targetGasLimit = params.BeaconConfig().DefaultBuilderGasLimit
+		}
 		attr, err = payloadattribute.New(&enginev1.PayloadAttributesV4{
 			Timestamp:             uint64(t.Unix()),
 			PrevRandao:            random,
@@ -151,7 +155,7 @@ func (vs *Server) getLocalPayloadFromEngine(
 			Withdrawals:           withdrawals,
 			ParentBeaconBlockRoot: parentRoot[:],
 			SlotNumber:            uint64(slot),
-			TargetGasLimit:        val.GasLimit,
+			TargetGasLimit:        targetGasLimit,
 		})
 		if err != nil {
 			return nil, err

--- a/changelog/terence_payload-attrs-target-gas-limit.md
+++ b/changelog/terence_payload-attrs-target-gas-limit.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add `target_gas_limit` to Gloas `PayloadAttributesV4`.

--- a/consensus-types/payload-attribute/getters.go
+++ b/consensus-types/payload-attribute/getters.go
@@ -123,6 +123,7 @@ func (a *data) PbV4() (*enginev1.PayloadAttributesV4, error) {
 		Withdrawals:           a.withdrawals,
 		ParentBeaconBlockRoot: a.parentBeaconBlockRoot,
 		SlotNumber:            a.slotNumber,
+		TargetGasLimit:        a.targetGasLimit,
 	}, nil
 }
 

--- a/consensus-types/payload-attribute/types.go
+++ b/consensus-types/payload-attribute/types.go
@@ -22,6 +22,7 @@ type data struct {
 	withdrawals           []*enginev1.Withdrawal
 	parentBeaconBlockRoot []byte
 	slotNumber            uint64
+	targetGasLimit        uint64
 }
 
 var (
@@ -110,6 +111,7 @@ func initPayloadAttributeFromV4(a *enginev1.PayloadAttributesV4) (Attributer, er
 		withdrawals:           a.Withdrawals,
 		parentBeaconBlockRoot: a.ParentBeaconBlockRoot,
 		slotNumber:            a.SlotNumber,
+		targetGasLimit:        a.TargetGasLimit,
 	}, nil
 }
 

--- a/proto/engine/v1/execution_engine.pb.go
+++ b/proto/engine/v1/execution_engine.pb.go
@@ -1657,6 +1657,7 @@ type PayloadAttributesV4 struct {
 	Withdrawals           []*Withdrawal          `protobuf:"bytes,4,rep,name=withdrawals,proto3" json:"withdrawals,omitempty" ssz-max:"16"`
 	ParentBeaconBlockRoot []byte                 `protobuf:"bytes,5,opt,name=parent_beacon_block_root,json=parentBeaconBlockRoot,proto3" json:"parent_beacon_block_root,omitempty" ssz-size:"32"`
 	SlotNumber            uint64                 `protobuf:"varint,6,opt,name=slot_number,json=slotNumber,proto3" json:"slot_number,omitempty"`
+	TargetGasLimit        uint64                 `protobuf:"varint,7,opt,name=target_gas_limit,json=targetGasLimit,proto3" json:"target_gas_limit,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -1729,6 +1730,13 @@ func (x *PayloadAttributesV4) GetParentBeaconBlockRoot() []byte {
 func (x *PayloadAttributesV4) GetSlotNumber() uint64 {
 	if x != nil {
 		return x.SlotNumber
+	}
+	return 0
+}
+
+func (x *PayloadAttributesV4) GetTargetGasLimit() uint64 {
+	if x != nil {
+		return x.TargetGasLimit
 	}
 	return 0
 }

--- a/proto/engine/v1/execution_engine.proto
+++ b/proto/engine/v1/execution_engine.proto
@@ -226,7 +226,8 @@ message PayloadAttributesV3 {
   bytes parent_beacon_block_root = 5 [ (ethereum.eth.ext.ssz_size) = "32" ];
 }
 
-// PayloadAttributesV4 extends V3 with slot_number (Amsterdam/EIP-7843).
+// PayloadAttributesV4 extends V3 with slot_number (Amsterdam/EIP-7843) and
+// target_gas_limit.
 message PayloadAttributesV4 {
   uint64 timestamp = 1;
   bytes prev_randao = 2 [ (ethereum.eth.ext.ssz_size) = "32" ];
@@ -235,6 +236,7 @@ message PayloadAttributesV4 {
       [ (ethereum.eth.ext.ssz_max) = "withdrawal.size" ];
   bytes parent_beacon_block_root = 5 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 slot_number = 6;
+  uint64 target_gas_limit = 7;
 }
 
 message PayloadStatus {

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -828,6 +828,7 @@ type payloadAttributesV4JSON struct {
 	Withdrawals           []*Withdrawal  `json:"withdrawals"`
 	ParentBeaconBlockRoot hexutil.Bytes  `json:"parentBeaconBlockRoot"`
 	SlotNumber            hexutil.Uint64 `json:"slotNumber"`
+	TargetGasLimit        hexutil.Uint64 `json:"targetGasLimit"`
 }
 
 func (p *PayloadAttributesV4) MarshalJSON() ([]byte, error) {
@@ -843,6 +844,7 @@ func (p *PayloadAttributesV4) MarshalJSON() ([]byte, error) {
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: p.ParentBeaconBlockRoot,
 		SlotNumber:            hexutil.Uint64(p.SlotNumber),
+		TargetGasLimit:        hexutil.Uint64(p.TargetGasLimit),
 	})
 }
 
@@ -862,6 +864,7 @@ func (p *PayloadAttributesV4) UnmarshalJSON(enc []byte) error {
 	p.Withdrawals = withdrawals
 	p.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
 	p.SlotNumber = uint64(dec.SlotNumber)
+	p.TargetGasLimit = uint64(dec.TargetGasLimit)
 	return nil
 }
 


### PR DESCRIPTION
  - Add `target_gas_limit` field to `PayloadAttributesV4` to align `engine_forkchoiceUpdatedV4`.
  - Thread `val.GasLimit` from `TrackedValidator` through every `PayloadAttributesV4` construction site (proposer RPC, blockchain FCU, late-payload FCU, payload_attributes SSE event)
  - Implements [consensus-specs#5235](https://github.com/ethereum/consensus-specs/pull/5235) and [execution-apis#796](https://github.com/ethereum/execution-apis/pull/796).