### PR TITLE
Fix proposer attestation signature filter

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -522,7 +522,7 @@ func (vs *Server) filterPreviousEpochAttestationByTarget(att ethpb.Att, cp *ethp
 // 1. The attestation matches the current target view defined in `filterCurrentEpochAttestationByTarget`.
 // 2. The attestation matches the previous target view defined in `filterPreviousEpochAttestationByTarget`.
 // 3. The attestation matches certain fork choice conditions defined in `filterCurrentEpochAttestationByForkchoice`.
-// The remaining attestations are sent for batch signature verification. If the batch verification fails, each signature is verified individually.
+// The attestations are sent for batch signature verification. If the batch verification fails, each signature is verified individually.
 func (vs *Server) filterAttestationBySignature(ctx context.Context, atts proposerAtts, st state.BeaconState) (proposerAtts, error) {
 	headSlot := vs.HeadFetcher.HeadSlot()
 	targetEpoch := slots.ToEpoch(headSlot)
@@ -582,13 +582,8 @@ func (vs *Server) filterAttestationBySignature(ctx context.Context, atts propose
 		unverifiedAtts = append(unverifiedAtts, att)
 	}
 
-	if len(unverifiedAtts) == 0 {
-		return verifiedAtts, nil
-	}
-
-	unverifiedAtts = unverifiedAtts.filterBatchSignature(ctx, st)
-
-	return append(verifiedAtts, unverifiedAtts...), nil
+	candidateAtts := append(verifiedAtts, unverifiedAtts...)
+	return candidateAtts.filterBatchSignature(ctx, st), nil
 }
 
 // filterBatchSignature verifies the signatures of the attestation set.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -804,6 +804,59 @@ func Test_filterBatchSignature(t *testing.T) {
 	assert.DeepEqual(t, aGood[0], aFiltered[0])
 }
 
+func Test_filterAttestationBySignature_VerifiesTargetAndForkchoiceMatches(t *testing.T) {
+	st, k := util.DeterministicGenesisState(t, 64)
+	atts, err := util.GenerateAttestations(st, k, 1, 0, false)
+	require.NoError(t, err)
+	goodAtt := atts[0]
+	badAtt := goodAtt.Clone()
+	badAtt.SetSignature(make([]byte, 96))
+
+	targetRoot := [32]byte(goodAtt.GetData().Target.Root)
+	headRoot := bytesutil.PadTo([]byte("head"), 32)
+	headSlot := primitives.Slot(0)
+	currentSlot := primitives.Slot(0)
+	s := &Server{
+		HeadFetcher: &chainMock.ChainService{
+			MockHeadSlot: &headSlot,
+			Root:         headRoot,
+			TargetRoot:   targetRoot,
+		},
+		TimeFetcher: &chainMock.ChainService{Slot: &currentSlot},
+	}
+
+	filtered, err := s.filterAttestationBySignature(t.Context(), proposerAtts{goodAtt, badAtt}, st)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(filtered))
+	require.DeepEqual(t, goodAtt, filtered[0])
+
+	currentSlot = params.BeaconConfig().SlotsPerEpoch
+	headSlot = currentSlot
+	filtered, err = s.filterAttestationBySignature(t.Context(), proposerAtts{badAtt}, st)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(filtered))
+
+	forkchoiceAtt := goodAtt.Clone()
+	forkchoiceAtt.GetData().Slot = params.BeaconConfig().SlotsPerEpoch
+	forkchoiceAtt.GetData().Target.Epoch = slots.ToEpoch(forkchoiceAtt.GetData().Slot)
+	forkchoiceAtt.GetData().BeaconBlockRoot = forkchoiceAtt.GetData().Target.Root
+	forkchoiceAtt.SetSignature(make([]byte, 96))
+	forkchoiceRoot := [32]byte(forkchoiceAtt.GetData().BeaconBlockRoot)
+	nonMatchingTargetRoot := [32]byte{'x'}
+	s.HeadFetcher = &chainMock.ChainService{
+		MockHeadSlot: &headSlot,
+		Root:         headRoot,
+		TargetRoot:   nonMatchingTargetRoot,
+	}
+	s.ForkchoiceFetcher = &chainMock.ChainService{
+		BlockSlot:      0,
+		CanonicalRoots: map[[32]byte]bool{forkchoiceRoot: true},
+	}
+	filtered, err = s.filterAttestationBySignature(t.Context(), proposerAtts{forkchoiceAtt}, st)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(filtered))
+}
+
 func Test_isAttestationFromCurrentEpoch(t *testing.T) {
 	slot := primitives.Slot(1)
 	epoch := slots.ToEpoch(slot)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -11,10 +11,13 @@ import (
 	chainMock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/electra"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/operations/attestations"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/operations/attestations/mock"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls/blst"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -465,9 +468,6 @@ func Test_packAttestations(t *testing.T) {
 	}
 	cb := primitives.NewAttestationCommitteeBits()
 	cb.SetBitAt(0, true)
-	key, err := blst.RandKey()
-	require.NoError(t, err)
-	sig := key.Sign([]byte{'X'})
 	electraAtt := &ethpb.AttestationElectra{
 		AggregationBits: bitfield.Bitlist{0b11111},
 		CommitteeBits:   cb,
@@ -482,16 +482,17 @@ func Test_packAttestations(t *testing.T) {
 				Root:  make([]byte, 32),
 			},
 		},
-		Signature: sig.Marshal(),
+		Signature: make([]byte, 96),
 	}
-	pool := attestations.NewPool()
-	require.NoError(t, pool.SaveAggregatedAttestations([]ethpb.Att{phase0Att, electraAtt}))
 	slot := primitives.Slot(1)
-	s := &Server{AttPool: pool, HeadFetcher: &chainMock.ChainService{}, TimeFetcher: &chainMock.ChainService{Slot: &slot}}
 
 	t.Run("Phase 0", func(t *testing.T) {
-		st, _ := util.DeterministicGenesisState(t, 64)
+		st, keys := util.DeterministicGenesisState(t, 64)
+		signTestAttestation(t, st, keys, phase0Att)
+		pool := attestations.NewPool()
+		require.NoError(t, pool.SaveAggregatedAttestations([]ethpb.Att{phase0Att, electraAtt}))
 		require.NoError(t, st.SetSlot(1))
+		s := &Server{AttPool: pool, HeadFetcher: &chainMock.ChainService{}, TimeFetcher: &chainMock.ChainService{Slot: &slot}}
 
 		atts, err := s.packAttestations(ctx, st, 0)
 		require.NoError(t, err)
@@ -504,8 +505,12 @@ func Test_packAttestations(t *testing.T) {
 		cfg.ElectraForkEpoch = 1
 		params.OverrideBeaconConfig(cfg)
 
-		st, _ := util.DeterministicGenesisStateElectra(t, 64)
+		st, keys := util.DeterministicGenesisStateElectra(t, 64)
+		signTestAttestation(t, st, keys, electraAtt)
+		pool := attestations.NewPool()
+		require.NoError(t, pool.SaveAggregatedAttestations([]ethpb.Att{phase0Att, electraAtt}))
 		require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch+1))
+		s := &Server{AttPool: pool, HeadFetcher: &chainMock.ChainService{}, TimeFetcher: &chainMock.ChainService{Slot: &slot}}
 
 		atts, err := s.packAttestations(ctx, st, params.BeaconConfig().SlotsPerEpoch)
 		require.NoError(t, err)
@@ -518,8 +523,12 @@ func Test_packAttestations(t *testing.T) {
 		cfg.ElectraForkEpoch = 1
 		params.OverrideBeaconConfig(cfg)
 
-		st, _ := util.DeterministicGenesisStateDeneb(t, 64)
+		st, keys := util.DeterministicGenesisStateDeneb(t, 64)
+		signTestAttestation(t, st, keys, electraAtt)
+		pool := attestations.NewPool()
+		require.NoError(t, pool.SaveAggregatedAttestations([]ethpb.Att{phase0Att, electraAtt}))
 		require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch+1))
+		s := &Server{AttPool: pool, HeadFetcher: &chainMock.ChainService{}, TimeFetcher: &chainMock.ChainService{Slot: &slot}}
 
 		atts, err := s.packAttestations(ctx, st, params.BeaconConfig().SlotsPerEpoch)
 		require.NoError(t, err)
@@ -536,10 +545,6 @@ func TestPackAttestations_ElectraOnChainAggregates(t *testing.T) {
 	cfg.ElectraForkEpoch = 1
 	params.OverrideBeaconConfig(cfg)
 
-	key, err := blst.RandKey()
-	require.NoError(t, err)
-	sig := key.Sign([]byte{'X'})
-
 	cb0 := primitives.NewAttestationCommitteeBits()
 	cb0.SetBitAt(0, true)
 	cb1 := primitives.NewAttestationCommitteeBits()
@@ -552,13 +557,18 @@ func TestPackAttestations_ElectraOnChainAggregates(t *testing.T) {
 		BeaconBlockRoot: bytesutil.PadTo([]byte{'1'}, 32),
 	})
 
+	// 192 validators -> 2 committees per slot with 6 validators each
+	st, keys := util.DeterministicGenesisStateElectra(t, 192)
+	require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch+1))
+
 	att := func(bits byte, cb []byte, data *ethpb.AttestationData) *ethpb.AttestationElectra {
-		return &ethpb.AttestationElectra{
+		att := &ethpb.AttestationElectra{
 			AggregationBits: bitfield.Bitlist{bits},
 			CommitteeBits:   cb,
 			Data:            util.HydrateAttestationData(data),
-			Signature:       sig.Marshal(),
 		}
+		signTestAttestation(t, st, keys, att)
+		return att
 	}
 
 	// Glossary:
@@ -579,10 +589,6 @@ func TestPackAttestations_ElectraOnChainAggregates(t *testing.T) {
 
 	pool := &mock.PoolMock{}
 	require.NoError(t, pool.SaveAggregatedAttestations(sliceCast(aggregates)))
-
-	// 192 validators → 2 committees per slot with 6 validators each
-	st, _ := util.DeterministicGenesisStateElectra(t, 192)
-	require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch+1))
 
 	slot := primitives.Slot(1)
 	headSlot := primitives.Slot(0)
@@ -672,6 +678,37 @@ func TestPackAttestations_ElectraOnChainAggregates(t *testing.T) {
 			require.Equal(t, want, got)
 		}
 	})
+}
+
+func signTestAttestation(t testing.TB, st state.ReadOnlyBeaconState, keys []bls.SecretKey, att ethpb.Att) {
+	t.Helper()
+	committees, err := helpers.AttestationCommitteesFromState(t.Context(), st, att)
+	require.NoError(t, err)
+
+	forkEpoch := st.Fork().Epoch
+	domainEpoch := forkEpoch
+	if slots.ToEpoch(att.GetData().Slot) < forkEpoch {
+		require.NotEqual(t, primitives.Epoch(0), forkEpoch)
+		domainEpoch = forkEpoch.Sub(1)
+	}
+	domain, err := signing.Domain(st.Fork(), domainEpoch, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorsRoot())
+	require.NoError(t, err)
+	dataRoot, err := signing.ComputeSigningRoot(att.GetData(), domain)
+	require.NoError(t, err)
+
+	var sigs []bls.Signature
+	offset := uint64(0)
+	for _, committee := range committees {
+		for i, validatorIndex := range committee {
+			if att.GetAggregationBits().BitAt(offset + uint64(i)) {
+				sigs = append(sigs, keys[validatorIndex].Sign(dataRoot[:]))
+			}
+		}
+		offset += uint64(len(committee))
+	}
+	require.Equal(t, offset, att.GetAggregationBits().Len())
+	require.NotEqual(t, 0, len(sigs))
+	att.SetSignature(bls.AggregateSignatures(sigs).Marshal())
 }
 
 func sliceCast(atts []*ethpb.AttestationElectra) []ethpb.Att {

--- a/changelog/dbxe_fix-proposer-attestation-signature-filter.md
+++ b/changelog/dbxe_fix-proposer-attestation-signature-filter.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Verify all attestations selected for block proposals, including target and forkchoice matches, before including them in proposed blocks.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
This PR ensures proposer attestation selection verifies the BLS signatures of all attestations selected for block inclusion before returning a proposal.

Previously, attestations matching the current target, previous target, or forkchoice checks were treated as verified for proposal inclusion, while only the remaining attestations went through batch signature verification. Those target/forkchoice checks do not prove the attestation signature, so Prysm could return a proposal containing an invalid attestation and later reject the same signed block during submit-time validation.

**Which issues(s) does this PR fix?**

Fixes #16875

**Other notes for review**
The production change is intentionally limited to proposer attestation filtering. It does not enable broader proposer preprocessing.

Some existing proposer packing tests used synthetic attestations with arbitrary or zero signatures. Those fixtures are now signed correctly, while preserving their original structure and assertions.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
