### PR TITLE
Fix epoch processing slowdown caused by per validator interface boxing

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -186,16 +186,19 @@ func (s *Service) processLightClientUpdates(cfg *postBlockProcessConfig) {
 // boundary in order to compute the right proposer indices after processing
 // state transition. The caller of this function must not hold a lock in forkchoice store.
 func (s *Service) updateCachesPostBlockProcessing(cfg *postBlockProcessConfig) {
+	ctx, span := trace.StartSpan(cfg.ctx, "blockChain.updateCachesPostBlockProcessing")
+	defer span.End()
+
 	slot := cfg.postState.Slot()
 	root := cfg.roblock.Root()
-	if err := transition.UpdateNextSlotCache(cfg.ctx, root[:], cfg.postState); err != nil {
+	if err := transition.UpdateNextSlotCache(ctx, root[:], cfg.postState); err != nil {
 		log.WithError(err).Error("Could not update next slot state cache")
 		return
 	}
 	if !slots.IsEpochEnd(slot) {
 		return
 	}
-	if err := s.handleEpochBoundary(cfg.ctx, slot, cfg.postState, root[:]); err != nil {
+	if err := s.handleEpochBoundary(ctx, slot, cfg.postState, root[:]); err != nil {
 		log.WithError(err).Error("Could not handle epoch boundary")
 	}
 }

--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -5,6 +5,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -146,15 +147,22 @@ func (c *CommitteeCache) Committee(ctx context.Context, slot primitives.Slot, se
 // AddCommitteeShuffledList adds Committee shuffled list object to the cache. T
 // his method also trims the least recently list if the cache size has ready the max cache size limit.
 func (c *CommitteeCache) AddCommitteeShuffledList(ctx context.Context, committees *Committees) error {
+	ctx, span := trace.StartSpan(ctx, "committeeCache.AddCommitteeShuffledList")
+	defer span.End()
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	if err := ctx.Err(); err != nil {
+		span.SetAttributes(trace.StringAttribute("context_error", err.Error()))
 		return err
 	}
+
 	key, err := committeeKeyFn(committees)
 	if err != nil {
-		return err
+		return fmt.Errorf("committee key fn: %w", err)
 	}
+
 	_ = c.CommitteeCache.Add(key, committees)
 	return nil
 }

--- a/beacon-chain/core/electra/transition.go
+++ b/beacon-chain/core/electra/transition.go
@@ -52,7 +52,7 @@ var (
 //	    process_participation_flag_updates(state)
 //	    process_sync_committee_updates(state)
 func ProcessEpoch(ctx context.Context, state state.BeaconState) error {
-	_, span := trace.StartSpan(ctx, "electra.ProcessEpoch")
+	ctx, span := trace.StartSpan(ctx, "electra.ProcessEpoch")
 	defer span.End()
 
 	if state == nil || state.IsNil() {

--- a/beacon-chain/core/fulu/transition.go
+++ b/beacon-chain/core/fulu/transition.go
@@ -13,6 +13,9 @@ import (
 )
 
 func ProcessEpoch(ctx context.Context, state state.BeaconState) error {
+	ctx, span := trace.StartSpan(ctx, "fulu.ProcessEpoch")
+	defer span.End()
+
 	if err := electra.ProcessEpoch(ctx, state); err != nil {
 		return errors.Wrap(err, "could not process epoch in fulu transition")
 	}
@@ -20,7 +23,7 @@ func ProcessEpoch(ctx context.Context, state state.BeaconState) error {
 }
 
 func ProcessProposerLookahead(ctx context.Context, state state.BeaconState) error {
-	_, span := trace.StartSpan(ctx, "fulu.processProposerLookahead")
+	ctx, span := trace.StartSpan(ctx, "fulu.processProposerLookahead")
 	defer span.End()
 
 	if state == nil || state.IsNil() {

--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -455,7 +455,10 @@ func VerifyBitfieldLength(bf bitfield.Bitfield, committeeSize uint64) error {
 
 // ShuffledIndices uses input beacon state and returns the shuffled indices of the input epoch,
 // the shuffled indices then can be used to break up into committees.
-func ShuffledIndices(s state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]primitives.ValidatorIndex, error) {
+func ShuffledIndices(ctx context.Context, s state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]primitives.ValidatorIndex, error) {
+	_, span := trace.StartSpan(ctx, "helpers.ShuffledIndices")
+	defer span.End()
+
 	seed, err := Seed(s, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get seed for epoch %d", epoch)
@@ -500,7 +503,7 @@ func UpdateCommitteeCache(ctx context.Context, state state.ReadOnlyBeaconState, 
 	if committeeCache.HasEntry(string(seed[:])) {
 		return nil
 	}
-	shuffledIndices, err := ShuffledIndices(state, e)
+	shuffledIndices, err := ShuffledIndices(ctx, state, e)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -329,6 +329,9 @@ func ProcessSlotsCore(ctx context.Context, span trace.Span, state state.BeaconSt
 
 // ProcessEpoch is a wrapper on fork specific epoch processing
 func ProcessEpoch(ctx context.Context, state state.BeaconState) (state.BeaconState, error) {
+	ctx, span := prysmTrace.StartSpan(ctx, "core.state.ProcessEpoch")
+	defer span.End()
+
 	var err error
 	if time.CanProcessEpoch(state) {
 		if state.Version() >= version.Gloas {

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -228,6 +228,7 @@ func (b *BeaconState) ValidatorsReadOnlySeq() iter.Seq2[primitives.ValidatorInde
 			return
 		}
 
+		rov := new(readOnlyValidator)
 		for i := range b.validatorsMultiValue.Len(b) {
 			v, err := b.validatorsMultiValue.At(b, uint64(i))
 			if err != nil {
@@ -235,7 +236,8 @@ func (b *BeaconState) ValidatorsReadOnlySeq() iter.Seq2[primitives.ValidatorInde
 				return
 			}
 
-			if !yield(primitives.ValidatorIndex(i), NewValidatorFromCompact(v)) {
+			rov.validator = v
+			if !yield(primitives.ValidatorIndex(i), rov) {
 				return
 			}
 		}

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -43,9 +43,11 @@ func (b *BeaconState) validatorsReadOnlyVal() []state.ReadOnlyValidator {
 	}
 	v := b.validatorsMultiValue.Value(b)
 
+	backing := make([]readOnlyValidator, len(v))
 	res := make([]state.ReadOnlyValidator, len(v))
-	for i := range res {
-		res[i] = NewValidatorFromCompact(v[i])
+	for i := range v {
+		backing[i].validator = v[i]
+		res[i] = &backing[i]
 	}
 	return res
 }

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -181,12 +181,15 @@ func (b *BeaconState) AggregateKeyFromIndices(idxs []uint64) (bls.PublicKey, err
 	defer b.lock.RUnlock()
 
 	pubKeys := make([][]byte, len(idxs))
+	backing := make([]byte, len(idxs)*fieldparams.BLSPubkeyLength)
 	for i, idx := range idxs {
 		v, err := b.validatorsMultiValue.At(b, idx)
 		if err != nil {
 			return nil, err
 		}
-		pubKeys[i] = v.PublicKey[:]
+		buf := backing[i*fieldparams.BLSPubkeyLength : (i+1)*fieldparams.BLSPubkeyLength]
+		copy(buf, v.PublicKey[:])
+		pubKeys[i] = buf
 	}
 	return bls.AggregatePublicKeys(pubKeys)
 }

--- a/beacon-chain/state/state-native/getters_validator_test.go
+++ b/beacon-chain/state/state-native/getters_validator_test.go
@@ -189,6 +189,34 @@ func BenchmarkValidatorsReadOnlySeq(b *testing.B) {
 	}
 }
 
+// BenchmarkValidatorsReadOnly measures the cost of building the full slice of read-only
+// validator wrappers returned by ValidatorsReadOnly.
+func BenchmarkValidatorsReadOnly(b *testing.B) {
+	const n = 2_300_000 // ~ number of validators on mainnet at the time of writing
+
+	vals := make([]*ethpb.Validator, n)
+	for i := range vals {
+		pk := make([]byte, 48)
+		wc := make([]byte, 32)
+		pk[0] = byte(i)
+		vals[i] = &ethpb.Validator{
+			PublicKey:             pk,
+			WithdrawalCredentials: wc,
+			EffectiveBalance:      32_000_000_000,
+			ExitEpoch:             100,
+			ActivationEpoch:       1,
+		}
+	}
+	st, err := statenative.InitializeFromProtoUnsafeDeneb(&ethpb.BeaconStateDeneb{Validators: vals})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ros := st.ValidatorsReadOnly()
+		require.Equal(b, n, len(ros))
+	}
+}
+
 // BenchmarkAggregateKeyFromIndices measures the cost of aggregating validator public
 // keys.
 func BenchmarkAggregateKeyFromIndices(b *testing.B) {

--- a/beacon-chain/state/state-native/getters_validator_test.go
+++ b/beacon-chain/state/state-native/getters_validator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	statenative "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
 	testtmpl "github.com/OffchainLabs/prysm/v7/beacon-chain/state/testing"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -185,5 +186,23 @@ func BenchmarkValidatorsReadOnlySeq(b *testing.B) {
 		for _, v := range st.ValidatorsReadOnlySeq() {
 			_ = v.EffectiveBalance()
 		}
+	}
+}
+
+// BenchmarkAggregateKeyFromIndices measures the cost of aggregating validator public
+// keys.
+func BenchmarkAggregateKeyFromIndices(b *testing.B) {
+	n := params.BeaconConfig().MaxValidatorsPerCommittee
+
+	st, _ := util.DeterministicGenesisState(b, n)
+	idxs := make([]uint64, n)
+	for i := range idxs {
+		idxs[i] = uint64(i)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_, err := st.AggregateKeyFromIndices(idxs)
+		require.NoError(b, err)
 	}
 }

--- a/beacon-chain/state/state-native/getters_validator_test.go
+++ b/beacon-chain/state/state-native/getters_validator_test.go
@@ -158,3 +158,32 @@ func TestHasPendingBalanceToWithdraw(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, ok)
 }
+
+// BenchmarkValidatorsReadOnlySeq measures the per-validator cost of iterating the
+// registry through the ReadOnlyValidator wrapper.
+func BenchmarkValidatorsReadOnlySeq(b *testing.B) {
+	const n = 2_300_000 // ~ number of validators on mainnet at the time of writing
+
+	vals := make([]*ethpb.Validator, n)
+	for i := range vals {
+		pk := make([]byte, 48)
+		wc := make([]byte, 32)
+		pk[0] = byte(i)
+		vals[i] = &ethpb.Validator{
+			PublicKey:             pk,
+			WithdrawalCredentials: wc,
+			EffectiveBalance:      32_000_000_000,
+			ExitEpoch:             100,
+			ActivationEpoch:       1,
+		}
+	}
+	st, err := statenative.InitializeFromProtoUnsafeDeneb(&ethpb.BeaconStateDeneb{Validators: vals})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		for _, v := range st.ValidatorsReadOnlySeq() {
+			_ = v.EffectiveBalance()
+		}
+	}
+}

--- a/beacon-chain/state/state-native/setters_validator.go
+++ b/beacon-chain/state/state-native/setters_validator.go
@@ -33,12 +33,13 @@ func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
 func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val state.ReadOnlyValidator) (*ethpb.Validator, error)) error {
 	var changedVals []uint64
 	l := b.validatorsMultiValue.Len(b)
+	ro := new(readOnlyValidator)
 	for i := range l {
 		v, err := b.validatorsMultiValue.At(b, uint64(i))
 		if err != nil {
 			return err
 		}
-		ro := NewValidatorFromCompact(v)
+		ro.validator = v
 		newVal, err := f(i, ro)
 		if err != nil {
 			return err

--- a/beacon-chain/state/state-native/setters_validator_test.go
+++ b/beacon-chain/state/state-native/setters_validator_test.go
@@ -3,6 +3,7 @@ package state_native_test
 import (
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -39,5 +40,37 @@ func BenchmarkAppendInactivityScore(b *testing.B) {
 	for i := 0; b.Loop(); i++ {
 		require.NoError(b, ref.AppendInactivityScore(uint64(i)))
 		ref = st.Copy()
+	}
+}
+
+// BenchmarkApplyToEveryValidator measures the per-validator cost of iterating the
+// registry through the ReadOnlyValidator wrapper.
+func BenchmarkApplyToEveryValidator(b *testing.B) {
+	const n = 2_300_000 // ~ number of validators on mainnet at the time of writing
+
+	vals := make([]*ethpb.Validator, n)
+	for i := range vals {
+		pk := make([]byte, 48)
+		wc := make([]byte, 32)
+		pk[0] = byte(i)
+		vals[i] = &ethpb.Validator{
+			PublicKey:             pk,
+			WithdrawalCredentials: wc,
+			EffectiveBalance:      32_000_000_000,
+			ExitEpoch:             100,
+			ActivationEpoch:       1,
+		}
+	}
+	st, err := state_native.InitializeFromProtoUnsafeDeneb(&ethpb.BeaconStateDeneb{Validators: vals})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		// Returning nil signals "no change", isolating the per-validator wrapper cost
+		// from the validator-update path.
+		require.NoError(b, st.ApplyToEveryValidator(func(_ int, v state.ReadOnlyValidator) (*ethpb.Validator, error) {
+			_ = v.EffectiveBalance()
+			return nil, nil
+		}))
 	}
 }

--- a/changelog/manu_readonly-validator-no-boxing.md
+++ b/changelog/manu_readonly-validator-no-boxing.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Add tracing spans to epoch processing (`core.state.ProcessEpoch`, `fulu.ProcessEpoch`), committee shuffling (`helpers.ShuffledIndices`), the committee cache (`committeeCache.AddCommitteeShuffledList`) and `blockChain.updateCachesPostBlockProcessing`.
+- Avoid one interface boxing per validator in `validatorsReadOnlyVal` and `ValidatorsReadOnlySeq`, and per public key in `AggregateKeyFromIndices` and `ApplyToEveryValidator`, to reduce allocations.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**

### Symptom

Starting at:
- https://github.com/OffchainLabs/prysm/pull/16535

Some 
```
level=error msg="Could not update committee cache" error="context deadline exceeded" package="beacon-chain/core/helpers"
```

errors started to pop at epoch transitions.

On the following picture:
- At the right of the dashed blue vertical line: Commit just before the guilty PR
- At the left of the dashed blue vertical line: The guilty PR
- Dashed blue vertical line: Node reboot
- Dashed red vertical lines: `Could not update committee cache` errors
<img width="979" height="309" alt="image" src="https://github.com/user-attachments/assets/0b77bc84-3f9b-4677-8d0f-63a08bc281eb" />


At first sight, it is very hard to understand why this precise PR would create these errors, since these errors and the PR seem totally unrelated.

The reason is actually deeper: The `Could not update committee cache` errors are only the tip of the iceberg.
These errors happen when the context in the `AddCommitteeShuffledList` is exceeded (line 158 of the following snippet).

https://github.com/OffchainLabs/prysm/blob/0474507ed65b1ed310e204fcdcbdca1197212cf0/beacon-chain/cache/committee.go#L147-L159

This context is set to a 5 second value (`slotDeadline`) in the `postBlockProcess` function.
https://github.com/OffchainLabs/prysm/blob/0474507ed65b1ed310e204fcdcbdca1197212cf0/beacon-chain/blockchain/process_block.go#L123-L130

If we see the `Could not update committee cache` error, it means that the whole `updateCachesPostBlockProcessing` function did not finish in 5 seconds. We have to understand why.

### Root cause
When we analyse the complete `updateCachesPostBlockProcessing` trace before and after this PR, we have:

**Before:**
<img width="938" height="798" alt="image" src="https://github.com/user-attachments/assets/8f6b7d9f-56d3-48e2-94c7-b3f23b6dee1c" />

**After:**
<img width="942" height="793" alt="image" src="https://github.com/user-attachments/assets/196e2424-ee54-4d53-9c02-ab2ce8a7068d" />

Summary:
| span | BEFORE #16535 | WITH #16535 | WITH THIS PR | ratio (WITH #16535 / BEFORE) | ratio (WITH THIS PR / BEFORE) |
  |---|---|---|---|---|---|
  | ProcessEpoch (total) | 3354ms | 5014ms | 3101ms | 1.50x | 0.92x |
  | electra.ProcessEpoch | 1827ms | 3210ms | 1797ms | 1.76x | 0.98x |
  | InitializePrecomputeValidators | 552ms | 1051ms | 551ms | 1.90x | 1.00x |
  | ProcessEpochParticipation | 127ms | 161ms | 120ms | 1.27x | 0.95x |
  | processProposerLookahead | 1541ms | 1865ms | 1353ms | 1.21x | 0.88x |
  | ActiveValidatorIndices | 1500ms | 1821ms | 1318ms | 1.21x | 0.88x |
  | ShuffledIndices | 1213ms | 1376ms | 1132ms | 1.13x | 0.93x |

==> We see that all these functions ballooned in execution time.

[#16535](https://github.com/OffchainLabs/prysm/pull/16535) replaced the state's `[]*ethpb.Validator` (pointers to individually heap-allocated proto objects) with a contiguous slice of compact `CompactValidator` value structs, cutting the validator set's memory footprint and pointer-chasing and improving cache locality. (See [#16535](https://github.com/OffchainLabs/prysm/pull/16535) description).

The regression was a side effect: it also changed the read-only wrapper from holding an 8-byte pointer to holding the 121-byte `CompactValidator` by value.

Since storing a value type into a `state.ReadOnlyValidator` interface forces Go to allocate on heap and copy it, every function walking the ~2.3M validator set now did ~2.3M allocations and ~270 MB of copying per pass (plus GC pressure), inflating all of them and eventually blowing past the 5 seconds deadline.

### Fix
This PR keeps [#16535](https://github.com/OffchainLabs/prysm/pull/16535)'s compact representation but stop boxing one wrapper per validator: the iterators (`ValidatorsReadOnlySeq` and `ApplyToEveryValidator`) reuse a single wrapper across the loop, `ValidatorsReadOnly` allocates the wrappers in one contiguous backing slice and stores pointers into it, and `AggregateKeyFromIndices` does the same for public keys.

- On the left: With the fix
- On the right: Without the fix
<img width="938" height="314" alt="image" src="https://github.com/user-attachments/assets/17ec804f-d9ac-402c-993d-23649c53c5ae" />

**develop**
<img width="957" height="907" alt="image" src="https://github.com/user-attachments/assets/239f779c-21a2-4250-b367-81fcec85f84f" />

**This PR**
<img width="944" height="817" alt="image" src="https://github.com/user-attachments/assets/2ab2b962-858a-4271-9c3d-287ee711f71d" />


**Which issues(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/16809

**Other notes for review**
> [!TIP]
>  This PR is engineered to be read commit by commit, with commit messages.
> Especially commit messages contain the benchmarks results before/after fixes.

> [!NOTE]
> **Why usually we don't care about interface boxing but here we do care?** 
>
> [Interface boxing](https://goperf.dev/01-common-patterns/interface-boxing/) is quite cheap in general. However, in some special cases like validators in the beacon state, where there is multiple millions validators, the added cost of single interface boxing starts to really impact the system.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
