### PR TITLE
Cap Gloas pending column cell count, reject malformed sidecars

### DIFF
--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -54,7 +54,9 @@ func (s *Service) validateDataColumnGloas(
 		if msg.Topic == nil || !strings.Contains(*msg.Topic+"/", expectedSubTopic) {
 			return blocks.VerifiedRODataColumn{}, errors.New("gloas data column on wrong subnet")
 		}
-		s.queuePendingGloasColumn(roDataColumn, pid)
+		if err := s.queuePendingGloasColumn(roDataColumn, pid); err != nil {
+			return blocks.VerifiedRODataColumn{}, err
+		}
 		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.New("gloas data column block not yet seen"))
 	}
 
@@ -124,14 +126,24 @@ func (s *Service) setSeenDataColumnRootIndex(root [fieldparams.RootLength]byte, 
 	s.seenDataColumnCache.Add(slot, key, true)
 }
 
-func (s *Service) queuePendingGloasColumn(roCol blocks.RODataColumn, pid peer.ID) {
+// queuePendingGloasColumn returns a non-nil error for malformed sidecars (the caller propagates it as ValidationReject).
+func (s *Service) queuePendingGloasColumn(roCol blocks.RODataColumn, pid peer.ID) error {
 	dc := roCol.DataColumnSidecarGloas()
 	if dc == nil {
-		return
+		return errors.New("nil gloas data column sidecar")
+	}
+	cells := len(dc.Column)
+	if cells == 0 || len(dc.KzgProofs) != cells {
+		return errors.Errorf("gloas data column length mismatch: cells=%d proofs=%d", cells, len(dc.KzgProofs))
+	}
+	cfg := params.BeaconConfig()
+	currentEpoch := slots.ToEpoch(s.cfg.clock.CurrentSlot())
+	if cells > max(cfg.MaxBlobsPerBlockAtEpoch(currentEpoch), cfg.MaxBlobsPerBlockAtEpoch(currentEpoch+1)) {
+		return errors.Errorf("gloas data column cell count %d exceeds network blob limit", cells)
 	}
 	idx := roCol.Index()
 	if idx >= fieldparams.NumberOfColumns {
-		return
+		return errors.Errorf("gloas data column index %d out of range", idx)
 	}
 
 	root := roCol.BlockRoot()
@@ -143,16 +155,17 @@ func (s *Service) queuePendingGloasColumn(roCol blocks.RODataColumn, pid peer.ID
 	entry := s.pendingGloasColumns[root]
 	if entry == nil {
 		if len(s.pendingGloasColumns) >= maxPendingGloasRoots {
-			return
+			return nil
 		}
 		entry = &pendingGloasEntry{slot: slot}
 		s.pendingGloasColumns[root] = entry
 	}
 
 	if entry.columns[idx] != nil {
-		return
+		return nil
 	}
 	entry.columns[idx] = &pendingColumnEntry{sidecar: dc, peer: pid}
+	return nil
 }
 
 func (s *Service) processPendingGloasColumns(root [fieldparams.RootLength]byte, blk interfaces.ReadOnlySignedBeaconBlock) {

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -112,6 +112,8 @@ func TestValidateDataColumnGloas(t *testing.T) {
 	t.Run("ignores unseen block", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		cfg := params.BeaconConfig()
+		cfg.DenebForkEpoch = 0
+		cfg.ElectraForkEpoch = 0
 		cfg.FuluForkEpoch = 0
 		cfg.GloasForkEpoch = 0
 		params.OverrideBeaconConfig(cfg)
@@ -134,6 +136,8 @@ func TestValidateDataColumnGloas(t *testing.T) {
 	t.Run("validates against bid commitments", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		cfg := params.BeaconConfig()
+		cfg.DenebForkEpoch = 0
+		cfg.ElectraForkEpoch = 0
 		cfg.FuluForkEpoch = 0
 		cfg.GloasForkEpoch = 0
 		params.OverrideBeaconConfig(cfg)
@@ -166,6 +170,8 @@ func TestValidateDataColumnGloas(t *testing.T) {
 	t.Run("rejects slot mismatch", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		cfg := params.BeaconConfig()
+		cfg.DenebForkEpoch = 0
+		cfg.ElectraForkEpoch = 0
 		cfg.FuluForkEpoch = 0
 		cfg.GloasForkEpoch = 0
 		params.OverrideBeaconConfig(cfg)
@@ -197,9 +203,44 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		_, err = service.validateDataColumnGloas(ctx, "aDummyPID", msg, roDataColumn, "/data_column_sidecar_%d/")
 		require.ErrorContains(t, "slot does not match block slot", err)
 	})
+
+	t.Run("rejects oversize column on queue path", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.DenebForkEpoch = 0
+		cfg.ElectraForkEpoch = 0
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		sidecar, _ := gloasFixture(t)
+		maxCells := params.BeaconConfig().MaxBlobCommitmentsPerBlock
+		sidecar.Column = make([][]byte, maxCells)
+		sidecar.KzgProofs = make([][]byte, maxCells)
+		for i := range sidecar.Column {
+			sidecar.Column[i] = make([]byte, 2048)
+			sidecar.KzgProofs[i] = make([]byte, 48)
+		}
+
+		service, message := serviceAndMessage(t, testNewDataColumnSidecarsVerifier(verification.MockDataColumnsVerifier{}), sidecar, sidecar.Index)
+		result, err := service.validateDataColumn(ctx, "aDummyPID", message)
+		require.NotNil(t, err)
+		require.Equal(t, pubsub.ValidationReject, result)
+
+		blockRoot := bytesutil.ToBytes32(sidecar.BeaconBlockRoot)
+		require.Equal(t, false, service.hasPendingGloasColumns(blockRoot))
+	})
 }
 
 func TestPendingGloasColumns(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
 	clock := startup.NewClock(time.Now(), [32]byte{})
 
 	t.Run("queue and retrieve", func(t *testing.T) {
@@ -218,7 +259,7 @@ func TestPendingGloasColumns(t *testing.T) {
 		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
 		require.NoError(t, err)
 
-		s.queuePendingGloasColumn(roCol, "peer1")
+		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
 		require.Equal(t, true, s.hasPendingGloasColumns(root))
 
 		entry := s.pendingGloasColumns[root]
@@ -243,8 +284,8 @@ func TestPendingGloasColumns(t *testing.T) {
 		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
 		require.NoError(t, err)
 
-		s.queuePendingGloasColumn(roCol, "peer1")
-		s.queuePendingGloasColumn(roCol, "peer2")
+		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer2"))
 		require.Equal(t, peer.ID("peer1"), s.pendingGloasColumns[root].columns[10].peer)
 	})
 
@@ -277,7 +318,76 @@ func TestPendingGloasColumns(t *testing.T) {
 		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
 		require.NoError(t, err)
 
-		s.queuePendingGloasColumn(roCol, "peer1")
+		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+		require.Equal(t, false, s.hasPendingGloasColumns(root))
+	})
+
+	t.Run("oversize column rejected", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		// SSZ allows 4096 cells; live max is much smaller. Without admission cap,
+		// this 8 MiB sidecar would sit on the heap until prune.
+		maxCells := params.BeaconConfig().MaxBlobCommitmentsPerBlock
+		cells := make([][]byte, maxCells)
+		proofs := make([][]byte, maxCells)
+		for i := range cells {
+			cells[i] = make([]byte, 2048)
+			proofs[i] = make([]byte, 48)
+		}
+		root := [32]byte{0x77}
+		dc := &ethpb.DataColumnSidecarGloas{
+			Index:           0,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: root[:],
+			Column:          cells,
+			KzgProofs:       proofs,
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+		require.NoError(t, err)
+
+		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+		require.Equal(t, false, s.hasPendingGloasColumns(root))
+	})
+
+	t.Run("empty column rejected", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		root := [32]byte{0x78}
+		dc := &ethpb.DataColumnSidecarGloas{
+			Index:           0,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: root[:],
+			Column:          nil,
+			KzgProofs:       nil,
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+		require.NoError(t, err)
+
+		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+		require.Equal(t, false, s.hasPendingGloasColumns(root))
+	})
+
+	t.Run("column proof length mismatch rejected", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		root := [32]byte{0x79}
+		dc := &ethpb.DataColumnSidecarGloas{
+			Index:           0,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: root[:],
+			Column:          [][]byte{make([]byte, 2048), make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+		require.NoError(t, err)
+
+		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
 		require.Equal(t, false, s.hasPendingGloasColumns(root))
 	})
 
@@ -298,7 +408,7 @@ func TestPendingGloasColumns(t *testing.T) {
 			}
 			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
 			require.NoError(t, err)
-			s.queuePendingGloasColumn(roCol, "peer1")
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
 		}
 		require.Equal(t, maxPendingGloasRoots, len(s.pendingGloasColumns))
 
@@ -313,7 +423,7 @@ func TestPendingGloasColumns(t *testing.T) {
 		}
 		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, overflowRoot)
 		require.NoError(t, err)
-		s.queuePendingGloasColumn(roCol, "peer1")
+		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
 		require.Equal(t, false, s.hasPendingGloasColumns(overflowRoot))
 
 		// Adding to an existing root should still work.
@@ -327,7 +437,7 @@ func TestPendingGloasColumns(t *testing.T) {
 		}
 		roCol2, err := blocks.NewRODataColumnGloasWithRoot(dc2, existingRoot)
 		require.NoError(t, err)
-		s.queuePendingGloasColumn(roCol2, "peer1")
+		require.NoError(t, s.queuePendingGloasColumn(roCol2, "peer1"))
 		require.NotNil(t, s.pendingGloasColumns[existingRoot].columns[1])
 	})
 
@@ -361,7 +471,7 @@ func TestPendingGloasColumns(t *testing.T) {
 		// Queue the sidecar.
 		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
 		require.NoError(t, err)
-		s.queuePendingGloasColumn(roCol, "peer1")
+		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
 		require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
 
 		// Process with the block.
@@ -404,7 +514,7 @@ func TestPendingGloasColumns(t *testing.T) {
 
 		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
 		require.NoError(t, err)
-		s.queuePendingGloasColumn(roCol, "badpeer")
+		require.NoError(t, s.queuePendingGloasColumn(roCol, "badpeer"))
 
 		s.processPendingGloasColumns(blockRoot, signedBlock)
 		require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))

--- a/changelog/terence_cap-pending-gloas-column-cells.md
+++ b/changelog/terence_cap-pending-gloas-column-cells.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cap Gloas data column sidecar cell count by `MaxBlobsPerBlockAtEpoch` at pending-queue admission, and require `KzgProofs` length to match `Column`.


### PR DESCRIPTION
- Cap Gloas data column sidecar cell count at `MaxBlobsPerBlockAtEpoch` at pending-queue admission. Without this, the SSZ `ssz-max="4096"` tag combined with the 8-root / 128-column queue lets a peer hold ~8 GiB of heap on the victim for unseen-block roots.
- Also require `len(KzgProofs) == len(Column)` and non-empty `Column`; malformed sidecars now return a plain error so `validateDataColumnGloas` propagates `ValidationReject` (gossipsub auto-downscores the peer).