### PR TITLE
add workflow to check generated go files

### DIFF
--- a/.github/workflows/check-generated-go.yml
+++ b/.github/workflows/check-generated-go.yml
@@ -1,0 +1,56 @@
+name: Check Generated Go Files
+
+on:
+  pull_request:
+    paths:
+      - 'proto/**/*.proto'
+      - 'proto/**/*.pb.go'
+      - 'proto/**/*.ssz.go'
+      - 'proto/**/BUILD'
+      - 'proto/**/BUILD.bazel'
+      - 'hack/update-go-pbs.sh'
+      - 'hack/update-go-ssz.sh'
+      - 'hack/common.sh'
+      - '.github/workflows/check-generated-go.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-generated-go:
+    runs-on: ubuntu-4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go 1.25.1
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.1'
+
+      - name: Install Bazelisk and goimports
+        run: |
+          go install github.com/bazelbuild/bazelisk@v1.26.0
+          go install golang.org/x/tools/cmd/goimports@v0.40.0
+          mkdir -p "$HOME/bin"
+          ln -sf "$(go env GOPATH)/bin/bazelisk" "$HOME/bin/bazel"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Regenerate protobuf and SSZ Go files
+        run: |
+          ./hack/update-go-pbs.sh
+          ./hack/update-go-ssz.sh
+
+      - name: Check for generated file updates
+        run: |
+          if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+            echo "Generated Go files are out-of-date."
+            echo "Run the following commands and commit the results:"
+            echo "  ./hack/update-go-pbs.sh"
+            echo "  ./hack/update-go-ssz.sh"
+            echo ""
+            git status --short --untracked-files=all
+            echo ""
+            git --no-pager diff --name-only
+            exit 1
+          fi

--- a/changelog/bastin_generated-go-git-action.md
+++ b/changelog/bastin_generated-go-git-action.md
@@ -1,0 +1,3 @@
+### Added
+
+- github workflow to check generated go files.


### PR DESCRIPTION
basically runs `/hack/update-go-pbs.sh` and `/hack/update-go-ssz.sh` and fails if there are any codebase changes.
only runs when something in `/proto/` is changed or one of the above files or the workflow file itself.
it takes around 8-10 minutes to run for eligible PRs.