### PR TITLE
`Saved state in DB`: Add duration in logs and metric.

### DIFF
--- a/beacon-chain/state/stategen/metrics.go
+++ b/beacon-chain/state/stategen/metrics.go
@@ -25,4 +25,10 @@ var (
 			Help: "Time it took to replay to slot",
 		},
 	)
+	saveStateToColdSummary = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "save_state_to_cold_milliseconds",
+			Help: "Time it took to save a state to the DB during migration to cold",
+		},
+	)
 )

--- a/beacon-chain/state/stategen/migrate.go
+++ b/beacon-chain/state/stategen/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
@@ -102,13 +103,19 @@ func (s *State) MigrateToCold(ctx context.Context, fRoot [32]byte) error {
 			continue
 		}
 
+		saveStart := time.Now()
 		if err := s.beaconDB.SaveState(ctx, aState, aRoot); err != nil {
 			return err
 		}
+
+		duration := time.Since(saveStart)
+		saveStateToColdSummary.Observe(float64(duration.Milliseconds()))
+
 		log.WithFields(
 			logrus.Fields{
-				"slot": aState.Slot(),
-				"root": hex.EncodeToString(bytesutil.Trunc(aRoot[:])),
+				"slot":     aState.Slot(),
+				"root":     hex.EncodeToString(bytesutil.Trunc(aRoot[:])),
+				"duration": duration,
 			}).Info("Saved state in DB")
 	}
 

--- a/changelog/manu_save-state-to-cold-metric.md
+++ b/changelog/manu_save-state-to-cold-metric.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add `save_state_to_cold_milliseconds` metric and log the duration of saving a state to the DB during migration to cold.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
`Saved state in DB`: Add duration in logs and metric.


Log on hoodi:
```
[2026-05-27 20:35:55.47]  INFO stategen: Saved state in DB duration=18.677959221s root=f1f70274e247 slot=3141632
```

Metric on Hoodi:
<img width="1028" height="311" alt="image" src="https://github.com/user-attachments/assets/7526e9ba-f82f-4906-9a51-bac62b54c3ea" />


**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
