### PR TITLE
`fetchOriginSidecars`: Check if block is `nil`.

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -241,7 +241,7 @@ func (s *Service) fetchOriginSidecars(peers []peer.ID) error {
 	if err != nil {
 		return errors.Wrap(err, "block")
 	}
-	if block.IsNil() {
+	if block == nil || block.IsNil() {
 		return errors.Errorf("origin block for root %#x not found in database", blockRoot)
 	}
 

--- a/changelog/manu_nil-block-origin-sidecars.md
+++ b/changelog/manu_nil-block-origin-sidecars.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `fetchOriginSidecars`: guard against a `nil` block interface before calling `IsNil` to avoid a panic when the origin block is missing from the database.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
`fetchOriginSidecars`: Check if block is `nil`.

**Which issues(s) does this PR fix?**

(Partially) fixes:
- https://github.com/OffchainLabs/prysm/issues/16824

I don't know why the block was not found is the DB.
But at least now in such a case it won't panic.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
