### PR TITLE
Add debug log when ignoring payload envelope not for current slot

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -170,6 +170,7 @@ func (s *Service) queuePendingPayloadEnvelope(
 ) (pubsub.ValidationResult, error) {
 	currentSlot := s.cfg.clock.CurrentSlot()
 	if env.Slot() != currentSlot {
+		log.WithField("envelopeSlot", env.Slot()).WithField("currentSlot", currentSlot).Debug("Ignoring payload envelope not for current slot")
 		return pubsub.ValidationIgnore, nil
 	}
 	st, err := s.cfg.chain.HeadStateReadOnly(ctx)

--- a/changelog/terence_log-envelope-slot-mismatch.md
+++ b/changelog/terence_log-envelope-slot-mismatch.md
@@ -1,0 +1,3 @@
+### Added
+
+- Debug log when ignoring a payload envelope whose slot is not the current slot.


### PR DESCRIPTION
This helps debugging scenario that a payload may get dropped without any error