### PR TITLE
Change Prysm client code into `PM` for Graffiti & Dedup JSON-RPC call functions for `engine_getClientVersionV1`

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -610,6 +610,12 @@ func (s *Service) GetClientVersionV1(ctx context.Context) ([]*structs.ClientVers
 	ctx, span := trace.StartSpan(ctx, "powchain.engine-api-client.GetClientVersionV1")
 	defer span.End()
 
+	// First 4 bytes of the git commit are used.
+	commit := version.GitCommit()
+	if len(commit) >= 8 {
+		commit = commit[:8]
+	}
+
 	var result []*structs.ClientVersionV1
 	err := s.rpcClient.CallContext(
 		ctx,
@@ -619,7 +625,7 @@ func (s *Service) GetClientVersionV1(ctx context.Context) ([]*structs.ClientVers
 			Code:    PrysmClientCode,
 			Name:    PrysmClientName,
 			Version: version.SemanticVersion(),
-			Commit:  version.GetCommitPrefix(),
+			Commit:  commit,
 		},
 	)
 	if err != nil {

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -71,17 +71,7 @@ var (
 	}
 )
 
-// ClientVersionV1 represents the response from engine_getClientVersionV1.
-type ClientVersionV1 struct {
-	Code    string `json:"code"`
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
-}
-
 const (
-	// GetClientVersionMethod is the engine_getClientVersionV1 method for JSON-RPC.
-	GetClientVersionMethod = "engine_getClientVersionV1"
 	// NewPayloadMethod v1 request string for JSON-RPC.
 	NewPayloadMethod = "engine_newPayloadV1"
 	// NewPayloadMethodV2 v2 request string for JSON-RPC.
@@ -412,24 +402,6 @@ func (s *Service) ExchangeCapabilities(ctx context.Context) ([]string, error) {
 	return elSupportedEndpointsSlice, nil
 }
 
-// GetClientVersion calls engine_getClientVersionV1 to retrieve EL client information.
-func (s *Service) GetClientVersion(ctx context.Context) ([]ClientVersionV1, error) {
-	ctx, span := trace.StartSpan(ctx, "powchain.engine-api-client.GetClientVersion")
-	defer span.End()
-
-	// Per spec, we send our own client info as the parameter
-	clVersion := ClientVersionV1{
-		Code:    CLCode,
-		Name:    Name,
-		Version: version.SemanticVersion(),
-		Commit:  version.GetCommitPrefix(),
-	}
-
-	var result []ClientVersionV1
-	err := s.rpcClient.CallContext(ctx, &result, GetClientVersionMethod, clVersion)
-	return result, handleRPCError(err)
-}
-
 // GetTerminalBlockHash returns the valid terminal block hash based on total difficulty.
 //
 // Spec code:
@@ -633,14 +605,10 @@ func (s *Service) GetBlobsV2(ctx context.Context, versionedHashes []common.Hash)
 	return result, handleRPCError(err)
 }
 
+// GetClientVersion calls engine_getClientVersionV1 to retrieve EL client information.
 func (s *Service) GetClientVersionV1(ctx context.Context) ([]*structs.ClientVersionV1, error) {
 	ctx, span := trace.StartSpan(ctx, "powchain.engine-api-client.GetClientVersionV1")
 	defer span.End()
-
-	commit := version.GitCommit()
-	if len(commit) >= 8 {
-		commit = commit[:8]
-	}
 
 	var result []*structs.ClientVersionV1
 	err := s.rpcClient.CallContext(
@@ -648,13 +616,12 @@ func (s *Service) GetClientVersionV1(ctx context.Context) ([]*structs.ClientVers
 		&result,
 		GetClientVersionV1,
 		structs.ClientVersionV1{
-			Code:    "PM",
-			Name:    "Prysm",
+			Code:    PrysmClientCode,
+			Name:    PrysmClientName,
 			Version: version.SemanticVersion(),
-			Commit:  commit,
+			Commit:  version.GetCommitPrefix(),
 		},
 	)
-
 	if err != nil {
 		return nil, handleRPCError(err)
 	}

--- a/beacon-chain/execution/graffiti_info.go
+++ b/beacon-chain/execution/graffiti_info.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	// CLCode is the two-letter client code for Prysm.
-	CLCode = "PR"
-	Name   = "Prysm"
+	// PrysmClientCode is the two-letter client code for Prysm.
+	PrysmClientCode = "PM"
+	PrysmClientName = "Prysm"
 )
 
 // GraffitiInfo holds version information for generating block graffiti.
@@ -89,19 +89,19 @@ func (g *GraffitiInfo) GenerateGraffiti(userGraffiti []byte) [32]byte {
 	switch {
 	case available >= 12:
 		// Full: user+EL(2)+commit(4)+CL(2)+commit(4)
-		graffiti = userStr + space(12) + g.elCode + elCommit4 + CLCode + clCommit4
+		graffiti = userStr + space(12) + g.elCode + elCommit4 + PrysmClientCode + clCommit4
 	case available >= 8:
 		// Reduced commits: user+EL(2)+commit(2)+CL(2)+commit(2)
-		graffiti = userStr + space(8) + g.elCode + elCommit2 + CLCode + clCommit2
+		graffiti = userStr + space(8) + g.elCode + elCommit2 + PrysmClientCode + clCommit2
 	case available >= 4:
 		// Codes only: user+EL(2)+CL(2)
-		graffiti = userStr + space(4) + g.elCode + CLCode
+		graffiti = userStr + space(4) + g.elCode + PrysmClientCode
 	case available >= 2:
 		// Single code: user+code(2)
 		if g.elCode != "" {
 			graffiti = userStr + space(2) + g.elCode
 		} else {
-			graffiti = userStr + space(2) + CLCode
+			graffiti = userStr + space(2) + PrysmClientCode
 		}
 	default:
 		// User graffiti only

--- a/beacon-chain/execution/graffiti_info.go
+++ b/beacon-chain/execution/graffiti_info.go
@@ -43,12 +43,12 @@ func (g *GraffitiInfo) UpdateFromEngine(code, commit string) {
 // fits without reducing the client version tier.
 //
 // Available Space | Format
-// ≥13 bytes       | user + space + EL(2)+commit(4)+CL(2)+commit(4)  e.g. "Sushi GEabcdPRe4f6"
-// 12 bytes        | user + EL(2)+commit(4)+CL(2)+commit(4)          e.g. "12345678901234567890GEabcdPRe4f6"
-// 9-11 bytes      | user + space + EL(2)+commit(2)+CL(2)+commit(2)  e.g. "12345678901234567890123 GEabPRe4"
-// 8 bytes         | user + EL(2)+commit(2)+CL(2)+commit(2)          e.g. "123456789012345678901234GEabPRe4"
-// 5-7 bytes       | user + space + EL(2)+CL(2)                      e.g. "123456789012345678901234567 GEPR"
-// 4 bytes         | user + EL(2)+CL(2)                              e.g. "1234567890123456789012345678GEPR"
+// ≥13 bytes       | user + space + EL(2)+commit(4)+CL(2)+commit(4)  e.g. "Sushi GEabcdPMe4f6"
+// 12 bytes        | user + EL(2)+commit(4)+CL(2)+commit(4)          e.g. "12345678901234567890GEabcdPMe4f6"
+// 9-11 bytes      | user + space + EL(2)+commit(2)+CL(2)+commit(2)  e.g. "12345678901234567890123 GEabPMe4"
+// 8 bytes         | user + EL(2)+commit(2)+CL(2)+commit(2)          e.g. "123456789012345678901234GEabPMe4"
+// 5-7 bytes       | user + space + EL(2)+CL(2)                      e.g. "123456789012345678901234567 GEPM"
+// 4 bytes         | user + EL(2)+CL(2)                              e.g. "1234567890123456789012345678GEPM"
 // 3 bytes         | user + space + code(2)                          e.g. "12345678901234567890123456789 GE"
 // 2 bytes         | user + code(2)                                  e.g. "123456789012345678901234567890GE"
 // <2 bytes        | user only                                       e.g. "1234567890123456789012345678901x"

--- a/beacon-chain/execution/graffiti_info_test.go
+++ b/beacon-chain/execution/graffiti_info_test.go
@@ -214,14 +214,14 @@ func TestGraffitiInfo_UpdateFromEngine(t *testing.T) {
 	// Initially no EL info - should still have CL info (PR + commit)
 	result := g.GenerateGraffiti([]byte{})
 	resultStr := trimNullBytes(string(result[:]))
-	require.Equal(t, "PR", resultStr[:2], "Expected CL info before update")
+	require.Equal(t, "PM", resultStr[:2], "Expected CL info before update")
 
 	// Update with EL info
 	g.UpdateFromEngine("GE", "1234abcd")
 
 	result = g.GenerateGraffiti([]byte{})
 	resultStr = trimNullBytes(string(result[:]))
-	require.Equal(t, "GE1234PR", resultStr[:8], "Expected EL+CL info after update")
+	require.Equal(t, "GE1234PM", resultStr[:8], "Expected EL+CL info after update")
 }
 
 func TestTruncateCommit(t *testing.T) {

--- a/beacon-chain/execution/graffiti_info_test.go
+++ b/beacon-chain/execution/graffiti_info_test.go
@@ -15,13 +15,13 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 		wantPrefix   string // user graffiti appears first
 		wantSuffix   string // client version info appended after
 	}{
-		// No EL info cases (CL info "PR" + commit still included when space allows)
+		// No EL info cases (CL info "PM" + commit still included when space allows)
 		{
 			name:         "No EL - empty user graffiti",
 			elCode:       "",
 			elCommit:     "",
 			userGraffiti: []byte{},
-			wantPrefix:   "PR", // Only CL code + commit (no user graffiti to prefix)
+			wantPrefix:   "PM", // Only CL code + commit (no user graffiti to prefix)
 		},
 		{
 			name:         "No EL - short user graffiti",
@@ -29,7 +29,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "",
 			userGraffiti: []byte("my validator"),
 			wantPrefix:   "my validator",
-			wantSuffix:   " PR", // space + CL code appended
+			wantSuffix:   " PM", // space + CL code appended
 		},
 		{
 			name:         "No EL - 28 char user graffiti (4 bytes available)",
@@ -37,15 +37,15 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "",
 			userGraffiti: []byte("1234567890123456789012345678"), // 28 chars, 4 bytes available = codes only
 			wantPrefix:   "1234567890123456789012345678",
-			wantSuffix:   "PR", // CL code (no EL, so just PR)
+			wantSuffix:   "PM", // CL code (no EL, so just PM)
 		},
 		{
 			name:         "No EL - 30 char user graffiti (2 bytes available)",
 			elCode:       "",
 			elCommit:     "",
-			userGraffiti: []byte("123456789012345678901234567890"), // 30 chars, 2 bytes available = fits PR
+			userGraffiti: []byte("123456789012345678901234567890"), // 30 chars, 2 bytes available = fits PM
 			wantPrefix:   "123456789012345678901234567890",
-			wantSuffix:   "PR",
+			wantSuffix:   "PM",
 		},
 		{
 			name:         "No EL - 31 char user graffiti (1 byte available)",
@@ -67,7 +67,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCode:       "GE",
 			elCommit:     "abcd1234",
 			userGraffiti: []byte{},
-			wantPrefix:   "GEabcdPR", // No user graffiti, starts with client info
+			wantPrefix:   "GEabcdPM", // No user graffiti, starts with client info
 		},
 		{
 			name:         "With EL - full format (short user graffiti)",
@@ -75,7 +75,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: []byte("Bob"),
 			wantPrefix:   "Bob",
-			wantSuffix:   " GEabcdPR", // space + EL(2)+commit(4)+CL(2)+commit(4)
+			wantSuffix:   " GEabcdPM", // space + EL(2)+commit(4)+CL(2)+commit(4)
 		},
 		{
 			name:         "With EL - full format (20 char user, 12 bytes available) - no space, would reduce tier",
@@ -83,7 +83,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: []byte("12345678901234567890"), // 20 chars, leaves exactly 12 bytes = full format, no room for space
 			wantPrefix:   "12345678901234567890",
-			wantSuffix:   "GEabcdPR",
+			wantSuffix:   "GEabcdPM",
 		},
 		{
 			name:         "With EL - full format (19 char user, 13 bytes available) - space fits",
@@ -91,7 +91,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: []byte("1234567890123456789"), // 19 chars, leaves 13 bytes = full format + space
 			wantPrefix:   "1234567890123456789",
-			wantSuffix:   " GEabcdPR",
+			wantSuffix:   " GEabcdPM",
 		},
 		{
 			name:         "With EL - reduced commits (24 char user, 8 bytes available) - no space, would reduce tier",
@@ -99,7 +99,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: []byte("123456789012345678901234"), // 24 chars, leaves exactly 8 bytes = reduced format, no room for space
 			wantPrefix:   "123456789012345678901234",
-			wantSuffix:   "GEabPR",
+			wantSuffix:   "GEabPM",
 		},
 		{
 			name:         "With EL - reduced commits (23 char user, 9 bytes available) - space fits",
@@ -107,7 +107,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: []byte("12345678901234567890123"), // 23 chars, leaves 9 bytes = reduced format + space
 			wantPrefix:   "12345678901234567890123",
-			wantSuffix:   " GEabPR",
+			wantSuffix:   " GEabPM",
 		},
 		{
 			name:         "With EL - codes only (28 char user, 4 bytes available) - no space, would reduce tier",
@@ -115,7 +115,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: []byte("1234567890123456789012345678"), // 28 chars, leaves exactly 4 bytes = codes only, no room for space
 			wantPrefix:   "1234567890123456789012345678",
-			wantSuffix:   "GEPR",
+			wantSuffix:   "GEPM",
 		},
 		{
 			name:         "With EL - codes only (27 char user, 5 bytes available) - space fits",
@@ -123,7 +123,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: []byte("123456789012345678901234567"), // 27 chars, leaves 5 bytes = codes only + space
 			wantPrefix:   "123456789012345678901234567",
-			wantSuffix:   " GEPR",
+			wantSuffix:   " GEPM",
 		},
 		{
 			name:         "With EL - EL code only (30 char user, 2 bytes available) - no space, would reduce tier",
@@ -162,7 +162,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCommit:     "abcd1234",
 			userGraffiti: append([]byte("test"), 0, 0, 0),
 			wantPrefix:   "test",
-			wantSuffix:   " GEabcdPR",
+			wantSuffix:   " GEabcdPM",
 		},
 		// 0x prefix handling - some ELs return 0x-prefixed commits
 		{
@@ -170,14 +170,14 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			elCode:       "GE",
 			elCommit:     "0xabcd1234",
 			userGraffiti: []byte{},
-			wantPrefix:   "GEabcdPR",
+			wantPrefix:   "GEabcdPM",
 		},
 		{
 			name:         "No 0x prefix - commit used as-is",
 			elCode:       "NM",
 			elCommit:     "abcd1234",
 			userGraffiti: []byte{},
-			wantPrefix:   "NMabcdPR",
+			wantPrefix:   "NMabcdPM",
 		},
 	}
 
@@ -211,7 +211,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 func TestGraffitiInfo_UpdateFromEngine(t *testing.T) {
 	g := NewGraffitiInfo()
 
-	// Initially no EL info - should still have CL info (PR + commit)
+	// Initially no EL info - should still have CL info (PM + commit)
 	result := g.GenerateGraffiti([]byte{})
 	resultStr := trimNullBytes(string(result[:]))
 	require.Equal(t, "PM", resultStr[:2], "Expected CL info before update")

--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -331,7 +331,7 @@ func (s *Service) updateGraffitiInfo() {
 	}
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
 	defer cancel()
-	versions, err := s.GetClientVersion(ctx)
+	versions, err := s.GetClientVersionV1(ctx)
 	if err != nil {
 		log.WithError(err).Debug("Could not get execution client version for graffiti")
 		return

--- a/changelog/syjn99_chore-dedup-get-client-version-v1.md
+++ b/changelog/syjn99_chore-dedup-get-client-version-v1.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Change Prysm client code into `"PM"` as per [identification document](https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#clientcode).
+
+### Ignored
+
+- Dedup JSON-RPC call functions for `engine_getClientVersionV1`.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix
> Other: Cleanup

**What does this PR do? Why is it needed?**

Our codebase have duplicative function for calling `engine_getClientVersionV1`: This PR dedups them. 

Also this PR changes our client code from `"PR"` into `"PM"`. Note that this will be only applied **when we update our graffiti info**. Engine API (`engine_getClientVersionV1`) and Beacon API (`GET /eth/v2/node/version`) are correctly using `"PM"`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

- Prysm Client code is listed in [here](https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#clientcode).

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
