### PR TITLE
Implement gloas gas limit consistency check

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -41,6 +41,7 @@ type ChainInfoFetcher interface {
 type ForkchoiceFetcher interface {
 	Ancestor(context.Context, []byte, primitives.Slot) ([]byte, error)
 	BlockHash(root [32]byte) ([32]byte, error)
+	GasLimit(root [32]byte) (uint64, error)
 	CachedHeadRoot() [32]byte
 	GetProposerHead() [32]byte
 	SetForkChoiceGenesisTime(time.Time)

--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@ -56,6 +56,13 @@ func (s *Service) BlockHash(root [32]byte) ([32]byte, error) {
 	return s.cfg.ForkChoiceStore.BlockHash(root)
 }
 
+// GasLimit returns the gas limit of the latest full payload at or before the given beacon block root from forkchoice.
+func (s *Service) GasLimit(root [32]byte) (uint64, error) {
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
+	return s.cfg.ForkChoiceStore.GasLimit(root)
+}
+
 // HasFullNode returns the corresponding value from forkchoice
 func (s *Service) HasFullNode(root [32]byte) bool {
 	s.cfg.ForkChoiceStore.RLock()

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -85,6 +85,7 @@ type ChainService struct {
 	ParentPayloadReadyVal *bool
 	ForkchoiceRoots       map[[32]byte]bool
 	ForkchoiceBlockHashes map[[32]byte][32]byte
+	ForkchoiceGasLimits   map[[32]byte]uint64
 	// Ancestors lets a test stub the result of Ancestor(root, slot) without
 	// wiring a full forkchoice store. Keyed by the input root.
 	Ancestors map[[32]byte][32]byte
@@ -883,6 +884,16 @@ func (s *ChainService) ParentPayloadReady(_ interfaces.ReadOnlyBeaconBlock) bool
 		return *s.ParentPayloadReadyVal
 	}
 	return true
+}
+
+// GasLimit mocks the execution payload gas limit lookup for a beacon block root.
+func (s *ChainService) GasLimit(root [32]byte) (uint64, error) {
+	if s.ForkchoiceGasLimits != nil {
+		if gasLimit, ok := s.ForkchoiceGasLimits[root]; ok {
+			return gasLimit, nil
+		}
+	}
+	return 0, errors.New("gas limit not found")
 }
 
 // DependentRootForEpoch mocks the same method in the chain service

--- a/beacon-chain/blockchain/tracked_proposer.go
+++ b/beacon-chain/blockchain/tracked_proposer.go
@@ -24,7 +24,7 @@ func (s *Service) proposerPreference(st state.ReadOnlyBeaconState, slot primitiv
 	if pref.ValidatorIndex != valIdx {
 		return cache.TrackedValidator{}, false
 	}
-	return cache.TrackedValidator{Active: true, FeeRecipient: pref.FeeRecipient, GasLimit: pref.GasLimit}, true
+	return cache.TrackedValidator{Active: true, FeeRecipient: pref.FeeRecipient, GasLimit: pref.TargetGasLimit}, true
 }
 
 // trackedProposer returns whether the beacon node was informed, via the

--- a/beacon-chain/cache/proposer_preferences.go
+++ b/beacon-chain/cache/proposer_preferences.go
@@ -12,7 +12,7 @@ type ProposerPreference struct {
 	DependentRoot  [32]byte
 	ValidatorIndex primitives.ValidatorIndex
 	FeeRecipient   primitives.ExecutionAddress
-	GasLimit       uint64
+	TargetGasLimit uint64
 }
 
 // ProposerPreferencesCache stores broadcast proposer preferences indexed by

--- a/beacon-chain/cache/proposer_preferences_test.go
+++ b/beacon-chain/cache/proposer_preferences_test.go
@@ -23,7 +23,7 @@ func TestProposerPreferencesCache_AddGetHas(t *testing.T) {
 		DependentRoot:  rootA,
 		ValidatorIndex: 7,
 		FeeRecipient:   primitives.ExecutionAddress{1, 2, 3, 4},
-		GasLimit:       42,
+		TargetGasLimit: 42,
 	}
 
 	require.Equal(t, false, c.Has(rootA, slot))
@@ -34,28 +34,28 @@ func TestProposerPreferencesCache_AddGetHas(t *testing.T) {
 	require.Equal(t, true, ok)
 	require.Equal(t, pref.ValidatorIndex, got.ValidatorIndex)
 	require.Equal(t, pref.FeeRecipient, got.FeeRecipient)
-	require.Equal(t, pref.GasLimit, got.GasLimit)
+	require.Equal(t, pref.TargetGasLimit, got.TargetGasLimit)
 }
 
 func TestProposerPreferencesCache_AddDuplicate(t *testing.T) {
 	c := NewProposerPreferencesCache()
 	slot := primitives.Slot(456)
 
-	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeA, GasLimit: 10}, slot))
-	require.Equal(t, false, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeB, GasLimit: 20}, slot))
+	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeA, TargetGasLimit: 10}, slot))
+	require.Equal(t, false, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeB, TargetGasLimit: 20}, slot))
 
 	pref, ok := c.Get(rootA, slot)
 	require.Equal(t, true, ok)
 	require.Equal(t, feeA, pref.FeeRecipient)
-	require.Equal(t, uint64(10), pref.GasLimit)
+	require.Equal(t, uint64(10), pref.TargetGasLimit)
 }
 
 func TestProposerPreferencesCache_DifferentBranchesSameSlot(t *testing.T) {
 	c := NewProposerPreferencesCache()
 	slot := primitives.Slot(456)
 
-	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeA, GasLimit: 10}, slot))
-	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootB, ValidatorIndex: 5, FeeRecipient: feeB, GasLimit: 20}, slot))
+	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeA, TargetGasLimit: 10}, slot))
+	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootB, ValidatorIndex: 5, FeeRecipient: feeB, TargetGasLimit: 20}, slot))
 
 	prefA, ok := c.Get(rootA, slot)
 	require.Equal(t, true, ok)
@@ -72,7 +72,7 @@ func TestProposerPreferencesCache_Clear(t *testing.T) {
 	c := NewProposerPreferencesCache()
 	slot := primitives.Slot(789)
 
-	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 1, FeeRecipient: feeA, GasLimit: 10}, slot))
+	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 1, FeeRecipient: feeA, TargetGasLimit: 10}, slot))
 	c.Clear()
 
 	require.Equal(t, false, c.Has(rootA, slot))
@@ -83,9 +83,9 @@ func TestProposerPreferencesCache_Clear(t *testing.T) {
 func TestProposerPreferencesCache_PruneBefore(t *testing.T) {
 	c := NewProposerPreferencesCache()
 
-	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 1, FeeRecipient: feeA, GasLimit: 10}, 10))
-	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 2, FeeRecipient: feeB, GasLimit: 11}, 11))
-	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeC, GasLimit: 12}, 12))
+	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 1, FeeRecipient: feeA, TargetGasLimit: 10}, 10))
+	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 2, FeeRecipient: feeB, TargetGasLimit: 11}, 11))
+	require.Equal(t, true, c.Add(ProposerPreference{DependentRoot: rootA, ValidatorIndex: 3, FeeRecipient: feeC, TargetGasLimit: 12}, 12))
 
 	c.PruneBefore(11)
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences.go
@@ -95,7 +95,7 @@ func (vs *Server) SubmitSignedProposerPreferences(
 			DependentRoot:  dependentRoot,
 			ValidatorIndex: msg.Message.ValidatorIndex,
 			FeeRecipient:   bytesutil.ToBytes20(msg.Message.FeeRecipient),
-			GasLimit:       msg.Message.GasLimit,
+			TargetGasLimit: msg.Message.TargetGasLimit,
 		}, proposalSlot)
 		broadcast++
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences_test.go
@@ -38,11 +38,11 @@ func TestSubmitSignedProposerPreferences_OK(t *testing.T) {
 		SignedProposerPreferences: []*ethpb.SignedProposerPreferences{
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xcc}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xcc}, 32),
 					ProposalSlot:   proposalSlot,
 					ValidatorIndex: 2,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       30_000_000,
+					TargetGasLimit: 30_000_000,
 				},
 				Signature: make([]byte, 96),
 			},
@@ -56,7 +56,7 @@ func TestSubmitSignedProposerPreferences_OK(t *testing.T) {
 	pref, ok := cache.Get([32]byte{0xcc}, proposalSlot)
 	require.Equal(t, true, ok)
 	require.DeepEqual(t, req.SignedProposerPreferences[0].Message.FeeRecipient, pref.FeeRecipient[:])
-	require.Equal(t, req.SignedProposerPreferences[0].Message.GasLimit, pref.GasLimit)
+	require.Equal(t, req.SignedProposerPreferences[0].Message.TargetGasLimit, pref.TargetGasLimit)
 }
 
 func TestSubmitSignedProposerPreferences_Multiple(t *testing.T) {
@@ -80,21 +80,21 @@ func TestSubmitSignedProposerPreferences_Multiple(t *testing.T) {
 		SignedProposerPreferences: []*ethpb.SignedProposerPreferences{
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xaa}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xaa}, 32),
 					ProposalSlot:   currentSlot + 1,
 					ValidatorIndex: 2,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       30_000_000,
+					TargetGasLimit: 30_000_000,
 				},
 				Signature: make([]byte, 96),
 			},
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xbb}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xbb}, 32),
 					ProposalSlot:   currentSlot + 2,
 					ValidatorIndex: 5,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       25_000_000,
+					TargetGasLimit: 25_000_000,
 				},
 				Signature: make([]byte, 96),
 			},
@@ -109,7 +109,7 @@ func TestSubmitSignedProposerPreferences_Multiple(t *testing.T) {
 	require.Equal(t, true, ok)
 	pref2, ok := c.Get([32]byte{0xbb}, currentSlot+2)
 	require.Equal(t, true, ok)
-	require.Equal(t, uint64(25_000_000), pref2.GasLimit)
+	require.Equal(t, uint64(25_000_000), pref2.TargetGasLimit)
 }
 
 func TestSubmitSignedProposerPreferences_DuplicateSlot(t *testing.T) {
@@ -127,7 +127,7 @@ func TestSubmitSignedProposerPreferences_DuplicateSlot(t *testing.T) {
 		DependentRoot:  [32]byte{0xcc},
 		ValidatorIndex: 2,
 		FeeRecipient:   primitives.ExecutionAddress{},
-		GasLimit:       30_000_000,
+		TargetGasLimit: 30_000_000,
 	}, proposalSlot)
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: false},
@@ -140,11 +140,11 @@ func TestSubmitSignedProposerPreferences_DuplicateSlot(t *testing.T) {
 		SignedProposerPreferences: []*ethpb.SignedProposerPreferences{
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xcc}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xcc}, 32),
 					ProposalSlot:   proposalSlot,
 					ValidatorIndex: 2,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       30_000_000,
+					TargetGasLimit: 30_000_000,
 				},
 				Signature: make([]byte, 96),
 			},
@@ -177,11 +177,11 @@ func TestSubmitSignedProposerPreferences_InvalidEpoch(t *testing.T) {
 		SignedProposerPreferences: []*ethpb.SignedProposerPreferences{
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xcc}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xcc}, 32),
 					ProposalSlot:   currentSlot,
 					ValidatorIndex: 2,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       30_000_000,
+					TargetGasLimit: 30_000_000,
 				},
 				Signature: make([]byte, 96),
 			},
@@ -218,11 +218,11 @@ func TestSubmitSignedProposerPreferences_CurrentEpochFutureSlot(t *testing.T) {
 		SignedProposerPreferences: []*ethpb.SignedProposerPreferences{
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xcc}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xcc}, 32),
 					ProposalSlot:   proposalSlot,
 					ValidatorIndex: 2,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       30_000_000,
+					TargetGasLimit: 30_000_000,
 				},
 				Signature: make([]byte, 96),
 			},
@@ -254,11 +254,11 @@ func TestSubmitSignedProposerPreferences_Syncing(t *testing.T) {
 		SignedProposerPreferences: []*ethpb.SignedProposerPreferences{
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xcc}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xcc}, 32),
 					ProposalSlot:   currentSlot + 1,
 					ValidatorIndex: 2,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       30_000_000,
+					TargetGasLimit: 30_000_000,
 				},
 				Signature: make([]byte, 96),
 			},
@@ -292,11 +292,11 @@ func TestSubmitSignedProposerPreferences_BroadcastsForProposalEpoch(t *testing.T
 		SignedProposerPreferences: []*ethpb.SignedProposerPreferences{
 			{
 				Message: &ethpb.ProposerPreferences{
-					DependentRoot: bytesutil.PadTo([]byte{0xcc}, 32),
+					DependentRoot:  bytesutil.PadTo([]byte{0xcc}, 32),
 					ProposalSlot:   proposalSlot,
 					ValidatorIndex: 2,
 					FeeRecipient:   make([]byte, 20),
-					GasLimit:       30_000_000,
+					TargetGasLimit: 30_000_000,
 				},
 				Signature: make([]byte, 96),
 			},

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -86,10 +86,6 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyFeeRecipientMatches(pref.FeeRecipient[:]); err != nil {
 		return pubsub.ValidationReject, err
 	}
-	// [REJECT] bid.gas_limit matches the gas_limit from the proposer's SignedProposerPreferences associated with bid.slot.
-	if err := v.VerifyGasLimitMatches(pref.GasLimit); err != nil {
-		return pubsub.ValidationReject, err
-	}
 	// The spec lists signature validation later, but the "first signed bid seen
 	// with a valid signature" gate below depends on knowing validity first.
 	if err := v.VerifySignature(st); err != nil {
@@ -110,8 +106,16 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyBuilderCanCoverBid(st); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	// [IGNORE] bid.parent_block_hash is the block hash of a known execution payload in fork choice.
+	// [IGNORE] bid.parent_block_hash is the block hash of a known execution payload in fork choice
+	// and bid.gas_limit is compatible with parent_gas_limit and the proposer's target.
 	if err := v.VerifyParentBlockHash(s.cfg.chain.BlockHash); err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+	parentGasLimit, err := s.cfg.chain.GasLimit(parentBlockRoot)
+	if err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+	if err := v.VerifyGasLimitTargetCompatible(parentGasLimit, pref.TargetGasLimit); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 	// [IGNORE] bid.parent_block_root is the hash tree root of a known beacon block in fork choice.

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -104,9 +104,9 @@ func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name:      "gas limit mismatch",
-			verifier:  mockExecutionPayloadBidVerifier{errGasLimitMismatch: errors.New("wrong gas limit")},
-			result:    pubsub.ValidationReject,
+			name:      "gas limit incompatible",
+			verifier:  mockExecutionPayloadBidVerifier{errGasLimitIncompatible: errors.New("incompatible gas limit")},
+			result:    pubsub.ValidationIgnore,
 			wantError: true,
 		},
 		{
@@ -240,17 +240,17 @@ func TestValidateExecutionPayloadBidGossip_FeeRecipientMismatch(t *testing.T) {
 	require.ErrorIs(t, err, verification.ErrBidFeeRecipientMismatch)
 }
 
-func TestValidateExecutionPayloadBidGossip_GasLimitMismatch(t *testing.T) {
+func TestValidateExecutionPayloadBidGossip_GasLimitIncompatible(t *testing.T) {
 	ctx := context.Background()
 	s, msg, _ := setupExecutionPayloadBidService(t)
 	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
-		mockExecutionPayloadBidVerifier{errGasLimitMismatch: verification.ErrBidGasLimitMismatch},
+		mockExecutionPayloadBidVerifier{errGasLimitIncompatible: verification.ErrBidGasLimitIncompatible},
 	)
 
 	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
 	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationReject, result)
-	require.ErrorIs(t, err, verification.ErrBidGasLimitMismatch)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+	require.ErrorIs(t, err, verification.ErrBidGasLimitIncompatible)
 }
 
 func TestExecutionPayloadBidSubscriber_WrongMessage(t *testing.T) {
@@ -285,7 +285,7 @@ type mockExecutionPayloadBidVerifier struct {
 	errBuilderActive        error
 	errExecutionPayment     error
 	errFeeRecipientMismatch error
-	errGasLimitMismatch     error
+	errGasLimitIncompatible error
 	errParentBlockRootSeen  error
 	errParentBlockHash      error
 	errBuilderCanCoverBid   error
@@ -310,8 +310,8 @@ func (m *mockExecutionPayloadBidVerifier) VerifyFeeRecipientMatches([]byte) erro
 	return m.errFeeRecipientMismatch
 }
 
-func (m *mockExecutionPayloadBidVerifier) VerifyGasLimitMatches(uint64) error {
-	return m.errGasLimitMismatch
+func (m *mockExecutionPayloadBidVerifier) VerifyGasLimitTargetCompatible(uint64, uint64) error {
+	return m.errGasLimitIncompatible
 }
 
 func (m *mockExecutionPayloadBidVerifier) VerifyParentBlockRootSeen(func([32]byte) bool) error {
@@ -375,6 +375,7 @@ func setupExecutionPayloadBidService(t *testing.T) (*Service, *pubsub.Message, *
 			[32]byte{0x02}: true,
 		},
 		ForkchoiceBlockHashes: map[[32]byte][32]byte{[32]byte{0x02}: [32]byte{0x01}},
+		ForkchoiceGasLimits:   map[[32]byte]uint64{[32]byte{0x02}: 1},
 	}
 	s := &Service{
 		seenExecutionPayloadBidCache:    newSlotAwareCache(10),
@@ -394,7 +395,7 @@ func setupExecutionPayloadBidService(t *testing.T) (*Service, *pubsub.Message, *
 		DependentRoot:  genesisRoot,
 		ValidatorIndex: 0,
 		FeeRecipient:   bytesutil.ToBytes20(signedBid.Message.FeeRecipient),
-		GasLimit:       signedBid.Message.GasLimit,
+		TargetGasLimit: signedBid.Message.GasLimit,
 	}, signedBid.Message.Slot))
 	msg := executionPayloadBidToPubsub(t, s, p, signedBid)
 	return s, msg, signedBid

--- a/beacon-chain/sync/validate_signed_proposer_preferences.go
+++ b/beacon-chain/sync/validate_signed_proposer_preferences.go
@@ -119,7 +119,7 @@ func (s *Service) validateSignedProposerPreferencesGossip(ctx context.Context, p
 		DependentRoot:  dependentRoot,
 		ValidatorIndex: signedPreferences.Message.ValidatorIndex,
 		FeeRecipient:   bytesutil.ToBytes20(signedPreferences.Message.FeeRecipient),
-		GasLimit:       signedPreferences.Message.GasLimit,
+		TargetGasLimit: signedPreferences.Message.TargetGasLimit,
 	}, slot)
 	msg.ValidatorData = signedPreferences
 	return pubsub.ValidationAccept, nil

--- a/beacon-chain/sync/validate_signed_proposer_preferences_test.go
+++ b/beacon-chain/sync/validate_signed_proposer_preferences_test.go
@@ -120,7 +120,7 @@ func TestValidateSignedProposerPreferencesGossip_AlreadySeen(t *testing.T) {
 		DependentRoot:  dependentRoot,
 		ValidatorIndex: signedPreferences.Message.ValidatorIndex,
 		FeeRecipient:   primitives.ExecutionAddress{0x01},
-		GasLimit:       10,
+		TargetGasLimit: 10,
 	}, signedPreferences.Message.ProposalSlot))
 	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestValidateSignedProposerPreferencesGossip_CacheHitSkipsStateLoad(t *testi
 		DependentRoot:  dependentRoot,
 		ValidatorIndex: signedPreferences.Message.ValidatorIndex,
 		FeeRecipient:   primitives.ExecutionAddress{0x01},
-		GasLimit:       10,
+		TargetGasLimit: 10,
 	}, signedPreferences.Message.ProposalSlot))
 	require.NoError(t, s.cfg.beaconDB.DeleteState(ctx, dependentRoot))
 
@@ -164,7 +164,7 @@ func TestValidateSignedProposerPreferencesGossip_HappyPath(t *testing.T) {
 	got, ok := s.proposerPreferencesCache.Get(dependentRoot, signedPreferences.Message.ProposalSlot)
 	require.Equal(t, true, ok)
 	require.DeepEqual(t, signedPreferences.Message.FeeRecipient, got.FeeRecipient[:])
-	require.Equal(t, signedPreferences.Message.GasLimit, got.GasLimit)
+	require.Equal(t, signedPreferences.Message.TargetGasLimit, got.TargetGasLimit)
 	validatorData, ok := msg.ValidatorData.(*ethpb.SignedProposerPreferences)
 	require.Equal(t, true, ok)
 	require.DeepEqual(t, signedPreferences, validatorData)
@@ -183,11 +183,11 @@ func TestSignedProposerPreferencesSubscriber_HappyPath(t *testing.T) {
 }
 
 type mockSignedProposerPreferencesVerifier struct {
-	errCurrentOrNextEpoch  error
-	errDependentRootSeen   error
-	errValidProposalSlot   error
-	errSignature           error
-	lastStateSlot          primitives.Slot
+	errCurrentOrNextEpoch error
+	errDependentRootSeen  error
+	errValidProposalSlot  error
+	errSignature          error
+	lastStateSlot         primitives.Slot
 }
 
 var _ verification.SignedProposerPreferencesVerifier = &mockSignedProposerPreferencesVerifier{}
@@ -277,7 +277,7 @@ func setupSignedProposerPreferencesService(t *testing.T) (*Service, *pubsub.Mess
 			ProposalSlot:   33,
 			ValidatorIndex: 0,
 			FeeRecipient:   bytes.Repeat([]byte{0x01}, 20),
-			GasLimit:       30_000_000,
+			TargetGasLimit: 30_000_000,
 		},
 		Signature: bytes.Repeat([]byte{0x02}, 96),
 	}

--- a/beacon-chain/verification/BUILD.bazel
+++ b/beacon-chain/verification/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "execution_payload_bid_test.go",
         "execution_payload_envelope_test.go",
         "filesystem_test.go",
+        "gas_limit_test.go",
         "initializer_test.go",
         "payload_attestation_test.go",
         "result_test.go",

--- a/beacon-chain/verification/execution_payload_bid.go
+++ b/beacon-chain/verification/execution_payload_bid.go
@@ -16,9 +16,9 @@ var ExecutionPayloadBidGossipRequirements = []Requirement{
 	RequireBidBuilderActive,
 	RequireBidExecutionPaymentZero,
 	RequireBidFeeRecipientMatches,
-	RequireBidGasLimitMatches,
 	RequireBidParentBlockRootSeen,
 	RequireBidParentBlockHashValid,
+	RequireBidGasLimitCompatible,
 	RequireBidBuilderCanCover,
 	RequireBidSignatureValid,
 }
@@ -31,7 +31,7 @@ var (
 	ErrBidBuilderNotActive        = errors.New("builder is not active")
 	ErrBidExecutionPaymentNonZero = errors.New("execution payment is non-zero")
 	ErrBidFeeRecipientMismatch    = errors.New("fee recipient does not match proposer preferences")
-	ErrBidGasLimitMismatch        = errors.New("gas limit does not match proposer preferences")
+	ErrBidGasLimitIncompatible    = errors.New("bid gas limit is incompatible with parent and target")
 	ErrBidParentBlockRootNotSeen  = errors.New("parent block root not seen")
 	ErrBidParentBlockHashMismatch = errors.New("parent block hash does not match forkchoice")
 	ErrBidBuilderCannotCover      = errors.New("builder cannot cover bid")
@@ -110,18 +110,44 @@ func (v *BidVerifier) VerifyFeeRecipientMatches(expected []byte) (err error) {
 	return nil
 }
 
-// VerifyGasLimitMatches verifies the bid gas limit matches the expected proposer preferences value.
-func (v *BidVerifier) VerifyGasLimitMatches(expected uint64) (err error) {
-	defer v.record(RequireBidGasLimitMatches, &err)
+// VerifyGasLimitTargetCompatible verifies the bid gas limit is compatible with
+// the parent payload's gas limit and the proposer's target via the EIP-1559
+// elasticity rule.
+func (v *BidVerifier) VerifyGasLimitTargetCompatible(parentGasLimit, targetGasLimit uint64) (err error) {
+	defer v.record(RequireBidGasLimitCompatible, &err)
 
 	bid, err := v.b.Bid()
 	if err != nil {
 		return errors.Wrap(err, "failed to get bid")
 	}
-	if bid.GasLimit() != expected {
-		return fmt.Errorf("%w: bid=%d expected=%d", ErrBidGasLimitMismatch, bid.GasLimit(), expected)
+	if !isGasLimitTargetCompatible(parentGasLimit, bid.GasLimit(), targetGasLimit) {
+		return fmt.Errorf("%w: bid=%d parent=%d target=%d", ErrBidGasLimitIncompatible, bid.GasLimit(), parentGasLimit, targetGasLimit)
 	}
 	return nil
+}
+
+// isGasLimitTargetCompatible reports whether gasLimit is compatible with
+// targetGasLimit under the EIP-1559 transition rule from parentGasLimit.
+//
+//	<spec fn="is_gas_limit_target_compatible" fork="gloas">
+//	def is_gas_limit_target_compatible(
+//	    parent_gas_limit: uint64, gas_limit: uint64, target_gas_limit: uint64
+//	) -> bool:
+//	    max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
+//	    min_gas_limit = parent_gas_limit - max_gas_limit_difference
+//	    max_gas_limit = parent_gas_limit + max_gas_limit_difference
+//
+//	    if target_gas_limit >= min_gas_limit and target_gas_limit <= max_gas_limit:
+//	        return gas_limit == target_gas_limit
+//	    if target_gas_limit > max_gas_limit:
+//	        return gas_limit == max_gas_limit
+//	    return gas_limit == min_gas_limit
+//	</spec>
+func isGasLimitTargetCompatible(parentGasLimit, gasLimit, targetGasLimit uint64) bool {
+	maxDiff := max(parentGasLimit/1024, 1) - 1
+	minLimit := parentGasLimit - maxDiff
+	maxLimit := parentGasLimit + maxDiff
+	return gasLimit == min(max(targetGasLimit, minLimit), maxLimit)
 }
 
 // VerifyParentBlockRootSeen verifies the parent beacon block root is known.

--- a/beacon-chain/verification/execution_payload_bid_test.go
+++ b/beacon-chain/verification/execution_payload_bid_test.go
@@ -108,16 +108,20 @@ func TestBidVerifier_VerifyFeeRecipientMatches(t *testing.T) {
 	require.ErrorIs(t, verifier.VerifyFeeRecipientMatches(bytes.Repeat([]byte{0xff}, 20)), ErrBidFeeRecipientMismatch)
 }
 
-func TestBidVerifier_VerifyGasLimitMatches(t *testing.T) {
+func TestBidVerifier_VerifyGasLimitTargetCompatible(t *testing.T) {
 	signed := testSignedExecutionPayloadBid(t, 1)
 	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signed)
 	require.NoError(t, err)
 
-	verifier := &BidVerifier{results: newResults(RequireBidGasLimitMatches), b: wrapped}
-	require.NoError(t, verifier.VerifyGasLimitMatches(signed.Message.GasLimit))
+	// bid.gas_limit is 1 (from testSignedExecutionPayloadBid). With parent=1 the
+	// elasticity rule allows only gas_limit=1, so compatible target is 1.
+	parentGasLimit := signed.Message.GasLimit
 
-	verifier = &BidVerifier{results: newResults(RequireBidGasLimitMatches), b: wrapped}
-	require.ErrorIs(t, verifier.VerifyGasLimitMatches(signed.Message.GasLimit+1), ErrBidGasLimitMismatch)
+	verifier := &BidVerifier{results: newResults(RequireBidGasLimitCompatible), b: wrapped}
+	require.NoError(t, verifier.VerifyGasLimitTargetCompatible(parentGasLimit, signed.Message.GasLimit))
+
+	verifier = &BidVerifier{results: newResults(RequireBidGasLimitCompatible), b: wrapped}
+	require.ErrorIs(t, verifier.VerifyGasLimitTargetCompatible(parentGasLimit, signed.Message.GasLimit+1), ErrBidGasLimitIncompatible)
 }
 
 func TestBidVerifier_VerifyParentBlockRootSeen(t *testing.T) {

--- a/beacon-chain/verification/gas_limit_test.go
+++ b/beacon-chain/verification/gas_limit_test.go
@@ -1,0 +1,72 @@
+package verification
+
+import "testing"
+
+func TestIsGasLimitTargetCompatible(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentGasLimit uint64
+		gasLimit       uint64
+		targetGasLimit uint64
+		want           bool
+	}{
+		{
+			name:           "increase within limit",
+			parentGasLimit: 60_000_000,
+			gasLimit:       60_000_100,
+			targetGasLimit: 60_000_100,
+			want:           true,
+		},
+		{
+			name:           "increase exceeding limit clamps to max",
+			parentGasLimit: 60_000_000,
+			gasLimit:       60_058_592, // 60_000_000 + (60_000_000/1024 - 1)
+			targetGasLimit: 100_000_000,
+			want:           true,
+		},
+		{
+			name:           "increase exceeding limit off by one fails",
+			parentGasLimit: 60_000_000,
+			gasLimit:       60_058_593,
+			targetGasLimit: 100_000_000,
+			want:           false,
+		},
+		{
+			name:           "decrease within limit",
+			parentGasLimit: 60_000_000,
+			gasLimit:       59_999_990,
+			targetGasLimit: 59_999_990,
+			want:           true,
+		},
+		{
+			name:           "decrease exceeding limit clamps to min",
+			parentGasLimit: 60_000_000,
+			gasLimit:       59_941_408, // 60_000_000 - (60_000_000/1024 - 1)
+			targetGasLimit: 30_000_000,
+			want:           true,
+		},
+		{
+			name:           "target equals parent",
+			parentGasLimit: 60_000_000,
+			gasLimit:       60_000_000,
+			targetGasLimit: 60_000_000,
+			want:           true,
+		},
+		{
+			name:           "parent gas limit underflows is guarded",
+			parentGasLimit: 1023,
+			gasLimit:       1023,
+			targetGasLimit: 60_000_000,
+			want:           true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isGasLimitTargetCompatible(tt.parentGasLimit, tt.gasLimit, tt.targetGasLimit)
+			if got != tt.want {
+				t.Errorf("isGasLimitTargetCompatible(%d, %d, %d) = %v, want %v",
+					tt.parentGasLimit, tt.gasLimit, tt.targetGasLimit, got, tt.want)
+			}
+		})
+	}
+}

--- a/beacon-chain/verification/interface.go
+++ b/beacon-chain/verification/interface.go
@@ -102,9 +102,9 @@ type ExecutionPayloadBidVerifier interface {
 	VerifyBuilderActive(state.ReadOnlyBeaconState) error
 	VerifyExecutionPaymentZero() error
 	VerifyFeeRecipientMatches([]byte) error
-	VerifyGasLimitMatches(uint64) error
 	VerifyParentBlockRootSeen(func([32]byte) bool) error
 	VerifyParentBlockHash(func([32]byte) ([32]byte, error)) error
+	VerifyGasLimitTargetCompatible(parentGasLimit, targetGasLimit uint64) error
 	VerifyBuilderCanCoverBid(state.ReadOnlyBeaconState) error
 	VerifySignature(state.ReadOnlyBeaconState) error
 	SatisfyRequirement(Requirement)

--- a/beacon-chain/verification/requirements.go
+++ b/beacon-chain/verification/requirements.go
@@ -43,7 +43,7 @@ const (
 	RequireBidBuilderActive
 	RequireBidExecutionPaymentZero
 	RequireBidFeeRecipientMatches
-	RequireBidGasLimitMatches
+	RequireBidGasLimitCompatible
 	RequireBidParentBlockRootSeen
 	RequireBidParentBlockHashValid
 	RequireBidBuilderCanCover

--- a/beacon-chain/verification/result.go
+++ b/beacon-chain/verification/result.go
@@ -75,8 +75,8 @@ func (r Requirement) String() string {
 		return "RequireBidExecutionPaymentZero"
 	case RequireBidFeeRecipientMatches:
 		return "RequireBidFeeRecipientMatches"
-	case RequireBidGasLimitMatches:
-		return "RequireBidGasLimitMatches"
+	case RequireBidGasLimitCompatible:
+		return "RequireBidGasLimitCompatible"
 	case RequireBidParentBlockRootSeen:
 		return "RequireBidParentBlockRootSeen"
 	case RequireBidParentBlockHashValid:

--- a/beacon-chain/verification/signed_proposer_preferences_test.go
+++ b/beacon-chain/verification/signed_proposer_preferences_test.go
@@ -103,7 +103,7 @@ func TestProposerPreferencesVerifier_VerifySignature_ForkBoundary(t *testing.T) 
 			ProposalSlot:   proposalSlot,
 			ValidatorIndex: validatorIndex,
 			FeeRecipient:   bytes.Repeat([]byte{0x01}, 20),
-			GasLimit:       30_000_000,
+			TargetGasLimit: 30_000_000,
 		},
 	}
 	// Sign using config fork (like the DomainData RPC does).
@@ -143,7 +143,7 @@ func newSignedProposerPreferencesState(t *testing.T, currentSlot, proposalSlot p
 			ProposalSlot:   proposalSlot,
 			ValidatorIndex: validatorIndex,
 			FeeRecipient:   bytes.Repeat([]byte{0x01}, 20),
-			GasLimit:       30_000_000,
+			TargetGasLimit: 30_000_000,
 		},
 	}
 	signed.Signature = signProposerPreferencesWithConfigFork(t, keys[validatorIndex], signed.Message, st)

--- a/changelog/terence_gas-limit-target-compatible.md
+++ b/changelog/terence_gas-limit-target-compatible.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Implement Gloas gas limit consistency check for bids (consensus-specs#5236).

--- a/proto/prysm/v1alpha1/gloas.pb.go
+++ b/proto/prysm/v1alpha1/gloas.pb.go
@@ -215,7 +215,7 @@ type ProposerPreferences struct {
 	ProposalSlot   github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot           `protobuf:"varint,2,opt,name=proposal_slot,json=proposalSlot,proto3" json:"proposal_slot,omitempty" cast-type:"github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"`
 	ValidatorIndex github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex `protobuf:"varint,3,opt,name=validator_index,json=validatorIndex,proto3" json:"validator_index,omitempty" cast-type:"github.com/OffchainLabs/prysm/v7/consensus-types/primitives.ValidatorIndex"`
 	FeeRecipient   []byte                                                                     `protobuf:"bytes,4,opt,name=fee_recipient,json=feeRecipient,proto3" json:"fee_recipient,omitempty" ssz-size:"20"`
-	GasLimit       uint64                                                                     `protobuf:"varint,5,opt,name=gas_limit,json=gasLimit,proto3" json:"gas_limit,omitempty"`
+	TargetGasLimit uint64                                                                     `protobuf:"varint,5,opt,name=target_gas_limit,json=targetGasLimit,proto3" json:"target_gas_limit,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -278,9 +278,9 @@ func (x *ProposerPreferences) GetFeeRecipient() []byte {
 	return nil
 }
 
-func (x *ProposerPreferences) GetGasLimit() uint64 {
+func (x *ProposerPreferences) GetTargetGasLimit() uint64 {
 	if x != nil {
-		return x.GasLimit
+		return x.TargetGasLimit
 	}
 	return 0
 }

--- a/proto/prysm/v1alpha1/gloas.proto
+++ b/proto/prysm/v1alpha1/gloas.proto
@@ -75,8 +75,8 @@ message SignedExecutionPayloadBid {
   bytes signature = 2 [ (ethereum.eth.ext.ssz_size) = "96" ];
 }
 
-// ProposerPreferences communicates a proposer fee recipient and gas limit for a
-// future proposal slot.
+// ProposerPreferences communicates a proposer fee recipient and target gas
+// limit for a future proposal slot.
 //
 // Spec:
 // class ProposerPreferences(Container):
@@ -84,7 +84,7 @@ message SignedExecutionPayloadBid {
 //     proposal_slot: Slot
 //     validator_index: ValidatorIndex
 //     fee_recipient: ExecutionAddress
-//     gas_limit: uint64
+//     target_gas_limit: uint64
 message ProposerPreferences {
   bytes dependent_root = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 proposal_slot = 2 [
@@ -96,7 +96,7 @@ message ProposerPreferences {
             "github.com/OffchainLabs/prysm/v7/consensus-types/"
             "primitives.ValidatorIndex" ];
   bytes fee_recipient = 4 [ (ethereum.eth.ext.ssz_size) = "20" ];
-  uint64 gas_limit = 5;
+  uint64 target_gas_limit = 5;
 }
 
 // SignedProposerPreferences wraps proposer preferences with a signature.

--- a/proto/prysm/v1alpha1/gloas.ssz.go
+++ b/proto/prysm/v1alpha1/gloas.ssz.go
@@ -420,8 +420,8 @@ func (p *ProposerPreferences) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	}
 	dst = append(dst, p.FeeRecipient...)
 
-	// Field (4) 'GasLimit'
-	dst = ssz.MarshalUint(dst, p.GasLimit)
+	// Field (4) 'TargetGasLimit'
+	dst = ssz.MarshalUint(dst, p.TargetGasLimit)
 
 	return
 }
@@ -452,8 +452,8 @@ func (p *ProposerPreferences) UnmarshalSSZ(buf []byte) error {
 	}
 	p.FeeRecipient = append(p.FeeRecipient, buf[48:68]...)
 
-	// Field (4) 'GasLimit'
-	p.GasLimit = ssz.UnmarshallUint[uint64](buf[68:76])
+	// Field (4) 'TargetGasLimit'
+	p.TargetGasLimit = ssz.UnmarshallUint[uint64](buf[68:76])
 
 	return err
 }
@@ -493,8 +493,8 @@ func (p *ProposerPreferences) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	hh.PutBytes(p.FeeRecipient)
 
-	// Field (4) 'GasLimit'
-	ssz.PutUint(hh, p.GasLimit)
+	// Field (4) 'TargetGasLimit'
+	ssz.PutUint(hh, p.TargetGasLimit)
 
 	hh.Merkleize(indx)
 	return

--- a/validator/client/registration_test.go
+++ b/validator/client/registration_test.go
@@ -159,7 +159,7 @@ func Test_signProposerPreferences(t *testing.T) {
 		ProposalSlot:   123,
 		ValidatorIndex: 456,
 		FeeRecipient:   bytesutil.PadTo([]byte("fee"), 20),
-		GasLimit:       789,
+		TargetGasLimit: 789,
 	}
 
 	domain, err := signing.ComputeDomain(

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1135,7 +1135,7 @@ func (v *validator) buildProposerPreferences(
 					ProposalSlot:   proposalSlot,
 					ValidatorIndex: duty.ValidatorIndex,
 					FeeRecipient:   feeRecipient[:],
-					GasLimit:       gasLimit,
+					TargetGasLimit: gasLimit,
 				}
 				signedPref, err := v.signProposerPreferences(ctx, km, pk, pref)
 				if err != nil {

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -2250,7 +2250,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 		require.Equal(t, 1, len(prefs))
 		require.Equal(t, primitives.ValidatorIndex(1), prefs[0].Message.ValidatorIndex)
 		require.Equal(t, nextEpochProposerSlot, prefs[0].Message.ProposalSlot)
-		require.Equal(t, uint64(42000000), prefs[0].Message.GasLimit)
+		require.Equal(t, uint64(42000000), prefs[0].Message.TargetGasLimit)
 		require.DeepEqual(t, feeRecipient[:], prefs[0].Message.FeeRecipient)
 		require.NotNil(t, prefs[0].Signature)
 	})
@@ -2446,7 +2446,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 		prefs := v.buildProposerPreferences(t.Context(), km, midEpochSlot, false)
 		require.Equal(t, 1, len(prefs))
 		require.DeepEqual(t, customFeeRecipient[:], prefs[0].Message.FeeRecipient)
-		require.Equal(t, uint64(99000000), prefs[0].Message.GasLimit)
+		require.Equal(t, uint64(99000000), prefs[0].Message.TargetGasLimit)
 
 		// Restore default settings for other subtests.
 		v.proposerSettings = &proposer.Settings{
@@ -2661,7 +2661,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 					ProposerSlots:  []primitives.Slot{7},
 				},
 			},
-			NextEpochDuties: []*ethpb.ValidatorDuty{},
+			NextEpochDuties:   []*ethpb.ValidatorDuty{},
 			PrevDependentRoot: testProposerPrefDependentRoot,
 			CurrDependentRoot: testProposerPrefDependentRoot,
 		})
@@ -2728,7 +2728,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 					ProposerSlots:  []primitives.Slot{midEpochSlot + 2},
 				},
 			},
-			NextEpochDuties: []*ethpb.ValidatorDuty{},
+			NextEpochDuties:   []*ethpb.ValidatorDuty{},
 			PrevDependentRoot: testProposerPrefDependentRoot,
 			CurrDependentRoot: testProposerPrefDependentRoot,
 		})
@@ -2768,7 +2768,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 					ProposerSlots:  []primitives.Slot{5},
 				},
 			},
-			NextEpochDuties: []*ethpb.ValidatorDuty{},
+			NextEpochDuties:   []*ethpb.ValidatorDuty{},
 			PrevDependentRoot: testProposerPrefDependentRoot,
 			CurrDependentRoot: testProposerPrefDependentRoot,
 		})


### PR DESCRIPTION
- Rename `ProposerPreferences.gas_limit -> target_gas_limit`
- Add `IsGasLimitTargetCompatible(parent, gas, target)` implementing the EIP-1559 ±1/1024 elasticity rule, with the spec's 7 unit tests
- Replace strict bid `REJECT` `(gas_limit == prefs.gas_limit)` with an `IGNORE` check chained off `VerifyParentBlockHash` using the new `VerifyGasLimitTargetCompatible` verifier