### PR TITLE
Clear dangling origin checkpoint pointer on historical prune

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -477,14 +477,10 @@ func (s *Store) DeleteHistoricalDataBeforeSlot(ctx context.Context, cutoffSlot p
 		return 0, err
 	}
 
-	// Return early if there's nothing to delete.
-	if len(slotRoots) == 0 {
-		return 0, nil
-	}
-
 	// Perform all deletions in a single transaction for atomicity
 	var numSlotsDeleted int
 	err = s.db.Update(func(tx *bolt.Tx) error {
+		blocksBkt := tx.Bucket(blocksBucket)
 		for _, sr := range slotRoots {
 			// Return if context is cancelled or deadline is exceeded.
 			if ctx.Err() != nil {
@@ -541,6 +537,13 @@ func (s *Store) DeleteHistoricalDataBeforeSlot(ctx context.Context, cutoffSlot p
 			s.blockCache.Del(string(sr.root[:]))
 			// Delete state summary from cache
 			s.stateSummaryCache.delete(sr.root)
+		}
+
+		originRoot := blocksBkt.Get(originCheckpointBlockRootKey)
+		if originRoot != nil && blocksBkt.Get(originRoot) == nil {
+			if err = blocksBkt.Delete(originCheckpointBlockRootKey); err != nil {
+				return errors.Wrap(err, "could not delete origin checkpoint block root")
+			}
 		}
 
 		return nil

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -618,6 +618,66 @@ func TestStore_HistoricalDataBeforeSlot(t *testing.T) {
 
 }
 
+func TestStore_DeleteHistoricalDataBeforeSlot_ClearsOriginCheckpointPointerWhenOriginBlockPruned(t *testing.T) {
+	db := setupDB(t)
+	ctx := t.Context()
+
+	require.NoError(t, db.SaveGenesisBlockRoot(ctx, genesisBlockRoot))
+	blks := makeBlocks(t, 0, 8, genesisBlockRoot)
+	require.NoError(t, db.SaveBlocks(ctx, blks))
+
+	originBlk := blks[2]
+	originRoot, err := originBlk.Block().HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveOriginCheckpointBlockRoot(ctx, originRoot))
+
+	gotRoot, err := db.OriginCheckpointBlockRoot(ctx)
+	require.NoError(t, err)
+	require.Equal(t, originRoot, gotRoot)
+	gotBlock, err := db.Block(ctx, originRoot)
+	require.NoError(t, err)
+	require.NotNil(t, gotBlock)
+
+	slotsDeleted, err := db.DeleteHistoricalDataBeforeSlot(ctx, originBlk.Block().Slot()+1, 8)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, slotsDeleted)
+
+	_, err = db.OriginCheckpointBlockRoot(ctx)
+	require.ErrorIs(t, err, ErrNotFoundOriginBlockRoot)
+	gotBlock, err = db.Block(ctx, originRoot)
+	require.NoError(t, err)
+	require.Equal(t, nil, gotBlock)
+}
+
+func TestStore_DeleteHistoricalDataBeforeSlot_ClearsAlreadyDanglingOriginCheckpointPointer(t *testing.T) {
+	db := setupDB(t)
+	ctx := t.Context()
+
+	require.NoError(t, db.SaveGenesisBlockRoot(ctx, genesisBlockRoot))
+	blks := makeBlocks(t, 0, 2, genesisBlockRoot)
+	require.NoError(t, db.SaveBlocks(ctx, blks))
+
+	originBlk := blks[0]
+	originRoot, err := originBlk.Block().HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveOriginCheckpointBlockRoot(ctx, originRoot))
+	require.NoError(t, db.DeleteBlock(ctx, originRoot))
+
+	gotRoot, err := db.OriginCheckpointBlockRoot(ctx)
+	require.NoError(t, err)
+	require.Equal(t, originRoot, gotRoot)
+	gotBlock, err := db.Block(ctx, originRoot)
+	require.NoError(t, err)
+	require.Equal(t, nil, gotBlock)
+
+	slotsDeleted, err := db.DeleteHistoricalDataBeforeSlot(ctx, primitives.Slot(0), 8)
+	require.NoError(t, err)
+	require.Equal(t, 0, slotsDeleted)
+
+	_, err = db.OriginCheckpointBlockRoot(ctx)
+	require.ErrorIs(t, err, ErrNotFoundOriginBlockRoot)
+}
+
 func TestStore_GenesisBlock(t *testing.T) {
 	db := setupDB(t)
 	ctx := t.Context()

--- a/changelog/satushh_clear-dangling-origin-checkpoint-pointer.md
+++ b/changelog/satushh_clear-dangling-origin-checkpoint-pointer.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Clear the origin checkpoint block root pointer in `DeleteHistoricalDataBeforeSlot` when the origin block has been pruned, so `OriginCheckpointBlockRoot` no longer returns a dangling root.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`DeleteHistoricalDataBeforeSlot` deletes blocks/states/indices before a cutoff slot but never touches the `originCheckpointBlockRootKey` entry in `blocksBucket`. If the origin block falls within the pruned range, the pointer is left referencing a deleted block.

That breaks `fetchOriginSidecars` (beacon-chain/sync/initial-sync/service.go): `OriginCheckpointBlockRoot` returns the stale root, the follow-up `DB.Block(blockRoot)` returns `nil`, and initial sync fails with origin block for root %#x not found in database instead of skipping origin-sidecar fetch via ErrNotFoundOriginBlockRoot.

  Fix:

At the end of the `DeleteHistoricalDataBeforeSlot` bolt tx, if `originCheckpointBlockRootKey` points to a root whose block is no longer in blocksBucket, delete the pointer. 

The empty-slotRoots early return is removed so the cleanup also catches origin pointers that were orphaned by a prior path (e.g. an earlier DeleteBlock).


**Which issues(s) does this PR fix?**

Potentially Fixes https://github.com/OffchainLabs/prysm/issues/16824

**Other notes for review**

Read the tests first to get an easier understanding. The tests fail in develop.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
