### PR TITLE
Reconstruct Gloas genesis bid from state.latest_execution_payload_bid

### DIFF
--- a/beacon-chain/core/blocks/genesis.go
+++ b/beacon-chain/core/blocks/genesis.go
@@ -193,8 +193,9 @@ func NewGenesisBlockForState(ctx context.Context, st state.BeaconState) (interfa
 			Signature: params.BeaconConfig().EmptySignature[:],
 		})
 	case *ethpb.BeaconStateGloas:
+		gs := ps.(*ethpb.BeaconStateGloas)
 		return blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
-			Block:     gloasGenesisBlock(root),
+			Block:     gloasGenesisBlock(root, gs.LatestExecutionPayloadBid),
 			Signature: params.BeaconConfig().EmptySignature[:],
 		})
 	default:
@@ -202,7 +203,24 @@ func NewGenesisBlockForState(ctx context.Context, st state.BeaconState) (interfa
 	}
 }
 
-func gloasGenesisBlock(root [fieldparams.RootLength]byte) *ethpb.BeaconBlockGloas {
+func gloasGenesisBlock(root [fieldparams.RootLength]byte, latestBid *ethpb.ExecutionPayloadBid) *ethpb.BeaconBlockGloas {
+	// The genesis block body's signed_execution_payload_bid mirrors the state's
+	// latest_execution_payload_bid so the reconstructed block's body_root matches
+	// state.latest_block_header.body_root (which the genesis distribution tool
+	// commits to). Falling back to a zero bid is only useful in tests that
+	// initialize a Gloas state without populating latest_execution_payload_bid.
+	bidMessage := latestBid.Copy()
+	if bidMessage == nil {
+		bidMessage = &ethpb.ExecutionPayloadBid{
+			ParentBlockHash:       make([]byte, 32),
+			ParentBlockRoot:       make([]byte, 32),
+			BlockHash:             make([]byte, 32),
+			PrevRandao:            make([]byte, 32),
+			FeeRecipient:          make([]byte, 20),
+			BlobKzgCommitments:    make([][]byte, 0),
+			ExecutionRequestsRoot: make([]byte, 32),
+		}
+	}
 	return &ethpb.BeaconBlockGloas{
 		ParentRoot: params.BeaconConfig().ZeroHash[:],
 		StateRoot:  root[:],
@@ -218,15 +236,7 @@ func gloasGenesisBlock(root [fieldparams.RootLength]byte) *ethpb.BeaconBlockGloa
 				SyncCommitteeSignature: make([]byte, fieldparams.BLSSignatureLength),
 			},
 			SignedExecutionPayloadBid: &ethpb.SignedExecutionPayloadBid{
-				Message: &ethpb.ExecutionPayloadBid{
-					ParentBlockHash:       make([]byte, 32),
-					ParentBlockRoot:       make([]byte, 32),
-					BlockHash:             make([]byte, 32),
-					PrevRandao:            make([]byte, 32),
-					FeeRecipient:          make([]byte, 20),
-					BlobKzgCommitments:    make([][]byte, 0),
-					ExecutionRequestsRoot: make([]byte, 32),
-				},
+				Message:   bidMessage,
 				Signature: make([]byte, fieldparams.BLSSignatureLength),
 			},
 			PayloadAttestations:     make([]*ethpb.PayloadAttestation, 0),

--- a/changelog/barnabasbusa_fix-gloas-genesis-bid-from-state.md
+++ b/changelog/barnabasbusa_fix-gloas-genesis-bid-from-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Reconstruct the Gloas genesis block's `signed_execution_payload_bid.message` from `state.latest_execution_payload_bid` instead of zero defaults. This makes Prysm's genesis `block_root` match the value committed to in `state.latest_block_header.body_root` (i.e. the value other clients return), fixing a divergence where Prysm produced an orphaned genesis block (`0xfef8248511…`) on glamsterdam-devnet-4 while every other client returned the canonical `0x2ed167c7…`. Without this, the validator client failed to propose at slot 1 with "parent root … does not match the latest block header signing root in state".


### PR DESCRIPTION
## Summary

Follow-up to 794a2280 ("Fix: initialise ExecutionRequestsRoot and ParentExecutionRequests in gloasGenesisBlock"). That commit stopped Prysm from panicking when computing the genesis body root, but the bid itself was still all-zero — so on glamsterdam-devnet-4 the two Prysm nodes returned an orphaned genesis `block_root` (`0xfef8248511…`) while every Lighthouse/Lodestar node returned the canonical `0x2ed167c7…`. All clients still agreed on the state root, but only Prysm's locally-built block disagreed with what `state.latest_block_header.body_root` committed to.

The validator client surfaced this at slot 1 against the BN's own state:

```
ERROR rpc/validator: Finished building block error=… could not process block header:
parent root 0xfef8248511… does not match the latest block header signing root in
state 0x2ed167c7…
```

Diffing the JSON body returned by Lighthouse vs Prysm at slot 0, the only two fields that differ are inside `signed_execution_payload_bid.message`:

| field | Lighthouse / Lodestar (canonical) | Prysm (orphan) |
|---|---|---|
| `parent_block_hash` | `0xab172d9e48985f…` (== `state.latest_block_hash`) | `0x0000…` |
| `execution_requests_root` | `0x85e253b40599…` (== `hash_tree_root(ExecutionRequests())`) | `0x0000…` |

Both values appear verbatim in the parsed genesis state's `latest_execution_payload_bid`, confirming the genesis distribution tool commits to `body.signed_execution_payload_bid.message == state.latest_execution_payload_bid`. This PR threads `state.LatestExecutionPayloadBid` into `gloasGenesisBlock` so the reconstructed body matches.

The fallback (zero bid + non-zero `ExecutionRequestsRoot`) is kept for the few tests that build a `BeaconStateGloas` without populating `latest_execution_payload_bid`.

A separate PR with the same logic targets `develop`: #16821.

## Test plan

- [x] `go build ./...`
- [x] `go test ./beacon-chain/core/blocks/ -run TestGenesis`
- [ ] On a fresh glamsterdam-devnet-4 Kurtosis enclave with `cl-*-prysm` and `cl-*-lodestar`/`cl-*-lighthouse` nodes, confirm:
  - All CL nodes return the same genesis `block_root` from `/eth/v1/beacon/headers/0`.
  - Prysm validators propose successfully starting at slot 1 (no "parent root … does not match" error).