### PR TITLE
Bump spec to v1.7.0-alpha.8

### DIFF
--- a/.ethspecify.yml
+++ b/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.7
+version: v1.7.0-alpha.8
 style: full
 
 specrefs:
@@ -82,6 +82,7 @@ exceptions:
     - GLOAS_FORK_EPOCH#gloas
     - GLOAS_FORK_VERSION#gloas
     - MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS#gloas
+    - PAYLOAD_DUE_BPS#gloas
     - SYNC_MESSAGE_DUE_BPS_GLOAS#gloas
     # heze
     - HEZE_FORK_EPOCH#heze
@@ -150,8 +151,11 @@ exceptions:
     - ExpectedWithdrawals#capella
     - LightClientStore#capella
     - Seen#capella
+    # deneb
+    - Seen#deneb
     # electra
     - ExpectedWithdrawals#electra
+    - Seen#electra
     # fulu
     - BlobParameters#fulu
     # gloas
@@ -378,6 +382,11 @@ exceptions:
     - upgrade_lc_optimistic_update_to_deneb#deneb
     - upgrade_lc_store_to_deneb#deneb
     - upgrade_lc_update_to_deneb#deneb
+    - validate_beacon_aggregate_and_proof_gossip#deneb
+    - validate_beacon_attestation_gossip#deneb
+    - validate_beacon_block_gossip#deneb
+    - validate_blob_sidecar_gossip#deneb
+    - validate_voluntary_exit_gossip#deneb
     # electra
     - compute_max_request_blob_sidecars#electra
     - compute_weak_subjectivity_period#electra
@@ -400,6 +409,10 @@ exceptions:
     - upgrade_lc_optimistic_update_to_electra#electra
     - upgrade_lc_store_to_electra#electra
     - upgrade_lc_update_to_electra#electra
+    - validate_beacon_aggregate_and_proof_gossip#electra
+    - validate_beacon_attestation_gossip#electra
+    - validate_beacon_block_gossip#electra
+    - validate_blob_sidecar_gossip#electra
     # fulu
     - compute_max_request_data_column_sidecars#fulu
     - compute_matrix#fulu
@@ -411,12 +424,16 @@ exceptions:
     - recover_matrix#fulu
     # gloas
     - get_latest_message_epoch#gloas
+    - get_payload_due_ms#gloas
+    - is_gas_limit_target_compatible#gloas
     - is_payload_verified#gloas
     - on_execution_payload_envelope#gloas
+    - payload_data_availability#gloas
+    - payload_timeliness#gloas
     - settle_builder_payment#gloas
+    - should_build_on_full#gloas
     - compute_ptc#gloas
     - initialize_ptc_window#gloas
-    - is_payload_data_available#gloas
     - is_pending_validator#gloas
     - process_ptc_window#gloas
     - compute_balance_weighted_selection#gloas
@@ -454,7 +471,6 @@ exceptions:
     - is_builder_withdrawal_credential#gloas
     - is_merge_transition_complete#gloas
     - is_parent_node_full#gloas
-    - is_payload_timely#gloas
     - is_supporting_vote#gloas
     - is_valid_indexed_payload_attestation#gloas
     - notify_ptc_messages#gloas

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -273,7 +273,7 @@ filegroup(
     url = "https://github.com/ethereum/EIPs/archive/5480440fe51742ed23342b68cf106cefd427e39d.tar.gz",
 )
 
-consensus_spec_version = "v1.7.0-alpha.7"
+consensus_spec_version = "v1.7.0-alpha.8"
 
 load("@prysm//tools:download_spectests.bzl", "consensus_spec_tests")
 
@@ -281,8 +281,8 @@ consensus_spec_tests(
     name = "consensus_spec_tests",
     flavors = {
         "general": "sha256-szDpBVO2Ebi8/bwbiWFpW6H4c5gxnpU3hAUS31AF02E=",
-        "minimal": "sha256-BYVf3E2lbvttjDoz/38Pnb+aG5VyuOaOEH/DuhK1V/k=",
-        "mainnet": "sha256-qWxStQPh2lMF3xyMCZdKK5WglUXP/upjtEC+gDBZ9dY=",
+        "minimal": "sha256-SBEdtQ+HwaxFCuPwzcvkJazRuur6LlMol3egANCwH4Y=",
+        "mainnet": "sha256-alrKgbLxWFRNb8/jLInQ0eJru5ScAWnxM0rEOzdm/YE=",
     },
     version = consensus_spec_version,
 )
@@ -298,7 +298,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    integrity = "sha256-oRIZFRcuobU9Ih4jBYF4OPAkww0PFnf2ZeHoj1wkduA=",
+    integrity = "sha256-x0OkYCK+MJfPoEAnEmpftgl60ervC4W3zCg0KA9XiXU=",
     strip_prefix = "consensus-specs-" + consensus_spec_version[1:],
     url = "https://github.com/ethereum/consensus-specs/archive/refs/tags/%s.tar.gz" % consensus_spec_version,
 )

--- a/beacon-chain/core/gloas/deposit_request.go
+++ b/beacon-chain/core/gloas/deposit_request.go
@@ -29,7 +29,7 @@ func ProcessDepositRequests(ctx context.Context, beaconState state.BeaconState, 
 
 // processDepositRequest processes the specific deposit request
 //
-//	<spec fn="process_deposit_request" fork="gloas" hash="0e8b94ab">
+//	<spec fn="process_deposit_request" fork="gloas" hash="a6fff32f">
 //	def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
 //	    # [New in Gloas:EIP7732]
 //	    builder_pubkeys = [b.pubkey for b in state.builders]
@@ -43,7 +43,7 @@ func ProcessDepositRequests(ctx context.Context, beaconState state.BeaconState, 
 //	    if is_builder or (
 //	        is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
 //	        and not is_validator
-//	        and not is_pending_validator(state, deposit_request.pubkey)
+//	        and not is_pending_validator(state.pending_deposits, deposit_request.pubkey)
 //	    ):
 //	        # Apply builder deposits immediately
 //	        apply_deposit_for_builder(

--- a/beacon-chain/core/gloas/payload_attestation.go
+++ b/beacon-chain/core/gloas/payload_attestation.go
@@ -109,10 +109,10 @@ func indexedPayloadAttestation(ctx context.Context, st state.ReadOnlyBeaconState
 
 // computePTC computes the payload timeliness committee for a given slot.
 //
-//	<spec fn="compute_ptc" fork="gloas" hash="0f323552">
+//	<spec fn="compute_ptc" fork="gloas" hash="1dcaa117">
 //	def compute_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
 //	    """
-//	    Get the payload timeliness committee for the given ``slot``.
+//	    Get the payload timeliness committee, with possible duplicates, for the given ``slot``.
 //	    """
 //	    epoch = compute_epoch_at_slot(slot)
 //	    seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
@@ -196,7 +196,7 @@ func ptcSeed(st state.ReadOnlyBeaconState, epoch primitives.Epoch, slot primitiv
 
 // selectByBalance selects a balance-weighted subset of input candidates.
 //
-//	<spec fn="compute_balance_weighted_selection" fork="gloas" hash="f99b3e37">
+//	<spec fn="compute_balance_weighted_selection" fork="gloas" hash="e5dff16e">
 //	def compute_balance_weighted_selection(
 //	    state: BeaconState,
 //	    indices: Sequence[ValidatorIndex],
@@ -208,7 +208,7 @@ func ptcSeed(st state.ReadOnlyBeaconState, epoch primitives.Epoch, slot primitiv
 //	    Return ``size`` indices sampled by effective balance, using ``indices``
 //	    as candidates. If ``shuffle_indices`` is ``True``, candidate indices
 //	    are themselves sampled from ``indices`` by shuffling it, otherwise
-//	    ``indices`` is traversed in order.
+//	    ``indices`` is traversed in order. The returned list can contain duplicates.
 //	    """
 //	    MAX_RANDOM_VALUE = 2**16 - 1
 //	    total = uint64(len(indices))

--- a/beacon-chain/core/gloas/upgrade.go
+++ b/beacon-chain/core/gloas/upgrade.go
@@ -17,7 +17,7 @@ import (
 
 // UpgradeToGloas updates inputs a generic state to return the version Gloas state.
 //
-//	<spec fn="upgrade_to_gloas" fork="gloas" hash="e0974e00">
+//	<spec fn="upgrade_to_gloas" fork="gloas" hash="d9a22a92">
 //	def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
 //	    epoch = fulu.get_current_epoch(pre)
 //
@@ -81,6 +81,7 @@ import (
 //	        # [New in Gloas:EIP7732]
 //	        latest_execution_payload_bid=ExecutionPayloadBid(
 //	            block_hash=pre.latest_execution_payload_header.block_hash,
+//	            gas_limit=pre.latest_execution_payload_header.gas_limit,
 //	            execution_requests_root=hash_tree_root(ExecutionRequests()),
 //	        ),
 //	        # [New in Gloas:EIP7732]
@@ -344,6 +345,7 @@ func upgradeToGloas(beaconState state.BeaconState) (state.BeaconState, error) {
 		NextSyncCommittee:           nextSyncCommittee,
 		LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
 			BlockHash:             payloadHeader.BlockHash(),
+			GasLimit:              payloadHeader.GasLimit(),
 			FeeRecipient:          make([]byte, fieldparams.FeeRecipientLength),
 			ParentBlockHash:       make([]byte, fieldparams.RootLength),
 			ParentBlockRoot:       make([]byte, fieldparams.RootLength),

--- a/beacon-chain/core/helpers/deposit.go
+++ b/beacon-chain/core/helpers/deposit.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -74,6 +75,51 @@ func BatchVerifyPendingDepositsSignatures(ctx context.Context, deposits []*ethpb
 		return false, nil
 	}
 	return true, nil
+}
+
+// IsPendingValidator checks whether a pending deposit with a valid signature exists in the
+// given queue for the given pubkey.
+//
+//	<spec fn="is_pending_validator" fork="gloas" hash="4cec3c3c">
+//	def is_pending_validator(pending_deposits: Sequence[PendingDeposit], pubkey: BLSPubkey) -> bool:
+//	    """
+//	    Check if a pending deposit with a valid signature is in the queue for the given pubkey.
+//	    """
+//	    for pending_deposit in pending_deposits:
+//	        if pending_deposit.pubkey != pubkey:
+//	            continue
+//	        if is_valid_deposit_signature(
+//	            pending_deposit.pubkey,
+//	            pending_deposit.withdrawal_credentials,
+//	            pending_deposit.amount,
+//	            pending_deposit.signature,
+//	        ):
+//	            return True
+//	    return False
+//	</spec>
+func IsPendingValidator(pendingDeposits []*ethpb.PendingDeposit, pubkey []byte) (bool, error) {
+	for _, deposit := range pendingDeposits {
+		if deposit == nil {
+			continue
+		}
+		if !bytes.Equal(deposit.PublicKey, pubkey) {
+			continue
+		}
+		valid, err := IsValidDepositSignature(&ethpb.Deposit_Data{
+			PublicKey:             deposit.PublicKey,
+			WithdrawalCredentials: deposit.WithdrawalCredentials,
+			Amount:                deposit.Amount,
+			Signature:             deposit.Signature,
+		})
+		if err != nil {
+			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Warn("Could not verify pending deposit signature")
+			continue
+		}
+		if valid {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // IsValidDepositSignature returns whether deposit_data is valid

--- a/beacon-chain/state/state-native/getters_deposits.go
+++ b/beacon-chain/state/state-native/getters_deposits.go
@@ -1,9 +1,6 @@
 package state_native
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -34,57 +31,15 @@ func (b *BeaconState) PendingDeposits() ([]*ethpb.PendingDeposit, error) {
 	return b.pendingDepositsVal(), nil
 }
 
-// IsPendingValidator checks whether a pending deposit with a valid signature exists for the
-// given pubkey. This method requires access to the RLock on the state and only applies in
-// electra or later.
-//
-// <spec fn="is_pending_validator" fork="gloas" hash="9b409bab">
-// def is_pending_validator(state: BeaconState, pubkey: BLSPubkey) -> bool:
-//
-//	"""
-//	Check if a pending deposit with a valid signature is in the queue for the given pubkey.
-//	"""
-//	for pending_deposit in state.pending_deposits:
-//	    if pending_deposit.pubkey != pubkey:
-//	        continue
-//	    if is_valid_deposit_signature(
-//	        pending_deposit.pubkey,
-//	        pending_deposit.withdrawal_credentials,
-//	        pending_deposit.amount,
-//	        pending_deposit.signature,
-//	    ):
-//	        return True
-//	return False
-//
-// </spec>
+// IsPendingValidator checks the state's pending_deposits queue under RLock; the underlying
+// slice is not copied.
 func (b *BeaconState) IsPendingValidator(pubkey []byte) (bool, error) {
 	if b.version < version.Electra {
 		return false, errNotSupported("IsPendingValidator", b.version)
 	}
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	for _, deposit := range b.pendingDeposits {
-		if deposit == nil {
-			continue
-		}
-		if !bytes.Equal(deposit.PublicKey, pubkey) {
-			continue
-		}
-		valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
-			PublicKey:             deposit.PublicKey,
-			WithdrawalCredentials: deposit.WithdrawalCredentials,
-			Amount:                deposit.Amount,
-			Signature:             deposit.Signature,
-		})
-		if err != nil {
-			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Warn("Could not verify pending deposit signature")
-			continue
-		}
-		if valid {
-			return true, nil
-		}
-	}
-	return false, nil
+	return helpers.IsPendingValidator(b.pendingDeposits, pubkey)
 }
 
 func (b *BeaconState) pendingDepositsVal() []*ethpb.PendingDeposit {

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -653,7 +653,7 @@ func decreaseBalanceWithVal(currBalance, delta primitives.Gwei) primitives.Gwei 
 // OnboardBuildersFromPendingDeposits applies any pending builder deposits at the fork.
 // It mutates the state and prunes pending deposits accordingly.
 //
-//	<spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="2bd662c7">
+//	<spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="6bb266a4">
 //	def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
 //	    """
 //	    Applies any pending deposit for builders, effectively
@@ -663,41 +663,35 @@ func decreaseBalanceWithVal(currBalance, delta primitives.Gwei) primitives.Gwei 
 //
 //	    pending_deposits = []
 //	    for deposit in state.pending_deposits:
-//	        # Deposits for existing validators stay in pending queue
+//	        # Deposits for existing validators stay in the pending queue
 //	        if deposit.pubkey in validator_pubkeys:
 //	            pending_deposits.append(deposit)
 //	            continue
 //
-//	        # If the pubkey is associated with a builder that was created in a
-//	        # previous iteration or it is a builder deposit, try to apply the
-//	        # deposit to the new/existing builder. Note that the function
-//	        # apply_deposit_for_builder can mutate the state and may add a builder
-//	        # to the registry. For this reason, the list of builder pubkeys must
-//	        # be recomputed each iteration.
+//	        # Note that the function apply_deposit_for_builder can mutate the
+//	        # state and may add a builder to the registry. For this reason, the
+//	        # list of builder pubkeys must be recomputed each iteration.
 //	        builder_pubkeys = [b.pubkey for b in state.builders]
-//	        is_existing_builder = deposit.pubkey in builder_pubkeys
-//	        has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
-//	        if is_existing_builder or has_builder_credentials:
-//	            apply_deposit_for_builder(
-//	                state,
-//	                deposit.pubkey,
-//	                deposit.withdrawal_credentials,
-//	                deposit.amount,
-//	                deposit.signature,
-//	                deposit.slot,
-//	            )
-//	            continue
 //
-//	        # If there is a pending deposit for a new validator that has a valid
-//	        # signature, track the pubkey so that subsequent builder deposits for
-//	        # the same pubkey stay in pending (applied to the validator later)
-//	        # rather than creating a builder. Deposits with invalid signatures are
-//	        # dropped here since they would fail in apply_pending_deposit anyway.
-//	        if is_valid_deposit_signature(
-//	            deposit.pubkey, deposit.withdrawal_credentials, deposit.amount, deposit.signature
-//	        ):
-//	            validator_pubkeys.append(deposit.pubkey)
-//	            pending_deposits.append(deposit)
+//	        # Deposits for non-builders stay in the pending queue. If there is a
+//	        # valid pending deposit for a new validator with this pubkey, keep this
+//	        # deposit in the pending queue to be applied to that validator later.
+//	        if deposit.pubkey not in builder_pubkeys:
+//	            if not is_builder_withdrawal_credential(deposit.withdrawal_credentials):
+//	                pending_deposits.append(deposit)
+//	                continue
+//	            if is_pending_validator(pending_deposits, deposit.pubkey):
+//	                pending_deposits.append(deposit)
+//	                continue
+//
+//	        apply_deposit_for_builder(
+//	            state,
+//	            deposit.pubkey,
+//	            deposit.withdrawal_credentials,
+//	            deposit.amount,
+//	            deposit.signature,
+//	            deposit.slot,
+//	        )
 //
 //	    state.pending_deposits = pending_deposits
 //	</spec>
@@ -711,63 +705,32 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 
 	pendingDeposits := b.pendingDeposits
 	newPendingDeposits := make([]*ethpb.PendingDeposit, 0, len(pendingDeposits))
-	newValidatorPubkeys := make(map[[fieldparams.BLSPubkeyLength]byte]bool)
 
 	for _, deposit := range pendingDeposits {
 		pubkey := bytesutil.ToBytes48(deposit.PublicKey)
-		if _, ok := newValidatorPubkeys[pubkey]; ok {
-			newPendingDeposits = append(newPendingDeposits, deposit)
-			continue
-		}
 		if _, ok := b.validatorIndexByPubkey(pubkey); ok {
 			newPendingDeposits = append(newPendingDeposits, deposit)
 			continue
 		}
 
-		if idx, ok := b.builderIndexByPubkey(pubkey); ok {
-			if err := b.increaseBuilderBalance(idx, deposit.Amount); err != nil {
-				return err
-			}
-			continue
-		}
-
-		if helpers.IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials) {
-			valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
-				PublicKey:             deposit.PublicKey,
-				WithdrawalCredentials: deposit.WithdrawalCredentials,
-				Amount:                deposit.Amount,
-				Signature:             deposit.Signature,
-			})
-			if err != nil {
-				log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Could not verify builder deposit signature")
+		builderIdx, isExistingBuilder := b.builderIndexByPubkey(pubkey)
+		if !isExistingBuilder {
+			if !helpers.IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials) {
+				newPendingDeposits = append(newPendingDeposits, deposit)
 				continue
 			}
-			if valid {
-				depositEpoch := slots.ToEpoch(deposit.Slot)
-				if err := b.addBuilderFromDepositAtEpoch(pubkey, bytesutil.ToBytes32(deposit.WithdrawalCredentials), deposit.Amount, depositEpoch); err != nil {
-					log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Failed to apply builder deposit")
-					continue
-				}
-			} else {
-				log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).Debug("Invalid signature for builder deposit")
+			isPending, err := helpers.IsPendingValidator(newPendingDeposits, deposit.PublicKey)
+			if err != nil {
+				return err
 			}
-			continue
+			if isPending {
+				newPendingDeposits = append(newPendingDeposits, deposit)
+				continue
+			}
 		}
 
-		valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
-			PublicKey:             deposit.PublicKey,
-			WithdrawalCredentials: deposit.WithdrawalCredentials,
-			Amount:                deposit.Amount,
-			Signature:             deposit.Signature,
-		})
-		if err != nil {
-			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Could not verify validator deposit signature")
-		}
-		if valid {
-			newValidatorPubkeys[pubkey] = true
-			newPendingDeposits = append(newPendingDeposits, deposit)
-		} else {
-			log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).Debug("Invalid signature for validator deposit")
+		if err := b.applyDepositForBuilder(deposit, builderIdx, isExistingBuilder); err != nil {
+			return err
 		}
 	}
 
@@ -776,6 +739,55 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 	b.pendingDeposits = newPendingDeposits
 	b.markFieldAsDirty(types.PendingDeposits)
 
+	return nil
+}
+
+// <spec fn="apply_deposit_for_builder" fork="gloas" hash="e4bc98c7">
+// def apply_deposit_for_builder(
+//
+//	state: BeaconState,
+//	pubkey: BLSPubkey,
+//	withdrawal_credentials: Bytes32,
+//	amount: uint64,
+//	signature: BLSSignature,
+//	slot: Slot,
+//
+// ) -> None:
+//
+//	builder_pubkeys = [b.pubkey for b in state.builders]
+//	if pubkey not in builder_pubkeys:
+//	    # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
+//	    if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
+//	        add_builder_to_registry(state, pubkey, withdrawal_credentials, amount, slot)
+//	else:
+//	    # Increase balance by deposit amount
+//	    builder_index = builder_pubkeys.index(pubkey)
+//	    state.builders[builder_index].balance += amount
+//
+// </spec>
+func (b *BeaconState) applyDepositForBuilder(deposit *ethpb.PendingDeposit, builderIdx primitives.BuilderIndex, isExistingBuilder bool) error {
+	if isExistingBuilder {
+		return b.increaseBuilderBalance(builderIdx, deposit.Amount)
+	}
+	valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
+		PublicKey:             deposit.PublicKey,
+		WithdrawalCredentials: deposit.WithdrawalCredentials,
+		Amount:                deposit.Amount,
+		Signature:             deposit.Signature,
+	})
+	if err != nil {
+		log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Could not verify builder deposit signature")
+		return nil
+	}
+	if !valid {
+		log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).Debug("Invalid signature for builder deposit")
+		return nil
+	}
+	pubkey := bytesutil.ToBytes48(deposit.PublicKey)
+	depositEpoch := slots.ToEpoch(deposit.Slot)
+	if err := b.addBuilderFromDepositAtEpoch(pubkey, bytesutil.ToBytes32(deposit.WithdrawalCredentials), deposit.Amount, depositEpoch); err != nil {
+		log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).WithError(err).Debug("Failed to apply builder deposit")
+	}
 	return nil
 }
 

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -714,22 +714,27 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 		}
 
 		builderIdx, isExistingBuilder := b.builderIndexByPubkey(pubkey)
-		if !isExistingBuilder {
-			if !helpers.IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials) {
-				newPendingDeposits = append(newPendingDeposits, deposit)
-				continue
-			}
-			isPending, err := helpers.IsPendingValidator(newPendingDeposits, deposit.PublicKey)
-			if err != nil {
+		if isExistingBuilder {
+			if err := b.increaseBuilderBalance(builderIdx, deposit.Amount); err != nil {
 				return err
 			}
-			if isPending {
-				newPendingDeposits = append(newPendingDeposits, deposit)
-				continue
-			}
+			continue
 		}
 
-		if err := b.applyDepositForBuilder(deposit, builderIdx, isExistingBuilder); err != nil {
+		if !helpers.IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials) {
+			newPendingDeposits = append(newPendingDeposits, deposit)
+			continue
+		}
+		isPending, err := helpers.IsPendingValidator(newPendingDeposits, deposit.PublicKey)
+		if err != nil {
+			return err
+		}
+		if isPending {
+			newPendingDeposits = append(newPendingDeposits, deposit)
+			continue
+		}
+
+		if err := b.applyDepositForNewBuilder(deposit); err != nil {
 			return err
 		}
 	}
@@ -765,10 +770,7 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 //	    state.builders[builder_index].balance += amount
 //
 // </spec>
-func (b *BeaconState) applyDepositForBuilder(deposit *ethpb.PendingDeposit, builderIdx primitives.BuilderIndex, isExistingBuilder bool) error {
-	if isExistingBuilder {
-		return b.increaseBuilderBalance(builderIdx, deposit.Amount)
-	}
+func (b *BeaconState) applyDepositForNewBuilder(deposit *ethpb.PendingDeposit) error {
 	valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
 		PublicKey:             deposit.PublicKey,
 		WithdrawalCredentials: deposit.WithdrawalCredentials,

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -1064,7 +1064,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		require.Equal(t, 0, len(st.builders))
 	})
 
-	t.Run("drops invalid non-builder deposit", func(t *testing.T) {
+	t.Run("keeps invalid non-builder deposit in pending queue", func(t *testing.T) {
 		sk, err := bls.RandKey()
 		require.NoError(t, err)
 		validatorCreds := nonBuilderWithdrawalCredentials()
@@ -1072,8 +1072,40 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{deposit}, 0)
 		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
-		require.Equal(t, 0, len(st.pendingDeposits))
+		require.Equal(t, 1, len(st.pendingDeposits))
 		require.Equal(t, 0, len(st.builders))
+	})
+
+	t.Run("creates builder then increases balance for same pubkey", func(t *testing.T) {
+		sk, err := bls.RandKey()
+		require.NoError(t, err)
+		builderCreds := builderWithdrawalCredentials(0x11)
+		depSlot := primitives.Slot(params.BeaconConfig().SlotsPerEpoch * 2)
+		depositCreate := newPendingDeposit(t, sk, builderCreds, 10, depSlot, true)
+		depositTopUp := newPendingDeposit(t, sk, builderCreds, 5, depSlot, true)
+
+		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositCreate, depositTopUp}, 0)
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.Equal(t, 0, len(st.pendingDeposits))
+		require.Equal(t, 1, len(st.builders))
+		require.Equal(t, primitives.Gwei(15), st.builders[0].Balance)
+	})
+
+	t.Run("invalid validator deposit followed by valid builder deposit same pubkey", func(t *testing.T) {
+		sk, err := bls.RandKey()
+		require.NoError(t, err)
+		validatorCreds := nonBuilderWithdrawalCredentials()
+		builderCreds := builderWithdrawalCredentials(0xFF)
+
+		depositInvalidValidator := newPendingDeposit(t, sk, validatorCreds, 5, 0, false)
+		depositBuilder := newPendingDeposit(t, sk, builderCreds, 7, 0, true)
+
+		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositInvalidValidator, depositBuilder}, 0)
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.Equal(t, 1, len(st.pendingDeposits))
+		require.DeepEqual(t, depositInvalidValidator, st.pendingDeposits[0])
+		require.Equal(t, 1, len(st.builders))
+		require.Equal(t, primitives.Gwei(7), st.builders[0].Balance)
 	})
 }
 

--- a/changelog/terence_bump-spec-alpha8.md
+++ b/changelog/terence_bump-spec-alpha8.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Bump consensus spec tests to `v1.7.0-alpha.8`.
+- Raise `MIN_BUILDER_WITHDRAWABILITY_DELAY` to 8192 epochs.
+- Populate `latest_execution_payload_bid.gas_limit` in `upgrade_to_gloas`.
+- Defer signature validation when onboarding builders at the Gloas fork.

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -50,6 +50,7 @@ var placeholderFields = []string{
 	"MAX_BYTES_PER_INCLUSION_LIST",
 	"MAX_REQUEST_INCLUSION_LIST",
 	"NUMBER_OF_COLUMNS", // Configured as a constant in config/fieldparams/mainnet.go
+	"PAYLOAD_DUE_BPS",
 	"TARGET_NUMBER_OF_PEERS",
 	"UPDATE_TIMEOUT",
 	"WHISK_EPOCHS_PER_SHUFFLING_PHASE",

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -111,7 +111,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	EpochsPerEth1VotingPeriod:        64,
 	SlotsPerHistoricalRoot:           8192,
 	MinValidatorWithdrawabilityDelay: 256,
-	MinBuilderWithdrawabilityDelay:   64,
+	MinBuilderWithdrawabilityDelay:   8192,
 	ShardCommitteePeriod:             256,
 	MinEpochsToInactivityPenalty:     4,
 	Eth1FollowDistance:               2048,

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -540,8 +540,8 @@
     - file: config/params/mainnet_config.go
       search: MinBuilderWithdrawabilityDelay
   spec: |
-    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="be7f8473">
-    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 64
+    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="e1cd053c">
+    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 8192
     </spec>
 
 - name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS#deneb
@@ -632,6 +632,13 @@
   spec: |
     <spec config_var="PAYLOAD_ATTESTATION_DUE_BPS" fork="gloas" hash="17307d0e">
     PAYLOAD_ATTESTATION_DUE_BPS: uint64 = 7500
+    </spec>
+
+- name: PAYLOAD_DUE_BPS#gloas
+  sources: []
+  spec: |
+    <spec config_var="PAYLOAD_DUE_BPS" fork="gloas" hash="ee4d44de">
+    PAYLOAD_DUE_BPS: uint64 = 7500
     </spec>
 
 - name: PROPOSER_REORG_CUTOFF_BPS#phase0

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -1622,13 +1622,13 @@
 - name: ProposerPreferences#gloas
   sources: []
   spec: |
-    <spec ssz_object="ProposerPreferences" fork="gloas" hash="5ef93db5">
+    <spec ssz_object="ProposerPreferences" fork="gloas" hash="305cd154">
     class ProposerPreferences(Container):
         dependent_root: Root
         proposal_slot: Slot
         validator_index: ValidatorIndex
         fee_recipient: ExecutionAddress
-        gas_limit: uint64
+        target_gas_limit: uint64
     </spec>
 
 - name: ProposerSlashing#phase0

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -327,7 +327,7 @@
 - name: PayloadAttributes#gloas
   sources: []
   spec: |
-    <spec dataclass="PayloadAttributes" fork="gloas" hash="db78dd94">
+    <spec dataclass="PayloadAttributes" fork="gloas" hash="8e6c6fe5">
     class PayloadAttributes(object):
         timestamp: uint64
         prev_randao: Bytes32
@@ -336,12 +336,14 @@
         parent_beacon_block_root: Root
         # [New in Gloas:EIP7843]
         slot_number: uint64
+        # [New in Gloas]
+        target_gas_limit: uint64
     </spec>
 
 - name: PayloadAttributes#heze
   sources: []
   spec: |
-    <spec dataclass="PayloadAttributes" fork="heze" hash="77defb33">
+    <spec dataclass="PayloadAttributes" fork="heze" hash="c0dfb31c">
     class PayloadAttributes(object):
         timestamp: uint64
         prev_randao: Bytes32
@@ -349,6 +351,7 @@
         withdrawals: Sequence[Withdrawal]
         parent_beacon_block_root: Root
         slot_number: uint64
+        target_gas_limit: uint64
         # [New in Heze:EIP7805]
         inclusion_list_transactions: Sequence[Transaction]
     </spec>
@@ -406,6 +409,46 @@
         bls_to_execution_change_indices: Set[ValidatorIndex]
     </spec>
 
+- name: Seen#deneb
+  sources: []
+  spec: |
+    <spec dataclass="Seen" fork="deneb" hash="f4c42261">
+    class Seen(object):
+        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
+        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        aggregate_data_roots: Dict[Root, Set[Tuple[boolean, ...]]]
+        voluntary_exit_indices: Set[ValidatorIndex]
+        proposer_slashing_indices: Set[ValidatorIndex]
+        attester_slashing_indices: Set[ValidatorIndex]
+        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
+        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
+        bls_to_execution_change_indices: Set[ValidatorIndex]
+        # [New in Deneb]
+        blob_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, BlobIndex]]
+    </spec>
+
+- name: Seen#electra
+  sources: []
+  spec: |
+    <spec dataclass="Seen" fork="electra" hash="c81f78e0">
+    class Seen(object):
+        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
+        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        # [Modified in Electra:EIP7549]
+        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[boolean, ...]]]
+        voluntary_exit_indices: Set[ValidatorIndex]
+        proposer_slashing_indices: Set[ValidatorIndex]
+        attester_slashing_indices: Set[ValidatorIndex]
+        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
+        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
+        bls_to_execution_change_indices: Set[ValidatorIndex]
+        blob_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, BlobIndex]]
+    </spec>
+
 - name: Store#phase0
   sources: []
   spec: |
@@ -430,7 +473,7 @@
 - name: Store#gloas
   sources: []
   spec: |
-    <spec dataclass="Store" fork="gloas" hash="e7c1cf9d">
+    <spec dataclass="Store" fork="gloas" hash="c3c521fb">
     class Store(object):
         time: uint64
         genesis_time: uint64
@@ -442,20 +485,17 @@
         equivocating_indices: Set[ValidatorIndex]
         blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
         block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-        block_timeliness: Dict[Root, Vector[boolean, NUM_BLOCK_TIMELINESS_DEADLINES]] = field(
-            default_factory=dict
-        )
+        # [Modified in Gloas:EIP7732]
+        block_timeliness: Dict[Root, list[boolean]] = field(default_factory=dict)
         checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
         latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
         unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
         # [New in Gloas:EIP7732]
         payloads: Dict[Root, ExecutionPayloadEnvelope] = field(default_factory=dict)
         # [New in Gloas:EIP7732]
-        payload_timeliness_vote: Dict[Root, Vector[Optional[boolean], PTC_SIZE]] = field(
-            default_factory=dict
-        )
+        payload_timeliness_vote: Dict[Root, list[Optional[boolean]]] = field(default_factory=dict)
         # [New in Gloas:EIP7732]
-        payload_data_availability_vote: Dict[Root, Vector[Optional[boolean], PTC_SIZE]] = field(
+        payload_data_availability_vote: Dict[Root, list[Optional[boolean]]] = field(
             default_factory=dict
         )
     </spec>
@@ -463,7 +503,7 @@
 - name: Store#heze
   sources: []
   spec: |
-    <spec dataclass="Store" fork="heze" hash="4ad61488">
+    <spec dataclass="Store" fork="heze" hash="2849f1e5">
     class Store(object):
         time: uint64
         genesis_time: uint64
@@ -475,15 +515,13 @@
         equivocating_indices: Set[ValidatorIndex]
         blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
         block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-        block_timeliness: Dict[Root, Vector[boolean, NUM_BLOCK_TIMELINESS_DEADLINES]] = field(
-            default_factory=dict
-        )
+        block_timeliness: Dict[Root, list[boolean]] = field(default_factory=dict)
         checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
         latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
         unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
         payloads: Dict[Root, ExecutionPayloadEnvelope] = field(default_factory=dict)
-        payload_timeliness_vote: Dict[Root, Vector[boolean, PTC_SIZE]] = field(default_factory=dict)
-        payload_data_availability_vote: Dict[Root, Vector[boolean, PTC_SIZE]] = field(
+        payload_timeliness_vote: Dict[Root, list[Optional[boolean]]] = field(default_factory=dict)
+        payload_data_availability_vote: Dict[Root, list[Optional[boolean]]] = field(
             default_factory=dict
         )
         # [New in Heze:EIP7805]

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -594,7 +594,7 @@
 - name: compute_balance_weighted_selection#gloas
   sources: []
   spec: |
-    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="f99b3e37">
+    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="e5dff16e">
     def compute_balance_weighted_selection(
         state: BeaconState,
         indices: Sequence[ValidatorIndex],
@@ -606,7 +606,7 @@
         Return ``size`` indices sampled by effective balance, using ``indices``
         as candidates. If ``shuffle_indices`` is ``True``, candidate indices
         are themselves sampled from ``indices`` by shuffling it, otherwise
-        ``indices`` is traversed in order.
+        ``indices`` is traversed in order. The returned list can contain duplicates.
         """
         MAX_RANDOM_VALUE = 2**16 - 1
         total = uint64(len(indices))
@@ -1392,10 +1392,10 @@
 - name: compute_ptc#gloas
   sources: []
   spec: |
-    <spec fn="compute_ptc" fork="gloas" hash="0f323552">
+    <spec fn="compute_ptc" fork="gloas" hash="1dcaa117">
     def compute_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
         """
-        Get the payload timeliness committee for the given ``slot``.
+        Get the payload timeliness committee, with possible duplicates, for the given ``slot``.
         """
         epoch = compute_epoch_at_slot(slot)
         seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
@@ -4944,6 +4944,14 @@
         return bls.Sign(privkey, signing_root)
     </spec>
 
+- name: get_payload_due_ms#gloas
+  sources: []
+  spec: |
+    <spec fn="get_payload_due_ms" fork="gloas" hash="6ccf7f5c">
+    def get_payload_due_ms() -> uint64:
+        return get_slot_component_duration_ms(PAYLOAD_DUE_BPS)
+    </spec>
+
 - name: get_payload_status_tiebreaker#gloas
   sources: []
   spec: |
@@ -5091,12 +5099,14 @@
 - name: get_proposer_dependent_root#gloas
   sources: []
   spec: |
-    <spec fn="get_proposer_dependent_root" fork="gloas" hash="2fabad44">
+    <spec fn="get_proposer_dependent_root" fork="gloas" hash="9a7daf1b">
     def get_proposer_dependent_root(state: BeaconState, epoch: Epoch) -> Root:
         """
         Return the dependent root for the proposer lookahead at ``epoch``.
         """
-        return get_block_root_at_slot(state, Slot(compute_start_slot_at_epoch(Epoch(epoch - 1)) - 1))
+        return get_block_root_at_slot(
+            state, Slot(compute_start_slot_at_epoch(Epoch(epoch - MIN_SEED_LOOKAHEAD)) - 1)
+        )
     </spec>
 
 - name: get_proposer_head#phase0
@@ -5568,13 +5578,13 @@
 - name: get_upcoming_proposal_slots#gloas
   sources: []
   spec: |
-    <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="87d7a07d">
+    <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="43252ec9">
     def get_upcoming_proposal_slots(
         state: BeaconState, validator_index: ValidatorIndex
     ) -> Sequence[Slot]:
         """
-        Get the future slots in the current epoch and the slots in the next
-        epoch for which ``validator_index`` is proposing.
+        Get the future slots within the proposer lookahead for which
+        ``validator_index`` is proposing.
         """
         current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
         upcoming_proposal_slots = []
@@ -6598,6 +6608,28 @@
         )
     </spec>
 
+- name: is_gas_limit_target_compatible#gloas
+  sources: []
+  spec: |
+    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="3fa22023">
+    def is_gas_limit_target_compatible(
+        parent_gas_limit: uint64, gas_limit: uint64, target_gas_limit: uint64
+    ) -> bool:
+        """
+        Check if ``gas_limit`` is compatible with ``target_gas_limit`` under the
+        EIP-1559 transition rule from ``parent_gas_limit``.
+        """
+        max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
+        min_gas_limit = parent_gas_limit - max_gas_limit_difference
+        max_gas_limit = parent_gas_limit + max_gas_limit_difference
+
+        if target_gas_limit >= min_gas_limit and target_gas_limit <= max_gas_limit:
+            return gas_limit == target_gas_limit
+        if target_gas_limit > max_gas_limit:
+            return gas_limit == max_gas_limit
+        return gas_limit == min_gas_limit
+    </spec>
+
 - name: is_head_late#phase0
   sources: []
   spec: |
@@ -6873,27 +6905,6 @@
         )
     </spec>
 
-- name: is_payload_data_available#gloas
-  sources: []
-  spec: |
-    <spec fn="is_payload_data_available" fork="gloas" hash="e061dae8">
-    def is_payload_data_available(store: Store, root: Root) -> bool:
-        """
-        Return whether the blob data for the beacon block with root ``root``
-        was voted as present by the PTC, and was locally determined to be available.
-        """
-        # The beacon block root must be known
-        assert root in store.payload_data_availability_vote
-
-        # If the payload is not locally available, the blob data
-        # is not considered available regardless of the PTC vote
-        if not is_payload_verified(store, root):
-            return False
-
-        votes = store.payload_data_availability_vote[root]
-        return sum(vote is True for vote in votes) > DATA_AVAILABILITY_TIMELY_THRESHOLD
-    </spec>
-
 - name: is_payload_inclusion_list_satisfied#heze
   sources: []
   spec: |
@@ -6914,27 +6925,6 @@
         return store.payload_inclusion_list_satisfaction[root]
     </spec>
 
-- name: is_payload_timely#gloas
-  sources: []
-  spec: |
-    <spec fn="is_payload_timely" fork="gloas" hash="e49ecafe">
-    def is_payload_timely(store: Store, root: Root) -> bool:
-        """
-        Return whether the execution payload for the beacon block with root ``root``
-        was voted as present by the PTC, and was locally determined to be available.
-        """
-        # The beacon block root must be known
-        assert root in store.payload_timeliness_vote
-
-        # If the payload is not locally available, the payload
-        # is not considered available regardless of the PTC vote
-        if not is_payload_verified(store, root):
-            return False
-
-        votes = store.payload_timeliness_vote[root]
-        return sum(vote is True for vote in votes) > PAYLOAD_TIMELY_THRESHOLD
-    </spec>
-
 - name: is_payload_verified#gloas
   sources: []
   spec: |
@@ -6951,12 +6941,12 @@
 - name: is_pending_validator#gloas
   sources: []
   spec: |
-    <spec fn="is_pending_validator" fork="gloas" hash="9b409bab">
-    def is_pending_validator(state: BeaconState, pubkey: BLSPubkey) -> bool:
+    <spec fn="is_pending_validator" fork="gloas" hash="4cec3c3c">
+    def is_pending_validator(pending_deposits: Sequence[PendingDeposit], pubkey: BLSPubkey) -> bool:
         """
         Check if a pending deposit with a valid signature is in the queue for the given pubkey.
         """
-        for pending_deposit in state.pending_deposits:
+        for pending_deposit in pending_deposits:
             if pending_deposit.pubkey != pubkey:
                 continue
             if is_valid_deposit_signature(
@@ -7343,17 +7333,17 @@
 - name: is_valid_proposal_slot#gloas
   sources: []
   spec: |
-    <spec fn="is_valid_proposal_slot" fork="gloas" hash="33b8f094">
+    <spec fn="is_valid_proposal_slot" fork="gloas" hash="991b8b00">
     def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
         """
-        Check if the validator is the proposer for the given slot in the current or
-        next epoch.
+        Check if the validator is the proposer for the given slot within the
+        proposer lookahead.
         """
         current_epoch = get_current_epoch(state)
         proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
         if proposal_epoch < current_epoch:
             return False
-        if proposal_epoch > current_epoch + Epoch(1):
+        if proposal_epoch > current_epoch + Epoch(MIN_SEED_LOOKAHEAD):
             return False
 
         index = (proposal_epoch - current_epoch) * SLOTS_PER_EPOCH
@@ -8036,7 +8026,7 @@
 - name: on_payload_attestation_message#gloas
   sources: []
   spec: |
-    <spec fn="on_payload_attestation_message" fork="gloas" hash="fd6b84cb">
+    <spec fn="on_payload_attestation_message" fork="gloas" hash="122499c4">
     def on_payload_attestation_message(
         store: Store, ptc_message: PayloadAttestationMessage, is_from_block: bool = False
     ) -> None:
@@ -8044,17 +8034,25 @@
         Run ``on_payload_attestation_message`` upon receiving a new ``ptc_message`` from
         either within a block or directly on the wire.
         """
-        # The beacon block root must be known
         data = ptc_message.data
+
         # PTC attestation must be for a known block. If block is unknown, delay consideration until the block is found
         assert data.beacon_block_root in store.block_states
         state = store.block_states[data.beacon_block_root]
-        ptc = get_ptc(state, data.slot)
+
         # PTC votes can only change the vote for their assigned beacon block, return early otherwise
         if data.slot != state.slot:
             return
+
+        # Get all positions of the attester in the PTC
+        ptc_indices = []
+        ptc = get_ptc(state, data.slot)
+        for ptc_index, validator_index in enumerate(ptc):
+            if validator_index == ptc_message.validator_index:
+                ptc_indices.append(ptc_index)
+
         # Check that the attester is from the PTC
-        assert ptc_message.validator_index in ptc
+        assert len(ptc_indices) > 0
 
         # Verify the signature and check that its for the current slot if it is coming from the wire
         if not is_from_block:
@@ -8069,12 +8067,13 @@
                     signature=ptc_message.signature,
                 ),
             )
+
         # Update the votes for the block
-        ptc_index = ptc.index(ptc_message.validator_index)
         payload_timeliness_vote = store.payload_timeliness_vote[data.beacon_block_root]
-        payload_timeliness_vote[ptc_index] = data.payload_present
         payload_data_availability_vote = store.payload_data_availability_vote[data.beacon_block_root]
-        payload_data_availability_vote[ptc_index] = data.blob_data_available
+        for ptc_index in ptc_indices:
+            payload_timeliness_vote[ptc_index] = data.payload_present
+            payload_data_availability_vote[ptc_index] = data.blob_data_available
     </spec>
 
 - name: on_tick#phase0
@@ -8114,6 +8113,50 @@
             update_checkpoints(
                 store, store.unrealized_justified_checkpoint, store.unrealized_finalized_checkpoint
             )
+    </spec>
+
+- name: payload_data_availability#gloas
+  sources: []
+  spec: |
+    <spec fn="payload_data_availability" fork="gloas" hash="9d298e0e">
+    def payload_data_availability(store: Store, root: Root, available: bool) -> bool:
+        """
+        Return whether the blob data for the beacon block with root ``root`` is
+        considered ``available`` (or not, when ``available`` is ``False``), taking into
+        consideration local availability and PTC votes.
+        """
+        # The beacon block root must be known
+        assert root in store.payload_data_availability_vote
+
+        # If the payload is not locally available, the blob data
+        # is not considered available regardless of the PTC vote
+        if not is_payload_verified(store, root):
+            return not available
+
+        votes = store.payload_data_availability_vote[root]
+        return sum(vote is available for vote in votes) > DATA_AVAILABILITY_TIMELY_THRESHOLD
+    </spec>
+
+- name: payload_timeliness#gloas
+  sources: []
+  spec: |
+    <spec fn="payload_timeliness" fork="gloas" hash="4490a649">
+    def payload_timeliness(store: Store, root: Root, timely: bool) -> bool:
+        """
+        Return whether the execution payload for the beacon block with root ``root``
+        is considered ``timely`` (or not, when ``timely`` is ``False``), taking into
+        consideration local availability and PTC votes.
+        """
+        # The beacon block root must be known
+        assert root in store.payload_timeliness_vote
+
+        # If the payload is not locally available, the payload
+        # is not considered available regardless of the PTC vote
+        if not is_payload_verified(store, root):
+            return not timely
+
+        votes = store.payload_timeliness_vote[root]
+        return sum(vote is timely for vote in votes) > PAYLOAD_TIMELY_THRESHOLD
     </spec>
 
 - name: prepare_execution_payload#bellatrix
@@ -8260,19 +8303,20 @@
 - name: prepare_execution_payload#heze
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="heze" hash="bc53fbc9">
+    <spec fn="prepare_execution_payload" fork="heze" hash="3531eee1">
     def prepare_execution_payload(
         store: Store,
+        head: ForkChoiceNode,
         state: BeaconState,
         safe_block_hash: Hash32,
         finalized_block_hash: Hash32,
         suggested_fee_recipient: ExecutionAddress,
+        target_gas_limit: uint64,
         execution_engine: ExecutionEngine,
     ) -> Optional[PayloadId]:
         parent_bid = state.latest_execution_payload_bid
-        parent_root = hash_tree_root(state.latest_block_header)
-        if should_extend_payload(store, parent_root):
-            envelope = store.payloads[parent_root]
+        if should_build_on_full(store, head):
+            envelope = store.payloads[head.root]
             # Make a copy of the state to avoid mutability issues
             state = copy(state)
             # Apply parent payload before computing withdrawals
@@ -8291,6 +8335,7 @@
             withdrawals=withdrawals,
             parent_beacon_block_root=hash_tree_root(state.latest_block_header),
             slot_number=state.slot,
+            target_gas_limit=target_gas_limit,
             # [New in Heze:EIP7805]
             inclusion_list_transactions=get_inclusion_list_transactions(
                 get_inclusion_list_store(), state, Slot(state.slot - 1), only_timely=False
@@ -8953,7 +8998,7 @@
 - name: process_deposit_request#gloas
   sources: []
   spec: |
-    <spec fn="process_deposit_request" fork="gloas" hash="0e8b94ab">
+    <spec fn="process_deposit_request" fork="gloas" hash="a6fff32f">
     def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
         # [New in Gloas:EIP7732]
         builder_pubkeys = [b.pubkey for b in state.builders]
@@ -8967,7 +9012,7 @@
         if is_builder or (
             is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
             and not is_validator
-            and not is_pending_validator(state, deposit_request.pubkey)
+            and not is_pending_validator(state.pending_deposits, deposit_request.pubkey)
         ):
             # Apply builder deposits immediately
             apply_deposit_for_builder(
@@ -11229,16 +11274,29 @@
         return len(equivocations) == 0
     </spec>
 
+- name: should_build_on_full#gloas
+  sources: []
+  spec: |
+    <spec fn="should_build_on_full" fork="gloas" hash="229e3638">
+    def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
+        assert head.payload_status != PAYLOAD_STATUS_PENDING
+        if head.payload_status == PAYLOAD_STATUS_EMPTY:
+            return False
+        return not payload_data_availability(store, head.root, available=False)
+    </spec>
+
 - name: should_extend_payload#gloas
   sources: []
   spec: |
-    <spec fn="should_extend_payload" fork="gloas" hash="f8ae3bd2">
+    <spec fn="should_extend_payload" fork="gloas" hash="fd2b578c">
     def should_extend_payload(store: Store, root: Root) -> bool:
         if not is_payload_verified(store, root):
             return False
         proposer_root = store.proposer_boost_root
+        payload_is_timely = payload_timeliness(store, root, timely=True)
+        payload_data_is_available = payload_data_availability(store, root, available=True)
         return (
-            (is_payload_timely(store, root) and is_payload_data_available(store, root))
+            (payload_is_timely and payload_data_is_available)
             or proposer_root == Root()
             or store.blocks[proposer_root].parent_root != root
             or is_parent_node_full(store, store.blocks[proposer_root])
@@ -11248,7 +11306,7 @@
 - name: should_extend_payload#heze
   sources: []
   spec: |
-    <spec fn="should_extend_payload" fork="heze" hash="70372050">
+    <spec fn="should_extend_payload" fork="heze" hash="38b03a9e">
     def should_extend_payload(store: Store, root: Root) -> bool:
         if not is_payload_verified(store, root):
             return False
@@ -11256,8 +11314,10 @@
         if not is_payload_inclusion_list_satisfied(store, root):
             return False
         proposer_root = store.proposer_boost_root
+        payload_is_timely = payload_timeliness(store, root, timely=True)
+        payload_data_is_available = payload_data_availability(store, root, available=True)
         return (
-            (is_payload_timely(store, root) and is_payload_data_available(store, root))
+            (payload_is_timely and payload_data_is_available)
             or proposer_root == Root()
             or store.blocks[proposer_root].parent_root != root
             or is_parent_node_full(store, store.blocks[proposer_root])
@@ -12614,7 +12674,7 @@
 - name: upgrade_to_gloas#gloas
   sources: []
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="e0974e00">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="d9a22a92">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -12678,6 +12738,7 @@
             # [New in Gloas:EIP7732]
             latest_execution_payload_bid=ExecutionPayloadBid(
                 block_hash=pre.latest_execution_payload_header.block_hash,
+                gas_limit=pre.latest_execution_payload_header.gas_limit,
                 execution_requests_root=hash_tree_root(ExecutionRequests()),
             ),
             # [New in Gloas:EIP7732]
@@ -12946,6 +13007,279 @@
         seen.aggregate_data_roots[aggregate_data_root].add(aggregate_bits)
     </spec>
 
+- name: validate_beacon_aggregate_and_proof_gossip#deneb
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="ec1dcf12">
+    def validate_beacon_aggregate_and_proof_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_aggregate_and_proof: SignedAggregateAndProof,
+        current_time_ms: uint64,
+    ) -> None:
+        """
+        Validate a SignedAggregateAndProof for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        aggregate_and_proof = signed_aggregate_and_proof.message
+        aggregate = aggregate_and_proof.aggregate
+        index = aggregate.data.index
+        aggregation_bits = aggregate.aggregation_bits
+
+        # [REJECT] The committee index is within the expected range
+        committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
+        if index >= committee_count:
+            raise GossipReject("committee index out of range")
+
+        # [New in Deneb:EIP7045]
+        # [IGNORE] The aggregate attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
+            raise GossipIgnore("aggregate slot is from a future slot")
+
+        # [Modified in Deneb:EIP7045]
+        # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
+        is_previous_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        is_current_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(attestation_epoch),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
+            raise GossipIgnore("aggregate epoch is not previous or current epoch")
+
+        # [REJECT] The aggregate attestation's epoch matches its target
+        if aggregate.data.target.epoch != compute_epoch_at_slot(aggregate.data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [REJECT] The number of aggregation bits matches the committee size
+        committee = get_beacon_committee(state, aggregate.data.slot, index)
+        if len(aggregation_bits) != len(committee):
+            raise GossipReject("aggregation bits length does not match committee size")
+
+        # [REJECT] The aggregate attestation has participants
+        attesting_indices = get_attesting_indices(state, aggregate)
+        if len(attesting_indices) < 1:
+            raise GossipReject("aggregate has no participants")
+
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_data_root, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        if (aggregator_index, target_epoch) in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+
+        # [REJECT] The selection proof selects the validator as an aggregator
+        if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
+            raise GossipReject("validator is not selected as aggregator")
+
+        # [REJECT] The aggregator's validator index is within the committee
+        if aggregator_index not in committee:
+            raise GossipReject("aggregator index not in committee")
+
+        # [REJECT] The selection proof signature is valid
+        aggregator = state.validators[aggregator_index]
+        domain = get_domain(state, DOMAIN_SELECTION_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate.data.slot, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, aggregate_and_proof.selection_proof):
+            raise GossipReject("invalid selection proof signature")
+
+        # [REJECT] The aggregator signature is valid
+        domain = get_domain(state, DOMAIN_AGGREGATE_AND_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate_and_proof, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, signed_aggregate_and_proof.signature):
+            raise GossipReject("invalid aggregator signature")
+
+        # [REJECT] The aggregate signature is valid
+        if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
+            raise GossipReject("invalid aggregate signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if aggregate.data.beacon_block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if aggregate.data.beacon_block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The target block is an ancestor of the LMD vote block
+        checkpoint_block = get_checkpoint_block(
+            store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
+        )
+        if checkpoint_block != aggregate.data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The finalized checkpoint is an ancestor of the block
+        finalized_checkpoint_block = get_checkpoint_block(
+            store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
+        )
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # Mark this aggregate as seen
+        seen.aggregator_epochs.add((aggregator_index, target_epoch))
+        if aggregate_data_root not in seen.aggregate_data_roots:
+            seen.aggregate_data_roots[aggregate_data_root] = set()
+        seen.aggregate_data_roots[aggregate_data_root].add(aggregate_bits)
+    </spec>
+
+- name: validate_beacon_aggregate_and_proof_gossip#electra
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="fd4d3e8f">
+    def validate_beacon_aggregate_and_proof_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_aggregate_and_proof: SignedAggregateAndProof,
+        current_time_ms: uint64,
+    ) -> None:
+        """
+        Validate a SignedAggregateAndProof for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        aggregate_and_proof = signed_aggregate_and_proof.message
+        aggregate = aggregate_and_proof.aggregate
+        aggregation_bits = aggregate.aggregation_bits
+
+        # [New in Electra:EIP7549]
+        # [REJECT] The aggregate attestation's data index is zero
+        if aggregate.data.index != 0:
+            raise GossipReject("aggregate data index is non-zero")
+
+        # [New in Electra:EIP7549]
+        # [REJECT] Exactly one committee is specified by the committee bits
+        committee_indices = get_committee_indices(aggregate.committee_bits)
+        if len(committee_indices) != 1:
+            raise GossipReject("aggregate committee bits must specify exactly one committee")
+        index = committee_indices[0]
+
+        # [REJECT] The committee index is within the expected range
+        committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
+        if index >= committee_count:
+            raise GossipReject("committee index out of range")
+
+        # [IGNORE] The aggregate attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
+            raise GossipIgnore("aggregate slot is from a future slot")
+
+        # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
+        is_previous_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        is_current_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(attestation_epoch),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
+            raise GossipIgnore("aggregate epoch is not previous or current epoch")
+
+        # [REJECT] The aggregate attestation's epoch matches its target
+        if aggregate.data.target.epoch != compute_epoch_at_slot(aggregate.data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [REJECT] The number of aggregation bits matches the committee size
+        committee = get_beacon_committee(state, aggregate.data.slot, index)
+        if len(aggregation_bits) != len(committee):
+            raise GossipReject("aggregation bits length does not match committee size")
+
+        # [REJECT] The aggregate attestation has participants
+        attesting_indices = get_attesting_indices(state, aggregate)
+        if len(attesting_indices) < 1:
+            raise GossipReject("aggregate has no participants")
+
+        # [Modified in Electra:EIP7549]
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_cache_key = (aggregate_data_root, index)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        if (aggregator_index, target_epoch) in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+
+        # [REJECT] The selection proof selects the validator as an aggregator
+        if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
+            raise GossipReject("validator is not selected as aggregator")
+
+        # [REJECT] The aggregator's validator index is within the committee
+        if aggregator_index not in committee:
+            raise GossipReject("aggregator index not in committee")
+
+        # [REJECT] The selection proof signature is valid
+        aggregator = state.validators[aggregator_index]
+        domain = get_domain(state, DOMAIN_SELECTION_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate.data.slot, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, aggregate_and_proof.selection_proof):
+            raise GossipReject("invalid selection proof signature")
+
+        # [REJECT] The aggregator signature is valid
+        domain = get_domain(state, DOMAIN_AGGREGATE_AND_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate_and_proof, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, signed_aggregate_and_proof.signature):
+            raise GossipReject("invalid aggregator signature")
+
+        # [REJECT] The aggregate signature is valid
+        if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
+            raise GossipReject("invalid aggregate signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if aggregate.data.beacon_block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if aggregate.data.beacon_block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The target block is an ancestor of the LMD vote block
+        checkpoint_block = get_checkpoint_block(
+            store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
+        )
+        if checkpoint_block != aggregate.data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The finalized checkpoint is an ancestor of the block
+        finalized_checkpoint_block = get_checkpoint_block(
+            store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
+        )
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # Mark this aggregate as seen
+        seen.aggregator_epochs.add((aggregator_index, target_epoch))
+        if aggregate_cache_key not in seen.aggregate_data_roots:
+            seen.aggregate_data_roots[aggregate_cache_key] = set()
+        seen.aggregate_data_roots[aggregate_cache_key].add(aggregate_bits)
+    </spec>
+
 - name: validate_beacon_attestation_gossip#phase0
   sources: []
   spec: |
@@ -13036,10 +13370,228 @@
         seen.attestation_validator_epochs.add((participant_index, target_epoch))
     </spec>
 
+- name: validate_beacon_attestation_gossip#deneb
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="fc0076a8">
+    def validate_beacon_attestation_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        attestation: Attestation,
+        subnet_id: uint64,
+        current_time_ms: uint64,
+    ) -> None:
+        """
+        Validate an Attestation for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        data = attestation.data
+        committee_index = data.index
+        target_epoch = data.target.epoch
+        aggregation_bits = attestation.aggregation_bits
+
+        # [REJECT] The committee index is within the expected range
+        committees_per_slot = get_committee_count_per_slot(state, target_epoch)
+        if committee_index >= committees_per_slot:
+            raise GossipReject("committee index out of range")
+
+        # [REJECT] The attestation is for the correct subnet
+        expected_subnet = compute_subnet_for_attestation(
+            committees_per_slot, data.slot, committee_index
+        )
+        if expected_subnet != subnet_id:
+            raise GossipReject("attestation is for wrong subnet")
+
+        # [Modified in Deneb:EIP7045]
+        # [IGNORE] The attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, data.slot, current_time_ms):
+            raise GossipIgnore("attestation slot is from a future slot")
+
+        # [Modified in Deneb:EIP7045]
+        # [IGNORE] The attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(data.slot)
+        is_previous_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        is_current_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(attestation_epoch),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
+            raise GossipIgnore("attestation epoch is not previous or current epoch")
+
+        # [REJECT] The attestation's epoch matches its target
+        if target_epoch != compute_epoch_at_slot(data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [REJECT] The attestation is unaggregated (exactly one bit set)
+        num_bits_set = sum(1 for bit in aggregation_bits if bit)
+        if num_bits_set != 1:
+            raise GossipReject("attestation is not unaggregated")
+
+        # [REJECT] The number of aggregation bits matches the committee size
+        committee = get_beacon_committee(state, data.slot, committee_index)
+        if len(aggregation_bits) != len(committee):
+            raise GossipReject("aggregation bits length does not match committee size")
+
+        # [IGNORE] No other valid attestation seen for this validator and target epoch
+        participant_index = committee[aggregation_bits.index(True)]
+        if (participant_index, target_epoch) in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation from this validator for this epoch")
+
+        # [REJECT] The attestation signature is valid
+        indexed_attestation = get_indexed_attestation(state, attestation)
+        if not is_valid_indexed_attestation(state, indexed_attestation):
+            raise GossipReject("invalid attestation signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        beacon_block_root = data.beacon_block_root
+        if beacon_block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if beacon_block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The attestation's target block is an ancestor of the LMD vote block
+        target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+        if target_checkpoint_block != data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The current finalized_checkpoint is an ancestor of the block
+        finalized_checkpoint_block = get_checkpoint_block(
+            store, beacon_block_root, store.finalized_checkpoint.epoch
+        )
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # Mark this attestation as seen
+        seen.attestation_validator_epochs.add((participant_index, target_epoch))
+    </spec>
+
+- name: validate_beacon_attestation_gossip#electra
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="02f0dc34">
+    def validate_beacon_attestation_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        # [Modified in Electra:EIP7549]
+        attestation: SingleAttestation,
+        subnet_id: uint64,
+        current_time_ms: uint64,
+    ) -> None:
+        """
+        Validate a SingleAttestation for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        data = attestation.data
+        # [Modified in Electra:EIP7549]
+        committee_index = attestation.committee_index
+        attester_index = attestation.attester_index
+        target_epoch = data.target.epoch
+
+        # [New in Electra:EIP7549]
+        # [REJECT] The attestation's data index is zero
+        if data.index != 0:
+            raise GossipReject("attestation data index is non-zero")
+
+        # [REJECT] The committee index is within the expected range
+        committees_per_slot = get_committee_count_per_slot(state, target_epoch)
+        if committee_index >= committees_per_slot:
+            raise GossipReject("committee index out of range")
+
+        # [REJECT] The attestation is for the correct subnet
+        expected_subnet = compute_subnet_for_attestation(
+            committees_per_slot, data.slot, committee_index
+        )
+        if expected_subnet != subnet_id:
+            raise GossipReject("attestation is for wrong subnet")
+
+        # [IGNORE] The attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, data.slot, current_time_ms):
+            raise GossipIgnore("attestation slot is from a future slot")
+
+        # [IGNORE] The attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(data.slot)
+        is_previous_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        is_current_epoch_attestation = is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(attestation_epoch),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
+            raise GossipIgnore("attestation epoch is not previous or current epoch")
+
+        # [REJECT] The attestation's epoch matches its target
+        if target_epoch != compute_epoch_at_slot(data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [New in Electra:EIP7549]
+        # [REJECT] The attester is a member of the committee
+        committee = get_beacon_committee(state, data.slot, committee_index)
+        if attester_index not in committee:
+            raise GossipReject("attester is not a member of the committee")
+
+        # [Modified in Electra:EIP7549]
+        # [IGNORE] No other valid attestation seen for this validator and target epoch
+        if (attester_index, target_epoch) in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation from this validator for this epoch")
+
+        # [Modified in Electra:EIP7549]
+        # [REJECT] The attestation signature is valid
+        attester = state.validators[attester_index]
+        domain = get_domain(state, DOMAIN_BEACON_ATTESTER, target_epoch)
+        signing_root = compute_signing_root(data, domain)
+        if not bls.Verify(attester.pubkey, signing_root, attestation.signature):
+            raise GossipReject("invalid attestation signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        beacon_block_root = data.beacon_block_root
+        if beacon_block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if beacon_block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The attestation's target block is an ancestor of the LMD vote block
+        target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+        if target_checkpoint_block != data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The current finalized_checkpoint is an ancestor of the block
+        finalized_checkpoint_block = get_checkpoint_block(
+            store, beacon_block_root, store.finalized_checkpoint.epoch
+        )
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # Mark this attestation as seen
+        seen.attestation_validator_epochs.add((attester_index, target_epoch))
+    </spec>
+
 - name: validate_beacon_block_gossip#phase0
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="00fec786">
+    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="1368bba8">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -13060,7 +13612,7 @@
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
         # (MAY choose to validate and store such blocks for additional purposes
-        # -- e.g. slashing detection, archive nodes, etc).
+        # -- e.g. slashing detection, archive nodes, etc)
         finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
@@ -13108,14 +13660,14 @@
         if block.proposer_index != expected_proposer:
             raise GossipReject("block proposer_index does not match expected proposer")
 
-        # Mark this block as seen for this proposer/slot combination
+        # Mark this block as seen
         seen.proposer_slots.add((block.proposer_index, block.slot))
     </spec>
 
 - name: validate_beacon_block_gossip#bellatrix
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="0fd58589">
+    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="3df7ca9b">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -13139,7 +13691,7 @@
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
         # (MAY choose to validate and store such blocks for additional purposes
-        # -- e.g. slashing detection, archive nodes, etc).
+        # -- e.g. slashing detection, archive nodes, etc)
         finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
@@ -13210,14 +13762,14 @@
         if block.proposer_index != expected_proposer:
             raise GossipReject("block proposer_index does not match expected proposer")
 
-        # Mark this block as seen for this proposer/slot combination
+        # Mark this block as seen
         seen.proposer_slots.add((block.proposer_index, block.slot))
     </spec>
 
 - name: validate_beacon_block_gossip#capella
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="capella" hash="846c43c6">
+    <spec fn="validate_beacon_block_gossip" fork="capella" hash="b1ac5c00">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -13240,7 +13792,7 @@
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
         # (MAY choose to validate and store such blocks for additional purposes
-        # -- e.g. slashing detection, archive nodes, etc).
+        # -- e.g. slashing detection, archive nodes, etc)
         finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
@@ -13304,8 +13856,397 @@
         if block.proposer_index != expected_proposer:
             raise GossipReject("block proposer_index does not match expected proposer")
 
-        # Mark this block as seen for this proposer/slot combination
+        # Mark this block as seen
         seen.proposer_slots.add((block.proposer_index, block.slot))
+    </spec>
+
+- name: validate_beacon_block_gossip#deneb
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="4ab38790">
+    def validate_beacon_block_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_beacon_block: SignedBeaconBlock,
+        current_time_ms: uint64,
+        block_payload_statuses: Dict[Root, PayloadValidationStatus] = {},
+    ) -> None:
+        """
+        Validate a SignedBeaconBlock for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block = signed_beacon_block.message
+        execution_payload = block.body.execution_payload
+
+        # [IGNORE] The block is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+            raise GossipIgnore("block is from a future slot")
+
+        # [IGNORE] The block is from a slot greater than the latest finalized slot
+        # (MAY choose to validate and store such blocks for additional purposes
+        # -- e.g. slashing detection, archive nodes, etc)
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if block.slot <= finalized_slot:
+            raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
+
+        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
+        if (block.proposer_index, block.slot) in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until parent is retrieved)
+        if block.parent_root not in store.blocks:
+            raise GossipIgnore("block's parent has not been seen")
+
+        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
+        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
+            raise GossipReject("incorrect execution payload timestamp")
+
+        parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
+        if block.parent_root in block_payload_statuses:
+            parent_payload_status = block_payload_statuses[block.parent_root]
+
+        if block.parent_root not in store.block_states:
+            if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
+                # [REJECT] The block's parent passes validation
+                raise GossipReject("block's parent is invalid and EL result is unknown")
+
+            # [IGNORE] The block's parent passes validation
+            raise GossipIgnore("block's parent is invalid and EL result is known")
+
+        # [IGNORE] The block's parent's execution payload passes validation
+        if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
+            raise GossipIgnore("block's parent is valid and EL result is invalid")
+
+        # [REJECT] The block is from a higher slot than its parent
+        if block.slot <= store.blocks[block.parent_root].slot:
+            raise GossipReject("block is not from a higher slot than its parent")
+
+        # [REJECT] The current finalized checkpoint is an ancestor of the block
+        checkpoint_block = get_checkpoint_block(
+            store, block.parent_root, store.finalized_checkpoint.epoch
+        )
+        if checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipReject("finalized checkpoint is not an ancestor of block")
+
+        # [New in Deneb:EIP4844]
+        # [REJECT] The length of KZG commitments is less than or equal to the limit
+        if len(block.body.blob_kzg_commitments) > MAX_BLOBS_PER_BLOCK:
+            raise GossipReject("too many blob kzg commitments")
+
+        # [REJECT] The block is proposed by the expected proposer for the slot
+        # (if shuffling is not available, IGNORE instead and MAY be queued for later)
+        parent_state = store.block_states[block.parent_root].copy()
+        process_slots(parent_state, block.slot)
+        expected_proposer = get_beacon_proposer_index(parent_state)
+        if block.proposer_index != expected_proposer:
+            raise GossipReject("block proposer_index does not match expected proposer")
+
+        # Mark this block as seen
+        seen.proposer_slots.add((block.proposer_index, block.slot))
+    </spec>
+
+- name: validate_beacon_block_gossip#electra
+  sources: []
+  spec: |
+    <spec fn="validate_beacon_block_gossip" fork="electra" hash="8439df67">
+    def validate_beacon_block_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_beacon_block: SignedBeaconBlock,
+        current_time_ms: uint64,
+        block_payload_statuses: Dict[Root, PayloadValidationStatus] = {},
+    ) -> None:
+        """
+        Validate a SignedBeaconBlock for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block = signed_beacon_block.message
+        execution_payload = block.body.execution_payload
+
+        # [IGNORE] The block is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+            raise GossipIgnore("block is from a future slot")
+
+        # [IGNORE] The block is from a slot greater than the latest finalized slot
+        # (MAY choose to validate and store such blocks for additional purposes
+        # -- e.g. slashing detection, archive nodes, etc)
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if block.slot <= finalized_slot:
+            raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
+
+        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
+        if (block.proposer_index, block.slot) in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until parent is retrieved)
+        if block.parent_root not in store.blocks:
+            raise GossipIgnore("block's parent has not been seen")
+
+        # [REJECT] The block's execution payload timestamp is correct with respect to the slot
+        if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
+            raise GossipReject("incorrect execution payload timestamp")
+
+        parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
+        if block.parent_root in block_payload_statuses:
+            parent_payload_status = block_payload_statuses[block.parent_root]
+
+        if block.parent_root not in store.block_states:
+            if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
+                # [REJECT] The block's parent passes validation
+                raise GossipReject("block's parent is invalid and EL result is unknown")
+
+            # [IGNORE] The block's parent passes validation
+            raise GossipIgnore("block's parent is invalid and EL result is known")
+
+        # [IGNORE] The block's parent's execution payload passes validation
+        if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
+            raise GossipIgnore("block's parent is valid and EL result is invalid")
+
+        # [REJECT] The block is from a higher slot than its parent
+        if block.slot <= store.blocks[block.parent_root].slot:
+            raise GossipReject("block is not from a higher slot than its parent")
+
+        # [REJECT] The current finalized checkpoint is an ancestor of the block
+        checkpoint_block = get_checkpoint_block(
+            store, block.parent_root, store.finalized_checkpoint.epoch
+        )
+        if checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipReject("finalized checkpoint is not an ancestor of block")
+
+        # [Modified in Electra:EIP7691]
+        # [REJECT] The length of KZG commitments is less than or equal to the limit
+        if len(block.body.blob_kzg_commitments) > MAX_BLOBS_PER_BLOCK_ELECTRA:
+            raise GossipReject("too many blob kzg commitments")
+
+        # [REJECT] The block is proposed by the expected proposer for the slot
+        # (if shuffling is not available, IGNORE instead and MAY be queued for later)
+        parent_state = store.block_states[block.parent_root].copy()
+        process_slots(parent_state, block.slot)
+        expected_proposer = get_beacon_proposer_index(parent_state)
+        if block.proposer_index != expected_proposer:
+            raise GossipReject("block proposer_index does not match expected proposer")
+
+        # Mark this block as seen
+        seen.proposer_slots.add((block.proposer_index, block.slot))
+    </spec>
+
+- name: validate_blob_sidecar_gossip#deneb
+  sources: []
+  spec: |
+    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="df80723a">
+    def validate_blob_sidecar_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        blob_sidecar: BlobSidecar,
+        subnet_id: SubnetID,
+        current_time_ms: uint64,
+    ) -> None:
+        """
+        Validate a BlobSidecar for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block_header = blob_sidecar.signed_block_header.message
+
+        # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK
+        if blob_sidecar.index >= MAX_BLOBS_PER_BLOCK:
+            raise GossipReject("blob index out of range")
+
+        # [REJECT] The sidecar is for the correct subnet
+        if compute_subnet_for_blob_sidecar(blob_sidecar.index) != subnet_id:
+            raise GossipReject("blob sidecar is for wrong subnet")
+
+        # [IGNORE] The sidecar is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+            raise GossipIgnore("blob sidecar is from a future slot")
+
+        # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if block_header.slot <= finalized_slot:
+            raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
+
+        # [REJECT] The proposer index is a valid validator index
+        if block_header.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature of blob_sidecar.signed_block_header is valid
+        proposer = state.validators[block_header.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block_header.slot))
+        signing_root = compute_signing_root(block_header, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, blob_sidecar.signed_block_header.signature):
+            raise GossipReject("invalid proposer signature on blob sidecar block header")
+
+        # [IGNORE] The sidecar's block's parent has been seen
+        # (MAY be queued for processing once the parent block is retrieved)
+        if block_header.parent_root not in store.blocks:
+            raise GossipIgnore("blob sidecar's parent has not been seen")
+
+        # [REJECT] The sidecar's block's parent passes validation
+        if block_header.parent_root not in store.block_states:
+            raise GossipReject("blob sidecar's parent failed validation")
+
+        # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
+        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+            raise GossipReject("blob sidecar is not from a higher slot than its parent")
+
+        # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
+        checkpoint_block = get_checkpoint_block(
+            store, block_header.parent_root, store.finalized_checkpoint.epoch
+        )
+        if checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
+
+        # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
+        if not verify_blob_sidecar_inclusion_proof(blob_sidecar):
+            raise GossipReject("invalid blob sidecar inclusion proof")
+
+        # [REJECT] The sidecar's blob is valid as verified by verify_blob_kzg_proof
+        if not verify_blob_kzg_proof(
+            blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
+        ):
+            raise GossipReject("invalid blob kzg proof")
+
+        # [IGNORE] The sidecar is the first sidecar for the tuple
+        # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        if sidecar_tuple in seen.blob_sidecar_tuples:
+            raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
+
+        # [REJECT] The sidecar is proposed by the expected proposer_index
+        # (if shuffling is not available, IGNORE instead and MAY be queued for later)
+        parent_state = store.block_states[block_header.parent_root].copy()
+        process_slots(parent_state, block_header.slot)
+        expected_proposer = get_beacon_proposer_index(parent_state)
+        if block_header.proposer_index != expected_proposer:
+            raise GossipReject("blob sidecar proposer_index does not match expected proposer")
+
+        # Mark this blob sidecar as seen
+        seen.blob_sidecar_tuples.add(sidecar_tuple)
+    </spec>
+
+- name: validate_blob_sidecar_gossip#electra
+  sources: []
+  spec: |
+    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="184a7f15">
+    def validate_blob_sidecar_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        blob_sidecar: BlobSidecar,
+        subnet_id: SubnetID,
+        current_time_ms: uint64,
+    ) -> None:
+        """
+        Validate a BlobSidecar for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block_header = blob_sidecar.signed_block_header.message
+
+        # [Modified in Electra:EIP7691]
+        # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK_ELECTRA
+        if blob_sidecar.index >= MAX_BLOBS_PER_BLOCK_ELECTRA:
+            raise GossipReject("blob index out of range")
+
+        # [REJECT] The sidecar is for the correct subnet
+        if compute_subnet_for_blob_sidecar(blob_sidecar.index) != subnet_id:
+            raise GossipReject("blob sidecar is for wrong subnet")
+
+        # [IGNORE] The sidecar is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+            raise GossipIgnore("blob sidecar is from a future slot")
+
+        # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if block_header.slot <= finalized_slot:
+            raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
+
+        # [REJECT] The proposer index is a valid validator index
+        if block_header.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature of blob_sidecar.signed_block_header is valid
+        proposer = state.validators[block_header.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block_header.slot))
+        signing_root = compute_signing_root(block_header, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, blob_sidecar.signed_block_header.signature):
+            raise GossipReject("invalid proposer signature on blob sidecar block header")
+
+        # [IGNORE] The sidecar's block's parent has been seen
+        # (MAY be queued for processing once the parent block is retrieved)
+        if block_header.parent_root not in store.blocks:
+            raise GossipIgnore("blob sidecar's parent has not been seen")
+
+        # [REJECT] The sidecar's block's parent passes validation
+        if block_header.parent_root not in store.block_states:
+            raise GossipReject("blob sidecar's parent failed validation")
+
+        # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
+        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+            raise GossipReject("blob sidecar is not from a higher slot than its parent")
+
+        # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
+        checkpoint_block = get_checkpoint_block(
+            store, block_header.parent_root, store.finalized_checkpoint.epoch
+        )
+        if checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
+
+        # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
+        if not verify_blob_sidecar_inclusion_proof(blob_sidecar):
+            raise GossipReject("invalid blob sidecar inclusion proof")
+
+        # [REJECT] The sidecar's blob is valid as verified by verify_blob_kzg_proof
+        if not verify_blob_kzg_proof(
+            blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
+        ):
+            raise GossipReject("invalid blob kzg proof")
+
+        # [IGNORE] The sidecar is the first sidecar for the tuple
+        # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+        if sidecar_tuple in seen.blob_sidecar_tuples:
+            raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
+
+        # [REJECT] The sidecar is proposed by the expected proposer_index
+        # (if shuffling is not available, IGNORE instead and MAY be queued for later)
+        parent_state = store.block_states[block_header.parent_root].copy()
+        process_slots(parent_state, block_header.slot)
+        expected_proposer = get_beacon_proposer_index(parent_state)
+        if block_header.proposer_index != expected_proposer:
+            raise GossipReject("blob sidecar proposer_index does not match expected proposer")
+
+        # Mark this blob sidecar as seen
+        seen.blob_sidecar_tuples.add(sidecar_tuple)
     </spec>
 
 - name: validate_bls_to_execution_change_gossip#capella
@@ -13565,7 +14506,7 @@
 - name: validate_proposer_slashing_gossip#phase0
   sources: []
   spec: |
-    <spec fn="validate_proposer_slashing_gossip" fork="phase0" hash="82ced9eb">
+    <spec fn="validate_proposer_slashing_gossip" fork="phase0" hash="160a7073">
     def validate_proposer_slashing_gossip(
         seen: Seen,
         state: BeaconState,
@@ -13595,7 +14536,7 @@
         if header_1 == header_2:
             raise GossipReject("headers are not different")
 
-        # [REJECT] The proposer index is valid
+        # [REJECT] The proposer index is a valid validator index
         if proposer_index >= len(state.validators):
             raise GossipReject("proposer index out of range")
 
@@ -13620,7 +14561,7 @@
 - name: validate_sync_committee_contribution_and_proof_gossip#altair
   sources: []
   spec: |
-    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="6239c2b4">
+    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="36521201">
     def validate_sync_committee_contribution_and_proof_gossip(
         seen: Seen,
         state: BeaconState,
@@ -13635,7 +14576,6 @@
         contribution = contribution_and_proof.contribution
 
         # [IGNORE] The contribution's slot is for the current slot
-        # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
         if not is_current_slot(state, contribution.slot, current_time_ms):
             raise GossipIgnore("contribution is not for the current slot")
 
@@ -13729,7 +14669,7 @@
 - name: validate_sync_committee_message_gossip#altair
   sources: []
   spec: |
-    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="83a875a0">
+    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="bd79f23b">
     def validate_sync_committee_message_gossip(
         seen: Seen,
         state: BeaconState,
@@ -13742,7 +14682,6 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         # [IGNORE] The message's slot is for the current slot
-        # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
         if not is_current_slot(state, sync_committee_message.slot, current_time_ms):
             raise GossipIgnore("message is not for the current slot")
 
@@ -13841,6 +14780,62 @@
 
         # [REJECT] The signature is valid
         domain = get_domain(state, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch)
+        signing_root = compute_signing_root(voluntary_exit, domain)
+        if not bls.Verify(validator.pubkey, signing_root, signed_voluntary_exit.signature):
+            raise GossipReject("invalid voluntary exit signature")
+
+        # Mark this voluntary exit as seen
+        seen.voluntary_exit_indices.add(validator_index)
+    </spec>
+
+- name: validate_voluntary_exit_gossip#deneb
+  sources: []
+  spec: |
+    <spec fn="validate_voluntary_exit_gossip" fork="deneb" hash="59c64424">
+    def validate_voluntary_exit_gossip(
+        seen: Seen,
+        state: BeaconState,
+        signed_voluntary_exit: SignedVoluntaryExit,
+    ) -> None:
+        """
+        Validate a SignedVoluntaryExit for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        voluntary_exit = signed_voluntary_exit.message
+        validator_index = voluntary_exit.validator_index
+
+        # [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator
+        if validator_index in seen.voluntary_exit_indices:
+            raise GossipIgnore("already seen voluntary exit for this validator")
+
+        # [REJECT] The validator index is valid
+        if validator_index >= len(state.validators):
+            raise GossipReject("validator index out of range")
+
+        validator = state.validators[validator_index]
+        current_epoch = get_current_epoch(state)
+
+        # [REJECT] The validator is active
+        if not is_active_validator(validator, current_epoch):
+            raise GossipReject("validator is not active")
+
+        # [REJECT] The validator has not already initiated exit
+        if validator.exit_epoch != FAR_FUTURE_EPOCH:
+            raise GossipReject("validator has already initiated exit")
+
+        # [REJECT] The voluntary exit epoch is not in the future
+        if current_epoch < voluntary_exit.epoch:
+            raise GossipReject("voluntary exit epoch is in the future")
+
+        # [REJECT] The validator has been active long enough
+        if current_epoch < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
+            raise GossipReject("validator has not been active long enough")
+
+        # [Modified in Deneb:EIP7044]
+        # [REJECT] The signature is valid
+        domain = compute_domain(
+            DOMAIN_VOLUNTARY_EXIT, CAPELLA_FORK_VERSION, state.genesis_validators_root
+        )
         signing_root = compute_signing_root(voluntary_exit, domain)
         if not bls.Verify(validator.pubkey, signing_root, signed_voluntary_exit.signature):
             raise GossipReject("invalid voluntary exit signature")


### PR DESCRIPTION
## Summary

- Bump consensus spec tests to `v1.7.0-alpha.8`.
- Raise `MIN_BUILDER_WITHDRAWABILITY_DELAY` to 8192 epochs (consensus-specs#5223).
- Populate `latest_execution_payload_bid.gas_limit` in `upgrade_to_gloas` (consensus-specs#5236).
- Defer signature validation when onboarding builders at the Gloas fork (consensus-specs#5254).
- Refresh `<spec>` annotations and `specrefs/*.yml` against the alpha.8 pyspec.