### PR TITLE
Request parent payload envelopes in parallel with parent blocks

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -193,6 +193,7 @@ go_test(
         "once_test.go",
         "pending_attestations_queue_bucket_test.go",
         "pending_attestations_queue_test.go",
+        "pending_blocks_queue_payload_envelopes_test.go",
         "pending_blocks_queue_test.go",
         "pending_payload_envelope_test.go",
         "rate_limiter_test.go",

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -422,14 +422,20 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 			}).Debug("Requesting blocks by root")
 		}
 
+		// Optimistically request parent payload envelopes in parallel with the parent blocks.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func(pid core.PeerID, roots p2ptypes.BeaconBlockByRootsReq) {
+			defer wg.Done()
+			s.fetchAndQueuePayloadEnvelopesForRoots(ctx, pid, roots)
+		}(pid, req)
+
 		// Send the request to the peer.
 		if err := s.sendBeaconBlocksRequest(ctx, &req, pid); err != nil {
 			tracing.AnnotateError(span, err)
 			log.WithError(err).Debug("Could not send recent block request")
-		} else {
-			// For post-Gloas blocks received by root, fetch and queue payload envelopes by root.
-			s.fetchAndQueuePayloadEnvelopesForRoots(ctx, pid, req)
 		}
+		wg.Wait()
 
 		// Filter out roots that are already seen in pending blocks.
 		newRoots := make([][32]byte, 0, rootCount)
@@ -479,18 +485,14 @@ func (s *Service) fetchAndQueuePayloadEnvelopesForRoots(
 		log.WithError(err).Debug("Could not compute Gloas start slot")
 		return
 	}
+	// Nothing post-Gloas exists yet, so there are no envelopes to request.
+	if s.cfg.clock.CurrentSlot() < gloasStartSlot {
+		return
+	}
 
 	var envelopeRoots p2ptypes.ExecutionPayloadEnvelopesByRootReq
 	for _, root := range roots {
 		if s.cfg.beaconDB.HasExecutionPayloadEnvelope(ctx, root) {
-			continue
-		}
-		blk, found, err := s.pendingBlockByRoot(root)
-		if err != nil {
-			log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Debug("Could not inspect pending block by root")
-			continue
-		}
-		if !found || blk.Block().Slot() <= gloasStartSlot {
 			continue
 		}
 		envelopeRoots = append(envelopeRoots, root)
@@ -512,27 +514,6 @@ func (s *Service) fetchAndQueuePayloadEnvelopesForRoots(
 		}
 		s.queuePendingPayloadEnvelopeFromRootRequest(env)
 	}
-}
-
-func (s *Service) pendingBlockByRoot(root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, bool, error) {
-	s.pendingQueueLock.RLock()
-	defer s.pendingQueueLock.RUnlock()
-
-	for key := range s.slotToPendingBlocks.Items() {
-		slot := cacheKeyToSlot(key)
-		blks := s.pendingBlocksInCache(slot)
-		for _, blk := range blks {
-			blkRoot, err := blk.Block().HashTreeRoot()
-			if err != nil {
-				return nil, false, errors.Wrap(err, "hash tree root")
-			}
-			if blkRoot == root {
-				return blk, true, nil
-			}
-		}
-	}
-
-	return nil, false, nil
 }
 
 func (s *Service) queuePendingPayloadEnvelopeFromRootRequest(signedEnvelope *ethpb.SignedExecutionPayloadEnvelope) {

--- a/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
@@ -1,0 +1,166 @@
+package sync
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
+	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/libp2p/go-libp2p/core/network"
+)
+
+func makeSignedEnvelope(root [32]byte, slot primitives.Slot) *ethpb.SignedExecutionPayloadEnvelope {
+	return &ethpb.SignedExecutionPayloadEnvelope{
+		Message: &ethpb.ExecutionPayloadEnvelope{
+			Payload: &enginev1.ExecutionPayloadGloas{
+				ParentHash:    make([]byte, fieldparams.RootLength),
+				FeeRecipient:  make([]byte, 20),
+				StateRoot:     make([]byte, fieldparams.RootLength),
+				ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+				LogsBloom:     make([]byte, 256),
+				PrevRandao:    make([]byte, fieldparams.RootLength),
+				BaseFeePerGas: make([]byte, fieldparams.RootLength),
+				BlockHash:     make([]byte, fieldparams.RootLength),
+				SlotNumber:    slot,
+			},
+			BeaconBlockRoot:       root[:],
+			ParentBeaconBlockRoot: make([]byte, fieldparams.RootLength),
+		},
+		Signature: make([]byte, fieldparams.BLSSignatureLength),
+	}
+}
+
+func newEnvelopeFetchService(t *testing.T, p1 p2p.P2P) *Service {
+	chain := &mock.ChainService{
+		ValidatorsRoot: [32]byte{},
+		Genesis:        time.Now(),
+	}
+	r := &Service{
+		cfg: &config{
+			p2p:      p1,
+			beaconDB: dbtest.SetupDB(t),
+			chain:    chain,
+			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+		},
+		pendingPayloadEnvelopes: make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+	}
+	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
+	require.NoError(t, err)
+	r.ctxMap = ctxMap
+	return r
+}
+
+// Post-Gloas: an envelope is requested by root and queued even when no pending
+// block for that root exists in the queue. This locks in the PR's removal of the
+// per-block pendingBlockByRoot gate.
+func TestFetchAndQueuePayloadEnvelopesForRoots_QueuesWithoutPendingBlock(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	params.BeaconConfig().InitializeForkSchedule()
+
+	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+
+	r := newEnvelopeFetchService(t, p1)
+
+	root := [32]byte{0xAA}
+	env := makeSignedEnvelope(root, 1)
+
+	protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	p2.SetStreamHandler(protocolID, func(stream network.Stream) {
+		defer wg.Done()
+		req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+		require.Equal(t, 1, len(*req))
+		assert.Equal(t, root, (*req)[0])
+		assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
+		assert.NoError(t, stream.CloseWrite())
+	})
+
+	r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{root})
+
+	if util.WaitTimeout(&wg, time.Second) {
+		t.Fatal("Did not receive envelope-by-root request within 1 sec")
+	}
+
+	r.pendingEnvelopeLock.RLock()
+	defer r.pendingEnvelopeLock.RUnlock()
+	inner, ok := r.pendingPayloadEnvelopes[root]
+	require.Equal(t, true, ok)
+	require.Equal(t, 1, len(inner))
+	assert.NotNil(t, inner[0])
+}
+
+// Pre-Gloas: the chain-level CurrentSlot() < gloasStartSlot gate short-circuits
+// before any request is sent.
+func TestFetchAndQueuePayloadEnvelopesForRoots_PreGloasNoRequest(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 1_000_000 // far enough ahead that CurrentSlot() is well before it
+	params.OverrideBeaconConfig(cfg)
+	params.BeaconConfig().InitializeForkSchedule()
+
+	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+
+	r := newEnvelopeFetchService(t, p1)
+
+	protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
+	p2.SetStreamHandler(protocolID, func(network.Stream) {
+		t.Error("envelope request should not be sent before Gloas")
+	})
+
+	r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{{0xAA}})
+
+	assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
+}
+
+// Post-Gloas: a root whose envelope is already in the DB is filtered out, so no
+// request is sent for it.
+func TestFetchAndQueuePayloadEnvelopesForRoots_SkipsRootAlreadyInDB(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	params.BeaconConfig().InitializeForkSchedule()
+
+	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+
+	r := newEnvelopeFetchService(t, p1)
+
+	root := bytesutil.ToBytes32([]byte{0xCC})
+	env := makeSignedEnvelope(root, 1)
+	require.NoError(t, r.cfg.beaconDB.SaveExecutionPayloadEnvelope(t.Context(), env))
+
+	protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
+	p2.SetStreamHandler(protocolID, func(network.Stream) {
+		t.Error("no request should be sent for a root already present in the DB")
+	})
+
+	r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{root})
+
+	assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
+}

--- a/changelog/terence_gloas-parallel-parent-payload-fetch.md
+++ b/changelog/terence_gloas-parallel-parent-payload-fetch.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Gloas: request parent payload envelopes by root in parallel with parent blocks when filling pending-block gaps.


### PR DESCRIPTION
- When filling pending block gaps, request the parent's execution payload envelope by root in parallel with the parent block by root, instead of waiting for the block stream to finish first.
- Saves one round-trip sycning to head: a child building on a full parent needs the parent payload, and previously we only requested it after`sendBeaconBlocksRequest` returned
- Replaces the per-block pending-queue slot gate with a chain-level `CurrentSlot() >= gloasStartSlot` check so the envelope request no longer depends on the block already being queued. Removes the now-unused `pendingBlockByRoot` helper.
