### PR TITLE
Harden Gloas pending data column queue against penalty-free flooding

### DIFF
--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -198,7 +198,6 @@ func (s *Service) processPendingGloasColumns(root [fieldparams.RootLength]byte, 
 
 	verified := make([]blocks.VerifiedRODataColumn, 0, count)
 	var skipped int
-	badPeers := make(map[peer.ID]bool)
 	for _, pe := range entry.columns {
 		if pe == nil {
 			continue
@@ -219,17 +218,17 @@ func (s *Service) processPendingGloasColumns(root [fieldparams.RootLength]byte, 
 
 		if err := verifier.VerifyDataColumnSidecarSlotMatchesBlockGloas(); err != nil {
 			skipped++
-			badPeers[pe.peer] = true
+			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pe.peer)
 			continue
 		}
 		if err := verifier.VerifyDataColumnSidecarGloas(); err != nil {
 			skipped++
-			badPeers[pe.peer] = true
+			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pe.peer)
 			continue
 		}
 		if err := verifier.VerifyDataColumnSidecarKzgProofsGloas(); err != nil {
 			skipped++
-			badPeers[pe.peer] = true
+			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pe.peer)
 			continue
 		}
 
@@ -243,10 +242,6 @@ func (s *Service) processPendingGloasColumns(root [fieldparams.RootLength]byte, 
 
 		s.setSeenDataColumnRootIndex(root, v.Index(), v.Slot())
 		verified = append(verified, v)
-	}
-
-	for pid := range badPeers {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pid)
 	}
 
 	if len(verified) > 0 {
@@ -278,15 +273,44 @@ func (s *Service) prunePendingGloasColumns() {
 	for {
 		select {
 		case currentSlot := <-slotTicker.C():
-			s.pendingGloasColumnsLock.Lock()
-			for r, e := range s.pendingGloasColumns {
-				if e.slot+1 < currentSlot {
-					delete(s.pendingGloasColumns, r)
-				}
-			}
-			s.pendingGloasColumnsLock.Unlock()
+			s.pruneStaleGloasColumns(currentSlot)
 		case <-s.ctx.Done():
 			return
+		}
+	}
+}
+
+// pruneStaleGloasColumns drops entries whose slot has passed. A column queued for
+// a block root that never became known is treated as fabricated and its forwarding
+// peer is downscored; known-but-orphaned roots (honest reorgs) are spared.
+func (s *Service) pruneStaleGloasColumns(currentSlot primitives.Slot) {
+	type prunedRoot struct {
+		root  [fieldparams.RootLength]byte
+		peers []peer.ID
+	}
+	var pruned []prunedRoot
+	s.pendingGloasColumnsLock.Lock()
+	for r, e := range s.pendingGloasColumns {
+		if e.slot+1 < currentSlot {
+			peers := make([]peer.ID, 0, fieldparams.NumberOfColumns)
+			for _, pe := range e.columns {
+				if pe != nil {
+					peers = append(peers, pe.peer)
+				}
+			}
+			pruned = append(pruned, prunedRoot{root: r, peers: peers})
+			delete(s.pendingGloasColumns, r)
+		}
+	}
+	s.pendingGloasColumnsLock.Unlock()
+
+	// HasBlock + downscore outside the lock; a root we never learned of was fabricated.
+	for _, p := range pruned {
+		if s.cfg.chain == nil || s.cfg.chain.HasBlock(s.ctx, p.root) {
+			continue
+		}
+		for _, pid := range p.peers {
+			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pid)
 		}
 	}
 }

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -218,17 +218,17 @@ func (s *Service) processPendingGloasColumns(root [fieldparams.RootLength]byte, 
 
 		if err := verifier.VerifyDataColumnSidecarSlotMatchesBlockGloas(); err != nil {
 			skipped++
-			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pe.peer)
+			s.downscorePeer(pe.peer, "pendingGloasColumnSlotMismatch", logrus.Fields{"error": err})
 			continue
 		}
 		if err := verifier.VerifyDataColumnSidecarGloas(); err != nil {
 			skipped++
-			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pe.peer)
+			s.downscorePeer(pe.peer, "pendingGloasColumnInvalidSidecar", logrus.Fields{"error": err})
 			continue
 		}
 		if err := verifier.VerifyDataColumnSidecarKzgProofsGloas(); err != nil {
 			skipped++
-			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pe.peer)
+			s.downscorePeer(pe.peer, "pendingGloasColumnInvalidKzgProof", logrus.Fields{"error": err})
 			continue
 		}
 
@@ -291,16 +291,17 @@ func (s *Service) pruneStaleGloasColumns(currentSlot primitives.Slot) {
 	var pruned []prunedRoot
 	s.pendingGloasColumnsLock.Lock()
 	for r, e := range s.pendingGloasColumns {
-		if e.slot+1 < currentSlot {
-			peers := make([]peer.ID, 0, fieldparams.NumberOfColumns)
-			for _, pe := range e.columns {
-				if pe != nil {
-					peers = append(peers, pe.peer)
-				}
-			}
-			pruned = append(pruned, prunedRoot{root: r, peers: peers})
-			delete(s.pendingGloasColumns, r)
+		if e.slot+1 >= currentSlot {
+			continue
 		}
+		peers := make([]peer.ID, 0, fieldparams.NumberOfColumns)
+		for _, pe := range e.columns {
+			if pe != nil {
+				peers = append(peers, pe.peer)
+			}
+		}
+		pruned = append(pruned, prunedRoot{root: r, peers: peers})
+		delete(s.pendingGloasColumns, r)
 	}
 	s.pendingGloasColumnsLock.Unlock()
 
@@ -310,7 +311,7 @@ func (s *Service) pruneStaleGloasColumns(currentSlot primitives.Slot) {
 			continue
 		}
 		for _, pid := range p.peers {
-			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pid)
+			s.downscorePeer(pid, "pendingGloasColumnUnknownRoot", logrus.Fields{"root": fmt.Sprintf("%#x", p.root)})
 		}
 	}
 }

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -540,6 +540,57 @@ func TestPendingGloasColumns(t *testing.T) {
 		s.processPendingGloasColumns(root, blk)
 	})
 
+	t.Run("prune downscores fabricated root, spares known root", func(t *testing.T) {
+		ctx := t.Context()
+
+		p := p2ptest.NewTestP2P(t)
+		db := dbtest.SetupDB(t)
+
+		// A known root: a real block saved to the DB (e.g. an orphaned but seen block).
+		_, signedBlock := gloasFixture(t)
+		knownRoot, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveBlock(ctx, signedBlock))
+
+		// A fabricated root the node never learned of.
+		fabricatedRoot := [32]byte{0x99}
+
+		s := &Service{
+			cfg:                 &config{p2p: p, clock: clock, chain: &mock.ChainService{DB: db}},
+			ctx:                 ctx,
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+
+		// Honest peer queued one column for the known root.
+		known := &pendingGloasEntry{slot: 0}
+		known.columns[0] = &pendingColumnEntry{peer: "honestpeer"}
+		s.pendingGloasColumns[knownRoot] = known
+
+		// Evil peer queued three columns for the fabricated root.
+		fab := &pendingGloasEntry{slot: 0}
+		fab.columns[0] = &pendingColumnEntry{peer: "evilpeer"}
+		fab.columns[1] = &pendingColumnEntry{peer: "evilpeer"}
+		fab.columns[2] = &pendingColumnEntry{peer: "evilpeer"}
+		s.pendingGloasColumns[fabricatedRoot] = fab
+
+		// Both entries are stale relative to slot 5.
+		s.pruneStaleGloasColumns(5)
+
+		require.Equal(t, false, s.hasPendingGloasColumns(knownRoot))
+		require.Equal(t, false, s.hasPendingGloasColumns(fabricatedRoot))
+
+		scorer := p.Peers().Scorers().BadResponsesScorer()
+
+		// One increment per fabricated column.
+		evilCount, err := scorer.Count("evilpeer")
+		require.NoError(t, err)
+		require.Equal(t, 3, evilCount)
+
+		// The peer on the known (orphaned) root is untouched.
+		_, err = scorer.Count("honestpeer")
+		require.NotNil(t, err)
+	})
+
 	t.Run("prune keeps current and next slot", func(t *testing.T) {
 		s := &Service{
 			cfg:                 &config{clock: clock},

--- a/changelog/tt_fix-gloas-pending-column-downscore.md
+++ b/changelog/tt_fix-gloas-pending-column-downscore.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Downscore peers per invalid pending Gloas data column and penalize columns queued for block roots that never become known, preventing penalty-free flooding of the pending column queue.


### PR DESCRIPTION
  The problem:
  Today a peer can flood the gloas pending data-column queue for cheap:
  - Columns for a not-yet-seen block root are queued unverified and the validator returns ValidationIgnore, which doesn't propagate or penalize. So flooding costs the attacker nothing at ingest time.
  - The deferred check (processPendingGloasColumns) applied just one downscore per peer, no matter how many bad columns they sent.
  - Columns queued for a root that never showed up were never penalized at all.

  Make the penalties proportional to the abuse:
  1. Downscore per bad column.
  2. Penalize stale roots at prune time, that is roots never had block