### PR TITLE
Replace linear scan in `BuilderIndexByPubkey` with O(1) map

### DIFF
--- a/beacon-chain/state/state-native/beacon_state.go
+++ b/beacon-chain/state/state-native/beacon_state.go
@@ -9,6 +9,7 @@ import (
 	customtypes "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/custom-types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stateutil"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -73,6 +74,7 @@ type BeaconState struct {
 	// Gloas fields
 	latestExecutionPayloadBid    *ethpb.ExecutionPayloadBid
 	builders                     []*ethpb.Builder
+	builderIdxMap                map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex
 	nextWithdrawalBuilderIndex   primitives.BuilderIndex
 	executionPayloadAvailability []byte
 	builderPendingPayments       []*ethpb.BuilderPendingPayment

--- a/beacon-chain/state/state-native/getters_gloas.go
+++ b/beacon-chain/state/state-native/getters_gloas.go
@@ -367,15 +367,8 @@ func (b *BeaconState) BuilderIndexByPubkey(pubkey [fieldparams.BLSPubkeyLength]b
 }
 
 func (b *BeaconState) builderIndexByPubkey(pubkey [fieldparams.BLSPubkeyLength]byte) (primitives.BuilderIndex, bool) {
-	for i, builder := range b.builders {
-		if builder == nil {
-			continue
-		}
-		if bytes.Equal(builder.Pubkey, pubkey[:]) {
-			return primitives.BuilderIndex(i), true
-		}
-	}
-	return 0, false
+	idx, ok := b.builderIdxMap[pubkey]
+	return idx, ok
 }
 
 // ExpectedWithdrawalsGloas returns the withdrawals that a proposer will need to pack in the next block

--- a/beacon-chain/state/state-native/getters_gloas_test.go
+++ b/beacon-chain/state/state-native/getters_gloas_test.go
@@ -384,6 +384,115 @@ func TestBuilderIndexByPubkey(t *testing.T) {
 		require.Equal(t, true, ok)
 		require.Equal(t, wantIdx, idx)
 	})
+
+	t.Run("AddBuilderFromDeposit populates map", func(t *testing.T) {
+		st, err := InitializeFromProtoGloas(&ethpb.BeaconStateGloas{})
+		require.NoError(t, err)
+
+		var pk [fieldparams.BLSPubkeyLength]byte
+		copy(pk[:], bytes.Repeat([]byte{0xCD}, fieldparams.BLSPubkeyLength))
+		var wc [32]byte
+		require.NoError(t, st.AddBuilderFromDeposit(pk, wc, 1))
+
+		idx, ok := st.BuilderIndexByPubkey(pk)
+		require.Equal(t, true, ok)
+		require.Equal(t, primitives.BuilderIndex(0), idx)
+	})
+
+	t.Run("reused slot evicts old pubkey", func(t *testing.T) {
+		oldPk := bytes.Repeat([]byte{0x11}, fieldparams.BLSPubkeyLength)
+		st, err := InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+			Builders: []*ethpb.Builder{
+				{
+					Pubkey:            oldPk,
+					WithdrawableEpoch: 0,
+					Balance:           0,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		var oldPkArr [fieldparams.BLSPubkeyLength]byte
+		copy(oldPkArr[:], oldPk)
+		_, ok := st.BuilderIndexByPubkey(oldPkArr)
+		require.Equal(t, true, ok)
+
+		var newPk [fieldparams.BLSPubkeyLength]byte
+		copy(newPk[:], bytes.Repeat([]byte{0x22}, fieldparams.BLSPubkeyLength))
+		var wc [32]byte
+		require.NoError(t, st.AddBuilderFromDeposit(newPk, wc, 1))
+
+		_, ok = st.BuilderIndexByPubkey(oldPkArr)
+		require.Equal(t, false, ok)
+		idx, ok := st.BuilderIndexByPubkey(newPk)
+		require.Equal(t, true, ok)
+		require.Equal(t, primitives.BuilderIndex(0), idx)
+	})
+
+	t.Run("SetBuilders rebuilds map", func(t *testing.T) {
+		st, err := InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+			Builders: []*ethpb.Builder{
+				{Pubkey: bytes.Repeat([]byte{0x11}, fieldparams.BLSPubkeyLength)},
+			},
+		})
+		require.NoError(t, err)
+
+		var oldPk [fieldparams.BLSPubkeyLength]byte
+		copy(oldPk[:], bytes.Repeat([]byte{0x11}, fieldparams.BLSPubkeyLength))
+		newPkBytes := bytes.Repeat([]byte{0x33}, fieldparams.BLSPubkeyLength)
+		require.NoError(t, st.SetBuilders([]*ethpb.Builder{{Pubkey: newPkBytes}}))
+
+		_, ok := st.BuilderIndexByPubkey(oldPk)
+		require.Equal(t, false, ok)
+		var newPk [fieldparams.BLSPubkeyLength]byte
+		copy(newPk[:], newPkBytes)
+		idx, ok := st.BuilderIndexByPubkey(newPk)
+		require.Equal(t, true, ok)
+		require.Equal(t, primitives.BuilderIndex(0), idx)
+	})
+
+	t.Run("UpdateBuilderAtIndex swaps pubkey mapping", func(t *testing.T) {
+		oldPk := bytes.Repeat([]byte{0x11}, fieldparams.BLSPubkeyLength)
+		st, err := InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+			Builders: []*ethpb.Builder{
+				{Pubkey: oldPk},
+			},
+		})
+		require.NoError(t, err)
+
+		newPkBytes := bytes.Repeat([]byte{0x44}, fieldparams.BLSPubkeyLength)
+		require.NoError(t, st.UpdateBuilderAtIndex(0, &ethpb.Builder{Pubkey: newPkBytes}))
+
+		var oldPkArr [fieldparams.BLSPubkeyLength]byte
+		copy(oldPkArr[:], oldPk)
+		_, ok := st.BuilderIndexByPubkey(oldPkArr)
+		require.Equal(t, false, ok)
+		var newPk [fieldparams.BLSPubkeyLength]byte
+		copy(newPk[:], newPkBytes)
+		idx, ok := st.BuilderIndexByPubkey(newPk)
+		require.Equal(t, true, ok)
+		require.Equal(t, primitives.BuilderIndex(0), idx)
+	})
+
+	t.Run("Copy yields independent maps", func(t *testing.T) {
+		st, err := InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+			Builders: []*ethpb.Builder{
+				{Pubkey: bytes.Repeat([]byte{0x55}, fieldparams.BLSPubkeyLength)},
+			},
+		})
+		require.NoError(t, err)
+
+		copied := st.Copy()
+		var newPk [fieldparams.BLSPubkeyLength]byte
+		copy(newPk[:], bytes.Repeat([]byte{0x66}, fieldparams.BLSPubkeyLength))
+		var wc [32]byte
+		require.NoError(t, copied.AddBuilderFromDeposit(newPk, wc, 1))
+
+		_, ok := st.BuilderIndexByPubkey(newPk)
+		require.Equal(t, false, ok)
+		_, ok = copied.BuilderIndexByPubkey(newPk)
+		require.Equal(t, true, ok)
+	})
 }
 
 func TestBuilderPendingPayment(t *testing.T) {

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -52,7 +52,7 @@ var emptyBuilderPendingPayment = &ethpb.BuilderPendingPayment{
 func newBuilderIdxMap(builders []*ethpb.Builder) map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex {
 	m := make(map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex, len(builders))
 	for i, builder := range builders {
-		if builder == nil || len(builder.Pubkey) == 0 {
+		if builder == nil {
 			continue
 		}
 		m[bytesutil.ToBytes48(builder.Pubkey)] = primitives.BuilderIndex(i)
@@ -305,16 +305,11 @@ func (b *BeaconState) UpdateBuilderAtIndex(index primitives.BuilderIndex, builde
 		b.sharedFieldReferences[types.Builders] = stateutil.NewRef(1)
 	}
 
-	if old := builders[idx]; old != nil && len(old.Pubkey) > 0 {
+	if old := builders[idx]; old != nil {
 		delete(b.builderIdxMap, bytesutil.ToBytes48(old.Pubkey))
 	}
 	builders[idx] = ethpb.CopyBuilder(builder)
-	if len(builder.Pubkey) > 0 {
-		if b.builderIdxMap == nil {
-			b.builderIdxMap = make(map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex)
-		}
-		b.builderIdxMap[bytesutil.ToBytes48(builder.Pubkey)] = index
-	}
+	b.builderIdxMap[bytesutil.ToBytes48(builder.Pubkey)] = index
 	b.builders = builders
 
 	b.markFieldAsDirty(types.Builders)
@@ -396,7 +391,7 @@ func (b *BeaconState) addBuilderFromDepositAtEpoch(pubkey [fieldparams.BLSPubkey
 	}
 
 	if index < primitives.BuilderIndex(len(builders)) {
-		if old := builders[index]; old != nil && len(old.Pubkey) > 0 {
+		if old := builders[index]; old != nil {
 			delete(b.builderIdxMap, bytesutil.ToBytes48(old.Pubkey))
 		}
 		builders[index] = builder
@@ -404,9 +399,6 @@ func (b *BeaconState) addBuilderFromDepositAtEpoch(pubkey [fieldparams.BLSPubkey
 		gap := index - primitives.BuilderIndex(len(builders)) + 1
 		builders = append(builders, make([]*ethpb.Builder, gap)...)
 		builders[index] = builder
-	}
-	if b.builderIdxMap == nil {
-		b.builderIdxMap = make(map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex)
 	}
 	b.builderIdxMap[pubkey] = index
 	b.builders = builders

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -49,6 +49,17 @@ var emptyBuilderPendingPayment = &ethpb.BuilderPendingPayment{
 	},
 }
 
+func newBuilderIdxMap(builders []*ethpb.Builder) map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex {
+	m := make(map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex, len(builders))
+	for i, builder := range builders {
+		if builder == nil || len(builder.Pubkey) == 0 {
+			continue
+		}
+		m[bytesutil.ToBytes48(builder.Pubkey)] = primitives.BuilderIndex(i)
+	}
+	return m
+}
+
 // AppendBuilderPendingWithdrawals appends builder pending withdrawals to the beacon state.
 // If the withdrawals slice is shared, it copies the slice first to preserve references.
 func (b *BeaconState) AppendBuilderPendingWithdrawals(withdrawals []*ethpb.BuilderPendingWithdrawal) error {
@@ -294,7 +305,16 @@ func (b *BeaconState) UpdateBuilderAtIndex(index primitives.BuilderIndex, builde
 		b.sharedFieldReferences[types.Builders] = stateutil.NewRef(1)
 	}
 
+	if old := builders[idx]; old != nil && len(old.Pubkey) > 0 {
+		delete(b.builderIdxMap, bytesutil.ToBytes48(old.Pubkey))
+	}
 	builders[idx] = ethpb.CopyBuilder(builder)
+	if len(builder.Pubkey) > 0 {
+		if b.builderIdxMap == nil {
+			b.builderIdxMap = make(map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex)
+		}
+		b.builderIdxMap[bytesutil.ToBytes48(builder.Pubkey)] = index
+	}
 	b.builders = builders
 
 	b.markFieldAsDirty(types.Builders)
@@ -376,12 +396,19 @@ func (b *BeaconState) addBuilderFromDepositAtEpoch(pubkey [fieldparams.BLSPubkey
 	}
 
 	if index < primitives.BuilderIndex(len(builders)) {
+		if old := builders[index]; old != nil && len(old.Pubkey) > 0 {
+			delete(b.builderIdxMap, bytesutil.ToBytes48(old.Pubkey))
+		}
 		builders[index] = builder
 	} else {
 		gap := index - primitives.BuilderIndex(len(builders)) + 1
 		builders = append(builders, make([]*ethpb.Builder, gap)...)
 		builders[index] = builder
 	}
+	if b.builderIdxMap == nil {
+		b.builderIdxMap = make(map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex)
+	}
+	b.builderIdxMap[pubkey] = index
 	b.builders = builders
 
 	b.markFieldAsDirty(types.Builders)
@@ -805,6 +832,7 @@ func (b *BeaconState) SetBuilders(val []*ethpb.Builder) error {
 	b.sharedFieldReferences[types.Builders].MinusRef()
 	b.sharedFieldReferences[types.Builders] = stateutil.NewRef(1)
 	b.builders = val
+	b.builderIdxMap = newBuilderIdxMap(val)
 	b.markFieldAsDirty(types.Builders)
 	b.rebuildTrie[types.Builders] = true
 	return nil

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -897,6 +897,7 @@ func TestAddBuilderFromDeposit(t *testing.T) {
 					Balance:           0,
 				},
 			},
+			builderIdxMap: map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex{},
 		}
 
 		require.NoError(t, st.AddBuilderFromDeposit(pubkey, wc, 123))
@@ -931,6 +932,7 @@ func TestAddBuilderFromDeposit(t *testing.T) {
 					Balance:           1,
 				},
 			},
+			builderIdxMap: map[[fieldparams.BLSPubkeyLength]byte]primitives.BuilderIndex{},
 		}
 
 		require.NoError(t, st.AddBuilderFromDeposit(pubkey, wc, 5))

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -3,6 +3,7 @@ package state_native
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/bits"
 	"runtime"
 	"slices"
@@ -871,6 +872,7 @@ func InitializeFromProtoUnsafeGloas(st *ethpb.BeaconStateGloas) (state.BeaconSta
 		stateFieldLeaves:              make(map[types.FieldIndex]*fieldtrie.FieldTrie, len(fieldMap)),
 		rebuildTrie:                   make(map[types.FieldIndex]bool, fieldCount),
 		valMapHandler:                 stateutil.NewValMapHandler(st.Validators),
+		builderIdxMap:                 newBuilderIdxMap(st.Builders),
 	}
 
 	b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
@@ -1014,6 +1016,8 @@ func (b *BeaconState) Copy() state.BeaconState {
 
 		// Share the reference to validator index map.
 		valMapHandler: b.valMapHandler,
+
+		builderIdxMap: maps.Clone(b.builderIdxMap),
 	}
 
 	b.blockRootsMultiValue.Copy(b, dst)

--- a/changelog/terence_state-native-builder-pubkey-index.md
+++ b/changelog/terence_state-native-builder-pubkey-index.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Replace linear scan in `BuilderIndexByPubkey` with an O(1) pubkey→index map on the state.


### PR DESCRIPTION
- Replace linear scan in `BuilderIndexByPubkey` with an O(1) pubkey→index map on `BeaconState`. Per-state, deep-copied on `Copy()`