### PR TITLE
beacon-chain/execution: remove double metrics Observe in getBlobsV3

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -683,7 +683,6 @@ func (s *Service) GetBlobsV3(ctx context.Context, versionedHashes []common.Hash)
 	}
 
 	getBlobsV3RequestsTotal.Inc()
-	getBlobsV3Latency.Observe(time.Since(start).Seconds())
 	result := make([]*pb.BlobAndProofV2, len(versionedHashes))
 	err := s.rpcClient.CallContext(ctx, &result, GetBlobsV3, versionedHashes)
 	getBlobsV3Latency.Observe(time.Since(start).Seconds())


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

While debugging issues on the cell-level-delta devnet, Prysm/Geth is showing some strange metrics anomalies. The fix is just something I observed while inspecting the code.