### PR TITLE
beacon-chain/execution: use default histogram buckets for engine latency metrics

### DIFF
--- a/beacon-chain/execution/metrics.go
+++ b/beacon-chain/execution/metrics.go
@@ -50,7 +50,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "beacon_engine_getBlobsV3_request_duration_seconds",
 			Help:    "Duration of engine_getBlobsV3 requests in seconds",
-			Buckets: []float64{0.025, 0.05, 0.1, 0.2, 0.5, 1, 2, 4},
+			Buckets: prometheus.DefBuckets,
 		},
 	)
 	hasBlobsRequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
@@ -61,7 +61,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "beacon_engine_hasBlobs_request_duration_seconds",
 			Help:    "Duration of engine_hasBlobs requests in seconds",
-			Buckets: []float64{0.025, 0.05, 0.1, 0.2, 0.5, 1, 2, 4},
+			Buckets: prometheus.DefBuckets,
 		},
 	)
 	errParseCount = promauto.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR sets Prysm’s histogram buckets to the default values to make statistical analysis with Lighthouse easier.


**Which issues(s) does this PR fix?**

In the cell-level delta devnet, the Grafana dashboard showed that Geth had a 10s p90 latency for the getBlobsV3 response. However, we found that Prysm and Lighthouse had different bucket size settings. For Lighthouse, the buckets are [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 (+Inf)], which is the default Prometheus setting. However, Prysm was using custom buckets, [0.025, 0.05, 0.1, 0.2, 0.5, 1, 2, 4 (+Inf)], which led to distorted statistical results after the metrics were merged. Found by @fjl

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
