### PR TITLE
fixing parent block hash function for latest execution payload header removal

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -336,14 +336,12 @@ func (vs *Server) getParentBlockHash(ctx context.Context, st state.BeaconState, 
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get parent block slot")
 		}
-		if slots.ToEpoch(parentSlot) < params.BeaconConfig().GloasForkEpoch {
-			return getParentBlockHashPostCapella(st)
-		}
 		bid, err := st.LatestExecutionPayloadBid()
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get latest execution payload bid")
 		}
-		if parentFull {
+		// A pre-gloas parent is always full
+		if parentFull || slots.ToEpoch(parentSlot) < params.BeaconConfig().GloasForkEpoch {
 			bh := bid.BlockHash()
 			return bh[:], nil
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
@@ -228,6 +228,30 @@ func TestServer_getParentBlockHash_Gloas_Empty(t *testing.T) {
 	require.DeepEqual(t, parentBlockHash[:], got)
 }
 
+
+func TestServer_getParentBlockHash_Gloas_Transition(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 1
+	params.OverrideBeaconConfig(cfg)
+
+	blockHash := bytesutil.ToBytes32([]byte("parent-exec-block-hash"))
+	headRoot := bytesutil.ToBytes32([]byte("head-root"))
+	st, err := util.NewBeaconStateGloas(func(state *ethpb.BeaconStateGloas) error {
+		state.LatestExecutionPayloadBid.BlockHash = blockHash[:]
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Parent at slot 0 is pre-gloas (epoch 0 < GloasForkEpoch 1). A pre-gloas parent is always full,
+	// so even with parentFull=false we expect the parent's block hash, not an error.
+	chain := &chainMock.ChainService{BlockSlot: 0}
+	vs := &Server{ForkchoiceFetcher: chain, HeadFetcher: chain}
+	got, err := vs.getParentBlockHash(context.Background(), st, primitives.Slot(params.BeaconConfig().SlotsPerEpoch), headRoot, false)
+	require.NoError(t, err)
+	require.DeepEqual(t, blockHash[:], got)
+}
+
 func TestServer_applyParentExecutionPayloadToHead_PreGloas(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig().Copy()

--- a/beacon-chain/state/state-native/getters_payload_header.go
+++ b/beacon-chain/state/state-native/getters_payload_header.go
@@ -13,6 +13,10 @@ func (b *BeaconState) LatestExecutionPayloadHeader() (interfaces.ExecutionData, 
 	if b.version < version.Bellatrix {
 		return nil, errNotSupported("LatestExecutionPayloadHeader", b.version)
 	}
+	// gloas removed latest_execution_payload_header; callers must use LatestBlockHash or the bid.
+	if b.version >= version.Gloas {
+		return nil, errNotSupported("LatestExecutionPayloadHeader", b.version)
+	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()

--- a/beacon-chain/state/state-native/setters_payload_header_test.go
+++ b/beacon-chain/state/state-native/setters_payload_header_test.go
@@ -112,3 +112,11 @@ func TestSetLatestExecutionPayloadHeader(t *testing.T) {
 	})
 
 }
+
+// gloas removed latest_execution_payload_header, so the getter must error rather than wrap a nil.
+func TestLatestExecutionPayloadHeader_GloasNotSupported(t *testing.T) {
+	s, err := util.NewBeaconStateGloas()
+	require.NoError(t, err)
+	_, err = s.LatestExecutionPayloadHeader()
+	require.ErrorContains(t, "not supported", err)
+}

--- a/changelog/james-prysm_fix-gloas-parent-blockhash.md
+++ b/changelog/james-prysm_fix-gloas-parent-blockhash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix the first block at the fulu→gloas transition failing to build because `getParentBlockHash` read the removed execution payload header instead of the execution payload bid.


### PR DESCRIPTION

**What type of PR is this?**
Bug fix


**What does this PR do? Why is it needed?**

latest_execution_payload_header is removed in gloas, and so getParentBlockHashPostCapella(st) is not the correct function to call on fork transition when the parent slot is before gloas, instead we will pull it from the bid

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
