### PR TITLE
Evict per-peer RPC rate-limiter buckets on disconnect

### DIFF
--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -223,6 +223,17 @@ func (l *limiter) free() {
 	}
 }
 
+// removePeer reclaims the per-peer leaky buckets on disconnect
+func (l *limiter) removePeer(pid peer.ID) {
+	l.Lock()
+	defer l.Unlock()
+
+	key := pid.String()
+	for _, collector := range l.limiterMap {
+		collector.Remove(key)
+	}
+}
+
 // not to be used outside the rate limiter file as it is unsafe for concurrent usage
 // and is protected by a lock on all of its usages here.
 func (l *limiter) retrieveCollector(topic string) (*leakybucket.Collector, error) {

--- a/beacon-chain/sync/rate_limiter_test.go
+++ b/beacon-chain/sync/rate_limiter_test.go
@@ -110,3 +110,16 @@ func Test_limiter_retrieveCollector_requiresLock(t *testing.T) {
 	_, err := l.retrieveCollector("")
 	require.ErrorContains(t, "caller must hold read/write lock", err)
 }
+
+func TestRateLimiter_RemovePeer(t *testing.T) {
+	p1 := mockp2p.NewTestP2P(t)
+	rlimiter := newRateLimiter(p1)
+	pid := p1.PeerID()
+
+	c := rlimiter.limiterMap[rpcLimiterTopic]
+	c.Add(pid.String(), 1)
+	require.Equal(t, int64(1), c.Count(pid.String()))
+
+	rlimiter.removePeer(pid)
+	require.Equal(t, int64(0), c.Count(pid.String()))
+}

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -316,8 +316,8 @@ func (s *Service) Start() {
 	go s.processDataColumnLogs()
 
 	s.cfg.p2p.AddConnectionHandler(s.reValidatePeer, s.sendGoodbye)
-	s.cfg.p2p.AddDisconnectionHandler(func(_ context.Context, _ peer.ID) error {
-		// no-op
+	s.cfg.p2p.AddDisconnectionHandler(func(_ context.Context, id peer.ID) error {
+		s.rateLimiter.removePeer(id)
 		return nil
 	})
 	s.cfg.p2p.AddPingMethod(s.sendPingRequest)

--- a/changelog/terence_fix-rpc-rate-limiter-bucket-eviction.md
+++ b/changelog/terence_fix-rpc-rate-limiter-bucket-eviction.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Reclaim per-peer RPC rate-limiter leaky buckets on disconnect to prevent unbounded memory growth from connection churn.


### PR DESCRIPTION
This PR cleans up RPC rate-limiter state on peer disconnect previously they were retained for the node's lifetime