### PR TITLE
Cache the finalized hash in the store

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -472,6 +472,7 @@ func (f *ForkChoice) UpdateFinalizedCheckpoint(fc *forkchoicetypes.Checkpoint) e
 		return errInvalidNilCheckpoint
 	}
 	f.store.finalizedCheckpoint = fc
+	f.store.finalizedPayloadBlockHash = f.store.checkpointPayloadHashForRoot(fc.Root)
 	return nil
 }
 
@@ -581,9 +582,10 @@ func (f *ForkChoice) CachedHeadRoot() [32]byte {
 	return f.store.headNode.root
 }
 
-// FinalizedPayloadBlockHash returns the hash of the payload at the finalized checkpoint
+// FinalizedPayloadBlockHash returns the hash of the payload at the finalized checkpoint.
+// The value is cached by the store because the node that resolves it is pruned at finalization.
 func (f *ForkChoice) FinalizedPayloadBlockHash() [32]byte {
-	return f.store.checkpointPayloadHashForRoot(f.FinalizedCheckpoint().Root)
+	return f.store.finalizedPayloadBlockHash
 }
 
 // JustifiedPayloadBlockHash returns the hash of the payload at the justified checkpoint

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -784,7 +784,7 @@ func TestForkChoice_FinalizedAndJustifiedPayloadBlockHash_PreGloas(t *testing.T)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 
-	f.store.finalizedCheckpoint.Root = [32]byte{'a'}
+	require.NoError(t, f.UpdateFinalizedCheckpoint(&forkchoicetypes.Checkpoint{Root: [32]byte{'a'}}))
 	f.store.justifiedCheckpoint.Root = [32]byte{'a'}
 
 	require.Equal(t, [32]byte{'A'}, f.FinalizedPayloadBlockHash())

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -263,6 +263,7 @@ func (s *Store) prune(ctx context.Context) error {
 	if fn.parent == nil {
 		return nil
 	}
+	s.finalizedPayloadBlockHash = s.checkpointPayloadHashForRoot(finalizedRoot)
 
 	// Save the new finalized dependent root because it will be pruned
 	s.finalizedDependentRoot = fn.parent.node.root

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -34,6 +34,7 @@ type Store struct {
 	previousProposerBoostRoot     [fieldparams.RootLength]byte                  // previous block root that was boosted after being received in a timely manner.
 	previousProposerBoostScore    uint64                                        // previous proposer boosted root score.
 	finalizedDependentRoot        [fieldparams.RootLength]byte                  // dependent root at finalized checkpoint.
+	finalizedPayloadBlockHash     [fieldparams.RootLength]byte                  // cached payload hash at the finalized checkpoint. Refreshed before pruning at finalization since the node it resolves from is removed by prune.
 	committeeWeight               uint64                                        // tracks the total active validator balance divided by the number of slots per Epoch.
 	treeRootNode                  *Node                                         // the root node of the store tree.
 	headNode                      *Node                                         // last head Node

--- a/changelog/potuz_finalized_hash.md
+++ b/changelog/potuz_finalized_hash.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed finalized hash being zero. 


### PR DESCRIPTION
This PR fixes the problem that after pruning up to the finalized root on forkchoice, the parent hash is lost, thus we keep here the finalized hash on the store directly. It is updated at prune call whenever we actually prune up to a new finalization. 