### PR TITLE
add ssz functions for progressive merkliezation

### DIFF
--- a/changelog/bastin_progressive-ssz-functions.md
+++ b/changelog/bastin_progressive-ssz-functions.md
@@ -1,0 +1,3 @@
+### Added
+
+- progressive merklization functions in the ssz package

--- a/encoding/ssz/BUILD.bazel
+++ b/encoding/ssz/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "helpers.go",
         "htrutils.go",
         "merkleize.go",
+        "progressive_merkleize.go",
         "slice_root.go",
     ],
     importpath = "github.com/OffchainLabs/prysm/v7/encoding/ssz",
@@ -14,6 +15,7 @@ go_library(
     deps = [
         "//config/fieldparams:go_default_library",
         "//container/trie:go_default_library",
+        "//crypto/hash:go_default_library",
         "//crypto/hash/htr:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/engine/v1:go_default_library",
@@ -34,6 +36,7 @@ go_test(
         "htrutils_fuzz_test.go",
         "htrutils_test.go",
         "merkleize_test.go",
+        "progressive_merkleize_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/encoding/ssz/progressive_merkleize.go
+++ b/encoding/ssz/progressive_merkleize.go
@@ -1,0 +1,130 @@
+package ssz
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/OffchainLabs/prysm/v7/crypto/hash"
+)
+
+const maxProgressiveActiveFields = 256
+
+// MerkleizeProgressiveChunks computes the progressive Merkle root of 32-byte chunks.
+//
+// This is the EIP-7916 merkleize_progressive(chunks, num_leaves=1) helper.
+// Chunks are split into progressively larger subtrees with capacities 1, 4, 16,
+// 64, ...; each subtree root is then folded into the spine from deepest to
+// shallowest by hashing hash(subtree_root, successor_root).
+func MerkleizeProgressiveChunks(chunks [][32]byte) [32]byte {
+	if len(chunks) == 0 {
+		return [32]byte{}
+	}
+
+	n := len(chunks)
+	start := 0
+	subtreeCapacity := 1
+	subtreeRoots := make([][32]byte, 0)
+
+	for start < n {
+		width := min(subtreeCapacity, n-start)
+
+		subtree := make([][32]byte, width)
+		copy(subtree, chunks[start:start+width])
+		subtreeRoots = append(subtreeRoots, MerkleizeVector(subtree, uint64(subtreeCapacity)))
+
+		start += width
+		if start >= n {
+			break
+		}
+
+		if subtreeCapacity > math.MaxInt/4 {
+			subtreeCapacity = math.MaxInt
+		} else {
+			subtreeCapacity *= 4
+		}
+	}
+
+	hashFunc := hash.CustomSHA256Hasher()
+
+	// Fold successor roots from deepest subtree to shallowest subtree.
+	root := [32]byte{}
+	for i := len(subtreeRoots) - 1; i >= 0; i-- {
+		root = hashPair(hashFunc, subtreeRoots[i], root)
+	}
+	return root
+}
+
+// MerkleizeVectorSSZProgressive hashes each element and computes the
+// merkleize_progressive body root over the resulting field roots.
+func MerkleizeVectorSSZProgressive[T Hashable](elements []T) ([32]byte, error) {
+	roots := make([][32]byte, len(elements))
+	for i, el := range elements {
+		r, err := el.HashTreeRoot()
+		if err != nil {
+			return [32]byte{}, err
+		}
+		roots[i] = r
+	}
+	return MerkleizeProgressiveChunks(roots), nil
+}
+
+// MerkleizeListSSZProgressive hashes each element and computes the progressive
+// list root by mixing in the element count.
+func MerkleizeListSSZProgressive[T Hashable](elements []T) ([32]byte, error) {
+	body, err := MerkleizeVectorSSZProgressive(elements)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	var length [32]byte
+	binary.LittleEndian.PutUint64(length[:8], uint64(len(elements)))
+	return MixInLength(body, length[:]), nil
+}
+
+// SliceRootProgressive computes the progressive list root of hashable elements.
+func SliceRootProgressive[T Hashable](slice []T) ([32]byte, error) {
+	return MerkleizeListSSZProgressive(slice)
+}
+
+// ByteSliceRootProgressive computes the progressive list root of a byte slice
+// interpreted as ProgressiveByteList (alias of ProgressiveList[byte]).
+func ByteSliceRootProgressive(slice []byte) ([32]byte, error) {
+	var chunks [][32]byte
+	if len(slice) > 0 {
+		var err error
+		chunks, err = PackByChunk([][]byte{slice})
+		if err != nil {
+			return [32]byte{}, err
+		}
+	}
+
+	bytesRoot := MerkleizeProgressiveChunks(chunks)
+	var length [32]byte
+	binary.LittleEndian.PutUint64(length[:8], uint64(len(slice)))
+	return MixInLength(bytesRoot, length[:]), nil
+}
+
+// MixInActiveFields computes hash(root, pack_bits(activeFields)) where
+// activeFields is restricted to at most 256 bits.
+func MixInActiveFields(root [32]byte, activeFields []bool) ([32]byte, error) {
+	if len(activeFields) > maxProgressiveActiveFields {
+		return [32]byte{}, fmt.Errorf("active fields length %d exceeds maximum %d", len(activeFields), maxProgressiveActiveFields)
+	}
+
+	var packed [32]byte
+	for i, active := range activeFields {
+		if !active {
+			continue
+		}
+		packed[i/8] |= 1 << (uint(i) % 8)
+	}
+	return hashPair(hash.Hash, root, packed), nil
+}
+
+func hashPair(hashFunc func([]byte) [32]byte, left, right [32]byte) [32]byte {
+	var input [64]byte
+	copy(input[:32], left[:])
+	copy(input[32:], right[:])
+	return hashFunc(input[:])
+}

--- a/encoding/ssz/progressive_merkleize.go
+++ b/encoding/ssz/progressive_merkleize.go
@@ -29,8 +29,7 @@ func MerkleizeProgressiveChunks(chunks [][32]byte) [32]byte {
 	for start < n {
 		width := min(subtreeCapacity, n-start)
 
-		subtree := make([][32]byte, width)
-		copy(subtree, chunks[start:start+width])
+		subtree := chunks[start : start+width : start+width]
 		subtreeRoots = append(subtreeRoots, MerkleizeVector(subtree, uint64(subtreeCapacity)))
 
 		start += width

--- a/encoding/ssz/progressive_merkleize_test.go
+++ b/encoding/ssz/progressive_merkleize_test.go
@@ -1,0 +1,186 @@
+package ssz_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/crypto/hash"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+type staticHashable struct {
+	root [32]byte
+	err  error
+}
+
+func (s staticHashable) HashTreeRoot() ([32]byte, error) {
+	if s.err != nil {
+		return [32]byte{}, s.err
+	}
+	return s.root, nil
+}
+
+func chunkFromIndex(i int) [32]byte {
+	var out [32]byte
+	binary.LittleEndian.PutUint64(out[:8], uint64(i+1))
+	return out
+}
+
+func hashPair(left, right [32]byte) [32]byte {
+	var input [64]byte
+	copy(input[:32], left[:])
+	copy(input[32:], right[:])
+	return hash.Hash(input[:])
+}
+
+func referenceMerkleizeProgressive(chunks [][32]byte, numLeaves uint64) [32]byte {
+	if len(chunks) == 0 {
+		return [32]byte{}
+	}
+	if numLeaves == 0 {
+		panic("numLeaves must be positive")
+	}
+
+	take := len(chunks)
+	if uint64(take) > numLeaves {
+		take = int(numLeaves)
+	}
+	left := slices.Clone(chunks[:take])
+	a := ssz.MerkleizeVector(left, numLeaves)
+	b := referenceMerkleizeProgressive(chunks[take:], numLeaves*4)
+	return hashPair(a, b)
+}
+
+func TestMerkleizeProgressiveChunks_MatchesReference(t *testing.T) {
+	testCases := []int{0, 1, 2, 3, 5, 6, 21, 22, 85, 86}
+
+	for _, n := range testCases {
+		t.Run(fmt.Sprintf("len_%d", n), func(t *testing.T) {
+			chunks := make([][32]byte, n)
+			for i := range chunks {
+				chunks[i] = chunkFromIndex(i)
+			}
+
+			expected := referenceMerkleizeProgressive(chunks, 1)
+			actual := ssz.MerkleizeProgressiveChunks(chunks)
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestMerkleizeVectorSSZProgressive(t *testing.T) {
+	elements := []staticHashable{
+		{root: chunkFromIndex(0)},
+		{root: chunkFromIndex(1)},
+		{root: chunkFromIndex(2)},
+	}
+
+	root, err := ssz.MerkleizeVectorSSZProgressive(elements)
+	require.NoError(t, err)
+
+	expected := ssz.MerkleizeProgressiveChunks([][32]byte{
+		elements[0].root,
+		elements[1].root,
+		elements[2].root,
+	})
+	require.Equal(t, expected, root)
+}
+
+func TestMerkleizeVectorSSZProgressive_Error(t *testing.T) {
+	e := errors.New("merkleError")
+	elements := []staticHashable{{root: chunkFromIndex(0)}, {err: e}}
+
+	_, err := ssz.MerkleizeVectorSSZProgressive(elements)
+	require.ErrorContains(t, "merkleError", err)
+}
+
+func TestMerkleizeListSSZProgressive(t *testing.T) {
+	elements := []staticHashable{
+		{root: chunkFromIndex(10)},
+		{root: chunkFromIndex(11)},
+		{root: chunkFromIndex(12)},
+	}
+
+	got, err := ssz.MerkleizeListSSZProgressive(elements)
+	require.NoError(t, err)
+
+	body := ssz.MerkleizeProgressiveChunks([][32]byte{
+		elements[0].root,
+		elements[1].root,
+		elements[2].root,
+	})
+	var length [32]byte
+	binary.LittleEndian.PutUint64(length[:8], uint64(len(elements)))
+	expected := ssz.MixInLength(body, length[:])
+	require.Equal(t, expected, got)
+}
+
+func TestSliceRootProgressive(t *testing.T) {
+	elements := []staticHashable{{root: chunkFromIndex(0)}, {root: chunkFromIndex(1)}}
+
+	sliceRoot, err := ssz.SliceRootProgressive(elements)
+	require.NoError(t, err)
+	listRoot, err := ssz.MerkleizeListSSZProgressive(elements)
+	require.NoError(t, err)
+	require.Equal(t, listRoot, sliceRoot)
+}
+
+func TestByteSliceRootProgressive(t *testing.T) {
+	testCases := [][]byte{
+		nil,
+		{},
+		{0x01},
+		{0x01, 0x02, 0x03},
+		make([]byte, 32),
+		make([]byte, 33),
+	}
+	for _, input := range testCases {
+		t.Run(fmt.Sprintf("len_%d", len(input)), func(t *testing.T) {
+			got, err := ssz.ByteSliceRootProgressive(input)
+			require.NoError(t, err)
+
+			var chunks [][32]byte
+			if len(input) > 0 {
+				chunks, err = ssz.PackByChunk([][]byte{input})
+				require.NoError(t, err)
+			}
+			body := ssz.MerkleizeProgressiveChunks(chunks)
+			var length [32]byte
+			binary.LittleEndian.PutUint64(length[:8], uint64(len(input)))
+			expected := ssz.MixInLength(body, length[:])
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
+func TestByteSliceRootProgressive_EmptyReferenceRoot(t *testing.T) {
+	for _, input := range [][]byte{nil, {}} {
+		got, err := ssz.ByteSliceRootProgressive(input)
+		require.NoError(t, err)
+		require.Equal(t, "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b", fmt.Sprintf("%x", got))
+	}
+}
+
+func TestMixInActiveFields(t *testing.T) {
+	root := chunkFromIndex(42)
+	activeFields := []bool{true, false, true, true, false, false, false, true, true}
+
+	got, err := ssz.MixInActiveFields(root, activeFields)
+	require.NoError(t, err)
+
+	var packed [32]byte
+	packed[0] = 0b10001101
+	packed[1] = 0b00000001
+	expected := hashPair(root, packed)
+	require.Equal(t, expected, got)
+}
+
+func TestMixInActiveFields_TooMany(t *testing.T) {
+	activeFields := make([]bool, 257)
+	_, err := ssz.MixInActiveFields(chunkFromIndex(0), activeFields)
+	require.ErrorContains(t, "exceeds maximum 256", err)
+}

--- a/encoding/ssz/progressive_merkleize_test.go
+++ b/encoding/ssz/progressive_merkleize_test.go
@@ -161,6 +161,7 @@ func TestByteSliceRootProgressive_EmptyReferenceRoot(t *testing.T) {
 	for _, input := range [][]byte{nil, {}} {
 		got, err := ssz.ByteSliceRootProgressive(input)
 		require.NoError(t, err)
+		// taken from remerkleable reference implementation:
 		require.Equal(t, "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b", fmt.Sprintf("%x", got))
 	}
 }


### PR DESCRIPTION
Adding the progressive merkliezation functions for the SSZ package. 

- `MerkleizeProgressiveChunks`
- `MerkleizeVectorSSZProgressive`
- `MerkleizeListSSZProgressive`
- `SliceRootProgressive`
- `ByteSliceRootProgressive`
- `MixInActiveFields`