### PR TITLE
don't treat epoch boundary cache miss as skipped block in state diff migration

### DIFF
--- a/beacon-chain/state/stategen/migrate.go
+++ b/beacon-chain/state/stategen/migrate.go
@@ -162,7 +162,9 @@ func (s *State) migrateToColdHdiff(ctx context.Context, fRoot [32]byte) error {
 			aRoot = cached.root
 			aState = cached.state
 		} else {
-			_, roots, err := s.beaconDB.HighestRootsBelowSlot(ctx, slot)
+			// we check for slot+1 because we don't want to treat this slot as a missed block when it's not in cache.
+			// this specifically happens when the state is evicted from the caches in long non finalization.
+			_, roots, err := s.beaconDB.HighestRootsBelowSlot(ctx, slot+1)
 			if err != nil {
 				return err
 			}

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/kv"
 	testDB "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v7/config/features"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -476,6 +477,9 @@ func TestMigrateToColdHdiff_MissedNonBoundarySlots_BoundaryCacheMissed(t *testin
 	r96, err := b96.Block.HashTreeRoot()
 	require.NoError(t, err)
 	util.SaveBlock(t, ctx, beaconDB, b96)
+	// Simulate epoch boundary cache miss for slot 96 while hot cache still has the state.
+	// this makes sure the call to StateByRoot doesn't fail here.
+	service.hotStateCache.put(r96, state96)
 
 	finalizedState := beaconState.Copy()
 	require.NoError(t, finalizedState.SetSlot(128))
@@ -491,6 +495,83 @@ func TestMigrateToColdHdiff_MissedNonBoundarySlots_BoundaryCacheMissed(t *testin
 	assert.Equal(t, true, beaconDB.HasState(ctx, r32), "Did not save slot 32 checkpoint to database")
 	assert.Equal(t, true, beaconDB.HasState(ctx, r64), "Did not save slot 64 checkpoint to database")
 	assert.Equal(t, true, beaconDB.HasState(ctx, r96), "Did not save slot 96 checkpoint to database")
+}
+
+// TestMigrateToColdHdiff_BoundaryCacheMiss_UseTargetSlotRoot verifies that a
+// cache miss at a diff-tree slot still migrates using the block root at that
+// slot (or an equivalent <= slot selection), rather than strictly below it.
+func TestMigrateToColdHdiff_BoundaryCacheMiss_UseTargetSlotRoot(t *testing.T) {
+	ctx := t.Context()
+	setStateDiffExponents()
+	beaconDB := testDB.SetupDB(t)
+	require.NoError(t, beaconDB.(*kv.Store).InitStateDiffCacheForTesting(t, 0))
+	resetCfg := features.InitWithReset(&features.Flags{EnableStateDiff: true})
+	defer resetCfg()
+	service := New(beaconDB, doublylinkedtree.New())
+
+	genesisState, pks := util.DeterministicGenesisState(t, 32)
+	genesisStateRoot, err := genesisState.HashTreeRoot(ctx)
+	require.NoError(t, err)
+	genesis := blocks.NewGenesisBlock(genesisStateRoot[:])
+	util.SaveBlock(t, ctx, beaconDB, genesis)
+	gRoot, err := genesis.Block.HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, gRoot))
+	// Slot 0 base snapshot for state-diff.
+	require.NoError(t, beaconDB.SaveState(ctx, genesisState, gRoot))
+	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 0, Root: gRoot[:]}))
+
+	service.finalizedInfo = &finalizedInfo{
+		slot:  0,
+		root:  gRoot,
+		state: genesisState,
+	}
+
+	current := genesisState
+	var (
+		r32, r64, r96, r128 [32]byte
+		s32, s64, s96, s128 state.BeaconState
+	)
+	for _, slot := range []primitives.Slot{32, 64, 96, 128} {
+		b, err := util.GenerateFullBlock(current, pks, util.DefaultBlockGenConfig(), slot)
+		require.NoError(t, err)
+		wsb, err := consensusblocks.NewSignedBeaconBlock(b)
+		require.NoError(t, err)
+		nextState, err := executeStateTransitionStateGen(ctx, current, wsb)
+		require.NoError(t, err)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		util.SaveBlock(t, ctx, beaconDB, b)
+		require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: slot, Root: root[:]}))
+
+		current = nextState
+		switch slot {
+		case 32:
+			r32 = root
+			s32 = nextState.Copy()
+		case 64:
+			r64 = root
+			s64 = nextState.Copy()
+		case 96:
+			r96 = root
+			s96 = nextState.Copy()
+		case 128:
+			r128 = root
+			s128 = nextState.Copy()
+		}
+	}
+
+	// Simulate cache eviction for slot 96 only: keep 32/64 and finalized 128.
+	require.NoError(t, service.epochBoundaryStateCache.put(r32, s32))
+	require.NoError(t, service.epochBoundaryStateCache.put(r64, s64))
+	require.NoError(t, service.epochBoundaryStateCache.put(r128, s128))
+
+	require.NoError(t, service.MigrateToCold(ctx, r128))
+
+	// State by the slot-96 root should remain reconstructible after migration.
+	got96, err := beaconDB.State(ctx, r96)
+	require.NoError(t, err)
+	assert.DeepSSZEqual(t, s96.ToProtoUnsafe(), got96.ToProtoUnsafe(), "slot 96 state mismatch")
 }
 
 // TestMigrateToColdHdiff_NoOpWhenFinalizedSlotNotAdvanced verifies that

--- a/changelog/bastin_cache-miss-bug.md
+++ b/changelog/bastin_cache-miss-bug.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fixed a bug where we treated a epoch boundary cache miss as an skipped block in state diff migration.


### PR DESCRIPTION
The key info for this PR is this: **the function `HighestRootsBelowSlot(slot)` returns roots strictly < slot.** 

in hdiff migration, we call `HighestRootsBelowSlot(slot)` when the state is not found in the `epochBoundaryStateCache`. This basically assumes that this slot was missed. but this is incorrect in case of an evicted state from the cache due to long non finalization, and it will lead to saving the post state of the previous slot for that slot in the diff tree.
this is fixed by just calling `HighestRootsBelowSlot(slot+1)` instead. this makes sure we are checking for the target slot, and not incorrectly assuming anything.