### PR TITLE
Reverse wrong usage of `errors.Is` arguments after `validateBeaconBlock`

### DIFF
--- a/beacon-chain/p2p/peers/scorers/peer_status.go
+++ b/beacon-chain/p2p/peers/scorers/peer_status.go
@@ -88,9 +88,9 @@ func (s *PeerStatusScorer) isBadPeerNoLock(pid peer.ID) error {
 		p2ptypes.ErrInvalidRequest,
 	}
 
-	for _, err := range terminalErrs {
-		if errors.Is(peerData.ChainStateValidationError, err) {
-			return err
+	for _, terminalErr := range terminalErrs {
+		if errors.Is(peerData.ChainStateValidationError, terminalErr) {
+			return terminalErr
 		}
 	}
 

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -250,7 +250,7 @@ func (s *Service) processBlock(ctx context.Context, b interfaces.ReadOnlySignedB
 	blockSlot := b.Block().Slot()
 
 	if err := s.validateBeaconBlock(ctx, b, blkRoot); err != nil {
-		if !errors.Is(ErrOptimisticParent, err) {
+		if !errors.Is(err, ErrOptimisticParent) {
 			log.WithError(err).WithField("slot", blockSlot).Debug("Could not validate block")
 			return err
 		}

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -237,7 +237,7 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 			log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not validate beacon block")
 			return pubsub.ValidationReject, err
 		}
-		if !errors.Is(ErrOptimisticParent, err) {
+		if !errors.Is(err, ErrOptimisticParent) {
 			log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not validate beacon block")
 			return pubsub.ValidationIgnore, err
 		}

--- a/changelog/syjn99_chore-correct-errors-is.md
+++ b/changelog/syjn99_chore-correct-errors-is.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Swap `err` and `target` argument for function `errors.Is`.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

`errors.Is` receives target error as the second argument: If we **wrap** an error `ErrOptimisticParent` (in the future, e.g., `fmt.Errorf` or `errors.Wrap`), the gate won't work as we expected. Currently we don't wrap the error, so no functional behavior changes at this moment but will reduce an debugging effort in the future.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

Example:

```go
func TestReversedArgs(t *testing.T) {
	err := fmt.Errorf("could not validate bellatrix block: %w", ErrOptimisticParent)

	if errors.Is(err, ErrOptimisticParent) {
		fmt.Println("THIS LINE SHOULD BE PRINTED, AS EXPECTED")
	}

	if errors.Is(ErrOptimisticParent, err) {
		// Current behavior: `errors.Is` is wrongly used.
		fmt.Println("THIS LINE WON'T BE PRINTED")
	}
}
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
