### PR TITLE
Replace redundant `WaitGroup` patterns with `WaitGroup.Go`

### DIFF
--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -71,10 +71,8 @@ func (c *AttCaches) aggregateParallel(atts map[attestation.Id][]ethpb.Att, leftO
 
 	n := runtime.GOMAXPROCS(0) // defaults to the value of runtime.NumCPU
 	ch := make(chan []ethpb.Att, n)
-	wg.Add(n)
 	for range n {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for as := range ch {
 				aggregated, err := attaggregation.AggregateDisjointOneBitAtts(as)
 				if err != nil {
@@ -101,7 +99,7 @@ func (c *AttCaches) aggregateParallel(atts map[attestation.Id][]ethpb.Att, leftO
 					leftoverLock.Unlock()
 				}
 			}
-		}()
+		})
 	}
 
 	for _, as := range atts {

--- a/beacon-chain/p2p/broadcaster_test.go
+++ b/beacon-chain/p2p/broadcaster_test.go
@@ -79,9 +79,7 @@ func TestService_Broadcast(t *testing.T) {
 
 	// Async listen for the pubsub, must be before the broadcast.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func(tt *testing.T) {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer cancel()
 
@@ -91,9 +89,9 @@ func TestService_Broadcast(t *testing.T) {
 		result := &ethpb.Fork{}
 		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
 		if !proto.Equal(result, msg) {
-			tt.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
 		}
-	}(t)
+	})
 
 	// Broadcast to peers and wait.
 	require.NoError(t, p.Broadcast(t.Context(), msg))
@@ -196,9 +194,7 @@ func TestService_BroadcastAttestation(t *testing.T) {
 
 	// Async listen for the pubsub, must be before the broadcast.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func(tt *testing.T) {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer cancel()
 
@@ -208,9 +204,9 @@ func TestService_BroadcastAttestation(t *testing.T) {
 		result := &ethpb.Attestation{}
 		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
 		if !proto.Equal(result, msg) {
-			tt.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
 		}
-	}(t)
+	})
 
 	// Attempt to broadcast nil object should fail.
 	ctx := t.Context()
@@ -386,21 +382,19 @@ func TestService_BroadcastAttestationWithDiscoveryAttempts(t *testing.T) {
 
 	// Async listen for the pubsub, must be before the broadcast.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func(tt *testing.T) {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 4*time.Second)
 		defer cancel()
 
 		incomingMessage, err := sub.Next(ctx)
-		require.NoError(tt, err)
+		require.NoError(t, err)
 
 		result := &ethpb.Attestation{}
-		require.NoError(tt, p.Encoding().DecodeGossip(incomingMessage.Data, result))
+		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
 		if !proto.Equal(result, msg) {
-			tt.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
 		}
-	}(t)
+	})
 
 	// Broadcast to peers and wait.
 	require.NoError(t, p.BroadcastAttestation(t.Context(), subnet, msg))
@@ -452,9 +446,7 @@ func TestService_BroadcastSyncCommittee(t *testing.T) {
 
 	// Async listen for the pubsub, must be before the broadcast.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func(tt *testing.T) {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer cancel()
 
@@ -464,9 +456,9 @@ func TestService_BroadcastSyncCommittee(t *testing.T) {
 		result := &ethpb.SyncCommitteeMessage{}
 		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
 		if !proto.Equal(result, msg) {
-			tt.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
 		}
-	}(t)
+	})
 
 	// Broadcasting nil should fail.
 	ctx := t.Context()
@@ -532,9 +524,7 @@ func TestService_BroadcastBlob(t *testing.T) {
 
 	// Async listen for the pubsub, must be before the broadcast.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func(tt *testing.T) {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer cancel()
 
@@ -544,7 +534,7 @@ func TestService_BroadcastBlob(t *testing.T) {
 		result := &ethpb.BlobSidecar{}
 		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
 		require.DeepEqual(t, result, blobSidecar)
-	}(t)
+	})
 
 	// Attempt to broadcast nil object should fail.
 	ctx := t.Context()
@@ -598,9 +588,7 @@ func TestService_BroadcastLightClientOptimisticUpdate(t *testing.T) {
 
 	// Async listen for the pubsub, must be before the broadcast.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func(tt *testing.T) {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
 		defer cancel()
 
@@ -611,15 +599,15 @@ func TestService_BroadcastLightClientOptimisticUpdate(t *testing.T) {
 		require.NoError(t, err)
 		expectedDelay := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().SyncMessageDueBPS)
 		if time.Now().Before(slotStartTime.Add(expectedDelay)) {
-			tt.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
+			t.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
 		}
 
 		result := &ethpb.LightClientOptimisticUpdateAltair{}
 		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
 		if !proto.Equal(result, msg.Proto()) {
-			tt.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
 		}
-	}(t)
+	})
 
 	// Broadcasting nil should fail.
 	ctx := t.Context()
@@ -677,9 +665,7 @@ func TestService_BroadcastLightClientFinalityUpdate(t *testing.T) {
 
 	// Async listen for the pubsub, must be before the broadcast.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func(tt *testing.T) {
-		defer wg.Done()
+	wg.Go(func() {
 		ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
 		defer cancel()
 
@@ -690,15 +676,15 @@ func TestService_BroadcastLightClientFinalityUpdate(t *testing.T) {
 		require.NoError(t, err)
 		expectedDelay := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().SyncMessageDueBPS)
 		if time.Now().Before(slotStartTime.Add(expectedDelay)) {
-			tt.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
+			t.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
 		}
 
 		result := &ethpb.LightClientFinalityUpdateAltair{}
 		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
 		if !proto.Equal(result, msg.Proto()) {
-			tt.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
 		}
-	}(t)
+	})
 
 	// Broadcasting nil should fail.
 	ctx := t.Context()

--- a/beacon-chain/rpc/core/validator_test.go
+++ b/beacon-chain/rpc/core/validator_test.go
@@ -337,14 +337,12 @@ func TestPayloadAttestationData(t *testing.T) {
 		start := make(chan struct{})
 		var wg sync.WaitGroup
 		for i := range callers {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				<-start
 				resp, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 				require.IsNil(t, rpcErr)
 				results[i] = resp
-			}(i)
+			})
 		}
 		close(start)
 		wg.Wait()

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
@@ -375,14 +375,12 @@ func BenchmarkGetAttestationDataConcurrent(b *testing.B) {
 
 	for b.Loop() {
 		var wg sync.WaitGroup
-		wg.Add(5000) // for 5000 concurrent accesses
 
 		for range 5000 {
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				_, err := attesterServer.GetAttestationData(b.Context(), req)
 				require.NoError(b, err, "Could not get attestation info at slot")
-			}()
+			})
 		}
 		wg.Wait() // Wait for all goroutines to finish
 	}

--- a/beacon-chain/sync/backfill/log_test.go
+++ b/beacon-chain/sync/backfill/log_test.go
@@ -256,12 +256,10 @@ func TestConcurrentLogging(t *testing.T) {
 	var wg sync.WaitGroup
 	wait := make(chan struct{})
 	for range 10 {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			<-wait
-			defer wg.Done()
 			il.Log(logrus.InfoLevel, "concurrent message")
-		}()
+		})
 	}
 	close(wait) // maximize raciness by unblocking goroutines together
 	wg.Wait()

--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -743,11 +743,8 @@ func fetchDataColumnSidecarsFromPeers(
 	)
 
 	roDataColumnsByPeer := make(map[goPeer.ID][]blocks.RODataColumn)
-	wg.Add(len(indicesByRootByPeer))
 	for peerID, indicesByRoot := range indicesByRootByPeer {
-		go func(peerID goPeer.ID, indicesByRoot map[[fieldparams.RootLength]byte]map[uint64]bool) {
-			defer wg.Done()
-
+		wg.Go(func() {
 			requestedCount := 0
 			for _, indices := range indicesByRoot {
 				requestedCount += len(indices)
@@ -769,7 +766,7 @@ func fetchDataColumnSidecarsFromPeers(
 			mut.Lock()
 			defer mut.Unlock()
 			roDataColumnsByPeer[peerID] = roDataColumns
-		}(peerID, indicesByRoot)
+		})
 	}
 
 	wg.Wait()

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -33,11 +33,8 @@ func (s *Service) maintainPeerStatuses() {
 	interval := time.Duration(params.BeaconConfig().SlotsPerEpoch.Div(2).Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
 	async.RunEvery(s.ctx, interval, func() {
 		wg := new(sync.WaitGroup)
-		for _, pid := range s.cfg.p2p.Peers().Connected() {
-			wg.Add(1)
-			go func(id peer.ID) {
-				defer wg.Done()
-
+		for _, id := range s.cfg.p2p.Peers().Connected() {
+			wg.Go(func() {
 				log := log.WithFields(logrus.Fields{
 					"peer":  id,
 					"agent": agentString(id, s.cfg.p2p.Host()),
@@ -73,7 +70,7 @@ func (s *Service) maintainPeerStatuses() {
 						log.WithError(err).Debug("Cannot re-validate peer")
 					}
 				}
-			}(pid)
+			})
 		}
 		// Wait for all status checks to finish and then proceed onwards to
 		// pruning excess peers.

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -361,15 +361,13 @@ func (s *Service) Stop() error {
 
 	// Use WaitGroup to ensure all goodbye messages complete
 	var wg sync.WaitGroup
-	for _, peerID := range s.cfg.p2p.Peers().Connected() {
-		if s.cfg.p2p.Host().Network().Connectedness(peerID) == network.Connected {
-			wg.Add(1)
-			go func(pid peer.ID) {
-				defer wg.Done()
+	for _, pid := range s.cfg.p2p.Peers().Connected() {
+		if s.cfg.p2p.Host().Network().Connectedness(pid) == network.Connected {
+			wg.Go(func() {
 				if err := s.sendGoodByeAndDisconnect(goodbyeCtx, p2ptypes.GoodbyeCodeClientShutdown, pid); err != nil {
 					log.WithError(err).WithField("peerID", pid).Error("Failed to send goodbye message")
 				}
-			}(peerID)
+			})
 		}
 	}
 	wg.Wait()

--- a/changelog/syjn99_waitgroup-go.md
+++ b/changelog/syjn99_waitgroup-go.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use `sync.WaitGroup.Go` (Go 1.25) in place of the `wg.Add(1)` / `go func() { defer wg.Done(); ... }()` spawn-then-wait boilerplate.

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -47,16 +47,13 @@ func TestConfig_DataRace(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	wg := new(sync.WaitGroup)
 	for range 10 {
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			cfg := params.BeaconConfig()
 			params.OverrideBeaconConfig(cfg)
-		}()
-		go func() uint64 {
-			defer wg.Done()
-			return params.BeaconConfig().MaxDeposits
-		}()
+		})
+		wg.Go(func() {
+			_ = params.BeaconConfig().MaxDeposits
+		})
 	}
 	wg.Wait()
 }

--- a/consensus-types/hdiff/security_test.go
+++ b/consensus-types/hdiff/security_test.go
@@ -331,18 +331,15 @@ func TestConcurrencySafety(t *testing.T) {
 		var wg sync.WaitGroup
 		errors := make(chan error, numGoroutines*iterations)
 
-		for i := range numGoroutines {
-			wg.Add(1)
-			go func(workerID int) {
-				defer wg.Done()
-
+		for workerID := range numGoroutines {
+			wg.Go(func() {
 				for j := range iterations {
 					_, err := Diff(source, target)
 					if err != nil {
 						errors <- fmt.Errorf("worker %d iteration %d: %v", workerID, j, err)
 					}
 				}
-			}(i)
+			})
 		}
 
 		wg.Wait()
@@ -367,18 +364,15 @@ func TestConcurrencySafety(t *testing.T) {
 		var wg sync.WaitGroup
 		errors := make(chan error, numGoroutines)
 
-		for i := range numGoroutines {
-			wg.Add(1)
-			go func(workerID int) {
-				defer wg.Done()
-
+		for workerID := range numGoroutines {
+			wg.Go(func() {
 				// Each goroutine needs its own copy of the source state
 				localSource := source.Copy()
 				_, err := ApplyDiff(ctx, localSource, diff)
 				if err != nil {
 					errors <- fmt.Errorf("worker %d: %v", workerID, err)
 				}
-			}(i)
+			})
 		}
 
 		wg.Wait()

--- a/container/thread-safe/map_test.go
+++ b/container/thread-safe/map_test.go
@@ -86,20 +86,17 @@ func TestMap(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 100 {
-		wg.Add(1)
-		go func(w *sync.WaitGroup, scopedMap *Map[int, string]) {
-			defer w.Done()
-			v, ok := scopedMap.Get(1)
+		wg.Go(func() {
+			v, ok := tMap.Get(1)
 			require.Equal(t, true, ok)
 			require.Equal(t, "foo", v)
 
-			scopedMap.Put(3, "nyan")
+			tMap.Put(3, "nyan")
 
-			v, ok = scopedMap.Get(3)
+			v, ok = tMap.Get(3)
 			require.Equal(t, true, ok)
 			require.Equal(t, "nyan", v)
-
-		}(&wg, tMap)
+		})
 	}
 	wg.Wait()
 

--- a/tools/exploredb/main.go
+++ b/tools/exploredb/main.go
@@ -194,10 +194,8 @@ func readBucketStat(dbNameWithPath string, statsC chan<- *bucketStat) {
 	// for every bucket, calculate the stats and send it for printing.
 	// calculate the state of all the buckets in parallel.
 	var wg sync.WaitGroup
-	for _, bName := range buckets {
-		wg.Add(1)
-		go func(bukName string) {
-			defer wg.Done()
+	for _, bukName := range buckets {
+		wg.Go(func() {
 			count := uint64(0)
 			minValueSize := ^uint64(0)
 			maxValueSize := uint64(0)
@@ -247,7 +245,7 @@ func readBucketStat(dbNameWithPath string, statsC chan<- *bucketStat) {
 				maxValueSize:   maxValueSize,
 			}
 			statsC <- stat
-		}(bName)
+		})
 	}
 	wg.Wait()
 	close(statsC)

--- a/validator/client/aggregator_selector_test.go
+++ b/validator/client/aggregator_selector_test.go
@@ -95,12 +95,10 @@ func TestLocalSelector_AttestationSelectionProof_ConcurrentDedup(t *testing.T) {
 	results := make([][]byte, goroutines)
 	errs := make([]error, goroutines)
 
-	wg.Add(goroutines)
-	for i := range goroutines {
-		go func(idx int) {
-			defer wg.Done()
+	for idx := range goroutines {
+		wg.Go(func() {
 			results[idx], errs[idx] = s.AttestationSelectionProof(t.Context(), slot, pubKey)
-		}(i)
+		})
 	}
 	wg.Wait()
 

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/api/client"
-	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -237,10 +236,8 @@ func initialize(ctx context.Context, v iface.Validator) error {
 
 func performRoles(slotCtx context.Context, allRoles map[[48]byte][]iface.ValidatorRole, v iface.Validator, slot primitives.Slot, wg *sync.WaitGroup, span trace.Span) {
 	for pubKey, roles := range allRoles {
-		wg.Add(len(roles))
 		for _, role := range roles {
-			go func(role iface.ValidatorRole, pubKey [fieldparams.BLSPubkeyLength]byte) {
-				defer wg.Done()
+			wg.Go(func() {
 				switch role {
 				case iface.RoleAttester:
 					v.SubmitAttestation(slotCtx, slot, pubKey)
@@ -259,7 +256,7 @@ func performRoles(slotCtx context.Context, allRoles map[[48]byte][]iface.Validat
 				default:
 					log.Warnf("Unhandled role %v", role)
 				}
-			}(role, pubKey)
+			})
 		}
 	}
 

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -3373,12 +3373,10 @@ func TestGetAttestationData_PostElectraConcurrentAccess(t *testing.T) {
 	results := make([]*ethpb.AttestationData, numGoroutines)
 	errs := make([]error, numGoroutines)
 
-	for i := range numGoroutines {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+	for idx := range numGoroutines {
+		wg.Go(func() {
 			results[idx], errs[idx] = v.getAttestationData(context.Background(), postElectraSlot, primitives.CommitteeIndex(idx))
-		}(i)
+		})
 	}
 
 	wg.Wait()

--- a/validator/db/filesystem/attester_protection_test.go
+++ b/validator/db/filesystem/attester_protection_test.go
@@ -493,15 +493,11 @@ func BenchmarkStore_SaveAttestationForPubKey(b *testing.B) {
 		err := validatorDB.ClearDB()
 		require.NoError(b, err)
 
-		for _, pubkey := range pubkeys {
-			wg.Add(1)
-
-			go func(pk [fieldparams.BLSPubkeyLength]byte) {
-				defer wg.Done()
-
+		for _, pk := range pubkeys {
+			wg.Go(func() {
 				err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, attestation)
 				require.NoError(b, err)
-			}(pubkey)
+			})
 		}
 
 		b.StartTimer()

--- a/validator/db/kv/attester_protection_test.go
+++ b/validator/db/kv/attester_protection_test.go
@@ -382,15 +382,14 @@ func TestSaveAttestationForPubKey_BatchWrites_FullCapacity(t *testing.T) {
 	// For each public key, we attempt to save an attestation with signing root.
 	var wg sync.WaitGroup
 	for i, pubKey := range pubKeys {
-		wg.Add(1)
-		go func(j primitives.Epoch, pk [fieldparams.BLSPubkeyLength]byte, w *sync.WaitGroup) {
-			defer w.Done()
+		wg.Go(func() {
+			j := primitives.Epoch(i)
 			var signingRoot [32]byte
 			copy(signingRoot[:], fmt.Sprintf("%d", j))
 			att := createAttestation(j, j+1)
-			err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, att)
+			err := validatorDB.SaveAttestationForPubKey(ctx, pubKey, signingRoot, att)
 			require.NoError(t, err)
-		}(primitives.Epoch(i), pubKey, &wg)
+		})
 	}
 	wg.Wait()
 
@@ -439,15 +438,14 @@ func TestSaveAttestationForPubKey_BatchWrites_LowCapacity_TimerReached(t *testin
 	// For each public key, we attempt to save an attestation with signing root.
 	var wg sync.WaitGroup
 	for i, pubKey := range pubKeys {
-		wg.Add(1)
-		go func(j primitives.Epoch, pk [fieldparams.BLSPubkeyLength]byte, w *sync.WaitGroup) {
-			defer w.Done()
+		wg.Go(func() {
+			j := primitives.Epoch(i)
 			var signingRoot [32]byte
 			copy(signingRoot[:], fmt.Sprintf("%d", j))
 			att := createAttestation(j, j+1)
-			err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, att)
+			err := validatorDB.SaveAttestationForPubKey(ctx, pubKey, signingRoot, att)
 			require.NoError(t, err)
-		}(primitives.Epoch(i), pubKey, &wg)
+		})
 	}
 	wg.Wait()
 
@@ -599,15 +597,11 @@ func BenchmarkStore_SaveAttestationForPubKey(b *testing.B) {
 		err := validatorDB.ClearDB()
 		require.NoError(b, err)
 
-		for _, pubkey := range pubkeys {
-			wg.Add(1)
-
-			go func(pk [fieldparams.BLSPubkeyLength]byte) {
-				defer wg.Done()
-
+		for _, pk := range pubkeys {
+			wg.Go(func() {
 				err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, attestation)
 				require.NoError(b, err)
-			}(pubkey)
+			})
 		}
 
 		b.StartTimer()


### PR DESCRIPTION
**What type of PR is this?**

> Other: Cleanup

**What does this PR do? Why is it needed?**

Using `sync.WaitGroup.Go` in favor of boilterplate pattern (`wg.Add(N)` - `go func()` - `defer wg.Done()`).

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

- This has no functional change: more than a cosmetic one to reduce few lines of codebase and setting up a criteria for the future works.
- There are some exceptions: e.g., calling `wg.Done()` in the other caller. This PR doesn't try to refactor all those exceptions.
- Per the Go 1.22 loop-var change, each loop iteration now has its own scoped copy of the loop variable (default for modules on go 1.22+; this repo is on go 1.25), so the old per-iteration snapshot workaround - passing the loop variable as a goroutine argument - is no longer needed and capturing it directly in `wg.Go(func(){ … })` is equivalent.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
