### PR TITLE
Scaffold agent instructions: Add `AGENTS.md` and Prysm skills

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,36 @@
+# Prysm — Ethereum Consensus Layer Client
+
+Bazel is the first-class build system — always build and test with Bazel.
+
+## Skills
+
+The "how" lives in `.agents/skills/` — invoke these instead of running commands by hand:
+
+- `/precheck` — format, gazelle, code generators, build. Run before every commit.
+- `/test` — unit tests for affected packages. For any tests you add or modify, run this command.
+
+## Architecture
+
+Main executables in `cmd/` including `beacon-chain`, `validator`.
+
+- `beacon-chain/` — core chain: state transition (`core/`, per fork), block processing & fork choice (`blockchain/`), `state/`, `db/`, `p2p/`, `sync/`, RPC/API
+- `validator/` — key management, slashing protection, duties
+- `consensus-types/` — shared consensus type definitions
+- `proto/` — protobuf defs + generated code
+- `api/` — REST + gRPC
+- `config/` — chain params (`params/`) and feature flags (`features/`)
+- `testing/` — test utilities, spec conformance, end-to-end
+
+Prysm implements the [Ethereum consensus specs](https://github.com/ethereum/consensus-specs/tree/master/specs) (organized by fork - phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas, etc) — they are the source of truth for protocol behavior. Each containing:
+
+- *beacon-chain.md* — state transition / core logic
+- *fork-choice.md* — fork choice rules
+- *p2p-interface.md* — networking / gossip
+
+## Conventions
+
+- **Always run `/precheck` before every commit — it must pass** (format, gazelle, generators, build).
+- Branch from and target `develop`.
+- Every PR needs a changelog fragment: `changelog/<github_user>_<branch_name>.md` (managed by `unclog`).
+- Keep comments short — one line, no multi-line explanations.
+- Verify tests you add or modify with `/test`.

--- a/.agents/skills/precheck/SKILL.md
+++ b/.agents/skills/precheck/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: precheck
+description: Run pre-commit checks (gofmt, goimports, gazelle, code generators, build) before committing Prysm changes. Required before every commit.
+---
+
+# Pre-commit checks
+
+Run these in order from the repo root before every commit. Stop and report if any step fails.
+
+1. **gofmt** — format changed Go files:
+   ```bash
+   gofmt -l $(git diff --name-only --diff-filter=ACM HEAD | grep '\.go$')
+   ```
+   If output is non-empty, run `gofmt -w` on those files.
+
+2. **goimports** — organize imports:
+   ```bash
+   goimports -l $(git diff --name-only --diff-filter=ACM HEAD | grep '\.go$')
+   ```
+   If output is non-empty, run `goimports -w` on those files.
+
+3. **Gazelle — sync `deps.bzl`** (when `go.mod` changed):
+   ```bash
+   bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%prysm_deps -prune=true
+   git diff --exit-code deps.bzl
+   ```
+
+4. **Gazelle — sync `BUILD.bazel`**:
+   ```bash
+   bazel run //:gazelle -- fix --mode=diff
+   ```
+   If the diff is non-empty, run `bazel run //:gazelle -- fix`.
+
+5. **Regenerate protobuf** (when `.proto` files changed):
+   ```bash
+   hack/update-go-pbs.sh
+   ```
+
+6. **Regenerate SSZ** (when SSZ-tagged structs changed):
+   ```bash
+   hack/update-go-ssz.sh
+   ```
+
+7. **Regenerate mocks** (when proto service interfaces changed):
+   ```bash
+   hack/update-mockgen.sh
+   ```
+
+8. **Smoke run with Bazel**:
+   ```bash
+   bazel run //cmd/beacon-chain:beacon-chain  -- --help
+   bazel run //cmd/validator:validator  -- --help
+   ```
+
+Hack scripts are idempotent — if unsure which generated files are affected, run all three.
+
+## Report
+
+- Success: "✅ All pre-checks passed. Ready to commit."
+- Failure: name the failed check and the fix command.

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: test
+description: Run Prysm unit tests with Bazel for affected packages, or a given target.
+---
+
+# Unit test runner
+
+## Usage
+- `/test` — test affected packages (from git diff)
+- `/test //beacon-chain/sync/...` — test a specific target
+- `/test //...` — test everything (slow)
+
+## Steps
+
+1. **Determine targets** — if the user gave one, use it; otherwise derive from the diff:
+   ```bash
+   git diff --name-only HEAD | grep '\.go$' | xargs -I{} dirname {} | sort -u | sed 's|^|//|;s|$|/...|'
+   ```
+
+2. **Run**:
+   ```bash
+   bazel test <targets> \
+     --keep_going \
+     --test_output=errors \
+     --flaky_test_attempts=3 \
+     --build_tests_only
+   ```
+
+3. **Report**:
+   ```
+   ✅ Passed: X
+   ❌ Failed: Y
+     - //package:test — error summary
+   ```
+   Flaky tests that pass on retry are fine.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,11 @@ tmp
 
 # spectest coverage reports
 report.txt
+
+# Agent instructions (devs opt in locally; canonical copy lives in .agents/)
+AGENTS.md
+!.agents/AGENTS.md
+CLAUDE.md
+
+# Local CLAUDE instruction
+CLAUDE.local.md

--- a/changelog/syjn99_feat-scaffold-agent-instructions.md
+++ b/changelog/syjn99_feat-scaffold-agent-instructions.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Add `.agents/AGENTS.md` with basic skills.


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Add `AGENTS.md` (website: [agents.md](https://agents.md/)) and Prysm-specific skills under `.agents/` folder. `AGENTS.md` will focus on _what_ and _why_, and skills are responsible for _how_.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

- With this PR, you still need to set up your `AGENTS|CLAUDE.md` in the project root, as `.agents/AGENTS.md` isn't loaded automatically (neither Claude Code nor Codex). For Claude users, you can just point to the instruction in your `./CLAUDE.md`:

```markdown
@.agents/AGENTS.md
```

- This [article](https://code.claude.com/docs/en/memory) about memory management from Claude is worth reading.
- [CLAUDE USERS] For personalization, I would recommend using `CLAUDE.local.md` ([Source](https://code.claude.com/docs/en/memory#choose-where-to-put-claude-md-files)) which is already listed in `.gitignore`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
