### PR TITLE
Adopt `testing/synctest` in `beacon-chain/sync` test package: Remove waiting for random time

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -343,7 +343,11 @@ func (s *Service) waitForMinimumPeers() ([]peer.ID, error) {
 			"suitable": len(peers),
 			"required": required,
 		}).Info("Waiting for enough suitable peers before syncing")
-		time.Sleep(handshakePollingInterval)
+		select {
+		case <-s.ctx.Done():
+			return nil, s.ctx.Err()
+		case <-time.After(handshakePollingInterval):
+		}
 	}
 }
 

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/async/abool"
@@ -59,19 +60,19 @@ func TestService_InitStartStop(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		assert       func()
+		assert       func(*testing.T)
 		setGenesis   func() *startup.Clock
-		chainService func() *mock.ChainService
+		chainService func(*testing.T) *mock.ChainService
 	}{
 		{
 			name: "head is not ready",
-			assert: func() {
+			assert: func(t *testing.T) {
 				assert.LogsContain(t, hook, "Waiting for state to be initialized")
 			},
 		},
 		{
 			name: "future genesis",
-			chainService: func() *mock.ChainService {
+			chainService: func(t *testing.T) *mock.ChainService {
 				// Set to future time (genesis time hasn't arrived yet).
 				st, err := util.NewBeaconState()
 				require.NoError(t, err)
@@ -89,14 +90,14 @@ func TestService_InitStartStop(t *testing.T) {
 				var vr [32]byte
 				return startup.NewClock(time.Unix(4113849600, 0), vr)
 			},
-			assert: func() {
+			assert: func(t *testing.T) {
 				assert.LogsContain(t, hook, "Genesis time has not arrived - not syncing")
 				assert.LogsContain(t, hook, "Waiting for state to be initialized")
 			},
 		},
 		{
 			name: "zeroth epoch",
-			chainService: func() *mock.ChainService {
+			chainService: func(t *testing.T) *mock.ChainService {
 				// Set to nearby slot.
 				st, err := util.NewBeaconState()
 				require.NoError(t, err)
@@ -113,7 +114,7 @@ func TestService_InitStartStop(t *testing.T) {
 				var vr [32]byte
 				return startup.NewClock(time.Now().Add(-5*time.Minute), vr)
 			},
-			assert: func() {
+			assert: func(t *testing.T) {
 				assert.LogsContain(t, hook, "Chain started within the last epoch - not syncing")
 				assert.LogsDoNotContain(t, hook, "Genesis time has not arrived - not syncing")
 				assert.LogsContain(t, hook, "Waiting for state to be initialized")
@@ -121,7 +122,7 @@ func TestService_InitStartStop(t *testing.T) {
 		},
 		{
 			name: "already synced",
-			chainService: func() *mock.ChainService {
+			chainService: func(t *testing.T) *mock.ChainService {
 				// Set to some future slot, and then make sure that current head matches it.
 				st, err := util.NewBeaconState()
 				require.NoError(t, err)
@@ -141,7 +142,7 @@ func TestService_InitStartStop(t *testing.T) {
 				var vr [32]byte
 				return startup.NewClock(makeGenesisTime(futureSlot), vr)
 			},
-			assert: func() {
+			assert: func(t *testing.T) {
 				assert.LogsContain(t, hook, "Starting initial chain sync...")
 				assert.LogsContain(t, hook, "Already synced to the current chain head")
 				assert.LogsDoNotContain(t, hook, "Chain started within the last epoch - not syncing")
@@ -155,48 +156,42 @@ func TestService_InitStartStop(t *testing.T) {
 	connectPeers(t, p, []*peerData{}, p.Peers())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer hook.Reset()
-			ctx, cancel := context.WithCancel(t.Context())
-			defer cancel()
-			mc := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-			// Allow overriding with customized chain service.
-			if tt.chainService != nil {
-				mc = tt.chainService()
-			}
-			// Initialize feed
-			gs := startup.NewClockSynchronizer()
-			s := NewService(ctx, &Config{
-				P2P:                 p,
-				Chain:               mc,
-				ClockWaiter:         gs,
-				StateNotifier:       &mock.MockStateNotifier{},
-				InitialSyncComplete: make(chan struct{}),
-			})
-			s.verifierWaiter = verification.NewInitializerWaiter(gs, nil, nil, nil)
-
-			s.blobRetentionChecker = func(primitives.Slot) bool { return true }
-			time.Sleep(500 * time.Millisecond)
-			assert.NotNil(t, s)
-			if tt.setGenesis != nil {
-				require.NoError(t, gs.SetClock(tt.setGenesis()))
-			}
-
-			wg := &sync.WaitGroup{}
-			wg.Go(func() {
-				s.Start()
-			})
-
-			go func() {
-				// Allow to exit from test (on no head loop waiting for head is started).
-				// In most tests, this is redundant, as Start() already exited.
-				time.AfterFunc(3*time.Second, func() {
-					cancel()
+			synctest.Test(t, func(t *testing.T) {
+				defer hook.Reset()
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				mc := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+				// Allow overriding with customized chain service.
+				if tt.chainService != nil {
+					mc = tt.chainService(t)
+				}
+				// Initialize feed
+				gs := startup.NewClockSynchronizer()
+				s := NewService(ctx, &Config{
+					P2P:                 p,
+					Chain:               mc,
+					ClockWaiter:         gs,
+					StateNotifier:       &mock.MockStateNotifier{},
+					InitialSyncComplete: make(chan struct{}),
 				})
-			}()
-			if util.WaitTimeout(wg, time.Second*4) {
-				t.Fatalf("Test should have exited by now, timed out")
-			}
-			tt.assert()
+				s.verifierWaiter = verification.NewInitializerWaiter(gs, nil, nil, nil)
+
+				s.blobRetentionChecker = func(primitives.Slot) bool { return true }
+				assert.NotNil(t, s)
+				if tt.setGenesis != nil {
+					require.NoError(t, gs.SetClock(tt.setGenesis()))
+				}
+
+				wg := &sync.WaitGroup{}
+				wg.Go(func() {
+					s.Start()
+				})
+
+				// Allow the no-head case to exit after reaching the clock wait.
+				time.AfterFunc(3*time.Second, cancel)
+				wg.Wait()
+				tt.assert(t)
+			})
 		})
 	}
 }
@@ -224,82 +219,82 @@ func useMinimalInitialSyncConfig(t *testing.T) {
 	})
 }
 
-func newClockAtSlot(slot primitives.Slot) (*startup.Clock, time.Time) {
-	genesisTime := time.Unix(1_700_000_000, 0)
-	var validatorsRoot [32]byte
-	return startup.NewClock(genesisTime, validatorsRoot, startup.WithSlotAsNow(slot)), genesisTime
-}
-
 // TestService_Start_DoesNotMarkSyncedWhenStillBehindInSameEpoch verifies startup does not skip sync when head and current slot share an epoch but differ by slots.
 func TestService_Start_DoesNotMarkSyncedWhenStillBehindInSameEpoch(t *testing.T) {
 	useMinimalInitialSyncConfig(t)
+	p := p2ptest.NewTestP2P(t)
 
-	headSlot := primitives.Slot(88)
-	currentSlot := primitives.Slot(95)
+	synctest.Test(t, func(t *testing.T) {
+		headSlot := primitives.Slot(88)
+		currentSlot := primitives.Slot(95)
 
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, st.SetSlot(headSlot))
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, st.SetSlot(headSlot))
 
-	clock, genesisTime := newClockAtSlot(currentSlot)
-	gs := startup.NewClockSynchronizer()
-	require.NoError(t, gs.SetClock(clock))
+		genesisTime := time.Now().Add(-time.Hour)
+		var validatorsRoot [32]byte
+		clock := startup.NewClock(genesisTime, validatorsRoot, startup.WithSlotAsNow(currentSlot))
+		gs := startup.NewClockSynchronizer()
+		require.NoError(t, gs.SetClock(clock))
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	initialSyncComplete := make(chan struct{})
-	mc := &mock.ChainService{
-		State: st,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-		Genesis:        genesisTime,
-		ValidatorsRoot: [32]byte{},
-	}
+		initialSyncComplete := make(chan struct{})
+		mc := &mock.ChainService{
+			State: st,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+			Genesis:        genesisTime,
+			ValidatorsRoot: [32]byte{},
+		}
 
-	s := NewService(ctx, &Config{
-		P2P:                 p2ptest.NewTestP2P(t),
-		Chain:               mc,
-		ClockWaiter:         gs,
-		StateNotifier:       &mock.MockStateNotifier{},
-		InitialSyncComplete: initialSyncComplete,
+		s := NewService(ctx, &Config{
+			P2P:                 p,
+			Chain:               mc,
+			ClockWaiter:         gs,
+			StateNotifier:       &mock.MockStateNotifier{},
+			InitialSyncComplete: initialSyncComplete,
+		})
+		s.verifierWaiter = verification.NewInitializerWaiter(gs, nil, nil, nil)
+		s.blobRetentionChecker = func(primitives.Slot) bool { return true }
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			s.Start()
+		}()
+
+		synctest.Wait()
+
+		select {
+		case <-done:
+			t.Fatal("initial sync exited early while the node was still seven slots behind in the current epoch")
+		default:
+		}
+		require.Equal(t, true, s.Syncing(), "service should still be syncing while behind in the current epoch")
+		require.Equal(t, false, s.Synced(), "service should not report synced while behind in the current epoch")
+		select {
+		case <-initialSyncComplete:
+			t.Fatal("service closed InitialSyncComplete while still behind in the current epoch")
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("initial sync did not stop after context cancellation")
+		}
 	})
-	s.verifierWaiter = verification.NewInitializerWaiter(gs, nil, nil, nil)
-	s.blobRetentionChecker = func(primitives.Slot) bool { return true }
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		s.Start()
-	}()
-
-	time.Sleep(200 * time.Millisecond)
-
-	select {
-	case <-done:
-		t.Fatal("initial sync exited early while the node was still seven slots behind in the current epoch")
-	default:
-	}
-	require.Equal(t, true, s.Syncing(), "service should still be syncing while behind in the current epoch")
-	require.Equal(t, false, s.Synced(), "service should not report synced while behind in the current epoch")
-	select {
-	case <-initialSyncComplete:
-		t.Fatal("service closed InitialSyncComplete while still behind in the current epoch")
-	default:
-	}
-
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(6 * time.Second):
-		t.Fatal("initial sync did not stop after context cancellation")
-	}
 }
 
 func TestService_waitForStateInitialization(t *testing.T) {
 	hook := logTest.NewGlobal()
-	newService := func(ctx context.Context, mc *mock.ChainService) (*Service, *startup.ClockSynchronizer) {
+	newService := func(t *testing.T, ctx context.Context, mc *mock.ChainService) (*Service, *startup.ClockSynchronizer) {
 		cs := startup.NewClockSynchronizer()
 		ctx, cancel := context.WithCancel(ctx)
 		s := &Service{
@@ -323,86 +318,80 @@ func TestService_waitForStateInitialization(t *testing.T) {
 	}
 
 	t.Run("no state and context close", func(t *testing.T) {
-		defer hook.Reset()
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		synctest.Test(t, func(t *testing.T) {
+			defer hook.Reset()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
 
-		s, _ := newService(ctx, &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}})
-		s.blobRetentionChecker = func(primitives.Slot) bool { return true }
-		wg := &sync.WaitGroup{}
-		wg.Go(func() {
-			s.Start()
-		})
-		go func() {
-			time.AfterFunc(500*time.Millisecond, func() {
-				cancel()
+			s, _ := newService(t, ctx, &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}})
+			s.blobRetentionChecker = func(primitives.Slot) bool { return true }
+			wg := &sync.WaitGroup{}
+			wg.Go(func() {
+				s.Start()
 			})
-		}()
+			time.AfterFunc(500*time.Millisecond, cancel)
 
-		if util.WaitTimeout(wg, time.Second*2) {
-			t.Fatalf("Test should have exited by now, timed out")
-		}
-		assert.LogsContain(t, hook, "Waiting for state to be initialized")
-		assert.LogsContain(t, hook, "Initial-sync failed to receive startup event")
-		assert.LogsDoNotContain(t, hook, "Subscription to state notifier failed")
+			wg.Wait()
+			assert.LogsContain(t, hook, "Waiting for state to be initialized")
+			assert.LogsContain(t, hook, "Initial-sync failed to receive startup event")
+			assert.LogsDoNotContain(t, hook, "Subscription to state notifier failed")
+		})
 	})
 
 	t.Run("no state and state init event received", func(t *testing.T) {
-		defer hook.Reset()
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		synctest.Test(t, func(t *testing.T) {
+			defer hook.Reset()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
 
-		st, err := util.NewBeaconState()
-		require.NoError(t, err)
-		gt := st.GenesisTime()
-		s, gs := newService(ctx, &mock.ChainService{State: st, Genesis: gt, ValidatorsRoot: [32]byte{}})
-		s.blobRetentionChecker = func(primitives.Slot) bool { return true }
+			st, err := util.NewBeaconState()
+			require.NoError(t, err)
+			gt := st.GenesisTime()
+			s, gs := newService(t, ctx, &mock.ChainService{State: st, Genesis: gt, ValidatorsRoot: [32]byte{}})
+			s.blobRetentionChecker = func(primitives.Slot) bool { return true }
 
-		expectedGenesisTime := gt
-		wg := &sync.WaitGroup{}
-		wg.Go(func() {
-			s.Start()
-		})
-		rg := func() time.Time { return gt.Add(time.Second * 12) }
-		go func() {
+			expectedGenesisTime := gt
+			wg := &sync.WaitGroup{}
+			wg.Go(func() {
+				s.Start()
+			})
+			rg := func() time.Time { return gt.Add(time.Second * 12) }
 			time.AfterFunc(200*time.Millisecond, func() {
 				var vr [32]byte
 				require.NoError(t, gs.SetClock(startup.NewClock(expectedGenesisTime, vr, startup.WithNower(rg))))
 			})
-		}()
 
-		if util.WaitTimeout(wg, time.Second*2) {
-			t.Fatalf("Test should have exited by now, timed out")
-		}
-		assert.LogsContain(t, hook, "Waiting for state to be initialized")
-		assert.LogsContain(t, hook, "Received state initialized event")
-		assert.LogsDoNotContain(t, hook, "Context closed, exiting goroutine")
+			wg.Wait()
+			assert.LogsContain(t, hook, "Waiting for state to be initialized")
+			assert.LogsContain(t, hook, "Received state initialized event")
+			assert.LogsDoNotContain(t, hook, "Context closed, exiting goroutine")
+		})
 	})
 
 	t.Run("no state and state init event received and service start", func(t *testing.T) {
-		defer hook.Reset()
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
-		s, gs := newService(ctx, &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}})
-		// Initialize mock feed
-		_ = s.cfg.StateNotifier.StateFeed()
+		synctest.Test(t, func(t *testing.T) {
+			defer hook.Reset()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			s, gs := newService(t, ctx, &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}})
+			// Initialize mock feed
+			_ = s.cfg.StateNotifier.StateFeed()
 
-		expectedGenesisTime := time.Now().Add(60 * time.Second)
-		wg := &sync.WaitGroup{}
-		wg.Go(func() {
+			expectedGenesisTime := time.Now().Add(60 * time.Second)
+			wg := &sync.WaitGroup{}
 			time.AfterFunc(500*time.Millisecond, func() {
 				var vr [32]byte
 				require.NoError(t, gs.SetClock(startup.NewClock(expectedGenesisTime, vr)))
 			})
-			s.Start()
-		})
+			wg.Go(func() {
+				s.Start()
+			})
 
-		if util.WaitTimeout(wg, time.Second*5) {
-			t.Fatalf("Test should have exited by now, timed out")
-		}
-		assert.LogsContain(t, hook, "Waiting for state to be initialized")
-		assert.LogsContain(t, hook, "Received state initialized event")
-		assert.LogsDoNotContain(t, hook, "Context closed, exiting goroutine")
+			wg.Wait()
+			assert.LogsContain(t, hook, "Waiting for state to be initialized")
+			assert.LogsContain(t, hook, "Received state initialized event")
+			assert.LogsDoNotContain(t, hook, "Context closed, exiting goroutine")
+		})
 	})
 }
 

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
@@ -910,7 +911,6 @@ func TestAlreadySyncingBlock(t *testing.T) {
 }
 
 func TestExpirationCache_PruneOldBlocksCorrectly(t *testing.T) {
-	ctx := t.Context()
 	db := dbtest.SetupDB(t)
 
 	mockChain := &mock.ChainService{
@@ -927,42 +927,46 @@ func TestExpirationCache_PruneOldBlocksCorrectly(t *testing.T) {
 	}()
 	pendingBlockExpTime = 500 * time.Millisecond
 
-	r := NewService(ctx,
-		WithStateGen(stategen.New(db, doublylinkedtree.New())),
-		WithDatabase(db),
-		WithChainService(mockChain),
-		WithP2P(p1),
-	)
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ProposerIndex = 10
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-	wsb, err := blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b1Root))
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		r := NewService(ctx,
+			WithStateGen(stategen.New(db, doublylinkedtree.New())),
+			WithDatabase(db),
+			WithChainService(mockChain),
+			WithP2P(p1),
+		)
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ProposerIndex = 10
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+		wsb, err := blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b1Root))
 
-	// Add new block with the same slot.
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 1
-	b2.Block.ProposerIndex = 11
-	b2Root, err := b2.Block.HashTreeRoot()
-	require.NoError(t, err)
-	wsb, err = blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b2Root))
+		// Add new block with the same slot.
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 1
+		b2.Block.ProposerIndex = 11
+		b2Root, err := b2.Block.HashTreeRoot()
+		require.NoError(t, err)
+		wsb, err = blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b2Root))
 
-	require.Equal(t, true, r.seenPendingBlocks[b1Root])
-	require.Equal(t, true, r.seenPendingBlocks[b2Root])
-	require.Equal(t, 2, len(r.pendingBlocksInCache(1)))
+		require.Equal(t, true, r.seenPendingBlocks[b1Root])
+		require.Equal(t, true, r.seenPendingBlocks[b2Root])
+		require.Equal(t, 2, len(r.pendingBlocksInCache(1)))
 
-	// Wait for expiration cache to cleanup and remove old block.
-	time.Sleep(2 * pendingBlockExpTime)
+		// Advance fake time so the expiration cache prunes both blocks.
+		time.Sleep(2 * pendingBlockExpTime)
+		synctest.Wait()
 
-	// Run pending queue with expired blocks.
-	require.NoError(t, r.processPendingBlocks(ctx))
+		// Run pending queue with expired blocks.
+		require.NoError(t, r.processPendingBlocks(ctx))
 
-	assert.Equal(t, false, r.seenPendingBlocks[b1Root])
-	assert.Equal(t, false, r.seenPendingBlocks[b2Root])
-	assert.Equal(t, 0, len(r.pendingBlocksInCache(1)))
+		assert.Equal(t, false, r.seenPendingBlocks[b1Root])
+		assert.Equal(t, false, r.seenPendingBlocks[b2Root])
+		assert.Equal(t, 0, len(r.pendingBlocksInCache(1)))
+	})
 }

--- a/changelog/syjn99_test-synctest-beacon-chain-sync.md
+++ b/changelog/syjn99_test-synctest-beacon-chain-sync.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Adopt `testing/synctest` in `beacon-chain/sync` test package: Rewrite tests for randomly waiting/sleeping something "happens".


### PR DESCRIPTION
**What type of PR is this?**

> Testing

**What does this PR do? Why is it needed?**

Just like other PRs (#16911, #16927), this PR attempts to adopt `synctest` package in our codebase. Some numbers:

Before:
```
//beacon-chain/sync/backfill:go_default_test                             PASSED in 0.4s
  WARNING: //beacon-chain/sync/backfill:go_default_test: Test execution time (0.4s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//beacon-chain/sync/checkpoint:go_default_test                           PASSED in 0.3s
  WARNING: //beacon-chain/sync/checkpoint:go_default_test: Test execution time (0.3s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//beacon-chain/sync/initial-sync:go_default_test                         PASSED in 12.2s
  WARNING: //beacon-chain/sync/initial-sync:go_default_test: Test execution time (12.2s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//beacon-chain/sync/verify:go_default_test                               PASSED in 0.4s
//beacon-chain/sync:go_default_test                                      PASSED in 2.5s
```

After
```
//beacon-chain/sync/backfill:go_default_test                             PASSED in 0.2s
  WARNING: //beacon-chain/sync/backfill:go_default_test: Test execution time (0.2s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//beacon-chain/sync/checkpoint:go_default_test                           PASSED in 0.2s
  WARNING: //beacon-chain/sync/checkpoint:go_default_test: Test execution time (0.2s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//beacon-chain/sync/initial-sync:go_default_test                         PASSED in 0.3s
  WARNING: //beacon-chain/sync/initial-sync:go_default_test: Test execution time (0.3s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
//beacon-chain/sync/verify:go_default_test                               PASSED in 0.2s
//beacon-chain/sync:go_default_test                                      PASSED in 0.4s
```

It turns out `//beacon-chain/sync/initial-sync:` wastes over 10 seconds just for waiting *something* to happen. With `synctest`, we can advance when the goroutine is *durably* blocked (not including I/O, for example).

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

As most of the diff includes whitespaces, so I'd recommend to toggle "hide whitespace" option when you're trying to review this PR in Github UI.

Use this command for the numbers that suggested above:

```
$ bazel test //beacon-chain/sync/... \
  --test_filter="TestService_InitStartStop|TestService_Start_DoesNotMarkSyncedWhenStillBehindInSameEpoch|TestService_waitForStateInitialization|TestService_markSynced|TestExpirationCache_PruneOldBlocksCorrectly" \
  --nocache_test_results
```

Note that there are tons of spots that `synctest` can be leveraged in our `beacon-chain/sync` code, but I think I need to setup testing helpers to simulate. Reference: https://go.dev/blog/synctest#testing-networked-code

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
