### PR TITLE
Fix honest reorg in Gloas

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -136,6 +136,7 @@ go_test(
         "mock_test.go",
         "pow_block_test.go",
         "process_attestation_test.go",
+        "process_block_helpers_test.go",
         "process_block_test.go",
         "receive_attestation_test.go",
         "receive_block_test.go",

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -220,3 +220,24 @@ func (s *Service) fcuFromReorgData(hr [32]byte, hash [32]byte, attr payloadattri
 	copy(pId[:], pid[:])
 	s.cfg.PayloadIDCache.Set(proposingSlot, hr, pId)
 }
+
+// This saves head and prunes atts from the pool only if the head is new and if we are either
+// 1. Not proposing next slot or, if we are,
+// 2. The incoming head block is not late.
+// If we are going to attempt to reorg the block we do not save head in the blockchain package
+// and continue treating the previous head as the tip of the chain. 
+func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessConfig) {
+	full := false
+	if !s.isNewHead(cfg.headRoot, full) {
+		return
+	}
+	proposingSlot := s.CurrentSlot() + 1
+	attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
+	if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
+		return
+	}
+	if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState, full); err != nil {
+		log.WithError(err).Error("Could not save head")
+	}
+	s.pruneAttsFromPool(ctx, cfg.postState, cfg.roblock)
+}

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -211,7 +211,7 @@ func (s *Service) fcuFromReorgData(hr [32]byte, hash [32]byte, attr payloadattri
 		log.WithError(err).Error("Could not update forkchoice with engine")
 	}
 	if pid == nil {
-		if attr != nil {
+		if !attr.IsEmpty() {
 			log.Warn("Engine did not return a payload ID for the fork choice update with attributes")
 		}
 		return

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -225,7 +225,7 @@ func (s *Service) fcuFromReorgData(hr [32]byte, hash [32]byte, attr payloadattri
 // 1. Not proposing next slot or, if we are,
 // 2. The incoming head block is not late.
 // If we are going to attempt to reorg the block we do not save head in the blockchain package
-// and continue treating the previous head as the tip of the chain. 
+// and continue treating the previous head as the tip of the chain.
 func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessConfig) {
 	full := false
 	if !s.isNewHead(cfg.headRoot, full) {

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -204,3 +204,19 @@ func (s *Service) latePayloadTasks(ctx context.Context) {
 	copy(pId[:], pid[:])
 	s.cfg.PayloadIDCache.Set(currentSlot+1, hr, pId)
 }
+
+func (s *Service) fcuFromReorgData(hr [32]byte, hash [32]byte, attr payloadattribute.Attributer, proposingSlot primitives.Slot) {
+	pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, hash, attr)
+	if err != nil {
+		log.WithError(err).Error("Could not update forkchoice with engine")
+	}
+	if pid == nil {
+		if attr != nil {
+			log.Warn("Engine did not return a payload ID for the fork choice update with attributes")
+		}
+		return
+	}
+	var pId [8]byte
+	copy(pId[:], pid[:])
+	s.cfg.PayloadIDCache.Set(proposingSlot, hr, pId)
+}

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -378,6 +378,66 @@ func TestNotifyForkchoiceUpdateGloas_NilAttributes(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestFcuFromReorgData_CachesPayloadID(t *testing.T) {
+	logHook := logTest.NewGlobal()
+	pid := &enginev1.PayloadIDBytes{1, 2, 3, 4, 5, 6, 7, 8}
+	s, _ := setupGloasService(t, &mockExecution.EngineClient{PayloadIDBytes: pid})
+
+	headRoot := bytesutil.ToBytes32([]byte("headroot"))
+	headHash := bytesutil.ToBytes32([]byte("headhash"))
+	proposingSlot := primitives.Slot(2)
+	attr, err := payloadattribute.New(&enginev1.PayloadAttributesV4{
+		Timestamp:             1,
+		PrevRandao:            make([]byte, 32),
+		SuggestedFeeRecipient: make([]byte, 20),
+		Withdrawals:           []*enginev1.Withdrawal{},
+		ParentBeaconBlockRoot: make([]byte, 32),
+	})
+	require.NoError(t, err)
+	require.Equal(t, false, attr.IsEmpty())
+
+	s.fcuFromReorgData(headRoot, headHash, attr, proposingSlot)
+
+	require.LogsDoNotContain(t, logHook, "Could not update forkchoice with engine")
+	cachedPid, has := s.cfg.PayloadIDCache.PayloadID(proposingSlot, headRoot)
+	require.Equal(t, true, has)
+	require.Equal(t, primitives.PayloadID(pid[:]), cachedPid)
+}
+
+func TestFcuFromReorgData_NilPayloadID_NoCache(t *testing.T) {
+	// Engine returns no payload ID (nil), so nothing should be cached.
+	s, _ := setupGloasService(t, &mockExecution.EngineClient{})
+
+	headRoot := bytesutil.ToBytes32([]byte("headroot"))
+	headHash := bytesutil.ToBytes32([]byte("headhash"))
+	proposingSlot := primitives.Slot(2)
+	attr := payloadattribute.EmptyWithVersion(version.Gloas)
+
+	s.fcuFromReorgData(headRoot, headHash, attr, proposingSlot)
+
+	_, has := s.cfg.PayloadIDCache.PayloadID(proposingSlot, headRoot)
+	require.Equal(t, false, has)
+}
+
+func TestFcuFromReorgData_EngineError(t *testing.T) {
+	logHook := logTest.NewGlobal()
+	// An invalid-payload status surfaces as an error from notifyForkchoiceUpdateGloas.
+	s, _ := setupGloasService(t, &mockExecution.EngineClient{
+		ErrForkchoiceUpdated: execution.ErrInvalidPayloadStatus,
+	})
+
+	headRoot := bytesutil.ToBytes32([]byte("headroot"))
+	headHash := bytesutil.ToBytes32([]byte("headhash"))
+	proposingSlot := primitives.Slot(2)
+	attr := payloadattribute.EmptyWithVersion(version.Gloas)
+
+	s.fcuFromReorgData(headRoot, headHash, attr, proposingSlot)
+
+	require.LogsContain(t, logHook, "Could not update forkchoice with engine")
+	_, has := s.cfg.PayloadIDCache.PayloadID(proposingSlot, headRoot)
+	require.Equal(t, false, has)
+}
+
 func TestSavePostPayload(t *testing.T) {
 	s, _ := setupGloasService(t, &mockExecution.EngineClient{})
 	ctx := t.Context()

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -110,15 +110,8 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	if cfg.roblock.Version() < version.Gloas {
 		s.sendFCU(cfg)
 	} else {
-		full := false
-		if s.isNewHead(cfg.headRoot, full) {
-			if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState, full); err != nil {
-				log.WithError(err).Error("Could not save head")
-			}
-			s.pruneAttsFromPool(ctx, cfg.postState, cfg.roblock)
-		}
+		s.saveHeadIfNeeded(ctx, cfg)
 	}
-
 	// Pre-Fulu the caches are updated when computing the payload attributes
 	if cfg.postState.Version() >= version.Fulu {
 		go func() {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -507,24 +507,3 @@ func (s *Service) ensureRootNotZeros(root [32]byte) [32]byte {
 	}
 	return root
 }
-
-// This saves head and prunes atts from the pool only if the head is new and if we are either
-// 1. Not proposing next slot or, if we are,
-// 2. The incoming head block is not late.
-// If we are going to attempt to reorg the block we do not save head in the blockchain package
-// and continue treating the previous head as the tip of the chain. 
-func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessConfig) {
-	full := false
-	if !s.isNewHead(cfg.headRoot, full) {
-		return
-	}
-	proposingSlot := s.CurrentSlot() + 1
-	attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
-	if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
-		return
-	}
-	if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState, full); err != nil {
-		log.WithError(err).Error("Could not save head")
-	}
-	s.pruneAttsFromPool(ctx, cfg.postState, cfg.roblock)
-}

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -508,6 +508,11 @@ func (s *Service) ensureRootNotZeros(root [32]byte) [32]byte {
 	return root
 }
 
+// This saves head and prunes atts from the pool only if the head is new and if we are either
+// 1. Not proposing next slot or, if we are,
+// 2. The incoming head block is not late.
+// If we are going to attempt to reorg the block we do not save head in the blockchain package
+// and continue treating the previous head as the tip of the chain. 
 func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessConfig) {
 	full := false
 	if !s.isNewHead(cfg.headRoot, full) {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -507,3 +507,19 @@ func (s *Service) ensureRootNotZeros(root [32]byte) [32]byte {
 	}
 	return root
 }
+
+func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessConfig) {
+	full := false
+	if !s.isNewHead(cfg.headRoot, full) {
+		return
+	}
+	proposingSlot := s.CurrentSlot() + 1
+	attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
+	if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
+		return
+	}
+	if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState, full); err != nil {
+		log.WithError(err).Error("Could not save head")
+	}
+	s.pruneAttsFromPool(ctx, cfg.postState, cfg.roblock)
+}

--- a/beacon-chain/blockchain/process_block_helpers_test.go
+++ b/beacon-chain/blockchain/process_block_helpers_test.go
@@ -1,0 +1,93 @@
+package blockchain
+
+import (
+	"testing"
+	"time"
+
+	mockExecution "github.com/OffchainLabs/prysm/v7/beacon-chain/execution/testing"
+	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
+	"github.com/OffchainLabs/prysm/v7/config/features"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+// When the current head is unchanged, saveHeadIfNeeded must return immediately
+// without touching the head or panicking.
+func TestSaveHeadIfNeeded_NotNewHead_NoOp(t *testing.T) {
+	s, _ := setupGloasService(t, &mockExecution.EngineClient{})
+	ctx := t.Context()
+
+	headRoot := bytesutil.ToBytes32([]byte("headroot"))
+	blockHash := bytesutil.ToBytes32([]byte("hash1"))
+	base, blk := testGloasState(t, 1, params.BeaconConfig().ZeroHash, blockHash)
+	st, err := state_native.InitializeFromProtoUnsafeGloas(base)
+	require.NoError(t, err)
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	roblock, err := blocks.NewROBlockWithRoot(signed, headRoot)
+	require.NoError(t, err)
+
+	// Pre-set head to the same root with full=false so isNewHead returns false.
+	s.head = &head{root: headRoot, block: signed, state: st, slot: 1, full: false}
+
+	cfg := &postBlockProcessConfig{ctx: ctx, roblock: roblock, headRoot: headRoot, postState: st}
+	s.saveHeadIfNeeded(ctx, cfg)
+
+	// Head must be untouched.
+	require.Equal(t, headRoot, s.head.root)
+	require.Equal(t, primitives.Slot(1), s.head.slot)
+}
+
+// Regression test for the honest reorg fix: when we are the next-slot proposer
+// (non-empty payload attribute) and forkchoice says the late head should be
+// orphaned (shouldOverrideFCU == true), saveHeadIfNeeded must NOT save the head.
+// Against the pre-fix code (which always saved the head for Gloas) this would
+// have set s.head to the late block.
+func TestSaveHeadIfNeeded_ProposingAndOverride_SkipsSave(t *testing.T) {
+	resetCfg := features.InitWithReset(&features.Flags{PrepareAllPayloads: true})
+	defer resetCfg()
+
+	service, tr := minimalTestService(t)
+	ctx, fcs := tr.ctx, tr.fcs
+
+	// Service clock: current slot == 2, so the proposing slot is 3.
+	service.SetGenesisTime(time.Now().Add(-time.Duration(2*params.BeaconConfig().SecondsPerSlot) * time.Second))
+
+	parentRoot := [32]byte{'a'}
+	headRoot := [32]byte{'b'}
+	ojc := &ethpb.Checkpoint{}
+	st, ro, err := prepareForkchoiceState(ctx, 1, parentRoot, [32]byte{}, [32]byte{}, ojc, ojc)
+	require.NoError(t, err)
+	require.NoError(t, fcs.InsertNode(ctx, st, ro))
+	st, ro, err = prepareForkchoiceState(ctx, 2, headRoot, parentRoot, [32]byte{}, ojc, ojc)
+	require.NoError(t, err)
+	require.NoError(t, fcs.InsertNode(ctx, st, ro))
+
+	// Forkchoice clock: the head node (slot 2) is from the current slot and arrived
+	// late, so ForkChoiceStore.ShouldOverrideFCU() returns true.
+	fcs.SetGenesisTime(time.Now().Add(-29 * time.Second))
+	head, err := fcs.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, headRoot, head)
+
+	// postState at slot 3 (== proposing slot) so getPayloadAttribute does not need to
+	// process slots and yields a non-empty attribute (we are proposing).
+	postState, _, err := prepareForkchoiceState(ctx, 3, [32]byte{'c'}, headRoot, [32]byte{}, ojc, ojc)
+	require.NoError(t, err)
+
+	require.Equal(t, primitives.Slot(2), service.CurrentSlot())
+	proposingSlot := service.CurrentSlot() + 1
+	attr := service.getPayloadAttribute(ctx, postState, proposingSlot, headRoot[:], false)
+	require.Equal(t, false, attr.IsEmpty())
+	require.Equal(t, true, service.shouldOverrideFCU(headRoot, proposingSlot))
+
+	// s.head is nil → isNewHead is true; the override must trigger an early return
+	// before saveHead is reached, leaving the head untouched (nil).
+	cfg := &postBlockProcessConfig{ctx: ctx, headRoot: headRoot, postState: postState}
+	service.saveHeadIfNeeded(ctx, cfg)
+	require.Equal(t, true, service.head == nil)
+}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -133,7 +133,7 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 	processAttsElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 
 	start = time.Now()
-	newHeadRoot, _, full, err := s.cfg.ForkChoiceStore.FullHead(ctx)
+	newHeadRoot, headHash, full, err := s.cfg.ForkChoiceStore.FullHead(ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not compute head from new attestations")
 		return
@@ -150,31 +150,12 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 	newAttHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 	if s.inRegularSync() {
 		attr := s.getPayloadAttribute(ctx, headState, proposingSlot, newHeadRoot[:], full)
-		if attr != nil && s.shouldOverrideFCU(newHeadRoot, proposingSlot) {
+		if !attr.IsEmpty() && s.shouldOverrideFCU(newHeadRoot, proposingSlot) {
 			return
 		}
 		postGloas := slots.ToEpoch(proposingSlot) >= params.BeaconConfig().GloasForkEpoch
 		if postGloas {
-			blockHash, hashErr := s.cfg.ForkChoiceStore.BlockHash(newHeadRoot)
-			if hashErr != nil {
-				log.WithError(hashErr).Error("Could not get block hash from forkchoice for FCU")
-			} else {
-				go func() {
-					pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, attr)
-					if err != nil {
-						log.WithError(err).Error("Could not update forkchoice with engine")
-					}
-					if pid == nil {
-						if attr != nil {
-							log.Warn("Engine did not return a payload ID for the fork choice update with attributes")
-						}
-						return
-					}
-					var pId [8]byte
-					copy(pId[:], pid[:])
-					s.cfg.PayloadIDCache.Set(proposingSlot, newHeadRoot, pId)
-				}()
-			}
+			go s.fcuFromReorgData(newHeadRoot, headHash, attr, proposingSlot)
 		} else {
 			fcuArgs := &fcuConfig{
 				headState:     headState,

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -160,20 +160,21 @@ func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROEx
 	s.headLock.Unlock()
 
 	attr := s.getPayloadAttribute(ctx, st, envelope.Slot()+1, headRoot[:], true)
-	if s.inRegularSync() {
-		go func() {
-			pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, attr)
-			if err != nil {
-				log.WithError(err).Error("Could not notify forkchoice update")
-				return
-			}
-			if attr != nil && !attr.IsEmpty() && pid != nil {
-				var pId [8]byte
-				copy(pId[:], pid[:])
-				s.cfg.PayloadIDCache.Set(envelope.Slot()+1, root, pId)
-			}
-		}()
+	if !s.inRegularSync() {
+		return nil
 	}
+	go func() {
+		pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, attr)
+		if err != nil {
+			log.WithError(err).Error("Could not notify forkchoice update")
+			return
+		}
+		if !attr.IsEmpty() && pid != nil {
+			var pId [8]byte
+			copy(pId[:], pid[:])
+			s.cfg.PayloadIDCache.Set(envelope.Slot()+1, root, pId)
+		}
+	}()
 	return nil
 }
 

--- a/changelog/potuz_gloas_reorgs.md
+++ b/changelog/potuz_gloas_reorgs.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed honest reorg feature in Gloas


### PR DESCRIPTION
Fix the honest reorg feature in Gloas and add a few other fixes. Notably we were using 

if `attr != nil && shouldOverrideFCU` then return early, but `attr != nil` is always satisfied since `getPayloadAttributes always returns a not nil empty attributes. 