### PR TITLE
Fix UpdateHead doc: caller must NOT hold forkchoice lock

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -116,7 +116,7 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 }
 
 // UpdateHead updates the canonical head of the chain based on information from fork-choice attestations and votes.
-// The caller of this function MUST hold a lock in forkchoice
+// The caller of this function MUST NOT hold the forkchoice lock; it is acquired inside.
 func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot) {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.blockchain.UpdateHead")
 	defer span.End()

--- a/changelog/terence_fix-update-head-stale-doc.md
+++ b/changelog/terence_fix-update-head-stale-doc.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Correct `UpdateHead` doc comment: callers must not hold the forkchoice lock; the function acquires it internally.


### PR DESCRIPTION
- Comment said caller must hold the forkchoice lock; function acquires it itself
- A caller following the doc would self-deadlock on the non-reentrant RWMutex
- Flip comment to match implementation