### PR TITLE
Add GasLimit accessor on forkchoice

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -926,3 +926,56 @@ func TestForkchoiceParentRoot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, zeroHash, root)
 }
+
+func prepareBellatrixForkchoiceStateWithGasLimit(
+	slot primitives.Slot,
+	blockRoot [32]byte,
+	parentRoot [32]byte,
+	payloadHash [32]byte,
+	gasLimit uint64,
+) (state.BeaconState, blocks.ROBlock, error) {
+	blockHeader := &ethpb.BeaconBlockHeader{ParentRoot: parentRoot[:]}
+	executionHeader := &enginev1.ExecutionPayloadHeader{BlockHash: payloadHash[:], GasLimit: gasLimit}
+	base := &ethpb.BeaconStateBellatrix{
+		Slot:                         slot,
+		RandaoMixes:                  make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+		CurrentJustifiedCheckpoint:   &ethpb.Checkpoint{},
+		FinalizedCheckpoint:          &ethpb.Checkpoint{},
+		LatestExecutionPayloadHeader: executionHeader,
+		LatestBlockHeader:            blockHeader,
+	}
+	st, err := state_native.InitializeFromProtoBellatrix(base)
+	if err != nil {
+		return nil, blocks.ROBlock{}, err
+	}
+	blk := &ethpb.SignedBeaconBlockBellatrix{
+		Block: &ethpb.BeaconBlockBellatrix{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body: &ethpb.BeaconBlockBodyBellatrix{
+				ExecutionPayload: &enginev1.ExecutionPayload{BlockHash: payloadHash[:], GasLimit: gasLimit},
+			},
+		},
+	}
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	if err != nil {
+		return nil, blocks.ROBlock{}, err
+	}
+	roblock, err := blocks.NewROBlockWithRoot(signed, blockRoot)
+	return st, roblock, err
+}
+
+func TestGasLimit_BellatrixInsertStoresGasLimit(t *testing.T) {
+	f := setup(0, 0)
+	ctx := t.Context()
+
+	root := indexToHash(1)
+	const gl = uint64(30_000_000)
+	st, roblock, err := prepareBellatrixForkchoiceStateWithGasLimit(1, root, params.BeaconConfig().ZeroHash, indexToHash(100), gl)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	got, err := f.GasLimit(root)
+	require.NoError(t, err)
+	assert.Equal(t, gl, got)
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -496,7 +496,7 @@ func (f *ForkChoice) BlockHash(root [32]byte) ([32]byte, error) {
 // GasLimit returns the gas limit of the latest full payload at or before root.
 func (f *ForkChoice) GasLimit(root [32]byte) (uint64, error) {
 	s := f.store
-	if fn, ok := s.fullNodeByRoot[root]; ok {
+	if fn := s.fullNodeByRoot[root]; fn != nil {
 		return fn.gasLimit, nil
 	}
 	en, ok := s.emptyNodeByRoot[root]

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -393,7 +393,7 @@ func (f *ForkChoice) InsertPayload(pe interfaces.ROExecutionPayloadEnvelope) err
 	}
 	exec, err := pe.Execution()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not get execution from payload envelope")
 	}
 	en.node.gasLimit = exec.GasLimit()
 	fn := &PayloadNode{

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -391,6 +391,11 @@ func (f *ForkChoice) InsertPayload(pe interfaces.ROExecutionPayloadEnvelope) err
 		// We don't import two payloads for the same root
 		return nil
 	}
+	exec, err := pe.Execution()
+	if err != nil {
+		return err
+	}
+	en.node.gasLimit = exec.GasLimit()
 	fn := &PayloadNode{
 		node:       en.node,
 		optimistic: true,
@@ -486,6 +491,23 @@ func (f *ForkChoice) BlockHash(root [32]byte) ([32]byte, error) {
 		return [32]byte{}, errors.Wrap(ErrNilNode, "could not get block hash for root")
 	}
 	return en.node.blockHash, nil
+}
+
+// GasLimit returns the gas limit of the latest full payload at or before root.
+func (f *ForkChoice) GasLimit(root [32]byte) (uint64, error) {
+	s := f.store
+	if fn, ok := s.fullNodeByRoot[root]; ok {
+		return fn.node.gasLimit, nil
+	}
+	en, ok := s.emptyNodeByRoot[root]
+	if !ok || en == nil {
+		return 0, errors.Wrap(ErrNilNode, "could not get gas limit for root")
+	}
+	fp := s.fullParent(en)
+	if fp == nil {
+		return 0, errors.New("no full ancestor with gas limit")
+	}
+	return fp.node.gasLimit, nil
 }
 
 func (s *Store) shouldApplyProposerBoost() bool {

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -395,12 +395,12 @@ func (f *ForkChoice) InsertPayload(pe interfaces.ROExecutionPayloadEnvelope) err
 	if err != nil {
 		return errors.Wrap(err, "could not get execution from payload envelope")
 	}
-	en.node.gasLimit = exec.GasLimit()
 	fn := &PayloadNode{
 		node:       en.node,
 		optimistic: true,
 		timestamp:  time.Now(),
 		full:       true,
+		gasLimit:   exec.GasLimit(),
 		children:   make([]*Node, 0),
 	}
 	s.fullNodeByRoot[root] = fn
@@ -497,7 +497,7 @@ func (f *ForkChoice) BlockHash(root [32]byte) ([32]byte, error) {
 func (f *ForkChoice) GasLimit(root [32]byte) (uint64, error) {
 	s := f.store
 	if fn, ok := s.fullNodeByRoot[root]; ok {
-		return fn.node.gasLimit, nil
+		return fn.gasLimit, nil
 	}
 	en, ok := s.emptyNodeByRoot[root]
 	if !ok || en == nil {
@@ -507,7 +507,7 @@ func (f *ForkChoice) GasLimit(root [32]byte) (uint64, error) {
 	if fp == nil {
 		return 0, errors.New("no full ancestor with gas limit")
 	}
-	return fp.node.gasLimit, nil
+	return fp.gasLimit, nil
 }
 
 func (s *Store) shouldApplyProposerBoost() bool {

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -499,7 +499,8 @@ func (f *ForkChoice) GasLimit(root [32]byte) (uint64, error) {
 	if fn := s.fullNodeByRoot[root]; fn != nil {
 		return fn.gasLimit, nil
 	}
-	if en := s.emptyNodeByRoot[root]; en == nil {
+	en := s.emptyNodeByRoot[root]
+	if en == nil {
 		return 0, errors.Wrap(ErrNilNode, "could not get gas limit for root")
 	}
 	fp := s.fullParent(en)

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -499,8 +499,7 @@ func (f *ForkChoice) GasLimit(root [32]byte) (uint64, error) {
 	if fn := s.fullNodeByRoot[root]; fn != nil {
 		return fn.gasLimit, nil
 	}
-	en, ok := s.emptyNodeByRoot[root]
-	if !ok || en == nil {
+	if en := s.emptyNodeByRoot[root]; en == nil {
 		return 0, errors.Wrap(ErrNilNode, "could not get gas limit for root")
 	}
 	fp := s.fullParent(en)

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -450,7 +450,7 @@ func TestGloasHeadComputation(t *testing.T) {
 	assert.Equal(t, uint64(0), fullA.weight)  // the parent does not inherit proposer boost
 	assert.Equal(t, uint64(0), fullA.balance)
 	assert.Equal(t, uint64(0), fullA.node.balance)
-	assert.Equal(t, uint64(0), emptyA.weight)     // neither does the empty block of A
+	assert.Equal(t, uint64(0), emptyA.weight) // neither does the empty block of A
 	assert.Equal(t, uint64(8), fullA.node.weight)
 
 	// Process an attestation for rootA at slotB, voting empty (payloadStatus=false).
@@ -1677,4 +1677,104 @@ func TestStore_Prune_IncompatibleFullFinalizedChildren(t *testing.T) {
 	require.Equal(t, false, emptyOk)
 	_, fullOk := s.fullNodeByRoot[rootC]
 	require.Equal(t, false, fullOk)
+}
+
+func prepareBellatrixForkchoiceStateWithGasLimit(
+	slot primitives.Slot,
+	blockRoot [32]byte,
+	parentRoot [32]byte,
+	payloadHash [32]byte,
+	gasLimit uint64,
+) (state.BeaconState, blocks.ROBlock, error) {
+	blockHeader := &ethpb.BeaconBlockHeader{ParentRoot: parentRoot[:]}
+	executionHeader := &enginev1.ExecutionPayloadHeader{BlockHash: payloadHash[:], GasLimit: gasLimit}
+	base := &ethpb.BeaconStateBellatrix{
+		Slot:                         slot,
+		RandaoMixes:                  make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+		CurrentJustifiedCheckpoint:   &ethpb.Checkpoint{},
+		FinalizedCheckpoint:          &ethpb.Checkpoint{},
+		LatestExecutionPayloadHeader: executionHeader,
+		LatestBlockHeader:            blockHeader,
+	}
+	st, err := state_native.InitializeFromProtoBellatrix(base)
+	if err != nil {
+		return nil, blocks.ROBlock{}, err
+	}
+	blk := &ethpb.SignedBeaconBlockBellatrix{
+		Block: &ethpb.BeaconBlockBellatrix{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body: &ethpb.BeaconBlockBodyBellatrix{
+				ExecutionPayload: &enginev1.ExecutionPayload{BlockHash: payloadHash[:], GasLimit: gasLimit},
+			},
+		},
+	}
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	if err != nil {
+		return nil, blocks.ROBlock{}, err
+	}
+	roblock, err := blocks.NewROBlockWithRoot(signed, blockRoot)
+	return st, roblock, err
+}
+
+func TestGasLimit_BellatrixInsertStoresGasLimit(t *testing.T) {
+	f := setup(0, 0)
+	ctx := t.Context()
+
+	root := indexToHash(1)
+	const gl = uint64(30_000_000)
+	st, roblock, err := prepareBellatrixForkchoiceStateWithGasLimit(1, root, params.BeaconConfig().ZeroHash, indexToHash(100), gl)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	got, err := f.GasLimit(root)
+	require.NoError(t, err)
+	assert.Equal(t, gl, got)
+}
+
+func TestGasLimit_UnknownRootErrors(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	_, err := f.GasLimit(indexToHash(999))
+	require.ErrorContains(t, ErrNilNode.Error(), err)
+}
+
+func TestGasLimit_GloasEmptyNodeWalksToFullAncestor(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	st, roblock, err := prepareGloasForkchoiceState(ctx, 1, rootA, params.BeaconConfig().ZeroHash, blockHashA, params.BeaconConfig().ZeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	const gl = uint64(42_000_000)
+	env := &ethpb.ExecutionPayloadEnvelope{
+		BeaconBlockRoot:       rootA[:],
+		ParentBeaconBlockRoot: make([]byte, 32),
+		Payload:               &enginev1.ExecutionPayloadGloas{GasLimit: gl},
+	}
+	pe, err := blocks.WrappedROExecutionPayloadEnvelope(env)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	// Child B builds on full A (matching parent hash) — gas limit lookup walks to full ancestor A.
+	rootB := indexToHash(2)
+	blockHashB := indexToHash(200)
+	st, roblock, err = prepareGloasForkchoiceState(ctx, 2, rootB, rootA, blockHashB, blockHashA, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	// B has no full node — GasLimit should walk to A's full ancestor.
+	_, hasFullB := f.store.fullNodeByRoot[rootB]
+	require.Equal(t, false, hasFullB)
+
+	got, err := f.GasLimit(rootB)
+	require.NoError(t, err)
+	assert.Equal(t, gl, got)
+
+	// Direct full lookup on A also returns gl.
+	got, err = f.GasLimit(rootA)
+	require.NoError(t, err)
+	assert.Equal(t, gl, got)
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -1679,59 +1679,6 @@ func TestStore_Prune_IncompatibleFullFinalizedChildren(t *testing.T) {
 	require.Equal(t, false, fullOk)
 }
 
-func prepareBellatrixForkchoiceStateWithGasLimit(
-	slot primitives.Slot,
-	blockRoot [32]byte,
-	parentRoot [32]byte,
-	payloadHash [32]byte,
-	gasLimit uint64,
-) (state.BeaconState, blocks.ROBlock, error) {
-	blockHeader := &ethpb.BeaconBlockHeader{ParentRoot: parentRoot[:]}
-	executionHeader := &enginev1.ExecutionPayloadHeader{BlockHash: payloadHash[:], GasLimit: gasLimit}
-	base := &ethpb.BeaconStateBellatrix{
-		Slot:                         slot,
-		RandaoMixes:                  make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
-		CurrentJustifiedCheckpoint:   &ethpb.Checkpoint{},
-		FinalizedCheckpoint:          &ethpb.Checkpoint{},
-		LatestExecutionPayloadHeader: executionHeader,
-		LatestBlockHeader:            blockHeader,
-	}
-	st, err := state_native.InitializeFromProtoBellatrix(base)
-	if err != nil {
-		return nil, blocks.ROBlock{}, err
-	}
-	blk := &ethpb.SignedBeaconBlockBellatrix{
-		Block: &ethpb.BeaconBlockBellatrix{
-			Slot:       slot,
-			ParentRoot: parentRoot[:],
-			Body: &ethpb.BeaconBlockBodyBellatrix{
-				ExecutionPayload: &enginev1.ExecutionPayload{BlockHash: payloadHash[:], GasLimit: gasLimit},
-			},
-		},
-	}
-	signed, err := blocks.NewSignedBeaconBlock(blk)
-	if err != nil {
-		return nil, blocks.ROBlock{}, err
-	}
-	roblock, err := blocks.NewROBlockWithRoot(signed, blockRoot)
-	return st, roblock, err
-}
-
-func TestGasLimit_BellatrixInsertStoresGasLimit(t *testing.T) {
-	f := setup(0, 0)
-	ctx := t.Context()
-
-	root := indexToHash(1)
-	const gl = uint64(30_000_000)
-	st, roblock, err := prepareBellatrixForkchoiceStateWithGasLimit(1, root, params.BeaconConfig().ZeroHash, indexToHash(100), gl)
-	require.NoError(t, err)
-	require.NoError(t, f.InsertNode(ctx, st, roblock))
-
-	got, err := f.GasLimit(root)
-	require.NoError(t, err)
-	assert.Equal(t, gl, got)
-}
-
 func TestGasLimit_UnknownRootErrors(t *testing.T) {
 	f := setupGloas(t, 0, 0)
 	_, err := f.GasLimit(indexToHash(999))

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -118,7 +118,6 @@ func (s *Store) insert(ctx context.Context,
 		finalizedEpoch:              finalizedEpoch,
 		unrealizedFinalizedEpoch:    finalizedEpoch,
 		blockHash:                   *blockHash,
-		gasLimit:                    gasLimit,
 		payloadAvailabilityVote:     bitfield.NewBitvector512(),
 		payloadDataAvailabilityVote: bitfield.NewBitvector512(),
 	}
@@ -153,6 +152,7 @@ func (s *Store) insert(ctx context.Context,
 			optimistic: true,
 			timestamp:  time.Now(),
 			full:       true,
+			gasLimit:   gasLimit,
 		}
 		ret = fn
 		s.fullNodeByRoot[root] = fn

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -86,6 +86,7 @@ func (s *Store) insert(ctx context.Context,
 	slot := block.Slot()
 	var parent *PayloadNode
 	blockHash := &[32]byte{}
+	var gasLimit uint64
 	if block.Version() >= version.Gloas {
 		if err := s.resolveParentPayloadStatus(block, &parent, blockHash); err != nil {
 			return nil, err
@@ -97,6 +98,7 @@ func (s *Store) insert(ctx context.Context,
 				return nil, err
 			}
 			copy(blockHash[:], execution.BlockHash())
+			gasLimit = execution.GasLimit()
 		}
 		parentRoot := block.ParentRoot()
 		en := s.emptyNodeByRoot[parentRoot]
@@ -116,6 +118,7 @@ func (s *Store) insert(ctx context.Context,
 		finalizedEpoch:              finalizedEpoch,
 		unrealizedFinalizedEpoch:    finalizedEpoch,
 		blockHash:                   *blockHash,
+		gasLimit:                    gasLimit,
 		payloadAvailabilityVote:     bitfield.NewBitvector512(),
 		payloadDataAvailabilityVote: bitfield.NewBitvector512(),
 	}

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -54,6 +54,7 @@ type Node struct {
 	slot                        primitives.Slot              // slot of the block converted to the node.
 	root                        [fieldparams.RootLength]byte // root of the block converted to the node.
 	blockHash                   [fieldparams.RootLength]byte // payloadHash of the block converted to the node.
+	gasLimit                    uint64                       // execution payload gas limit.
 	parent                      *PayloadNode                 // parent index of this node.
 	target                      *Node                        // target checkpoint for
 	bestDescendant              *Node                        // bestDescendant node of this node.

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -54,7 +54,6 @@ type Node struct {
 	slot                        primitives.Slot              // slot of the block converted to the node.
 	root                        [fieldparams.RootLength]byte // root of the block converted to the node.
 	blockHash                   [fieldparams.RootLength]byte // payloadHash of the block converted to the node.
-	gasLimit                    uint64                       // execution payload gas limit.
 	parent                      *PayloadNode                 // parent index of this node.
 	target                      *Node                        // target checkpoint for
 	bestDescendant              *Node                        // bestDescendant node of this node.
@@ -74,6 +73,7 @@ type PayloadNode struct {
 	full           bool      // whether this node represents a payload present or not
 	weight         uint64    // weight of this node: the total balance including children
 	balance        uint64    // the balance that voted for this node directly
+	gasLimit       uint64    // execution payload gas limit (only set on full nodes).
 	bestDescendant *Node     // bestDescendant node of this payload node.
 	node           *Node     // the consensus part of this full forkchoice node
 	timestamp      time.Time // The timestamp when the node was inserted.

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -97,6 +97,7 @@ type FastGetter interface {
 	PayloadWeights(root [32]byte) (emptyWeight, fullWeight uint64, err error)
 	ParentRoot(root [32]byte) ([32]byte, error)
 	BlockHash(root [32]byte) ([32]byte, error)
+	GasLimit(root [32]byte) (uint64, error)
 	CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool)
 }
 

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -219,6 +219,13 @@ func (ro *ROForkChoice) BlockHash(root [32]byte) ([32]byte, error) {
 	return ro.getter.BlockHash(root)
 }
 
+// GasLimit delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) GasLimit(root [32]byte) (uint64, error) {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.GasLimit(root)
+}
+
 // CanonicalNodeAtSlot delegates to the underlying forkchoice call, under a lock.
 func (ro *ROForkChoice) CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool) {
 	ro.l.RLock()

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -42,6 +42,7 @@ const (
 	targetRootForEpochCalled
 	parentRootCalled
 	blockHashCalled
+	gasLimitCalled
 	dependentRootCalled
 	dependentRootForEpochCalled
 	canonicalNodeAtSlotCalled
@@ -177,6 +178,11 @@ func TestROLocking(t *testing.T) {
 			name: "canonicalNodeAtSlotCalled",
 			call: canonicalNodeAtSlotCalled,
 			cb:   func(g FastGetter) { g.CanonicalNodeAtSlot(0) },
+		},
+		{
+			name: "gasLimitCalled",
+			call: gasLimitCalled,
+			cb:   func(g FastGetter) { _, err := g.GasLimit([32]byte{}); _discard(t, err) },
 		},
 	}
 	for _, c := range cases {
@@ -351,6 +357,11 @@ func (ro *mockROForkchoice) ParentRoot(_ [32]byte) ([32]byte, error) {
 func (ro *mockROForkchoice) BlockHash(_ [32]byte) ([32]byte, error) {
 	ro.calls = append(ro.calls, blockHashCalled)
 	return [32]byte{}, nil
+}
+
+func (ro *mockROForkchoice) GasLimit(_ [32]byte) (uint64, error) {
+	ro.calls = append(ro.calls, gasLimitCalled)
+	return 0, nil
 }
 
 func (ro *mockROForkchoice) CanonicalNodeAtSlot(_ primitives.Slot) ([32]byte, bool) {

--- a/changelog/terence_forkchoice-gas-limit.md
+++ b/changelog/terence_forkchoice-gas-limit.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add `GasLimit(root)` accessor on forkchoice for execution gas limit lookups.


### PR DESCRIPTION
- Add `GasLimit(root [32]byte) (uint64, error)` to the forkchoice `FastGetter` interface
- Capture the execution gas limit on a new `gasLimit` field of the forkchoice `Node` populated at `insert` for Bellatrix+ blocks, and at `InsertPayload` for Gloas (when the envelope arrives)
