### PR TITLE
Submit payload attestation on `execution_payload_available` event

### DIFF
--- a/api/client/event/event_stream.go
+++ b/api/client/event/event_stream.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	EventHead = "head"
+	EventHead             = "head"
+	EventExecutionPayload = "execution_payload_available"
 
 	EventError           = "error"
 	EventConnectionError = "connection_error"
@@ -23,7 +24,7 @@ var (
 	_ = EventStreamClient(&EventStream{})
 )
 
-var DefaultEventTopics = []string{EventHead}
+var DefaultEventTopics = []string{EventHead, EventExecutionPayload}
 
 type EventStreamClient interface {
 	Subscribe(eventsChannel chan<- *Event)

--- a/api/client/event/event_stream.go
+++ b/api/client/event/event_stream.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	EventHead             = "head"
-	EventExecutionPayload = "execution_payload_available"
+	EventHead                      = "head"
+	EventExecutionPayloadAvailable = "execution_payload_available"
 
 	EventError           = "error"
 	EventConnectionError = "connection_error"
@@ -24,7 +24,7 @@ var (
 	_ = EventStreamClient(&EventStream{})
 )
 
-var DefaultEventTopics = []string{EventHead, EventExecutionPayload}
+var DefaultEventTopics = []string{EventHead, EventExecutionPayloadAvailable}
 
 type EventStreamClient interface {
 	Subscribe(eventsChannel chan<- *Event)

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -956,9 +956,7 @@ func (s *Service) PayloadAttestationData(
 	}
 	cfg := params.BeaconConfig()
 	deadline := slotStart.Add(cfg.SlotComponentDuration(cfg.PayloadAttestationDueBPS))
-	if prysmTime.Now().Before(deadline) {
-		return nil, &RpcError{Reason: Unavailable, Err: fmt.Errorf("PTC deadline not yet reached for slot %d", slot)}
-	}
+	beforeDeadline := prysmTime.Now().Before(deadline)
 
 	if cached := s.payloadAttestationData.Load(); cached != nil && cached.Slot == slot {
 		return cached, nil
@@ -971,6 +969,12 @@ func (s *Service) PayloadAttestationData(
 		data, rpcErr := s.buildPayloadAttestationData(slot)
 		if rpcErr != nil {
 			return rpcErr, nil
+		}
+		// Before the deadline only the final result is safe to return: the payload
+		// arrived timely and the data is available. Otherwise both flags may still
+		// flip, so wait for the deadline.
+		if beforeDeadline && !(data.PayloadPresent && data.BlobDataAvailable) {
+			return &RpcError{Reason: Unavailable, Err: fmt.Errorf("payload attestation data not yet final for slot %d", slot)}, nil
 		}
 		s.payloadAttestationData.Store(data)
 		return data, nil

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -956,7 +956,6 @@ func (s *Service) PayloadAttestationData(
 	}
 	cfg := params.BeaconConfig()
 	deadline := slotStart.Add(cfg.SlotComponentDuration(cfg.PayloadAttestationDueBPS))
-	beforeDeadline := prysmTime.Now().Before(deadline)
 
 	if cached := s.payloadAttestationData.Load(); cached != nil && cached.Slot == slot {
 		return cached, nil
@@ -973,7 +972,7 @@ func (s *Service) PayloadAttestationData(
 		// Before the deadline only the final result is safe to return: the payload
 		// arrived timely and the data is available. Otherwise both flags may still
 		// flip, so wait for the deadline.
-		if beforeDeadline && !(data.PayloadPresent && data.BlobDataAvailable) {
+		if prysmTime.Now().Before(deadline) && !(data.PayloadPresent && data.BlobDataAvailable) {
 			return &RpcError{Reason: Unavailable, Err: fmt.Errorf("payload attestation data not yet final for slot %d", slot)}, nil
 		}
 		s.payloadAttestationData.Store(data)

--- a/beacon-chain/rpc/core/validator_test.go
+++ b/beacon-chain/rpc/core/validator_test.go
@@ -250,7 +250,7 @@ func TestPayloadAttestationData(t *testing.T) {
 		assert.Equal(t, true, data.PayloadPresent)
 		assert.Equal(t, true, data.BlobDataAvailable)
 	})
-	t.Run("before PTC deadline → Unavailable", func(t *testing.T) {
+	t.Run("before PTC deadline and not final → Unavailable", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		cfg := params.BeaconConfig().Copy()
 		cfg.GloasForkEpoch = 0
@@ -267,8 +267,33 @@ func TestPayloadAttestationData(t *testing.T) {
 		_, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, ErrorReason(Unavailable), rpcErr.Reason)
-		assert.ErrorContains(t, "PTC deadline not yet reached", rpcErr.Err)
+		assert.ErrorContains(t, "not yet final", rpcErr.Err)
 		assert.Equal(t, (*ethpb.PayloadAttestationData)(nil), s.payloadAttestationData.Load())
+	})
+	t.Run("before PTC deadline but final → returns data early", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		slot := primitives.Slot(0)
+		root := bytesutil.PadTo([]byte{0xAA}, 32)
+		chain := &mockChain.ChainService{
+			Slot:               &slot,
+			Genesis:            time.Now(),
+			Root:               root,
+			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
+			MockCanonicalFull:  map[primitives.Slot]bool{slot: true},
+			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
+		}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain}
+
+		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
+		require.IsNil(t, rpcErr)
+		assert.DeepEqual(t, root, data.BeaconBlockRoot)
+		assert.Equal(t, true, data.PayloadPresent)
+		assert.Equal(t, true, data.BlobDataAvailable)
+		require.NotNil(t, s.payloadAttestationData.Load())
 	})
 	t.Run("result is cached per slot and bypassed on slot change", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)

--- a/changelog/terence_ptc-attest-on-payload-event.md
+++ b/changelog/terence_ptc-attest-on-payload-event.md
@@ -1,0 +1,3 @@
+### Changed
+
+- PTC members submit payload attestations as soon as the `execution_payload_available` event fires.

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "log_helpers.go",
         "metrics.go",
         "payload_attestation.go",
+        "payload_availability.go",
         "propose.go",
         "propose_gloas.go",
         "registration.go",

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -117,6 +117,7 @@ go_test(
         "log_test.go",
         "metrics_test.go",
         "payload_attestation_test.go",
+        "payload_availability_test.go",
         "propose_gloas_test.go",
         "propose_test.go",
         "registration_test.go",
@@ -133,6 +134,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//api/client/event:go_default_library",
         "//api/grpc:go_default_library",
         "//api/server/structs:go_default_library",
         "//async/event:go_default_library",

--- a/validator/client/payload_attestation.go
+++ b/validator/client/payload_attestation.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
@@ -21,6 +22,52 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// payloadAvailability releases per-slot waiters when an execution_payload_available
+// event is received, so PTC members can attest as soon as the payload and blobs are
+// available rather than waiting for the attestation deadline.
+type payloadAvailability struct {
+	mu    sync.Mutex
+	chans map[primitives.Slot]chan struct{}
+}
+
+func newPayloadAvailability() *payloadAvailability {
+	return &payloadAvailability{chans: make(map[primitives.Slot]chan struct{})}
+}
+
+// waiter returns a channel closed once the payload for slot is available.
+func (p *payloadAvailability) waiter(slot primitives.Slot) <-chan struct{} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ch, ok := p.chans[slot]
+	if !ok {
+		ch = make(chan struct{})
+		p.chans[slot] = ch
+	}
+	return ch
+}
+
+// notify releases waiters for slot and prunes older slots. A closed channel is
+// stored so a waiter that registers after the event still observes availability.
+func (p *payloadAvailability) notify(slot primitives.Slot) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ch, ok := p.chans[slot]
+	if !ok {
+		ch = make(chan struct{})
+		p.chans[slot] = ch
+	}
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+	for s := range p.chans {
+		if s < slot {
+			delete(p.chans, s)
+		}
+	}
+}
+
 // SubmitPayloadAttestation submits a payload attestation message for a PTC member.
 func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitives.Slot, pubKey [fieldparams.BLSPubkeyLength]byte) {
 	ctx, span := trace.StartSpan(ctx, "validator.SubmitPayloadAttestation")
@@ -31,7 +78,7 @@ func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitive
 		return
 	}
 
-	v.waitUntilSlotComponent(ctx, slot, params.BeaconConfig().PayloadAttestationDueBPS)
+	v.waitForPayloadAvailableOrDeadline(ctx, slot)
 
 	data, err := v.validatorClient.PayloadAttestationData(ctx, slot)
 	if err != nil {

--- a/validator/client/payload_attestation.go
+++ b/validator/client/payload_attestation.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
@@ -22,52 +21,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// payloadAvailability releases per-slot waiters when an execution_payload_available
-// event is received, so PTC members can attest as soon as the payload and blobs are
-// available rather than waiting for the attestation deadline.
-type payloadAvailability struct {
-	mu    sync.Mutex
-	chans map[primitives.Slot]chan struct{}
-}
-
-func newPayloadAvailability() *payloadAvailability {
-	return &payloadAvailability{chans: make(map[primitives.Slot]chan struct{})}
-}
-
-// waiter returns a channel closed once the payload for slot is available.
-func (p *payloadAvailability) waiter(slot primitives.Slot) <-chan struct{} {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	ch, ok := p.chans[slot]
-	if !ok {
-		ch = make(chan struct{})
-		p.chans[slot] = ch
-	}
-	return ch
-}
-
-// notify releases waiters for slot and prunes older slots. A closed channel is
-// stored so a waiter that registers after the event still observes availability.
-func (p *payloadAvailability) notify(slot primitives.Slot) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	ch, ok := p.chans[slot]
-	if !ok {
-		ch = make(chan struct{})
-		p.chans[slot] = ch
-	}
-	select {
-	case <-ch:
-	default:
-		close(ch)
-	}
-	for s := range p.chans {
-		if s < slot {
-			delete(p.chans, s)
-		}
-	}
-}
-
 // SubmitPayloadAttestation submits a payload attestation message for a PTC member.
 func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitives.Slot, pubKey [fieldparams.BLSPubkeyLength]byte) {
 	ctx, span := trace.StartSpan(ctx, "validator.SubmitPayloadAttestation")
@@ -83,11 +36,11 @@ func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitive
 	data, err := v.validatorClient.PayloadAttestationData(ctx, slot)
 	if err != nil {
 		if status.Code(errors.Cause(err)) == codes.Unavailable {
-			validatorPayloadAttestationSubmissionTotal.WithLabelValues("skipped_no_block").Inc()
+			validatorPayloadAttestationSubmissionTotal.WithLabelValues("skipped_unavailable").Inc()
 			log.WithFields(logrus.Fields{
 				"slot":   slot,
 				"reason": status.Convert(errors.Cause(err)).Message(),
-			}).Info("Skipping payload attestation: beacon node has no head block for slot")
+			}).Info("Skipping payload attestation: data unavailable")
 			tracing.AnnotateError(span, err)
 			return
 		}

--- a/validator/client/payload_attestation_test.go
+++ b/validator/client/payload_attestation_test.go
@@ -66,7 +66,7 @@ func TestSubmitPayloadAttestation_NoHeadBlockForSlot(t *testing.T) {
 			var pubKey [fieldparams.BLSPubkeyLength]byte
 			copy(pubKey[:], validatorKey.PublicKey().Marshal())
 			validator.SubmitPayloadAttestation(t.Context(), 1, pubKey)
-			require.LogsContain(t, hook, "Skipping payload attestation: beacon node has no head block for slot")
+			require.LogsContain(t, hook, "Skipping payload attestation: data unavailable")
 			require.LogsDoNotContain(t, hook, "Could not request payload attestation data")
 		})
 	}

--- a/validator/client/payload_availability.go
+++ b/validator/client/payload_availability.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"sync"
+
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+)
+
+// payloadAvailability releases per-slot waiters when an execution_payload_available
+// event is received, so PTC members can attest as soon as the payload and blobs are
+// available rather than waiting for the attestation deadline.
+type payloadAvailability struct {
+	mu    sync.Mutex
+	chans map[primitives.Slot]chan struct{}
+}
+
+func newPayloadAvailability() *payloadAvailability {
+	return &payloadAvailability{chans: make(map[primitives.Slot]chan struct{})}
+}
+
+// waiter returns a channel closed once the payload for slot is available.
+func (p *payloadAvailability) waiter(slot primitives.Slot) <-chan struct{} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ch, ok := p.chans[slot]
+	if !ok {
+		ch = make(chan struct{})
+		p.chans[slot] = ch
+	}
+	return ch
+}
+
+// notify releases waiters for slot and prunes older slots. A closed channel is
+// stored so a waiter that registers after the event still observes availability.
+func (p *payloadAvailability) notify(slot primitives.Slot) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ch, ok := p.chans[slot]
+	if !ok {
+		ch = make(chan struct{})
+		p.chans[slot] = ch
+	}
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+	for s := range p.chans {
+		if s < slot {
+			delete(p.chans, s)
+		}
+	}
+}

--- a/validator/client/payload_availability_test.go
+++ b/validator/client/payload_availability_test.go
@@ -73,7 +73,7 @@ func TestProcessEvent_ExecutionPayloadAvailableNotifiesWaiter(t *testing.T) {
 
 	data, err := json.Marshal(&structs.ExecutionPayloadAvailableEvent{Slot: "42", BlockRoot: "0xabc"})
 	require.NoError(t, err)
-	v.ProcessEvent(t.Context(), &eventClient.Event{EventType: eventClient.EventExecutionPayload, Data: data})
+	v.ProcessEvent(t.Context(), &eventClient.Event{EventType: eventClient.EventExecutionPayloadAvailable, Data: data})
 
 	require.Equal(t, true, isClosed(ch))
 }
@@ -84,7 +84,7 @@ func TestProcessEvent_ExecutionPayloadBadSlotDoesNotNotify(t *testing.T) {
 
 	data, err := json.Marshal(&structs.ExecutionPayloadAvailableEvent{Slot: "not-a-number", BlockRoot: "0xabc"})
 	require.NoError(t, err)
-	v.ProcessEvent(t.Context(), &eventClient.Event{EventType: eventClient.EventExecutionPayload, Data: data})
+	v.ProcessEvent(t.Context(), &eventClient.Event{EventType: eventClient.EventExecutionPayloadAvailable, Data: data})
 
 	require.Equal(t, false, isClosed(ch))
 }

--- a/validator/client/payload_availability_test.go
+++ b/validator/client/payload_availability_test.go
@@ -1,0 +1,156 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	eventClient "github.com/OffchainLabs/prysm/v7/api/client/event"
+	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestPayloadAvailability_WaiterThenNotify(t *testing.T) {
+	p := newPayloadAvailability()
+	ch := p.waiter(1)
+	require.Equal(t, false, isClosed(ch))
+	p.notify(1)
+	require.Equal(t, true, isClosed(ch))
+}
+
+func TestPayloadAvailability_NotifyThenWaiter(t *testing.T) {
+	p := newPayloadAvailability()
+	p.notify(1)
+	require.Equal(t, true, isClosed(p.waiter(1)), "waiter registered after notify should observe availability")
+}
+
+func TestPayloadAvailability_MultipleWaitersSameSlot(t *testing.T) {
+	p := newPayloadAvailability()
+	a := p.waiter(1)
+	b := p.waiter(1)
+	p.notify(1)
+	require.Equal(t, true, isClosed(a))
+	require.Equal(t, true, isClosed(b))
+}
+
+func TestPayloadAvailability_NotifyIsIdempotent(t *testing.T) {
+	p := newPayloadAvailability()
+	p.waiter(1)
+	p.notify(1)
+	p.notify(1) // must not panic by double-closing.
+}
+
+func TestPayloadAvailability_PrunesOlderSlots(t *testing.T) {
+	p := newPayloadAvailability()
+	p.waiter(1)
+	p.waiter(2)
+	p.notify(3)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, has1 := p.chans[1]
+	_, has2 := p.chans[2]
+	_, has3 := p.chans[3]
+	require.Equal(t, false, has1)
+	require.Equal(t, false, has2)
+	require.Equal(t, true, has3)
+}
+
+func TestProcessEvent_ExecutionPayloadAvailableNotifiesWaiter(t *testing.T) {
+	v := &validator{payloadAvailability: newPayloadAvailability()}
+	ch := v.payloadAvailability.waiter(42)
+
+	data, err := json.Marshal(&structs.ExecutionPayloadAvailableEvent{Slot: "42", BlockRoot: "0xabc"})
+	require.NoError(t, err)
+	v.ProcessEvent(t.Context(), &eventClient.Event{EventType: eventClient.EventExecutionPayload, Data: data})
+
+	require.Equal(t, true, isClosed(ch))
+}
+
+func TestProcessEvent_ExecutionPayloadBadSlotDoesNotNotify(t *testing.T) {
+	v := &validator{payloadAvailability: newPayloadAvailability()}
+	ch := v.payloadAvailability.waiter(42)
+
+	data, err := json.Marshal(&structs.ExecutionPayloadAvailableEvent{Slot: "not-a-number", BlockRoot: "0xabc"})
+	require.NoError(t, err)
+	v.ProcessEvent(t.Context(), &eventClient.Event{EventType: eventClient.EventExecutionPayload, Data: data})
+
+	require.Equal(t, false, isClosed(ch))
+}
+
+func TestWaitForPayloadAvailableOrDeadline_ReturnsOnEvent(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	v := &validator{
+		genesisTime:         time.Now().Add(time.Hour), // deadline far in the future.
+		payloadAvailability: newPayloadAvailability(),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		v.waitForPayloadAvailableOrDeadline(t.Context(), 0)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	v.payloadAvailability.notify(0)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not return after payload available event")
+	}
+}
+
+func TestWaitForPayloadAvailableOrDeadline_ReturnsOnDeadline(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	v := &validator{
+		genesisTime:         time.Time{}, // deadline already elapsed.
+		payloadAvailability: newPayloadAvailability(),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		v.waitForPayloadAvailableOrDeadline(t.Context(), primitives.Slot(1))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not return after deadline elapsed")
+	}
+}
+
+func TestWaitForPayloadAvailableOrDeadline_ReturnsOnContextCancel(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	v := &validator{
+		genesisTime:         time.Now().Add(time.Hour), // deadline far in the future.
+		payloadAvailability: newPayloadAvailability(),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		v.waitForPayloadAvailableOrDeadline(ctx, 0)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not return after context cancellation")
+	}
+}

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -95,6 +95,7 @@ func setupWithKey(t *testing.T, validatorKey bls.SecretKey, isSlashingProtection
 		validatorClient:     m.validatorClient,
 		graffiti:            []byte{},
 		duties:              &dutyStore{},
+		payloadAvailability: newPayloadAvailability(),
 		submittedAtts:       make(map[submittedAttKey]*submittedAtt),
 		submittedAggregates: make(map[submittedAttKey]*submittedAtt),
 		pubkeyToStatus: map[[fieldparams.BLSPubkeyLength]byte]*validatorStatus{

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -232,6 +232,7 @@ func (v *ValidatorService) Start() {
 		disableDutiesPolling:         v.disableDutiesPolling,
 		accountsChangedChannel:       make(chan [][fieldparams.BLSPubkeyLength]byte, 1),
 		eventsChannel:                make(chan *eventClient.Event, 1),
+		payloadAvailability:          newPayloadAvailability(),
 	}
 
 	val := v.validator.(*validator)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -905,7 +905,7 @@ func (v *validator) ProcessEvent(ctx context.Context, event *eventClient.Event) 
 				log.WithError(err).Error("Failed to check dependent roots")
 			}
 		}
-	case eventClient.EventExecutionPayload:
+	case eventClient.EventExecutionPayloadAvailable:
 		payloadEvent := &structs.ExecutionPayloadAvailableEvent{}
 		if err := json.Unmarshal(event.Data, payloadEvent); err != nil {
 			log.WithError(err).Error("Failed to unmarshal execution payload event into JSON")

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -80,6 +80,7 @@ type validator struct {
 	cachedAttestationData        *ethpb.AttestationData
 	accountsChangedChannel       chan [][fieldparams.BLSPubkeyLength]byte
 	eventsChannel                chan *eventClient.Event
+	payloadAvailability          *payloadAvailability
 	highestValidSlot             primitives.Slot
 	submittedAggregates          map[submittedAttKey]*submittedAtt
 	graffitiStruct               *graffiti.Graffiti
@@ -904,6 +905,18 @@ func (v *validator) ProcessEvent(ctx context.Context, event *eventClient.Event) 
 				log.WithError(err).Error("Failed to check dependent roots")
 			}
 		}
+	case eventClient.EventExecutionPayload:
+		payloadEvent := &structs.ExecutionPayloadAvailableEvent{}
+		if err := json.Unmarshal(event.Data, payloadEvent); err != nil {
+			log.WithError(err).Error("Failed to unmarshal execution payload event into JSON")
+			return
+		}
+		uintSlot, err := strconv.ParseUint(payloadEvent.Slot, 10, 64)
+		if err != nil {
+			log.WithError(err).Error("Failed to parse execution payload event slot")
+			return
+		}
+		v.payloadAvailability.notify(primitives.Slot(uintSlot))
 	default:
 		// just keep going and log the error
 		log.WithField("type", event.EventType).WithField("data", string(event.Data)).Warn("Received an unknown event")

--- a/validator/client/wait_helpers.go
+++ b/validator/client/wait_helpers.go
@@ -46,6 +46,33 @@ func (v *validator) waitUntilSlotComponent(ctx context.Context, slot primitives.
 	}
 }
 
+// waitForPayloadAvailableOrDeadline blocks until the execution_payload_available
+// event for slot is received or the payload attestation deadline is reached,
+// whichever comes first.
+func (v *validator) waitForPayloadAvailableOrDeadline(ctx context.Context, slot primitives.Slot) {
+	ctx, span := trace.StartSpan(ctx, "validator.waitForPayloadAvailableOrDeadline")
+	defer span.End()
+
+	deadline, err := v.slotComponentDeadline(slot, params.BeaconConfig().PayloadAttestationDueBPS)
+	if err != nil {
+		log.WithError(err).WithField("slot", slot).Error("Slot overflows, unable to wait for payload attestation deadline")
+		return
+	}
+	available := v.payloadAvailability.waiter(slot)
+	wait := prysmTime.Until(deadline)
+	if wait <= 0 {
+		return
+	}
+	t := time.NewTimer(wait)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		tracing.AnnotateError(span, ctx.Err())
+	case <-available:
+	case <-t.C:
+	}
+}
+
 func (v *validator) slotComponentSpanName(component primitives.BP) string {
 	cfg := params.BeaconConfig()
 	switch component {


### PR DESCRIPTION
This PR changes validator behavior to submit payload attestation as soon as payload and blob are available