### PR TITLE
Dedup bid at the earliest point in gossip validation

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -54,6 +54,13 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 		return pubsub.ValidationIgnore, err
 	}
 
+	// [IGNORE] this is the first signed bid seen with a valid signature from the given builder for this slot.
+	// Cache is populated only after VerifySignature below; a hit here implies a valid-sig bid was already seen.
+	builderKey := executionPayloadBidBuilderKey(bid.Slot(), bid.BuilderIndex())
+	if s.hasSeenExecutionPayloadBidBuilder(builderKey) {
+		return pubsub.ValidationIgnore, nil
+	}
+
 	// [IGNORE] bid.slot is the current slot or the next slot.
 	if err := v.VerifyCurrentOrNextSlot(); err != nil {
 		return pubsub.ValidationIgnore, err
@@ -86,16 +93,8 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyFeeRecipientMatches(pref.FeeRecipient[:]); err != nil {
 		return pubsub.ValidationReject, err
 	}
-	// The spec lists signature validation later, but the "first signed bid seen
-	// with a valid signature" gate below depends on knowing validity first.
 	if err := v.VerifySignature(st); err != nil {
 		return pubsub.ValidationReject, err
-	}
-
-	// [IGNORE] this is the first signed bid seen with a valid signature from the given builder for this slot.
-	builderKey := executionPayloadBidBuilderKey(bid.Slot(), bid.BuilderIndex())
-	if s.hasSeenExecutionPayloadBidBuilder(builderKey) {
-		return pubsub.ValidationIgnore, nil
 	}
 	s.setSeenExecutionPayloadBidBuilder(bid.Slot(), builderKey)
 	// [IGNORE] this bid is the highest value bid seen for the tuple (bid.slot, bid.parent_block_hash, bid.parent_block_root).
@@ -122,8 +121,6 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyParentBlockRootSeen(s.cfg.chain.InForkchoice); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	// [REJECT] signed_execution_payload_bid.signature is valid with respect to the bid.builder_index.
-	// Verified earlier to satisfy the "first valid signed bid seen" condition.
 	msg.ValidatorData = signedBid
 	return pubsub.ValidationAccept, nil
 }

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -51,6 +51,26 @@ func TestValidateExecutionPayloadBidGossip_AlreadySeenBuilder(t *testing.T) {
 	require.Equal(t, pubsub.ValidationIgnore, result)
 }
 
+// Dedup must short-circuit before every later check; duplicates pay only the cache lookup.
+func TestValidateExecutionPayloadBidGossip_DedupShortCircuitsAllLaterChecks(t *testing.T) {
+	ctx := context.Background()
+	s, msg, signedBid := setupExecutionPayloadBidService(t)
+	key := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
+	s.setSeenExecutionPayloadBidBuilder(signedBid.Message.Slot, key)
+	// Every subsequent verifier method would Reject/Ignore if it ran; the cache hit must skip them all.
+	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
+		errCurrentOrNextSlot:    errors.New("slot"),
+		errBuilderActive:        errors.New("builder"),
+		errExecutionPayment:     errors.New("payment"),
+		errFeeRecipientMismatch: errors.New("fee"),
+		errSignature:            errors.New("sig"),
+	})
+
+	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+}
+
 func TestValidateExecutionPayloadBidGossip_ProposerPreferencesUnseen(t *testing.T) {
 	ctx := context.Background()
 	s, msg, _ := setupExecutionPayloadBidService(t)

--- a/changelog/terence_dedup-bid-before-sig-verify.md
+++ b/changelog/terence_dedup-bid-before-sig-verify.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Run the `(slot, builder_index)` dedup before BLS signature verification in `validateExecutionPayloadBidGossip`. Duplicates of an already-seen bid now short-circuit without running `VerifySignature`.


### PR DESCRIPTION
- Move the `(slot, builder_index)` dedup cache check immediately after `b.Bid()` in `validateExecutionPayloadBidGossip`, before every later check including BLS sig verify