### PR TITLE
Fix data column sidecars JSON response post-Gloas

### DIFF
--- a/api/server/structs/endpoints_debug.go
+++ b/api/server/structs/endpoints_debug.go
@@ -58,10 +58,10 @@ type ForkChoiceNodeExtraData struct {
 }
 
 type GetDebugDataColumnSidecarsResponse struct {
-	Version             string               `json:"version"`
-	ExecutionOptimistic bool                 `json:"execution_optimistic"`
-	Finalized           bool                 `json:"finalized"`
-	Data                []*DataColumnSidecar `json:"data"`
+	Version             string          `json:"version"`
+	ExecutionOptimistic bool            `json:"execution_optimistic"`
+	Finalized           bool            `json:"finalized"`
+	Data                json.RawMessage `json:"data"` // []*DataColumnSidecar pre-Gloas, []*DataColumnSidecarGloas post-Gloas
 }
 
 type DataColumnSidecar struct {
@@ -71,4 +71,12 @@ type DataColumnSidecar struct {
 	KzgProofs                    []string                 `json:"kzg_proofs"`
 	SignedBeaconBlockHeader      *SignedBeaconBlockHeader `json:"signed_block_header"`
 	KzgCommitmentsInclusionProof []string                 `json:"kzg_commitments_inclusion_proof"`
+}
+
+type DataColumnSidecarGloas struct {
+	Index           string   `json:"index"`
+	Column          []string `json:"column"`
+	KzgProofs       []string `json:"kzg_proofs"`
+	Slot            string   `json:"slot"`
+	BeaconBlockRoot string   `json:"beacon_block_root"`
 }

--- a/beacon-chain/rpc/eth/debug/handlers.go
+++ b/beacon-chain/rpc/eth/debug/handlers.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -306,9 +307,20 @@ func (s *Server) DataColumnSidecars(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := buildDataColumnSidecarsJsonResponse(verifiedDataColumns)
+	var data json.RawMessage
+	if blk.Version() >= version.Gloas {
+		sidecars := buildDataColumnSidecarsGloasJsonResponse(verifiedDataColumns)
+		data, err = json.Marshal(sidecars)
+	} else {
+		sidecars, buildErr := buildDataColumnSidecarsJsonResponse(verifiedDataColumns)
+		if buildErr != nil {
+			httputil.HandleError(w, "Could not build data column sidecars response: "+buildErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		data, err = json.Marshal(sidecars)
+	}
 	if err != nil {
-		httputil.HandleError(w, "Could not build data column sidecars response: "+err.Error(), http.StatusInternalServerError)
+		httputil.HandleError(w, "Could not marshal data column sidecars: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 	resp := &structs.GetDebugDataColumnSidecarsResponse{
@@ -398,6 +410,31 @@ func buildDataColumnSidecarsJsonResponse(verifiedDataColumns []blocks.VerifiedRO
 		}
 	}
 	return sidecars, nil
+}
+
+func buildDataColumnSidecarsGloasJsonResponse(verifiedDataColumns []blocks.VerifiedRODataColumn) []*structs.DataColumnSidecarGloas {
+	sidecars := make([]*structs.DataColumnSidecarGloas, len(verifiedDataColumns))
+	for i, dc := range verifiedDataColumns {
+		cells := dc.Column()
+		column := make([]string, len(cells))
+		for j, cell := range cells {
+			column[j] = hexutil.Encode(cell)
+		}
+		proofs := dc.KzgProofs()
+		kzgProofs := make([]string, len(proofs))
+		for j, proof := range proofs {
+			kzgProofs[j] = hexutil.Encode(proof)
+		}
+		root := dc.BlockRoot()
+		sidecars[i] = &structs.DataColumnSidecarGloas{
+			Index:           strconv.FormatUint(dc.Index(), 10),
+			Column:          column,
+			KzgProofs:       kzgProofs,
+			Slot:            strconv.FormatUint(uint64(dc.Slot()), 10),
+			BeaconBlockRoot: hexutil.Encode(root[:]),
+		}
+	}
+	return sidecars
 }
 
 // buildDataColumnSidecarsSSZResponse builds SSZ response for data column sidecars

--- a/beacon-chain/rpc/eth/debug/handlers_test.go
+++ b/beacon-chain/rpc/eth/debug/handlers_test.go
@@ -810,7 +810,81 @@ func TestDataColumnSidecars(t *testing.T) {
 
 		resp := &structs.GetDebugDataColumnSidecarsResponse{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-		require.Equal(t, 0, len(resp.Data))
+		var data []*structs.DataColumnSidecar
+		require.NoError(t, json.Unmarshal(resp.Data, &data))
+		require.Equal(t, 0, len(data))
+	})
+
+	t.Run("Gloas data columns", func(t *testing.T) {
+		originalConfig := params.BeaconConfig()
+		defer func() { params.OverrideBeaconConfig(originalConfig) }()
+
+		config := params.BeaconConfig().Copy()
+		config.FuluForkEpoch = 0
+		config.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(config)
+
+		signedTestBlock := util.NewBeaconBlockGloas()
+		signedTestBlock.Block.Slot = 7
+		roBlock, err := blocks.NewSignedBeaconBlock(signedTestBlock)
+		require.NoError(t, err)
+
+		chainService := &blockchainmock.ChainService{}
+		currentSlot := primitives.Slot(7)
+		chainService.Slot = &currentSlot
+		chainService.OptimisticRoots = make(map[[32]byte]bool)
+		chainService.FinalizedRoots = make(map[[32]byte]bool)
+
+		beaconRoot := bytesutil.PadTo([]byte{0xab, 0xcd}, 32)
+		cell := bytesutil.PadTo([]byte{0x11, 0x22}, 2048)
+		proof := bytesutil.PadTo([]byte{0x33}, 48)
+		gloasSidecar := &ethpb.DataColumnSidecarGloas{
+			Index:           3,
+			Column:          [][]byte{cell},
+			KzgProofs:       [][]byte{proof},
+			Slot:            7,
+			BeaconBlockRoot: beaconRoot,
+		}
+		roDc, err := blocks.NewRODataColumnGloas(gloasSidecar)
+		require.NoError(t, err)
+		verified := blocks.NewVerifiedRODataColumn(roDc)
+
+		mockBlocker := &testutil.MockBlocker{
+			DataColumnsFunc: func(ctx context.Context, id string, indices []int) ([]blocks.VerifiedRODataColumn, *core.RpcError) {
+				return []blocks.VerifiedRODataColumn{verified}, nil
+			},
+			BlockToReturn: roBlock,
+		}
+
+		s := &Server{
+			GenesisTimeFetcher:    chainService,
+			OptimisticModeFetcher: chainService,
+			FinalizationFetcher:   chainService,
+			Blocker:               mockBlocker,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/debug/beacon/data_column_sidecars/head", nil)
+		request.SetPathValue("block_id", "head")
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.DataColumnSidecars(writer, request)
+		require.Equal(t, http.StatusOK, writer.Code)
+
+		resp := &structs.GetDebugDataColumnSidecarsResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		require.Equal(t, version.String(version.Gloas), resp.Version)
+
+		var data []*structs.DataColumnSidecarGloas
+		require.NoError(t, json.Unmarshal(resp.Data, &data))
+		require.Equal(t, 1, len(data))
+		require.Equal(t, "3", data[0].Index)
+		require.Equal(t, "7", data[0].Slot)
+		require.Equal(t, hexutil.Encode(beaconRoot), data[0].BeaconBlockRoot)
+		require.Equal(t, 1, len(data[0].Column))
+		require.Equal(t, hexutil.Encode(cell), data[0].Column[0])
+		require.Equal(t, 1, len(data[0].KzgProofs))
+		require.Equal(t, hexutil.Encode(proof), data[0].KzgProofs[0])
 	})
 }
 

--- a/changelog/potuz_column_sidecars.md
+++ b/changelog/potuz_column_sidecars.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed data column sidecars post gloas in the beacon API.


### PR DESCRIPTION
After Gloas, debug data_column_sidecars endpoint was 500-ing because the JSON builder called Fulu-only accessors (KzgCommitments, SignedBlockHeader, KzgCommitmentsInclusionProof) on Gloas-wrapped RODataColumns. Add a Gloas JSON shape and branch on block version; the SSZ path was already fork-correct.

h/t: reported by @barnabasbusa 