### PR TITLE
Update Discord invite link in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Note: The latest and most up-to-date documentation can be found on our [docs por
 
 Excited by our work and want to get involved in building out our sharding releases? Or maybe you haven't learned as much about the Ethereum protocol but are a savvy developer? 
 
-You can explore our [Open Issues](https://github.com/OffchainLabs/prysm/issues) in-the works for our different releases. Feel free to fork our repo and start creating PR’s after assigning yourself to an issue of interest. We are always chatting on [Discord](https://discord.gg/prysm) drop us a line there if you want to get more involved or have any questions on our implementation!
+You can explore our [Open Issues](https://github.com/OffchainLabs/prysm/issues) in-the works for our different releases. Feel free to fork our repo and start creating PR’s after assigning yourself to an issue of interest. We are always chatting on [Discord](https://discord.gg/qEZK94mFXP) drop us a line there if you want to get more involved or have any questions on our implementation!
 
 > [!IMPORTANT] 
 > Please, **do not send pull requests for trivial changes**, such as typos, these will be rejected. These types of pull requests incur a cost to reviewers and do not provide much value to the project. If you are unsure, please open an issue first to discuss the change.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/OffchainLabs/prysm)](https://goreportcard.com/report/github.com/OffchainLabs/prysm)
 [![Consensus_Spec_Version 1.4.0](https://img.shields.io/badge/Consensus%20Spec%20Version-v1.4.0-blue.svg)](https://github.com/ethereum/consensus-specs/tree/v1.4.0)
 [![Execution_API_Version 1.0.0-beta.2](https://img.shields.io/badge/Execution%20API%20Version-v1.0.0.beta.2-blue.svg)](https://github.com/ethereum/execution-apis/tree/v1.0.0-beta.2/src/engine)
-[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/prysm)
+[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/qEZK94mFXP)
 [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/OffchainLabs/prysm/badge)](https://www.gitpoap.io/gh/OffchainLabs/prysm)
 
 </div>
@@ -25,7 +25,7 @@ See the [Changelog](https://github.com/OffchainLabs/prysm/releases) for details 
 
 A detailed set of installation and usage instructions as well as breakdowns of each individual component are available in the **[official documentation portal](https://prysm.offchainlabs.com/docs/)**.
 
-💬 **Need help?** Join our **[Discord Community](https://discord.gg/prysm)** for support.
+💬 **Need help?** Join our **[Discord Community](https://discord.gg/qEZK94mFXP)** for support (this invite link never expires).
 
 ---
 

--- a/beacon-chain/README.md
+++ b/beacon-chain/README.md
@@ -4,6 +4,6 @@ This is the main project folder for the beacon chain implementation of Ethereum 
 
 You can also read our main [README](https://github.com/prysmaticlabs/prysm/blob/master/README.md) and join our active chat room on Discord.
 
-[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/prysm)
+[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/qEZK94mFXP)
 
 Also, read the official beacon chain [specification](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md), this design spec serves as a source of truth for the beacon chain implementation we follow at Prysmatic Labs.

--- a/changelog/terence_update-discord-invite-link.md
+++ b/changelog/terence_update-discord-invite-link.md
@@ -1,1 +1,3 @@
+### Changed
+
 - Update Discord invite link in README to a permanent (non-expiring) URL.

--- a/changelog/terence_update-discord-invite-link.md
+++ b/changelog/terence_update-discord-invite-link.md
@@ -1,0 +1,1 @@
+- Update Discord invite link in README to a permanent (non-expiring) URL.

--- a/validator/README.md
+++ b/validator/README.md
@@ -4,6 +4,6 @@ This is the main project folder for a validator client implementation of Ethereu
 
 You can also read our main [README](https://github.com/prysmaticlabs/prysm/blob/master/README.md) and join our active chat room on Discord.
 
-[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/prysm)
+[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/qEZK94mFXP)
 
 To further understand the responsibilities of an Ethereum validator, we recommend reading the official specification [here](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/validator.md)


### PR DESCRIPTION
## Summary
- Replace the Discord invite link in `README.md` with `https://discord.gg/qEZK94mFXP`, which never expires.
- Note in the community line that the invite is permanent.

## Test plan
- [x] Links render correctly in rendered README.