### PR TITLE
Run payload envelope DA check concurrently

### DIFF
--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -81,20 +81,24 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 		return elErr
 	})
 
+	g.Go(func() error {
+		bid, err := blockState.LatestExecutionPayloadBid()
+		if err != nil {
+			return errors.Wrap(err, "could not get latest execution payload bid")
+		}
+		if bid == nil || len(bid.BlobKzgCommitments()) == 0 {
+			return nil
+		}
+		if err := s.areDataColumnsAvailable(gCtx, root, envelope.Slot()); err != nil {
+			return errors.Wrap(err, "data availability check failed for payload envelope")
+		}
+		return nil
+	})
+
 	if err := g.Wait(); err != nil {
 		return err
 	}
 
-	// DA check: verify data columns are available before inserting payload.
-	bid, err := blockState.LatestExecutionPayloadBid()
-	if err != nil {
-		return errors.Wrap(err, "could not get latest execution payload bid")
-	}
-	if bid != nil && len(bid.BlobKzgCommitments()) > 0 {
-		if err := s.areDataColumnsAvailable(ctx, root, envelope.Slot()); err != nil {
-			return errors.Wrap(err, "data availability check failed for payload envelope")
-		}
-	}
 	if err := s.savePostPayload(ctx, signed); err != nil {
 		return err
 	}

--- a/changelog/terencechain_da-check-concurrent-envelope.md
+++ b/changelog/terencechain_da-check-concurrent-envelope.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Run the data availability check concurrently with payload verification and EL validation when processing execution payload envelopes.


### PR DESCRIPTION
When processing an execution payload envelope, the data availability (DA) check previously ran sequentially after consensus verification and EL validation had both completed. This moves the DA check into the same `errgroup` so it runs concurrently with payload verification and EL `newPayload` validation.

- The DA check only runs when the latest bid carries blob KZG commitments (unchanged behavior).
- Uses the group context (`gCtx`) so a failure in any of the three cancels the others.

This enables https://github.com/ethereum/beacon-APIs/pull/588 to emit `execution_payload_available`
