### PR TITLE
Thread context through envelope VerifySignature

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -132,7 +132,7 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 	}
 
 	// [REJECT] signed_execution_payload_envelope.signature is valid with respect to the builder's public key.
-	if err := v.VerifySignature(st); err != nil {
+	if err := v.VerifySignature(ctx, st); err != nil {
 		return pubsub.ValidationReject, err
 	}
 	s.setSeenPayloadEnvelope(root, env.BuilderIndex())
@@ -204,7 +204,7 @@ func (s *Service) queuePendingPayloadEnvelope(
 	}
 
 	if !isSelfBuild || proposerInLookahead {
-		if err := v.VerifySignature(st); err != nil {
+		if err := v.VerifySignature(ctx, st); err != nil {
 			if isSelfBuild {
 				s.selfBuildSigFailures++
 				log.WithError(err).Debug("Ignoring self-built payload with invalid signature")

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -239,7 +239,7 @@ func (m *mockExecutionPayloadEnvelopeVerifier) VerifyExecutionRequestsRoot(_ int
 	return nil
 }
 
-func (m *mockExecutionPayloadEnvelopeVerifier) VerifySignature(_ state.ReadOnlyBeaconState) error {
+func (m *mockExecutionPayloadEnvelopeVerifier) VerifySignature(_ context.Context, _ state.ReadOnlyBeaconState) error {
 	return m.errSignature
 }
 

--- a/beacon-chain/verification/execution_payload_envelope.go
+++ b/beacon-chain/verification/execution_payload_envelope.go
@@ -24,7 +24,7 @@ type ExecutionPayloadEnvelopeVerifier interface {
 	VerifyBuilderValid(interfaces.ROExecutionPayloadBid) error
 	VerifyPayloadHash(interfaces.ROExecutionPayloadBid) error
 	VerifyExecutionRequestsRoot(interfaces.ROExecutionPayloadBid) error
-	VerifySignature(state.ReadOnlyBeaconState) error
+	VerifySignature(context.Context, state.ReadOnlyBeaconState) error
 	SatisfyRequirement(Requirement)
 }
 
@@ -170,10 +170,10 @@ func (v *EnvelopeVerifier) VerifyExecutionRequestsRoot(bid interfaces.ROExecutio
 }
 
 // VerifySignature verifies the signature of the execution payload envelope.
-func (v *EnvelopeVerifier) VerifySignature(st state.ReadOnlyBeaconState) (err error) {
+func (v *EnvelopeVerifier) VerifySignature(ctx context.Context, st state.ReadOnlyBeaconState) (err error) {
 	defer v.record(RequireBuilderSignatureValid, &err)
 
-	err = validatePayloadEnvelopeSignature(st, v.e)
+	err = validatePayloadEnvelopeSignature(ctx, st, v.e)
 	if err != nil {
 		env, envErr := v.e.Envelope()
 		if envErr != nil {
@@ -200,14 +200,14 @@ func (v *EnvelopeVerifier) record(req Requirement, err *error) {
 }
 
 // validatePayloadEnvelopeSignature verifies the signature of a signed execution payload envelope
-func validatePayloadEnvelopeSignature(st state.ReadOnlyBeaconState, e interfaces.ROSignedExecutionPayloadEnvelope) error {
+func validatePayloadEnvelopeSignature(ctx context.Context, st state.ReadOnlyBeaconState, e interfaces.ROSignedExecutionPayloadEnvelope) error {
 	env, err := e.Envelope()
 	if err != nil {
 		return errors.Wrap(err, "failed to get envelope")
 	}
 	var pubkey []byte
 	if env.BuilderIndex() == params.BeaconConfig().BuilderIndexSelfBuild {
-		proposerIdx, err := helpers.BeaconProposerIndexAtSlot(context.TODO(), st, env.Slot())
+		proposerIdx, err := helpers.BeaconProposerIndexAtSlot(ctx, st, env.Slot())
 		if err != nil {
 			return errors.Wrap(err, "failed to get proposer index at slot")
 		}

--- a/beacon-chain/verification/execution_payload_envelope_test.go
+++ b/beacon-chain/verification/execution_payload_envelope_test.go
@@ -126,7 +126,7 @@ func TestEnvelopeVerifier_VerifySignature_Builder(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := &EnvelopeVerifier{results: newResults(RequireBuilderSignatureValid), e: wrapped}
-	require.NoError(t, verifier.VerifySignature(st))
+	require.NoError(t, verifier.VerifySignature(t.Context(), st))
 
 	sk2, err := bls.RandKey()
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestEnvelopeVerifier_VerifySignature_Builder(t *testing.T) {
 	wrapped, err = blocks.WrappedROSignedExecutionPayloadEnvelope(env)
 	require.NoError(t, err)
 	verifier = &EnvelopeVerifier{results: newResults(RequireBuilderSignatureValid), e: wrapped}
-	require.ErrorIs(t, verifier.VerifySignature(st), signing.ErrSigFailedToVerify)
+	require.ErrorIs(t, verifier.VerifySignature(t.Context(), st), signing.ErrSigFailedToVerify)
 }
 
 func TestEnvelopeVerifier_VerifySignature_SelfBuild(t *testing.T) {
@@ -164,7 +164,7 @@ func TestEnvelopeVerifier_VerifySignature_SelfBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := &EnvelopeVerifier{results: newResults(RequireBuilderSignatureValid), e: wrapped}
-	require.NoError(t, verifier.VerifySignature(st))
+	require.NoError(t, verifier.VerifySignature(t.Context(), st))
 }
 
 func testSignedExecutionPayloadEnvelope(t *testing.T, slot primitives.Slot, builderIdx primitives.BuilderIndex, root, blockHash [32]byte) *ethpb.SignedExecutionPayloadEnvelope {

--- a/changelog/terence_envelope-verify-signature-ctx.md
+++ b/changelog/terence_envelope-verify-signature-ctx.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Thread context through envelope `VerifySignature` instead of `context.TODO()`.


### PR DESCRIPTION
- Replace `context.TODO()` in `validatePayloadEnvelopeSignature` with a real context threaded from the gossip validation pipeline
- `ExecutionPayloadEnvelopeVerifier.VerifySignature` now takes `ctx`, so `BeaconProposerIndexAtSlot` respects caller cancellation