### PR TITLE
Use HeadSlot() in computePayloadWithdrawals

### DIFF
--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -78,7 +78,7 @@ func (s *Service) checkIfProposing(st state.ReadOnlyBeaconState, slot primitives
 // execution requests on a state copy before computing withdrawals.
 // If the parent was empty, it returns the existing payload_expected_withdrawals.
 func (s *Service) computePayloadWithdrawals(ctx context.Context, st state.BeaconState, parentRoot [32]byte, headFull bool) ([]*enginev1.Withdrawal, error) {
-	if slots.ToEpoch(s.head.slot) < params.BeaconConfig().GloasForkEpoch {
+	if slots.ToEpoch(s.HeadSlot()) < params.BeaconConfig().GloasForkEpoch {
 		result, err := st.ExpectedWithdrawalsGloas()
 		if err != nil {
 			return nil, errors.Wrap(err, "could not compute expected withdrawals")

--- a/changelog/terence_fix-gloas-head-slot-race.md
+++ b/changelog/terence_fix-gloas-head-slot-race.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use `HeadSlot()` in `computePayloadWithdrawals` instead of reading `s.head.slot` directly, to avoid a data race with `setHead`.


### PR DESCRIPTION
- Direct `s.head.slot` read had no lock — races with `setHead`, NPE risk if `s.head` is nil
- Use `HeadSlot()`