### PR TITLE
Defer signature validation when onboarding builders at the Gloas fork

### DIFF
--- a/beacon-chain/core/gloas/deposit_request.go
+++ b/beacon-chain/core/gloas/deposit_request.go
@@ -29,7 +29,7 @@ func ProcessDepositRequests(ctx context.Context, beaconState state.BeaconState, 
 
 // processDepositRequest processes the specific deposit request
 //
-//	<spec fn="process_deposit_request" fork="gloas" hash="0e8b94ab">
+//	<spec fn="process_deposit_request" fork="gloas">
 //	def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
 //	    # [New in Gloas:EIP7732]
 //	    builder_pubkeys = [b.pubkey for b in state.builders]
@@ -43,7 +43,7 @@ func ProcessDepositRequests(ctx context.Context, beaconState state.BeaconState, 
 //	    if is_builder or (
 //	        is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
 //	        and not is_validator
-//	        and not is_pending_validator(state, deposit_request.pubkey)
+//	        and not is_pending_validator(state.pending_deposits, deposit_request.pubkey)
 //	    ):
 //	        # Apply builder deposits immediately
 //	        apply_deposit_for_builder(

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native:go_default_library",
+        "//beacon-chain/state/testing:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/core/helpers/deposit.go
+++ b/beacon-chain/core/helpers/deposit.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -74,6 +75,51 @@ func BatchVerifyPendingDepositsSignatures(ctx context.Context, deposits []*ethpb
 		return false, nil
 	}
 	return true, nil
+}
+
+// IsPendingValidator checks whether a pending deposit with a valid signature exists in the
+// given queue for the given pubkey.
+//
+//	<spec fn="is_pending_validator" fork="gloas">
+//	def is_pending_validator(pending_deposits: Sequence[PendingDeposit], pubkey: BLSPubkey) -> bool:
+//	    """
+//	    Check if a pending deposit with a valid signature is in the queue for the given pubkey.
+//	    """
+//	    for pending_deposit in pending_deposits:
+//	        if pending_deposit.pubkey != pubkey:
+//	            continue
+//	        if is_valid_deposit_signature(
+//	            pending_deposit.pubkey,
+//	            pending_deposit.withdrawal_credentials,
+//	            pending_deposit.amount,
+//	            pending_deposit.signature,
+//	        ):
+//	            return True
+//	    return False
+//	</spec>
+func IsPendingValidator(pendingDeposits []*ethpb.PendingDeposit, pubkey []byte) (bool, error) {
+	for _, deposit := range pendingDeposits {
+		if deposit == nil {
+			continue
+		}
+		if !bytes.Equal(deposit.PublicKey, pubkey) {
+			continue
+		}
+		valid, err := IsValidDepositSignature(&ethpb.Deposit_Data{
+			PublicKey:             deposit.PublicKey,
+			WithdrawalCredentials: deposit.WithdrawalCredentials,
+			Amount:                deposit.Amount,
+			Signature:             deposit.Signature,
+		})
+		if err != nil {
+			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Warn("Could not verify pending deposit signature")
+			continue
+		}
+		if valid {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // IsValidDepositSignature returns whether deposit_data is valid

--- a/beacon-chain/core/helpers/deposit_test.go
+++ b/beacon-chain/core/helpers/deposit_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
+	stateTesting "github.com/OffchainLabs/prysm/v7/beacon-chain/state/testing"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/container/trie"
@@ -177,4 +178,46 @@ func TestBatchVerifyPendingDepositsSignatures_InvalidSignature(t *testing.T) {
 	verified, err := helpers.BatchVerifyPendingDepositsSignatures(t.Context(), []*ethpb.PendingDeposit{pendingDeposit})
 	require.NoError(t, err)
 	require.Equal(t, false, verified)
+}
+
+func TestIsPendingValidator(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	validDeposit := stateTesting.GeneratePendingDeposit(t, sk, 1000, [32]byte{0x01}, 0)
+
+	t.Run("valid signature returns true", func(t *testing.T) {
+		ok, err := helpers.IsPendingValidator([]*ethpb.PendingDeposit{validDeposit}, validDeposit.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+
+	t.Run("invalid signature returns false", func(t *testing.T) {
+		invalid := &ethpb.PendingDeposit{
+			PublicKey:             validDeposit.PublicKey,
+			WithdrawalCredentials: validDeposit.WithdrawalCredentials,
+			Amount:                validDeposit.Amount,
+			Signature:             make([]byte, fieldparams.BLSSignatureLength),
+		}
+		ok, err := helpers.IsPendingValidator([]*ethpb.PendingDeposit{invalid}, validDeposit.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, false, ok)
+	})
+
+	t.Run("unknown pubkey returns false", func(t *testing.T) {
+		ok, err := helpers.IsPendingValidator([]*ethpb.PendingDeposit{validDeposit}, []byte{9, 9, 9})
+		require.NoError(t, err)
+		require.Equal(t, false, ok)
+	})
+
+	t.Run("nil entry skipped", func(t *testing.T) {
+		ok, err := helpers.IsPendingValidator([]*ethpb.PendingDeposit{nil, validDeposit}, validDeposit.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+
+	t.Run("empty slice returns false", func(t *testing.T) {
+		ok, err := helpers.IsPendingValidator(nil, validDeposit.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, false, ok)
+	})
 }

--- a/beacon-chain/state/state-native/getters_deposits.go
+++ b/beacon-chain/state/state-native/getters_deposits.go
@@ -1,9 +1,6 @@
 package state_native
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -34,57 +31,15 @@ func (b *BeaconState) PendingDeposits() ([]*ethpb.PendingDeposit, error) {
 	return b.pendingDepositsVal(), nil
 }
 
-// IsPendingValidator checks whether a pending deposit with a valid signature exists for the
-// given pubkey. This method requires access to the RLock on the state and only applies in
-// electra or later.
-//
-// <spec fn="is_pending_validator" fork="gloas" hash="9b409bab">
-// def is_pending_validator(state: BeaconState, pubkey: BLSPubkey) -> bool:
-//
-//	"""
-//	Check if a pending deposit with a valid signature is in the queue for the given pubkey.
-//	"""
-//	for pending_deposit in state.pending_deposits:
-//	    if pending_deposit.pubkey != pubkey:
-//	        continue
-//	    if is_valid_deposit_signature(
-//	        pending_deposit.pubkey,
-//	        pending_deposit.withdrawal_credentials,
-//	        pending_deposit.amount,
-//	        pending_deposit.signature,
-//	    ):
-//	        return True
-//	return False
-//
-// </spec>
+// IsPendingValidator checks the state's pending_deposits queue under RLock; the underlying
+// slice is not copied.
 func (b *BeaconState) IsPendingValidator(pubkey []byte) (bool, error) {
 	if b.version < version.Electra {
 		return false, errNotSupported("IsPendingValidator", b.version)
 	}
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	for _, deposit := range b.pendingDeposits {
-		if deposit == nil {
-			continue
-		}
-		if !bytes.Equal(deposit.PublicKey, pubkey) {
-			continue
-		}
-		valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
-			PublicKey:             deposit.PublicKey,
-			WithdrawalCredentials: deposit.WithdrawalCredentials,
-			Amount:                deposit.Amount,
-			Signature:             deposit.Signature,
-		})
-		if err != nil {
-			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Warn("Could not verify pending deposit signature")
-			continue
-		}
-		if valid {
-			return true, nil
-		}
-	}
-	return false, nil
+	return helpers.IsPendingValidator(b.pendingDeposits, pubkey)
 }
 
 func (b *BeaconState) pendingDepositsVal() []*ethpb.PendingDeposit {

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -653,7 +653,7 @@ func decreaseBalanceWithVal(currBalance, delta primitives.Gwei) primitives.Gwei 
 // OnboardBuildersFromPendingDeposits applies any pending builder deposits at the fork.
 // It mutates the state and prunes pending deposits accordingly.
 //
-//	<spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="2bd662c7">
+//	<spec fn="onboard_builders_from_pending_deposits" fork="gloas">
 //	def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
 //	    """
 //	    Applies any pending deposit for builders, effectively
@@ -663,41 +663,35 @@ func decreaseBalanceWithVal(currBalance, delta primitives.Gwei) primitives.Gwei 
 //
 //	    pending_deposits = []
 //	    for deposit in state.pending_deposits:
-//	        # Deposits for existing validators stay in pending queue
+//	        # Deposits for existing validators stay in the pending queue
 //	        if deposit.pubkey in validator_pubkeys:
 //	            pending_deposits.append(deposit)
 //	            continue
 //
-//	        # If the pubkey is associated with a builder that was created in a
-//	        # previous iteration or it is a builder deposit, try to apply the
-//	        # deposit to the new/existing builder. Note that the function
-//	        # apply_deposit_for_builder can mutate the state and may add a builder
-//	        # to the registry. For this reason, the list of builder pubkeys must
-//	        # be recomputed each iteration.
+//	        # Note that the function apply_deposit_for_builder can mutate the
+//	        # state and may add a builder to the registry. For this reason, the
+//	        # list of builder pubkeys must be recomputed each iteration.
 //	        builder_pubkeys = [b.pubkey for b in state.builders]
-//	        is_existing_builder = deposit.pubkey in builder_pubkeys
-//	        has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
-//	        if is_existing_builder or has_builder_credentials:
-//	            apply_deposit_for_builder(
-//	                state,
-//	                deposit.pubkey,
-//	                deposit.withdrawal_credentials,
-//	                deposit.amount,
-//	                deposit.signature,
-//	                deposit.slot,
-//	            )
-//	            continue
 //
-//	        # If there is a pending deposit for a new validator that has a valid
-//	        # signature, track the pubkey so that subsequent builder deposits for
-//	        # the same pubkey stay in pending (applied to the validator later)
-//	        # rather than creating a builder. Deposits with invalid signatures are
-//	        # dropped here since they would fail in apply_pending_deposit anyway.
-//	        if is_valid_deposit_signature(
-//	            deposit.pubkey, deposit.withdrawal_credentials, deposit.amount, deposit.signature
-//	        ):
-//	            validator_pubkeys.append(deposit.pubkey)
-//	            pending_deposits.append(deposit)
+//	        # Deposits for non-builders stay in the pending queue. If there is a
+//	        # valid pending deposit for a new validator with this pubkey, keep this
+//	        # deposit in the pending queue to be applied to that validator later.
+//	        if deposit.pubkey not in builder_pubkeys:
+//	            if not is_builder_withdrawal_credential(deposit.withdrawal_credentials):
+//	                pending_deposits.append(deposit)
+//	                continue
+//	            if is_pending_validator(pending_deposits, deposit.pubkey):
+//	                pending_deposits.append(deposit)
+//	                continue
+//
+//	        apply_deposit_for_builder(
+//	            state,
+//	            deposit.pubkey,
+//	            deposit.withdrawal_credentials,
+//	            deposit.amount,
+//	            deposit.signature,
+//	            deposit.slot,
+//	        )
 //
 //	    state.pending_deposits = pending_deposits
 //	</spec>
@@ -711,63 +705,32 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 
 	pendingDeposits := b.pendingDeposits
 	newPendingDeposits := make([]*ethpb.PendingDeposit, 0, len(pendingDeposits))
-	newValidatorPubkeys := make(map[[fieldparams.BLSPubkeyLength]byte]bool)
 
 	for _, deposit := range pendingDeposits {
 		pubkey := bytesutil.ToBytes48(deposit.PublicKey)
-		if _, ok := newValidatorPubkeys[pubkey]; ok {
-			newPendingDeposits = append(newPendingDeposits, deposit)
-			continue
-		}
 		if _, ok := b.validatorIndexByPubkey(pubkey); ok {
 			newPendingDeposits = append(newPendingDeposits, deposit)
 			continue
 		}
 
-		if idx, ok := b.builderIndexByPubkey(pubkey); ok {
-			if err := b.increaseBuilderBalance(idx, deposit.Amount); err != nil {
-				return err
-			}
-			continue
-		}
-
-		if helpers.IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials) {
-			valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
-				PublicKey:             deposit.PublicKey,
-				WithdrawalCredentials: deposit.WithdrawalCredentials,
-				Amount:                deposit.Amount,
-				Signature:             deposit.Signature,
-			})
-			if err != nil {
-				log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Could not verify builder deposit signature")
+		builderIdx, isExistingBuilder := b.builderIndexByPubkey(pubkey)
+		if !isExistingBuilder {
+			if !helpers.IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials) {
+				newPendingDeposits = append(newPendingDeposits, deposit)
 				continue
 			}
-			if valid {
-				depositEpoch := slots.ToEpoch(deposit.Slot)
-				if err := b.addBuilderFromDepositAtEpoch(pubkey, bytesutil.ToBytes32(deposit.WithdrawalCredentials), deposit.Amount, depositEpoch); err != nil {
-					log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Failed to apply builder deposit")
-					continue
-				}
-			} else {
-				log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).Debug("Invalid signature for builder deposit")
+			isPending, err := helpers.IsPendingValidator(newPendingDeposits, deposit.PublicKey)
+			if err != nil {
+				return err
 			}
-			continue
+			if isPending {
+				newPendingDeposits = append(newPendingDeposits, deposit)
+				continue
+			}
 		}
 
-		valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
-			PublicKey:             deposit.PublicKey,
-			WithdrawalCredentials: deposit.WithdrawalCredentials,
-			Amount:                deposit.Amount,
-			Signature:             deposit.Signature,
-		})
-		if err != nil {
-			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Could not verify validator deposit signature")
-		}
-		if valid {
-			newValidatorPubkeys[pubkey] = true
-			newPendingDeposits = append(newPendingDeposits, deposit)
-		} else {
-			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).Debug("Invalid signature for validator deposit")
+		if err := b.applyDepositForBuilder(deposit, builderIdx, isExistingBuilder); err != nil {
+			return err
 		}
 	}
 
@@ -776,6 +739,55 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 	b.pendingDeposits = newPendingDeposits
 	b.markFieldAsDirty(types.PendingDeposits)
 
+	return nil
+}
+
+// <spec fn="apply_deposit_for_builder" fork="gloas" hash="e4bc98c7">
+// def apply_deposit_for_builder(
+//
+//	state: BeaconState,
+//	pubkey: BLSPubkey,
+//	withdrawal_credentials: Bytes32,
+//	amount: uint64,
+//	signature: BLSSignature,
+//	slot: Slot,
+//
+// ) -> None:
+//
+//	builder_pubkeys = [b.pubkey for b in state.builders]
+//	if pubkey not in builder_pubkeys:
+//	    # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
+//	    if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
+//	        add_builder_to_registry(state, pubkey, withdrawal_credentials, amount, slot)
+//	else:
+//	    # Increase balance by deposit amount
+//	    builder_index = builder_pubkeys.index(pubkey)
+//	    state.builders[builder_index].balance += amount
+//
+// </spec>
+func (b *BeaconState) applyDepositForBuilder(deposit *ethpb.PendingDeposit, builderIdx primitives.BuilderIndex, isExistingBuilder bool) error {
+	if isExistingBuilder {
+		return b.increaseBuilderBalance(builderIdx, deposit.Amount)
+	}
+	valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
+		PublicKey:             deposit.PublicKey,
+		WithdrawalCredentials: deposit.WithdrawalCredentials,
+		Amount:                deposit.Amount,
+		Signature:             deposit.Signature,
+	})
+	if err != nil {
+		log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Could not verify builder deposit signature")
+		return nil
+	}
+	if !valid {
+		log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).Debug("Invalid signature for builder deposit")
+		return nil
+	}
+	pubkey := bytesutil.ToBytes48(deposit.PublicKey)
+	depositEpoch := slots.ToEpoch(deposit.Slot)
+	if err := b.addBuilderFromDepositAtEpoch(pubkey, bytesutil.ToBytes32(deposit.WithdrawalCredentials), deposit.Amount, depositEpoch); err != nil {
+		log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Failed to apply builder deposit")
+	}
 	return nil
 }
 

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -1064,7 +1064,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		require.Equal(t, 0, len(st.builders))
 	})
 
-	t.Run("drops invalid non-builder deposit", func(t *testing.T) {
+	t.Run("keeps invalid non-builder deposit in pending queue", func(t *testing.T) {
 		sk, err := bls.RandKey()
 		require.NoError(t, err)
 		validatorCreds := nonBuilderWithdrawalCredentials()
@@ -1072,8 +1072,40 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{deposit}, 0)
 		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
-		require.Equal(t, 0, len(st.pendingDeposits))
+		require.Equal(t, 1, len(st.pendingDeposits))
 		require.Equal(t, 0, len(st.builders))
+	})
+
+	t.Run("creates builder then increases balance for same pubkey", func(t *testing.T) {
+		sk, err := bls.RandKey()
+		require.NoError(t, err)
+		builderCreds := builderWithdrawalCredentials(0x11)
+		depSlot := primitives.Slot(params.BeaconConfig().SlotsPerEpoch * 2)
+		depositCreate := newPendingDeposit(t, sk, builderCreds, 10, depSlot, true)
+		depositTopUp := newPendingDeposit(t, sk, builderCreds, 5, depSlot, true)
+
+		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositCreate, depositTopUp}, 0)
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.Equal(t, 0, len(st.pendingDeposits))
+		require.Equal(t, 1, len(st.builders))
+		require.Equal(t, primitives.Gwei(15), st.builders[0].Balance)
+	})
+
+	t.Run("invalid validator deposit followed by valid builder deposit same pubkey", func(t *testing.T) {
+		sk, err := bls.RandKey()
+		require.NoError(t, err)
+		validatorCreds := nonBuilderWithdrawalCredentials()
+		builderCreds := builderWithdrawalCredentials(0xFF)
+
+		depositInvalidValidator := newPendingDeposit(t, sk, validatorCreds, 5, 0, false)
+		depositBuilder := newPendingDeposit(t, sk, builderCreds, 7, 0, true)
+
+		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositInvalidValidator, depositBuilder}, 0)
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.Equal(t, 1, len(st.pendingDeposits))
+		require.DeepEqual(t, depositInvalidValidator, st.pendingDeposits[0])
+		require.Equal(t, 1, len(st.builders))
+		require.Equal(t, primitives.Gwei(7), st.builders[0].Balance)
 	})
 }
 

--- a/changelog/terence_onboard-builders-defer-sigs.md
+++ b/changelog/terence_onboard-builders-defer-sigs.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Defer signature validation for the pending_deposits queue when onboarding builders at the Gloas fork (consensus-specs#5254).


### PR DESCRIPTION
  - Port consensus-specs#5254: keep invalid validator-credential deposits in `pending_deposits` at the Gloas fork instead of dropping them eagerly. Signatures are still checked later in `apply_pending_deposit`.
  - Make `helpers.IsPendingValidator` a free function that takes a `pending_deposits` slice; state method delegates to it.