### PR TITLE
Reject and downscore peers that serve Fulu data column sidecars whose embedded `SignedBlockHeader` does not match the locally held beacon block.

### DIFF
--- a/beacon-chain/sync/backfill/columns.go
+++ b/beacon-chain/sync/backfill/columns.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/sync"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -23,6 +24,7 @@ var (
 	errUnexpectedBlockRoot       = errors.Wrap(errInvalidDataColumnResponse, "unexpected sidecar block root")
 	errCommitmentLengthMismatch  = errors.Wrap(errInvalidDataColumnResponse, "sidecar has different commitment count than block")
 	errCommitmentValueMismatch   = errors.Wrap(errInvalidDataColumnResponse, "sidecar commitments do not match block")
+	errSidecarSignatureMismatch  = errors.Wrap(errInvalidDataColumnResponse, "sidecar signed block header signature does not match block")
 )
 
 // tune the amount of columns we try to download from peers at once.
@@ -38,9 +40,10 @@ type columnBatch struct {
 }
 
 type toDownload struct {
-	remaining   peerdas.ColumnIndices
-	commitments [][]byte
-	slot        primitives.Slot
+	remaining      peerdas.ColumnIndices
+	commitments    [][]byte
+	slot           primitives.Slot
+	blockSignature [fieldparams.BLSSignatureLength]byte
 }
 
 func (cs *columnBatch) needed() peerdas.ColumnIndices {
@@ -218,6 +221,20 @@ func (v *validatingColumnRequest) countedValidation(cd blocks.RODataColumn) erro
 			return errors.Wrapf(errCommitmentValueMismatch, "root=%#x, slot=%d, index=%d", root, cd.Slot(), cd.Index())
 		}
 	}
+
+	// Cross-check the sidecar's embedded SignedBlockHeader signature against the
+	// locally held block. Gloas sidecars carry no header on the wire, so skip them.
+	if !cd.IsGloas() {
+		sbh, err := cd.SignedBlockHeader()
+		if err != nil {
+			return fmt.Errorf("sidecar signed block header root=%#x, index=%d: %w", root, cd.Index(), err)
+		}
+
+		if !bytes.Equal(sbh.Signature, expected.blockSignature[:]) {
+			return fmt.Errorf("root=%#x, slot=%d, index=%d: %w", root, cd.Slot(), cd.Index(), errSidecarSignatureMismatch)
+		}
+	}
+
 	if err := v.columnSync.store.Persist(v.columnSync.current, cd); err != nil {
 		return errors.Wrap(err, "persisting data column")
 	}
@@ -276,9 +293,10 @@ func buildColumnBatch(ctx context.Context, b batch, blks verifiedROBlocks, p p2p
 		}
 		summary.last = slot
 		summary.toDownload[b.Root()] = &toDownload{
-			remaining:   das.IndicesNotStored(store.Summary(b.Root()), indices),
-			commitments: cmts,
-			slot:        slot,
+			remaining:      das.IndicesNotStored(store.Summary(b.Root()), indices),
+			commitments:    cmts,
+			slot:           slot,
+			blockSignature: b.Signature(),
 		}
 	}
 

--- a/beacon-chain/sync/backfill/columns_test.go
+++ b/beacon-chain/sync/backfill/columns_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
 	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -727,6 +728,45 @@ func TestValidatingColumnRequest_CountedValidation(t *testing.T) {
 
 		err := vcr.countedValidation(roCols[0])
 		require.ErrorIs(t, err, errCommitmentLengthMismatch)
+	})
+
+	t.Run("sidecar signed block header signature mismatch returns error", func(t *testing.T) {
+		blockRoot := [32]byte{0x01}
+		commitment := make([]byte, 48)
+		commitment[0] = 0xaa
+		params := []util.DataColumnParam{
+			{
+				Index:          0,
+				Slot:           100,
+				ProposerIndex:  1,
+				ParentRoot:     blockRoot[:],
+				KzgCommitments: [][]byte{commitment},
+			},
+		}
+		roCols, _ := util.CreateTestVerifiedRoDataColumnSidecars(t, params)
+
+		var localBlockSig [fieldparams.BLSSignatureLength]byte
+		localBlockSig[0] = 0xff
+
+		vcr := &validatingColumnRequest{
+			columnSync: &columnSync{
+				columnBatch: &columnBatch{
+					toDownload: map[[32]byte]*toDownload{
+						roCols[0].BlockRoot(): {
+							remaining:      peerdas.NewColumnIndicesFromSlice([]uint64{0}),
+							commitments:    [][]byte{commitment},
+							blockSignature: localBlockSig,
+						},
+					},
+				},
+				peer: mockPeer,
+			},
+			bisector: newColumnBisector(func(peer.ID, string, error) {}),
+		}
+
+		err := vcr.countedValidation(roCols[0])
+		require.ErrorIs(t, err, errSidecarSignatureMismatch)
+		require.ErrorIs(t, err, errInvalidDataColumnResponse, "must trigger shouldDownscore")
 	})
 
 	t.Run("commitment value mismatch returns error", func(t *testing.T) {

--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -28,6 +28,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var ErrSidecarHeaderMismatch = errors.New("data column sidecar signed block header does not match local block")
+
 // DataColumnSidecarsParams stores the common parameters needed to
 // fetch data column sidecars from peers.
 type DataColumnSidecarsParams struct {
@@ -80,6 +82,7 @@ func FetchDataColumnSidecars(
 	storedIndicesByRoot := make(map[[fieldparams.RootLength]byte]map[uint64]bool, blockCount)
 
 	commitmentsByRoot := make(map[[fieldparams.RootLength]byte][][]byte, blockCount)
+	blockByRoot := make(map[[fieldparams.RootLength]byte]blocks.ROBlock, blockCount)
 
 	for _, roBlock := range roBlocks {
 		block := roBlock.Block()
@@ -100,6 +103,7 @@ func FetchDataColumnSidecars(
 		slotByRoot[root] = slot
 		slotsWithCommitments[slot] = true
 		commitmentsByRoot[root] = commitments
+		blockByRoot[root] = roBlock
 
 		storedIndices := params.Storage.Summary(root).Stored()
 		if len(storedIndices) > 0 {
@@ -123,7 +127,7 @@ func FetchDataColumnSidecars(
 	}
 
 	// Request direct sidecars from peers.
-	directSidecarsByRoot, err := requestDirectSidecarsFromPeers(params, slotByRoot, requestedIndices, slotsWithCommitments, storedIndicesByRoot, incompleteRoots, commitmentsByRoot)
+	directSidecarsByRoot, err := requestDirectSidecarsFromPeers(params, slotByRoot, requestedIndices, slotsWithCommitments, storedIndicesByRoot, incompleteRoots, commitmentsByRoot, blockByRoot)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "request direct sidecars from peers")
 	}
@@ -142,7 +146,7 @@ func FetchDataColumnSidecars(
 	}
 
 	// Request all possible indirect sidecars from peers which are neither stored nor in `directSidecarsByRoot`
-	indirectSidecarsByRoot, err := requestIndirectSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, storedIndicesByRoot, directSidecarsByRoot, requestedIndices, incompleteRoots, commitmentsByRoot)
+	indirectSidecarsByRoot, err := requestIndirectSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, storedIndicesByRoot, directSidecarsByRoot, requestedIndices, incompleteRoots, commitmentsByRoot, blockByRoot)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "request all sidecars from peers")
 	}
@@ -234,6 +238,7 @@ func requestDirectSidecarsFromPeers(
 	storedIndicesByRoot map[[fieldparams.RootLength]byte]map[uint64]bool,
 	incompleteRoots map[[fieldparams.RootLength]byte]bool,
 	commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte,
+	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 ) (map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn, error) {
 	start := time.Now()
 
@@ -294,7 +299,7 @@ func requestDirectSidecarsFromPeers(
 		setBidCommitments(commitmentsByRoot, roDataColumnsByPeer)
 
 		// Verify the received data column sidecars.
-		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(params.P2P, params.NewVerifier, roDataColumnsByPeer)
+		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(params.P2P, params.NewVerifier, blockByRoot, roDataColumnsByPeer)
 		if err != nil {
 			return nil, errors.Wrap(err, "verify data columns sidecars by peer")
 		}
@@ -344,6 +349,7 @@ func requestIndirectSidecarsFromPeers(
 	requestedIndices map[uint64]bool,
 	roots map[[fieldparams.RootLength]byte]bool,
 	commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte,
+	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 ) (map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn, error) {
 	start := time.Now()
 
@@ -416,7 +422,7 @@ func requestIndirectSidecarsFromPeers(
 		setBidCommitments(commitmentsByRoot, roDataColumnsByPeer)
 
 		// Verify the received data column sidecars.
-		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(p.P2P, p.NewVerifier, roDataColumnsByPeer)
+		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(p.P2P, p.NewVerifier, blockByRoot, roDataColumnsByPeer)
 		if err != nil {
 			return nil, errors.Wrap(err, "verify data columns sidecars by peer")
 		}
@@ -962,6 +968,7 @@ func buildByRootRequest(indicesByRoot map[[fieldparams.RootLength]byte]map[uint6
 func verifyDataColumnSidecarsByPeer(
 	p2p prysmP2P.P2P,
 	newVerifier verification.NewDataColumnsVerifier,
+	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 	roDataColumnsByPeer map[goPeer.ID][]blocks.RODataColumn,
 ) ([]blocks.VerifiedRODataColumn, error) {
 	// First optimistically verify all received data columns in a single batch.
@@ -975,7 +982,7 @@ func verifyDataColumnSidecarsByPeer(
 		roDataColumnSidecars = append(roDataColumnSidecars, columns...)
 	}
 
-	verifiedRoDataColumnSidecars, err := verifyByRootDataColumnSidecars(newVerifier, roDataColumnSidecars)
+	verifiedRoDataColumnSidecars, err := verifyByRootDataColumnSidecars(newVerifier, blockByRoot, roDataColumnSidecars)
 	if err == nil {
 		// This is the happy path where all sidecars are verified.
 		return verifiedRoDataColumnSidecars, nil
@@ -985,7 +992,7 @@ func verifyDataColumnSidecarsByPeer(
 	// Reverify peer by peer to identify faulty peer(s), reject all its sidecars, and downscore it.
 	verifiedRoDataColumnSidecars = make([]blocks.VerifiedRODataColumn, 0, count)
 	for peer, columns := range roDataColumnsByPeer {
-		peerVerifiedRoDataColumnSidecars, err := verifyByRootDataColumnSidecars(newVerifier, columns)
+		peerVerifiedRoDataColumnSidecars, err := verifyByRootDataColumnSidecars(newVerifier, blockByRoot, columns)
 		if err != nil {
 			// This peer has invalid sidecars.
 			log := log.WithError(err).WithField("peerID", peer)
@@ -1002,7 +1009,11 @@ func verifyDataColumnSidecarsByPeer(
 
 // verifyByRootDataColumnSidecars verifies the provided read-only data columns against the
 // requirements for data column sidecars received via the by root request.
-func verifyByRootDataColumnSidecars(newVerifier verification.NewDataColumnsVerifier, roDataColumns []blocks.RODataColumn) ([]blocks.VerifiedRODataColumn, error) {
+func verifyByRootDataColumnSidecars(
+	newVerifier verification.NewDataColumnsVerifier,
+	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
+	roDataColumns []blocks.RODataColumn,
+) ([]blocks.VerifiedRODataColumn, error) {
 	verifier := newVerifier(roDataColumns, verification.ByRootRequestDataColumnSidecarRequirements)
 
 	if err := verifier.ValidFields(); err != nil {
@@ -1015,6 +1026,17 @@ func verifyByRootDataColumnSidecars(newVerifier verification.NewDataColumnsVerif
 
 	if err := verifier.SidecarKzgProofVerified(); err != nil {
 		return nil, errors.Wrap(err, "sidecar KZG proof verified")
+	}
+
+	for _, sidecar := range roDataColumns {
+		block, ok := blockByRoot[sidecar.BlockRoot()]
+		if !ok {
+			return nil, fmt.Errorf("no local block for sidecar root %#x: %w", sidecar.BlockRoot(), ErrSidecarHeaderMismatch)
+		}
+
+		if err := verifySidecarHeaderMatchesBlock(sidecar, block); err != nil {
+			return nil, fmt.Errorf("root %#x: %w", sidecar.BlockRoot(), err)
+		}
 	}
 
 	verifiedRoDataColumns, err := verifier.VerifiedRODataColumns()
@@ -1222,4 +1244,24 @@ func computeTotalCount(input map[[fieldparams.RootLength]byte]map[uint64]bool) i
 		totalCount += len(indices)
 	}
 	return totalCount
+}
+
+// verifySidecarHeaderMatchesBlock checks that the signature in the sidecar's embedded SignedBlockHeader matches the block's signature.
+func verifySidecarHeaderMatchesBlock(sidecar blocks.RODataColumn, block blocks.ROBlock) error {
+	// Gloas sidecars do not include a SignedBlockHeader.
+	if sidecar.IsGloas() {
+		return nil
+	}
+
+	sidecarHeader, err := sidecar.SignedBlockHeader()
+	if err != nil {
+		return fmt.Errorf("signed block header: %w", err)
+	}
+
+	blockSignature := block.Signature()
+	if !bytes.Equal(sidecarHeader.Signature, blockSignature[:]) {
+		return ErrSidecarHeaderMismatch
+	}
+
+	return nil
 }

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -785,7 +785,7 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 		p2p := testp2p.NewTestP2P(t)
 
 		// Setup test data and expectations
-		_, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
 		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
 			"peer1": roDataColumnSidecars[start:5],
@@ -800,8 +800,12 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 		initializer, err := waiter.WaitForInitializer(t.Context())
 		require.NoError(t, err)
 
+		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+			roBlock.Root(): roBlock,
+		}
+
 		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, roDataColumnsByPeer)
+		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
 		require.NoError(t, err)
 
 		require.Equal(t, stop-start, len(actual))
@@ -823,7 +827,7 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 		p2p := testp2p.NewTestP2P(t)
 
 		// Setup test data and expectations
-		_, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
 		// Modify one sidecar to ensure proof verification fails.
 		if roDataColumnSidecars[middle].KzgProofs()[0][0] == 0 {
@@ -845,8 +849,12 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 		initializer, err := waiter.WaitForInitializer(t.Context())
 		require.NoError(t, err)
 
+		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+			roBlock.Root(): roBlock,
+		}
+
 		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, roDataColumnsByPeer)
+		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
 		require.NoError(t, err)
 
 		require.Equal(t, middle-start, len(actual))
@@ -857,6 +865,84 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 			expectedSidecar := expected[index]
 			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
 		}
+	})
+
+	t.Run("rogue peer with junk header signature", func(t *testing.T) {
+		const (
+			start, middle, stop = 0, 5, 15
+			blobCount           = 1
+		)
+
+		p2p := testp2p.NewTestP2P(t)
+
+		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+
+		origHeader, headerErr := roDataColumnSidecars[middle].SignedBlockHeader()
+		require.NoError(t, headerErr)
+		junkSig := make([]byte, fieldparams.BLSSignatureLength)
+		junkSig[0] = 0xff
+		roDataColumnSidecars[middle].DataColumnSidecar().SignedBlockHeader = &ethpb.SignedBeaconBlockHeader{
+			Header:    origHeader.Header,
+			Signature: junkSig,
+		}
+
+		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+			"peer1": roDataColumnSidecars[start:middle],
+			"peer2": roDataColumnSidecars[middle:stop],
+		}
+		gs := startup.NewClockSynchronizer()
+		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+		require.NoError(t, err)
+
+		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+		initializer, err := waiter.WaitForInitializer(t.Context())
+		require.NoError(t, err)
+
+		blocksByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+			roBlock.Root(): roBlock,
+		}
+
+		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blocksByRoot, roDataColumnsByPeer)
+		require.NoError(t, err)
+
+		// Only the honest peer's sidecars should be returned.
+		require.Equal(t, middle-start, len(actual))
+		for i := range actual {
+			actualSidecar := actual[i]
+			index := actualSidecar.Index()
+			expectedSidecar := expected[index]
+			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
+		}
+	})
+
+	t.Run("unknown block root", func(t *testing.T) {
+		const (
+			start, stop = 0, 15
+			blobCount   = 1
+		)
+
+		p2p := testp2p.NewTestP2P(t)
+
+		_, roDataColumnSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+
+		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+			"peer1": roDataColumnSidecars[start:stop],
+		}
+		gs := startup.NewClockSynchronizer()
+		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+		require.NoError(t, err)
+
+		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+		initializer, err := waiter.WaitForInitializer(t.Context())
+		require.NoError(t, err)
+
+		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{}
+
+		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(actual))
 	})
 }
 

--- a/changelog/enalepa_verify-dc-sidecar-header-vs-block.md
+++ b/changelog/enalepa_verify-dc-sidecar-header-vs-block.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reject and downscore peers that serve Fulu data column sidecars whose embedded `SignedBlockHeader` does not match the locally held beacon block.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
When a peer serves us a Fulu `DataColumnSidecar` via RPC, the by-root/range verification path runs only the following checks: `ValidFields`, `SidecarInclusionProven` and `SidecarKzgProofVerified`.
It omits `RequireValidProposerSignature` (per the Fulu p2p spec).

This lets a malicious peer craft a sidecar where the column cells, KZG proofs, inclusion proof, and the unsigned `BeaconBlockHeader` fields are all correct (so the block root matches), but the embedded `SignedBlockHeader.Signature` is junk. Such a sidecar passes verification and lands in the DB.

This PR checks that the sidecar's `SignedBlockHeader.Signature` matches the one in the block when receiving the RPC response. If not, the sidecar is rejected, and the peer downscored.

> [!NOTE]
> This check is only possible because Prysm never pulls a sidecar for a block it does not know.

> [!NOTE]
> This verification is for **Fulu** only, and is not applicable for **Gloas**.  

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
