### PR TITLE
Add `execution_payload_gossip` event topic support

### DIFF
--- a/api/server/structs/endpoints_events.go
+++ b/api/server/structs/endpoints_events.go
@@ -117,3 +117,10 @@ type PayloadEvent struct {
 	Slot      string `json:"slot"`
 	BlockRoot string `json:"block_root"`
 }
+
+type ExecutionPayloadGossipEvent struct {
+	Slot         string `json:"slot"`
+	BuilderIndex string `json:"builder_index"`
+	BlockHash    string `json:"block_hash"`
+	BlockRoot    string `json:"block_root"`
+}

--- a/beacon-chain/core/feed/operation/events.go
+++ b/beacon-chain/core/feed/operation/events.go
@@ -49,6 +49,10 @@ const (
 
 	// PayloadAttestationMessageReceived is sent after a payload attestation message is received from gossip or rpc.
 	PayloadAttestationMessageReceived = 13
+
+	// ExecutionPayloadGossipReceived is sent after an execution payload envelope has been received from
+	// gossip or API that passes validation rules.
+	ExecutionPayloadGossipReceived = 14
 )
 
 // UnAggregatedAttReceivedData is the data sent with UnaggregatedAttReceived events.
@@ -121,4 +125,12 @@ type DataColumnReceivedData struct {
 // PayloadAttestationMessageReceivedData is the data sent with PayloadAttestationMessageReceived events.
 type PayloadAttestationMessageReceivedData struct {
 	Message *ethpb.PayloadAttestationMessage
+}
+
+// ExecutionPayloadGossipReceivedData is the data sent with ExecutionPayloadGossipReceived events.
+type ExecutionPayloadGossipReceivedData struct {
+	Slot         primitives.Slot
+	BuilderIndex primitives.BuilderIndex
+	BlockHash    [32]byte
+	BlockRoot    [32]byte
 }

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -76,6 +76,9 @@ const (
 	DataColumnTopic = "data_column_sidecar"
 	// ExecutionPayloadTopic represents a new execution payload envelope event topic
 	ExecutionPayloadTopic = "execution_payload_available"
+	// ExecutionPayloadGossipTopic represents an execution payload envelope received from gossip or API
+	// that passes validation rules.
+	ExecutionPayloadGossipTopic = "execution_payload_gossip"
 	// ExecutionPayloadBidTopic represents a new execution payload bid event topic.
 	// This topic is currently not triggered but is recognized to avoid client subscription errors.
 	ExecutionPayloadBidTopic = "execution_payload_bid"
@@ -116,6 +119,7 @@ var opsFeedEventTopics = map[feed.EventType]string{
 	operation.BlockGossipReceived:               BlockGossipTopic,
 	operation.DataColumnReceived:                DataColumnTopic,
 	operation.PayloadAttestationMessageReceived: PayloadAttestationMessageTopic,
+	operation.ExecutionPayloadGossipReceived:    ExecutionPayloadGossipTopic,
 }
 
 var stateFeedEventTopics = map[feed.EventType]string{
@@ -483,6 +487,8 @@ func topicForEvent(event *feed.Event) string {
 		return PayloadAttestationMessageTopic
 	case *statefeed.PayloadProcessedData:
 		return ExecutionPayloadTopic
+	case *operation.ExecutionPayloadGossipReceivedData:
+		return ExecutionPayloadGossipTopic
 	default:
 		return InvalidTopic
 	}
@@ -664,6 +670,15 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 			return jsonMarshalReader(eventName, &structs.PayloadEvent{
 				Slot:      fmt.Sprintf("%d", v.Slot),
 				BlockRoot: hexutil.Encode(v.BlockRoot[:]),
+			})
+		}, nil
+	case *operation.ExecutionPayloadGossipReceivedData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, &structs.ExecutionPayloadGossipEvent{
+				Slot:         fmt.Sprintf("%d", v.Slot),
+				BuilderIndex: fmt.Sprintf("%d", v.BuilderIndex),
+				BlockHash:    hexutil.Encode(v.BlockHash[:]),
+				BlockRoot:    hexutil.Encode(v.BlockRoot[:]),
 			})
 		}, nil
 	default:

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -124,6 +124,7 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 		BlockGossipTopic,
 		DataColumnTopic,
 		PayloadAttestationMessageTopic,
+		ExecutionPayloadGossipTopic,
 	})
 	require.NoError(t, err)
 	ro, err := blocks.NewROBlob(util.HydrateBlobSidecar(&eth.BlobSidecar{}))
@@ -326,6 +327,15 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 					},
 					Signature: make([]byte, fieldparams.BLSSignatureLength),
 				},
+			},
+		},
+		{
+			Type: operation.ExecutionPayloadGossipReceived,
+			Data: &operation.ExecutionPayloadGossipReceivedData{
+				Slot:         1,
+				BuilderIndex: 2,
+				BlockHash:    [32]byte{'h'},
+				BlockRoot:    [32]byte{'r'},
 			},
 		},
 	}
@@ -745,7 +755,7 @@ func TestStuckReaderScenarios(t *testing.T) {
 
 func wedgedWriterTestCase(t *testing.T, queueDepth func([]*feed.Event) int) {
 	topics, events := operationEventsFixtures(t)
-	require.Equal(t, 13, len(events))
+	require.Equal(t, 14, len(events))
 
 	// set eventFeedDepth to a number lower than the events we intend to send to force the server to drop the reader.
 	stn := mockChain.NewEventFeedWrapper()

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -141,6 +143,20 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 	} else {
 		log.WithError(err).WithField("slot", env.Slot()).Debug("Could not compute execution payload envelope slot start time")
 	}
+
+	// execution_payload_gossip fires once the envelope passes gossip validation.
+	if s.cfg.operationNotifier != nil {
+		s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
+			Type: operation.ExecutionPayloadGossipReceived,
+			Data: &operation.ExecutionPayloadGossipReceivedData{
+				Slot:         env.Slot(),
+				BuilderIndex: env.BuilderIndex(),
+				BlockHash:    env.BlockHash(),
+				BlockRoot:    env.BeaconBlockRoot(),
+			},
+		})
+	}
+
 	return pubsub.ValidationAccept, nil
 }
 

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/async/abool"
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
@@ -133,6 +135,51 @@ func TestValidateExecutionPayloadEnvelope_HappyPath(t *testing.T) {
 	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
 }
 
+func TestValidateExecutionPayloadEnvelope_GossipEvent(t *testing.T) {
+	ctx := context.Background()
+	s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
+	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+
+	opChannel := make(chan *feed.Event, 1)
+	opSub := s.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+	defer opSub.Unsubscribe()
+
+	t.Run("gossip event emitted on valid envelope", func(t *testing.T) {
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
+
+		signed, ok := msg.ValidatorData.(*ethpb.SignedExecutionPayloadEnvelope)
+		require.Equal(t, true, ok)
+
+		select {
+		case event := <-opChannel:
+			require.Equal(t, feed.EventType(opfeed.ExecutionPayloadGossipReceived), event.Type)
+			data, ok := event.Data.(*opfeed.ExecutionPayloadGossipReceivedData)
+			require.Equal(t, true, ok)
+			require.Equal(t, primitives.Slot(1), data.Slot)
+			require.Equal(t, builderIdx, data.BuilderIndex)
+			require.Equal(t, root, data.BlockRoot)
+			require.Equal(t, bytesutil.ToBytes32(signed.Message.Payload.BlockHash), data.BlockHash)
+		case <-time.After(time.Second):
+			t.Fatal("expected execution_payload_gossip event was not received")
+		}
+	})
+
+	t.Run("self-origin envelope does not emit gossip event", func(t *testing.T) {
+		result, err := s.validateExecutionPayloadEnvelope(ctx, s.cfg.p2p.PeerID(), msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
+
+		select {
+		case event := <-opChannel:
+			t.Fatalf("did not expect a gossip event for a self-origin envelope, got type %v", event.Type)
+		case <-time.After(50 * time.Millisecond):
+			// No event received, as expected.
+		}
+	})
+}
+
 func TestExecutionPayloadEnvelopeSubscriber_WrongMessage(t *testing.T) {
 	s := &Service{cfg: &config{}}
 	err := s.executionPayloadEnvelopeSubscriber(context.Background(), &ethpb.BeaconBlock{})
@@ -221,12 +268,13 @@ func setupExecutionPayloadEnvelopeService(t *testing.T, envelopeSlot, blockSlot 
 		seenPayloadEnvelopeCache: lruwrpr.New(10),
 		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
 		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{},
-			chain:       chainService,
-			beaconDB:    db,
-			stateGen:    stateGen,
-			clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			p2p:               p,
+			initialSync:       &mockSync.Sync{},
+			chain:             chainService,
+			beaconDB:          db,
+			stateGen:          stateGen,
+			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			operationNotifier: chainService.OperationNotifier(),
 		},
 	}
 

--- a/changelog/syjn99_feat-execution-payload-gossip-event.md
+++ b/changelog/syjn99_feat-execution-payload-gossip-event.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added `execution_payload_gossip` event emission as per [beacon-APIs#588](https://github.com/ethereum/beacon-APIs/pull/588/).


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Adds event emission for `execution_payload_gossip` as per https://github.com/ethereum/beacon-APIs/pull/588.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

https://github.com/OffchainLabs/prysm/blob/e94d46b8c175530cac4deb5e0b082366ba9fb6be/beacon-chain/sync/validate_beacon_blocks.go#L276-L283

`execution_payload_gossip` mirrors `block_gossip` event, so you can see exactly same pattern as our implementation like above.

**Testing**

```
➜  kurtosis-config curl -X 'GET' \
  'http://<beacon-node-rpc-url>/eth/v1/events?topics=execution_payload_gossip' \
  -H 'accept: text/event-stream'

event: execution_payload_gossip
data: {"slot":"65","builder_index":"18446744073709551615","block_hash":"0x36b193697ddff3ece883e04a554e108c280ff5cb1c101aed886cb15bd76515bb","block_root":"0x765c25b8e75955f3f1eabbe6ab9bebc3a05f5fb94dcbbef20b1ddde4192c5244"}
```

with this config:

```yaml
participants:
  - el_type: ethrex
    el_image: ethpandaops/ethrex:glamsterdam-devnet-4
    el_extra_params:
      - --http.api=eth,net,web3,admin
    cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    vc_image: prysm-vc-custom-image:latest
    supernode: true
    count: 3
    cl_extra_params:
      - --subscribe-all-subnets
      - --verbosity=debug
    vc_extra_params:
      - --verbosity=debug

network_params:
  fulu_fork_epoch: 0
  gloas_fork_epoch: 2
  seconds_per_slot: 6
  genesis_delay: 40

additional_services:
  - dora

global_log_level: debug
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
