### PR TITLE
Hook up payload attestation message in fork choice spec tests

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/OffchainLabs/go-bitfield"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -519,6 +520,15 @@ func (f *ForkChoice) SetPTCVote(root [32]byte, ptcIdx uint64, payloadPresent, bl
 	n.node.payloadAttesters.SetBitAt(ptcIdx, true)
 	n.node.payloadAvailabilityVote.SetBitAt(ptcIdx, payloadPresent)
 	n.node.payloadDataAvailabilityVote.SetBitAt(ptcIdx, blobDataAvailable)
+}
+
+// PTCVotes returns the recorded PTC vote bitvectors for the given root. The caller MUST hold the forkchoice lock.
+func (f *ForkChoice) PTCVotes(root [32]byte) (attesters, payloadPresent, blobDataAvailable bitfield.Bitvector512, ok bool) {
+	n := f.store.emptyNodeByRoot[root]
+	if n == nil {
+		return nil, nil, nil, false
+	}
+	return n.node.payloadAttesters, n.node.payloadAvailabilityVote, n.node.payloadDataAvailabilityVote, true
 }
 
 // resolveVoteNode returns the node that should receive the balance of a vote. It returns always a PayloadNode, but the boolean indicates

--- a/changelog/terence_gloas-payload-attestation-spectests.md
+++ b/changelog/terence_gloas-payload-attestation-spectests.md
@@ -1,0 +1,3 @@
+### Added
+
+- Hook up `payload_attestation_message` steps and PTC vote checks in Gloas fork choice spec tests.

--- a/testing/spectest/shared/common/forkchoice/BUILD.bazel
+++ b/testing/spectest/shared/common/forkchoice/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
+        "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )
 

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OffchainLabs/go-bitfield"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/execution"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice"
+	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
@@ -134,6 +136,19 @@ func (bb *Builder) ExecutionPayloadEnvelope(t testing.TB, signed *ethpb.SignedEx
 	}
 }
 
+// PayloadAttestationMessage feeds the message to the chain service.
+// If expectValid is false the receive call must error; otherwise it must succeed.
+func (bb *Builder) PayloadAttestationMessage(t testing.TB, m *ethpb.PayloadAttestationMessage, expectValid bool) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	err := bb.service.ReceivePayloadAttestationMessage(ctx, m)
+	if expectValid {
+		require.NoError(t, err)
+	} else {
+		require.NotNil(t, err, "expected payload attestation message to be rejected")
+	}
+}
+
 // PoWBlock receives the block and notifies a mocked execution engine.
 func (bb *Builder) PoWBlock(pb *ethpb.PowBlock) {
 	bb.execMock.powBlocks[bytesutil.ToBytes32(pb.BlockHash)] = pb
@@ -205,4 +220,34 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 		require.DeepEqual(t, c.ShouldOverrideFCU.Result, bb.service.ShouldOverrideFCU())
 	}
 	*/
+	if c.PayloadTimelinessVote != nil || c.PayloadDataAvailabilityVote != nil {
+		dlt, ok := bb.fc.(*doublylinkedtree.ForkChoice)
+		require.Equal(t, true, ok, "forkchoice is not a doubly linked tree")
+		bb.fc.Lock()
+		defer bb.fc.Unlock()
+		if c.PayloadTimelinessVote != nil {
+			root := bytesutil.ToBytes32(common.FromHex(c.PayloadTimelinessVote.BlockRoot))
+			attesters, present, _, ok := dlt.PTCVotes(root)
+			require.Equal(t, true, ok, "no forkchoice node for payload_timeliness_vote root")
+			checkPTCVotes(t, "payload_timeliness_vote", c.PayloadTimelinessVote, attesters, present)
+		}
+		if c.PayloadDataAvailabilityVote != nil {
+			root := bytesutil.ToBytes32(common.FromHex(c.PayloadDataAvailabilityVote.BlockRoot))
+			attesters, _, da, ok := dlt.PTCVotes(root)
+			require.Equal(t, true, ok, "no forkchoice node for payload_data_availability_vote root")
+			checkPTCVotes(t, "payload_data_availability_vote", c.PayloadDataAvailabilityVote, attesters, da)
+		}
+	}
+}
+
+func checkPTCVotes(t testing.TB, name string, want *PTCVotes, attesters, values bitfield.Bitvector512) {
+	for i, v := range want.Votes {
+		voted := attesters.BitAt(uint64(i))
+		if v == nil {
+			require.Equal(t, false, voted, fmt.Sprintf("%s: unexpected vote at index %d", name, i))
+			continue
+		}
+		require.Equal(t, true, voted, fmt.Sprintf("%s: expected vote at index %d", name, i))
+		require.Equal(t, *v, values.BitAt(uint64(i)), fmt.Sprintf("%s: vote value mismatch at index %d", name, i))
+	}
 }

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -62,15 +62,19 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 		if len(testFolders) == 0 {
 			t.Fatalf("No test folders found for %s/%s/%s", config, version.String(fork), folderPath)
 		}
-		var skipTests = map[string]bool{
-			// Skipping because of #4807 backporting issues
-			"voting_source_beyond_two_epoch":         true,
-			"justified_update_always_if_better":      true,
-			"justified_update_not_realized_finality": true,
+		var skipTests = map[string]string{
+			"voting_source_beyond_two_epoch":                                         "#4807 backporting issues",
+			"justified_update_always_if_better":                                      "#4807 backporting issues",
+			"justified_update_not_realized_finality":                                 "#4807 backporting issues",
+			"on_payload_attestation_message_valid":                                   "PTC votes not recorded at duplicate committee seats (specs#5222)",
+			"on_payload_attestation_message_multiple_ptc_members_vote_independently": "PTC votes not recorded at duplicate committee seats (specs#5222)",
+			"on_payload_attestation_message_current_slot_and_signature":              "signature and current-slot checks live in gossip validation",
+			"on_payload_attestation_message_unknown_block_root":                      "unknown block root check lives in gossip validation",
+			"on_payload_attestation_message_slot_mismatch":                           "block slot match check lives in gossip validation",
 		}
 		for _, folder := range testFolders {
-			if skipTests[folder.Name()] {
-				t.Logf("Skipping test %s due to known issues", folder.Name())
+			if reason, ok := skipTests[folder.Name()]; ok {
+				t.Logf("Skipping test %s: %s", folder.Name(), reason)
 				continue
 			}
 			t.Run(folder.Name(), func(t *testing.T) {
@@ -212,6 +216,7 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 						expectValid := step.Valid == nil || *step.Valid
 						builder.ExecutionPayloadEnvelope(t, signed, expectValid)
 					}
+					runPayloadAttestationStep(t, step, folder, testsFolderPath, builder)
 					if step.PowBlock != nil {
 						powBlockFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), fmt.Sprint(*step.PowBlock, ".ssz_snappy"))
 						require.NoError(t, err)
@@ -226,6 +231,20 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 			})
 		}
 	}
+}
+
+func runPayloadAttestationStep(t *testing.T, step Step, folder os.DirEntry, testsFolderPath string, builder *Builder) {
+	if step.PayloadAttestationMessage == nil {
+		return
+	}
+	paFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), fmt.Sprint(*step.PayloadAttestationMessage, ".ssz_snappy"))
+	require.NoError(t, err)
+	paSSZ, err := snappy.Decode(nil /* dst */, paFile)
+	require.NoError(t, err)
+	msg := &ethpb.PayloadAttestationMessage{}
+	require.NoError(t, msg.UnmarshalSSZ(paSSZ), "Failed to unmarshal")
+	expectValid := step.Valid == nil || *step.Valid
+	builder.PayloadAttestationMessage(t, msg, expectValid)
 }
 
 func runBlobStep(t *testing.T,

--- a/testing/spectest/shared/common/forkchoice/type.go
+++ b/testing/spectest/shared/common/forkchoice/type.go
@@ -1,31 +1,39 @@
 package forkchoice
 
 type Step struct {
-	Tick             *int            `json:"tick"`
-	Block            *string         `json:"block"`
-	Blobs            *string         `json:"blobs"`
-	Proofs           []*string       `json:"proofs"`
-	Valid            *bool           `json:"valid"`
-	Attestation      *string         `json:"attestation"`
-	AttesterSlashing *string         `json:"attester_slashing"`
-	PayloadStatus    *MockEngineResp `json:"payload_status"`
-	PowBlock         *string         `json:"pow_block"`
-	Check            *Check          `json:"checks"`
-	DataColumns      []*string       `json:"columns"`
-	ExecutionPayload *string         `json:"execution_payload"`
+	Tick                      *int            `json:"tick"`
+	Block                     *string         `json:"block"`
+	Blobs                     *string         `json:"blobs"`
+	Proofs                    []*string       `json:"proofs"`
+	Valid                     *bool           `json:"valid"`
+	Attestation               *string         `json:"attestation"`
+	AttesterSlashing          *string         `json:"attester_slashing"`
+	PayloadStatus             *MockEngineResp `json:"payload_status"`
+	PowBlock                  *string         `json:"pow_block"`
+	Check                     *Check          `json:"checks"`
+	DataColumns               []*string       `json:"columns"`
+	ExecutionPayload          *string         `json:"execution_payload"`
+	PayloadAttestationMessage *string         `json:"payload_attestation_message"`
 }
 
 type Check struct {
-	Time                    *int            `json:"time"`
-	GenesisTime             int             `json:"genesis_time"`
-	ProposerBoostRoot       *string         `json:"proposer_boost_root"`
-	Head                    *SlotRoot       `json:"head"`
-	JustifiedCheckPoint     *EpochRoot      `json:"justified_checkpoint"`
-	BestJustifiedCheckPoint *EpochRoot      `json:"best_justified_checkpoint"`
-	FinalizedCheckPoint     *EpochRoot      `json:"finalized_checkpoint"`
-	GetProposerHead         *string         `json:"get_proposer_head"`
-	ShouldOverrideFCU       *ShouldOverride `json:"should_override_forkchoice_update"`
-	HeadPayloadStatus       *int            `json:"head_payload_status"`
+	Time                        *int            `json:"time"`
+	GenesisTime                 int             `json:"genesis_time"`
+	ProposerBoostRoot           *string         `json:"proposer_boost_root"`
+	Head                        *SlotRoot       `json:"head"`
+	JustifiedCheckPoint         *EpochRoot      `json:"justified_checkpoint"`
+	BestJustifiedCheckPoint     *EpochRoot      `json:"best_justified_checkpoint"`
+	FinalizedCheckPoint         *EpochRoot      `json:"finalized_checkpoint"`
+	GetProposerHead             *string         `json:"get_proposer_head"`
+	ShouldOverrideFCU           *ShouldOverride `json:"should_override_forkchoice_update"`
+	HeadPayloadStatus           *int            `json:"head_payload_status"`
+	PayloadTimelinessVote       *PTCVotes       `json:"payload_timeliness_vote"`
+	PayloadDataAvailabilityVote *PTCVotes       `json:"payload_data_availability_vote"`
+}
+
+type PTCVotes struct {
+	BlockRoot string  `json:"block_root"`
+	Votes     []*bool `json:"votes"`
 }
 
 type SlotRoot struct {


### PR DESCRIPTION
  The gloas `on_payload_attestation_message` fork choice spec tests were silently passing because the runner's `Step`/`Check` types had no fields for `payload_attestation_message` steps or the `payload_timeliness_vote` / `payload_data_availability_vote` checks, so YAML unmarshalling silently dropped both.

  - Add `payload_attestation_message` step support: unmarshals the message and feeds it through `ReceivePayloadAttestationMessage`, asserting acceptance/rejection per the step's`valid` field
  - Add `payload_timeliness_vote` / `payload_data_availability_vote` check support, comparing the per-seat PTC vote bitvectors in forkchoice (`null` = no vote, `true`/`false` = recorded value)
  - Add a `PTCVotes` getter on the doubly-linked-tree forkchoice to expose the vote bit vectors
  - Convert the skip list to `map[string]string` so each skip logs its rationale

  With the steps actually wired up, 2 of 7 test cases pass (`from_block`, `not_ptc_member`). The remaining 5 are skipped with rationales:

  | Test | Reason |
  |---|---|
  | `valid`, `multiple_ptc_members_vote_independently` | PTC votes are only recorded at the validator's first committee seat [consensus-specs#5222](https://github.com/ethereum/consensus-specs/pull/5222) requires recording at every duplicate seat (balance-weighted committee) |
  | `current_slot_and_signature` | Signature and current-slot checks live in gossip validation (`validate_payload_attestation.go`), not the fork choice handler |
  | `unknown_block_root` | Unknown block root check lives in gossip validation (`VerifyBlockRootSeen`) |
  | `slot_mismatch` | Block slot match check lives in gossip validation (`VerifyBlockSlotMatches`) |
