### PR TITLE
Fix data race on the shared err variable in beacon-api validator client's dutiesForEpoch

### DIFF
--- a/changelog/satushh_fix-dutiesforepoch-data-race.md
+++ b/changelog/satushh_fix-dutiesforepoch-data-race.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix data race on the shared `err` variable in `beacon-api` validator client's `dutiesForEpoch` where attester and proposer goroutines concurrently wrote to the same outer error.

--- a/validator/client/beacon-api/duties.go
+++ b/validator/client/beacon-api/duties.go
@@ -111,6 +111,7 @@ func (c *beaconApiValidatorClient) dutiesForEpoch(
 	var attesterDutiesContainer *structs.GetAttesterDutiesResponse
 	var err error
 	wg.Go(func() error {
+		var err error
 		attesterDutiesContainer, err = c.dutiesProvider.AttesterDuties(ctx, epoch, indices)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get attester duties for epoch `%d`", epoch)
@@ -171,6 +172,7 @@ func (c *beaconApiValidatorClient) dutiesForEpoch(
 
 	var proposerDutiesContainer *structs.GetProposerDutiesResponse
 	wg.Go(func() error {
+		var err error
 		proposerDutiesContainer, err = c.dutiesProvider.ProposerDuties(ctx, epoch)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get proposer duties for epoch `%d`", epoch)

--- a/validator/client/beacon-api/duties_test.go
+++ b/validator/client/beacon-api/duties_test.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1405,4 +1406,51 @@ func reverseSlice[T any](slice []T) []T {
 		reversedSlice[len(reversedSlice)-1-i] = slice[i]
 	}
 	return reversedSlice
+}
+
+// TestDutiesForEpoch_NoDataRaceOnSharedErr forces the attester and proposer goroutines
+// inside dutiesForEpoch to return concurrently so that any unsynchronized write to a
+// shared outer error variable is observable under `go test -race`.
+func TestDutiesForEpoch_NoDataRaceOnSharedErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := t.Context()
+	const epoch = primitives.Epoch(1)
+	const dependentRoot = "0xdeadbeef000000000000000000000000000000000000000000000000"
+
+	arrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	go func() {
+		<-arrived
+		<-arrived
+		close(release)
+	}()
+	barrier := func() {
+		arrived <- struct{}{}
+		<-release
+	}
+
+	dutiesProvider := mock.NewMockdutiesProvider(ctrl)
+	dutiesProvider.EXPECT().AttesterDuties(ctx, epoch, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ primitives.Epoch, _ []primitives.ValidatorIndex) (*structs.GetAttesterDutiesResponse, error) {
+			barrier()
+			return &structs.GetAttesterDutiesResponse{DependentRoot: dependentRoot}, nil
+		},
+	)
+	dutiesProvider.EXPECT().ProposerDuties(ctx, epoch).DoAndReturn(
+		func(_ context.Context, _ primitives.Epoch) (*structs.GetProposerDutiesResponse, error) {
+			barrier()
+			return &structs.GetProposerDutiesResponse{DependentRoot: dependentRoot}, nil
+		},
+	)
+
+	validatorClient := &beaconApiValidatorClient{dutiesProvider: dutiesProvider}
+	require.NoError(t, validatorClient.dutiesForEpoch(
+		ctx,
+		&ethpb.ValidatorDutiesContainer{},
+		epoch,
+		nil,
+		false,
+	))
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
