### PR TITLE
feat(api): expose peer-scoring fields on /eth/v1/node/peers

### DIFF
--- a/api/server/structs/endpoints_node.go
+++ b/api/server/structs/endpoints_node.go
@@ -46,11 +46,15 @@ type GetPeersResponse struct {
 }
 
 type Peer struct {
-	PeerId             string `json:"peer_id"`
-	Enr                string `json:"enr"`
-	LastSeenP2PAddress string `json:"last_seen_p2p_address"`
-	State              string `json:"state"`
-	Direction          string `json:"direction"`
+	PeerId             string   `json:"peer_id"`
+	Enr                string   `json:"enr"`
+	LastSeenP2PAddress string   `json:"last_seen_p2p_address"`
+	State              string   `json:"state"`
+	Direction          string   `json:"direction"`
+	AgentVersion       string   `json:"agent_version,omitempty"`
+	Score              *float64 `json:"score,omitempty"`
+	DisconnectReason   string   `json:"disconnect_reason,omitempty"`
+	DownscoreReasons   []string `json:"downscore_reasons,omitempty"`
 }
 
 type GetPeerCountResponse struct {

--- a/beacon-chain/p2p/peers/peerdata/store.go
+++ b/beacon-chain/p2p/peers/peerdata/store.go
@@ -65,6 +65,13 @@ type PeerData struct {
 	TopicScores      map[string]*ethpb.TopicScoreSnapshot
 	GossipScore      float64
 	BehaviourPenalty float64
+	// Goodbye tracking: most recent goodbye code observed for this peer,
+	// whether we sent it (SentByUs=true) or received it from the peer
+	// (SentByUs=false), and the time it was observed. Zero-valued when no
+	// goodbye has been exchanged.
+	LastGoodbyeCode     uint64
+	LastGoodbyeSentByUs bool
+	LastGoodbyeObserved time.Time
 }
 
 // NewStore creates new peer data store.

--- a/beacon-chain/p2p/peers/peerdata/store.go
+++ b/beacon-chain/p2p/peers/peerdata/store.go
@@ -68,10 +68,11 @@ type PeerData struct {
 	// Goodbye tracking: most recent goodbye code observed for this peer,
 	// whether we sent it (SentByUs=true) or received it from the peer
 	// (SentByUs=false), and the time it was observed. Zero-valued when no
-	// goodbye has been exchanged.
+	// goodbye has been exchanged. Field order: large -> small to satisfy
+	// nogo's maligned-struct check.
 	LastGoodbyeCode     uint64
-	LastGoodbyeSentByUs bool
 	LastGoodbyeObserved time.Time
+	LastGoodbyeSentByUs bool
 }
 
 // NewStore creates new peer data store.

--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -398,6 +398,37 @@ func (p *Status) SetNextValidTime(pid peer.ID, nextTime time.Time) {
 	peerData.NextValidTime = nextTime
 }
 
+// SetLastGoodbye records the most recent goodbye code exchanged with a peer.
+// sentByUs is true when the local node initiated the goodbye and false when
+// the code was received from the remote peer. The observation time is set
+// to time.Now() so callers do not need to thread a clock through.
+func (p *Status) SetLastGoodbye(pid peer.ID, code uint64, sentByUs bool) {
+	p.store.Lock()
+	defer p.store.Unlock()
+
+	peerData := p.store.PeerDataGetOrCreate(pid)
+	peerData.LastGoodbyeCode = code
+	peerData.LastGoodbyeSentByUs = sentByUs
+	peerData.LastGoodbyeObserved = time.Now()
+}
+
+// LastGoodbye returns the most recent goodbye code observed for a peer along
+// with the direction (sentByUs) and the observation timestamp. The returned
+// ok value is false when no goodbye has been recorded for the peer.
+func (p *Status) LastGoodbye(pid peer.ID) (code uint64, sentByUs bool, at time.Time, ok bool) {
+	p.store.RLock()
+	defer p.store.RUnlock()
+
+	peerData, exists := p.store.PeerData(pid)
+	if !exists {
+		return 0, false, time.Time{}, false
+	}
+	if peerData.LastGoodbyeObserved.IsZero() {
+		return 0, false, time.Time{}, false
+	}
+	return peerData.LastGoodbyeCode, peerData.LastGoodbyeSentByUs, peerData.LastGoodbyeObserved, true
+}
+
 // RandomizeBackOff adds extra backoff period during which peer won't be dialed.
 func (p *Status) RandomizeBackOff(pid peer.ID) {
 	p.store.Lock()

--- a/beacon-chain/rpc/eth/node/BUILD.bazel
+++ b/beacon-chain/rpc/eth/node/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
+        "@com_github_libp2p_go_libp2p//core/host:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/rpc/eth/node/BUILD.bazel
+++ b/beacon-chain/rpc/eth/node/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//beacon-chain/p2p:go_default_library",
         "//beacon-chain/p2p/peers:go_default_library",
         "//beacon-chain/p2p/peers/peerdata:go_default_library",
+        "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/rpc/eth/shared:go_default_library",
         "//beacon-chain/sync:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/rpc/eth/node/handlers_peers.go
+++ b/beacon-chain/rpc/eth/node/handlers_peers.go
@@ -344,8 +344,14 @@ func populatePeerScoreFields(p *structs.Peer, peerStatus *peers.Status, hst host
 		if reasons := downscoreReasons(peerStatus, id); len(reasons) > 0 {
 			p.DownscoreReasons = reasons
 		}
-		if code, _, _, ok := peerStatus.LastGoodbye(id); ok {
-			p.DisconnectReason = mapGoodbyeCode(code)
+		// Per beacon-API spec, `disconnect_reason` MUST only be populated when
+		// `state` is `disconnected` or `disconnecting`. `p.State` is the
+		// lowercased connection state set by the caller.
+		if p.State == strings.ToLower(stateDisconnected) ||
+			p.State == strings.ToLower(stateDisconnecting) {
+			if code, _, _, ok := peerStatus.LastGoodbye(id); ok {
+				p.DisconnectReason = mapGoodbyeCode(code)
+			}
 		}
 	}
 }

--- a/beacon-chain/rpc/eth/node/handlers_peers.go
+++ b/beacon-chain/rpc/eth/node/handlers_peers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/peers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/peers/peerdata"
+	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	"github.com/OffchainLabs/prysm/v7/proto/migration"
@@ -28,6 +29,19 @@ const (
 	downscoreReasonBadResponses = "rpc_invalid_response"
 	downscoreReasonPeerStatus   = "status_unviable_fork"
 	downscoreReasonGossip       = "behaviour_penalty"
+)
+
+// Mapping from Prysm's goodbye codes to the beacon-API spec's controlled
+// vocabulary for disconnect reasons. See beacon-chain/p2p/types/rpc_goodbye_codes.go
+// for the source-of-truth code values.
+const (
+	disconnectReasonClientShutdown = "client_shutdown"
+	disconnectReasonIrrelevantNet  = "irrelevant_network"
+	disconnectReasonIOError        = "io_error"
+	disconnectReasonUnviableFork   = "unviable_fork"
+	disconnectReasonTooManyPeers   = "too_many_peers"
+	disconnectReasonBadScore       = "bad_score"
+	disconnectReasonUnknown        = "unknown"
 )
 
 // GetPeer retrieves data about the given peer.
@@ -330,6 +344,32 @@ func populatePeerScoreFields(p *structs.Peer, peerStatus *peers.Status, hst host
 		if reasons := downscoreReasons(peerStatus, id); len(reasons) > 0 {
 			p.DownscoreReasons = reasons
 		}
+		if code, _, _, ok := peerStatus.LastGoodbye(id); ok {
+			p.DisconnectReason = mapGoodbyeCode(code)
+		}
+	}
+}
+
+// mapGoodbyeCode translates a Prysm goodbye code into the beacon-API spec's
+// controlled disconnect_reason vocabulary. Unrecognized codes fall back to
+// "unknown" so callers can still distinguish "we observed a goodbye" from
+// "no goodbye seen" (which omits the field entirely).
+func mapGoodbyeCode(code uint64) string {
+	switch p2ptypes.RPCGoodbyeCode(code) {
+	case p2ptypes.GoodbyeCodeClientShutdown:
+		return disconnectReasonClientShutdown
+	case p2ptypes.GoodbyeCodeWrongNetwork:
+		return disconnectReasonIrrelevantNet
+	case p2ptypes.GoodbyeCodeGenericError:
+		return disconnectReasonIOError
+	case p2ptypes.GoodbyeCodeUnableToVerifyNetwork:
+		return disconnectReasonUnviableFork
+	case p2ptypes.GoodbyeCodeTooManyPeers:
+		return disconnectReasonTooManyPeers
+	case p2ptypes.GoodbyeCodeBadScore, p2ptypes.GoodbyeCodeBanned:
+		return disconnectReasonBadScore
+	default:
+		return disconnectReasonUnknown
 	}
 }
 

--- a/beacon-chain/rpc/eth/node/handlers_peers.go
+++ b/beacon-chain/rpc/eth/node/handlers_peers.go
@@ -13,8 +13,21 @@ import (
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	"github.com/OffchainLabs/prysm/v7/proto/migration"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+)
+
+// libp2pAgentVersionKey is the peerstore key used by libp2p to store a peer's
+// agent version (advertised via the libp2p identify protocol).
+const libp2pAgentVersionKey = "AgentVersion"
+
+// Mapping from Prysm's scorer error categories to the beacon-API spec's
+// controlled vocabulary for downscore reasons.
+const (
+	downscoreReasonBadResponses = "rpc_invalid_response"
+	downscoreReasonPeerStatus   = "status_unviable_fork"
+	downscoreReasonGossip       = "behaviour_penalty"
 )
 
 // GetPeer retrieves data about the given peer.
@@ -75,15 +88,16 @@ func (s *Server) GetPeer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := &structs.GetPeerResponse{
-		Data: &structs.Peer{
-			PeerId:             rawId,
-			Enr:                "enr:" + serializedEnr,
-			LastSeenP2PAddress: p2pAddress.String(),
-			State:              strings.ToLower(v1ConnState.String()),
-			Direction:          strings.ToLower(v1PeerDirection.String()),
-		},
+	data := &structs.Peer{
+		PeerId:             rawId,
+		Enr:                "enr:" + serializedEnr,
+		LastSeenP2PAddress: p2pAddress.String(),
+		State:              strings.ToLower(v1ConnState.String()),
+		Direction:          strings.ToLower(v1PeerDirection.String()),
 	}
+	populatePeerScoreFields(data, peerStatus, s.peerHost(), id)
+
+	resp := &structs.GetPeerResponse{Data: data}
 	httputil.WriteJson(w, resp)
 }
 
@@ -102,7 +116,7 @@ func (s *Server) GetPeers(w http.ResponseWriter, r *http.Request) {
 		allIds := peerStatus.All()
 		allPeers := make([]*structs.Peer, 0, len(allIds))
 		for _, id := range allIds {
-			p, err := peerInfo(peerStatus, id)
+			p, err := peerInfo(peerStatus, s.peerHost(), id)
 			if err != nil {
 				httputil.HandleError(w, "Could not get peer info: "+err.Error(), http.StatusInternalServerError)
 				return
@@ -171,7 +185,7 @@ func (s *Server) GetPeers(w http.ResponseWriter, r *http.Request) {
 	}
 	filteredPeers := make([]*structs.Peer, 0, len(filteredIds))
 	for _, id := range filteredIds {
-		p, err := peerInfo(peerStatus, id)
+		p, err := peerInfo(peerStatus, s.peerHost(), id)
 		if err != nil {
 			httputil.HandleError(w, "Could not get peer info: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -234,7 +248,7 @@ func handleEmptyFilters(states []string, directions []string) (emptyState, empty
 	return emptyState, emptyDirection
 }
 
-func peerInfo(peerStatus *peers.Status, id peer.ID) (*structs.Peer, error) {
+func peerInfo(peerStatus *peers.Status, hst host.Host, id peer.ID) (*structs.Peer, error) {
 	enr, err := peerStatus.ENR(id)
 	if err != nil {
 		if errors.Is(err, peerdata.ErrPeerUnknown) {
@@ -284,6 +298,79 @@ func peerInfo(peerStatus *peers.Status, id peer.ID) (*structs.Peer, error) {
 	if serializedEnr != "" {
 		p.Enr = "enr:" + serializedEnr
 	}
+	populatePeerScoreFields(p, peerStatus, hst, id)
 
 	return p, nil
+}
+
+// peerHost returns the libp2p host if the server has a PeerManager configured.
+// In unit tests the PeerManager is often nil; callers must tolerate a nil host.
+func (s *Server) peerHost() host.Host {
+	if s.PeerManager == nil {
+		return nil
+	}
+	return s.PeerManager.Host()
+}
+
+// populatePeerScoreFields fills in the optional score-related fields on the
+// peer struct. All lookups are best-effort: missing data leaves the
+// corresponding field empty so it is omitted from the JSON response.
+func populatePeerScoreFields(p *structs.Peer, peerStatus *peers.Status, hst host.Host, id peer.ID) {
+	if p == nil {
+		return
+	}
+	if hst != nil {
+		if agent := agentVersion(hst, id); agent != "" {
+			p.AgentVersion = agent
+		}
+	}
+	if peerStatus != nil {
+		score := peerStatus.Scorers().Score(id)
+		p.Score = &score
+		if reasons := downscoreReasons(peerStatus, id); len(reasons) > 0 {
+			p.DownscoreReasons = reasons
+		}
+	}
+}
+
+// agentVersion looks up the peer's advertised libp2p agent string from the
+// host's peerstore. Returns an empty string when the value is unavailable.
+func agentVersion(hst host.Host, id peer.ID) string {
+	if hst == nil {
+		return ""
+	}
+	raw, err := hst.Peerstore().Get(id, libp2pAgentVersionKey)
+	if err != nil {
+		return ""
+	}
+	agent, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return agent
+}
+
+// downscoreReasons inspects each Prysm scorer to determine why a peer is
+// currently considered bad. The Prysm scorers do not retain a per-event
+// history, so this reflects the live state at the time of the request and
+// maps it to the spec's controlled vocabulary.
+func downscoreReasons(peerStatus *peers.Status, id peer.ID) []string {
+	if peerStatus == nil {
+		return nil
+	}
+	scorerSvc := peerStatus.Scorers()
+	if scorerSvc == nil {
+		return nil
+	}
+	reasons := make([]string, 0, 3)
+	if err := scorerSvc.BadResponsesScorer().IsBadPeer(id); err != nil {
+		reasons = append(reasons, downscoreReasonBadResponses)
+	}
+	if err := scorerSvc.PeerStatusScorer().IsBadPeer(id); err != nil {
+		reasons = append(reasons, downscoreReasonPeerStatus)
+	}
+	if err := scorerSvc.GossipScorer().IsBadPeer(id); err != nil {
+		reasons = append(reasons, downscoreReasonGossip)
+	}
+	return reasons
 }

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -63,6 +63,7 @@ func (s *Service) goodbyeRPCHandler(_ context.Context, msg any, stream libp2pcor
 		"isRateLimited": isRateLimitedPeer,
 	}).Debug("Received a goodbye message")
 
+	s.cfg.p2p.Peers().SetLastGoodbye(peerID, uint64(*m), false)
 	s.cfg.p2p.Peers().SetNextValidTime(peerID, goodByeBackoff(*m))
 
 	if err := s.cfg.p2p.Disconnect(peerID); err != nil {
@@ -124,6 +125,7 @@ func (s *Service) sendGoodByeMessage(ctx context.Context, code p2ptypes.RPCGoodb
 	if err != nil {
 		return err
 	}
+	s.cfg.p2p.Peers().SetLastGoodbye(id, uint64(code), true)
 	stream, err := s.cfg.p2p.Send(ctx, &code, topic, id)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Extends `/eth/v1/node/peers` (and `/eth/v1/node/peers/{peer_id}`) with four optional fields per a simplified beacon-API spec extension currently under discussion:

- `agent_version` — from libp2p peerstore (`host.Peerstore().Get(id, "AgentVersion")`)
- `score` — composite via `peerStatus.Scorers().Score(id)`
- `disconnect_reason` — from new `LastGoodbye*` tracking persisted on `peerdata.PeerData`
- `downscore_reasons` — live-derived from each scorer's `IsBadPeer(id)` (snapshot of current bad-state flags)

## Spec proposal

ethereum/beacon-APIs#606

## What's in this PR

1. **`structs.Peer`** (`api/server/structs/endpoints_node.go`) — adds 4 fields with `omitempty` JSON tags.
2. **Handler wiring** (`beacon-chain/rpc/eth/node/handlers_peers.go`) — populates the new fields in `peerInfo()` plus inline controlled-vocab translators (`mapGoodbyeCode`, `mapDownscoreReasons`).
3. **Goodbye persistence** (`beacon-chain/p2p/peers/peerdata/store.go` + `status.go`) — new `LastGoodbye{Code, SentByUs, Observed}` on `PeerData`, with `SetLastGoodbye()` / `LastGoodbye()` accessors.
4. **Goodbye recording** (`beacon-chain/sync/rpc_goodbye.go`) — records inbound goodbyes in `goodbyeRPCHandler` and outbound in `sendGoodByeMessage`.
5. **BUILD.bazel** — adds `@com_github_libp2p_go_libp2p//core/host` dep for the new `host.Peerstore()` call.

## Note on `downscore_reasons`

Rather than persisting per-event reason history, this derives the current bad-state classification at query time from each scorer:

- `BadResponsesScorer.IsBadPeer(id)` → `rpc_invalid_response`
- `PeerStatusScorer.IsBadPeer(id)` → `status_unviable_fork`
- `GossipScorer.IsBadPeer(id)` → `behaviour_penalty`

Empty array when the peer isn't currently flagged. This sidesteps event-history storage but means `downscore_reasons` reflects "currently bad for these reasons" rather than "recently downscored for these reasons" — both are valid interpretations of the field; happy to revisit.

## Coordinated implementations

Part of a coordinated multi-client effort — see ethereum/beacon-APIs#606 for the other five client PRs.

## Status

**Draft.** `go build ./beacon-chain/...` + `go test ./beacon-chain/p2p/peers/... ./beacon-chain/rpc/eth/node/...` pass. Bazel build also clean (required a struct-field reordering on `PeerData` to satisfy `nogo`'s maligned-struct check).