### PR TITLE
Fix data race on s.head.full in postPayloadTasks

### DIFF
--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -153,9 +153,11 @@ func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROEx
 	}
 	blockHash := bytesutil.ToBytes32(payload.BlockHash())
 
-	if s.head != nil {
+	s.headLock.Lock()
+	if s.head != nil && s.head.root == root {
 		s.head.full = true
 	}
+	s.headLock.Unlock()
 
 	attr := s.getPayloadAttribute(ctx, st, envelope.Slot()+1, headRoot[:], true)
 	if s.inRegularSync() {

--- a/changelog/terence_fix-head-full-data-race.md
+++ b/changelog/terence_fix-head-full-data-race.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Protect `s.head.full` write in `postPayloadTasks` with `headLock` to avoid a data race with `setHead` and concurrent readers.


### PR DESCRIPTION
- `s.head.full = true` written with no lock — races with `setHead` and RLock readers
- Take `headLock.Lock()` and re-check `s.head.root == root` before mutating