### PR TITLE
Remove obsolete `*Requests` fields in `ExecutionPayloadBody` (used in Engine API)

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -1005,7 +1005,7 @@ func upgradeSidecarsToVerifiedSidecars(roSidecars []blocks.RODataColumn) []block
 }
 
 func fullPayloadFromPayloadBody(
-	header interfaces.ExecutionData, body *pb.ExecutionPayloadBody, bVersion int,
+	header interfaces.ExecutionData, body *pb.ExecutionPayloadBodyV1, bVersion int,
 ) (interfaces.ExecutionData, error) {
 	if header == nil || header.IsNil() || body == nil {
 		return nil, errors.New("execution block and header cannot be nil")

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -1716,7 +1716,7 @@ func fixturesStruct() *payloadFixtures {
 		BlockHash:     foo[:],
 		Transactions:  [][]byte{foo[:]},
 	}
-	executionPayloadBodyFixture := &pb.ExecutionPayloadBody{
+	executionPayloadBodyFixture := &pb.ExecutionPayloadBodyV1{
 		Transactions: []hexutil.Bytes{foo[:]},
 		Withdrawals:  []*pb.Withdrawal{},
 	}
@@ -2058,7 +2058,7 @@ func fixturesStruct() *payloadFixtures {
 
 type payloadFixtures struct {
 	ExecutionBlock                    *pb.ExecutionBlock
-	ExecutionPayloadBody              *pb.ExecutionPayloadBody
+	ExecutionPayloadBody              *pb.ExecutionPayloadBodyV1
 	ExecutionPayload                  *pb.ExecutionPayload
 	ExecutionPayloadCapella           *pb.ExecutionPayloadCapella
 	EmptyExecutionPayloadDeneb        *pb.ExecutionPayloadDeneb
@@ -2492,7 +2492,7 @@ func TestReconstructBlindedBlockBatch(t *testing.T) {
 		blk, _ := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, slot, 0)
 		cli, srv := newMockEngine(t)
 		srv.registerDefault(func(msg *jsonrpcMessage, w http.ResponseWriter, req *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{nil}
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{nil}
 			mockWriteResult(t, w, msg, executionPayloadBodies)
 		})
 

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -1773,24 +1772,6 @@ func fixturesStruct() *payloadFixtures {
 		// added on top of the empty payload
 		Transactions: [][]byte{foo[:]},
 		Withdrawals:  []*pb.Withdrawal{},
-	}
-	depositRequests := make([]pb.DepositRequestV1, 3)
-	for i := range depositRequests {
-		amount := hexutil.Uint64(math.MaxUint16 - i)
-		creds := &common.Hash{}
-		creds.SetBytes([]byte{0, 0, byte(i)})
-		pubkey := pb.BlsPubkey{}
-		copy(pubkey[:], []byte{0, byte(i)})
-		sig := pb.BlsSig{}
-		copy(sig[:], []byte{0, 0, 0, byte(i)})
-		idx := hexutil.Uint64(i)
-		depositRequests[i] = pb.DepositRequestV1{
-			PubKey:                &pubkey,
-			WithdrawalCredentials: creds,
-			Amount:                &amount,
-			Signature:             &sig,
-			Index:                 &idx,
-		}
 	}
 	consolidationRequests := make([]pb.ConsolidationRequestV1, 1)
 	for i := range consolidationRequests {

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -1774,19 +1774,6 @@ func fixturesStruct() *payloadFixtures {
 		Transactions: [][]byte{foo[:]},
 		Withdrawals:  []*pb.Withdrawal{},
 	}
-	withdrawalRequests := make([]pb.WithdrawalRequestV1, 3)
-	for i := range withdrawalRequests {
-		amount := hexutil.Uint64(i)
-		address := &common.Address{}
-		address.SetBytes([]byte{0, 0, byte(i)})
-		pubkey := pb.BlsPubkey{}
-		copy(pubkey[:], []byte{0, byte(i)})
-		withdrawalRequests[i] = pb.WithdrawalRequestV1{
-			SourceAddress:   address,
-			ValidatorPubkey: &pubkey,
-			Amount:          &amount,
-		}
-	}
 	depositRequests := make([]pb.DepositRequestV1, 3)
 	for i := range depositRequests {
 		amount := hexutil.Uint64(math.MaxUint16 - i)

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -1773,20 +1773,6 @@ func fixturesStruct() *payloadFixtures {
 		Transactions: [][]byte{foo[:]},
 		Withdrawals:  []*pb.Withdrawal{},
 	}
-	consolidationRequests := make([]pb.ConsolidationRequestV1, 1)
-	for i := range consolidationRequests {
-		address := &common.Address{}
-		address.SetBytes([]byte{0, 0, byte(i)})
-		sPubkey := pb.BlsPubkey{}
-		copy(sPubkey[:], []byte{0, byte(i)})
-		tPubkey := pb.BlsPubkey{}
-		copy(tPubkey[:], []byte{0, byte(i)})
-		consolidationRequests[i] = pb.ConsolidationRequestV1{
-			SourceAddress: address,
-			SourcePubkey:  &sPubkey,
-			TargetPubkey:  &tPubkey,
-		}
-	}
 	hexUint := hexutil.Uint64(1)
 	executionPayloadWithValueFixtureCapella := &pb.GetPayloadV2ResponseJson{
 		ExecutionPayload: &pb.ExecutionPayloadCapellaJSON{

--- a/beacon-chain/execution/mock_test.go
+++ b/beacon-chain/execution/mock_test.go
@@ -150,10 +150,10 @@ func TestParseRequest(t *testing.T) {
 					}
 					nr = rang[1]
 				}
-				mockWriteResult(t, w, msg, make([]*pb.ExecutionPayloadBody, nr))
+				mockWriteResult(t, w, msg, make([]*pb.ExecutionPayloadBodyV1, nr))
 			})
 
-			result := make([]*pb.ExecutionPayloadBody, 0)
+			result := make([]*pb.ExecutionPayloadBodyV1, 0)
 			var args []any
 			if len(c.byteArgs) > 0 {
 				args = []any{c.byteArgs}

--- a/beacon-chain/execution/payload_body.go
+++ b/beacon-chain/execution/payload_body.go
@@ -27,7 +27,7 @@ type reconstructionBatch map[[32]byte]uint64
 
 type blindedBlockReconstructor struct {
 	orderedBlocks []*blockWithHeader
-	bodies        map[[32]byte]*pb.ExecutionPayloadBody
+	bodies        map[[32]byte]*pb.ExecutionPayloadBodyV1
 	batches       map[string]reconstructionBatch
 }
 
@@ -45,7 +45,7 @@ func reconstructBlindedBlockBatch(ctx context.Context, client RPCClient, sbb []i
 func newBlindedBlockReconstructor(sbb []interfaces.ReadOnlySignedBeaconBlock) (*blindedBlockReconstructor, error) {
 	r := &blindedBlockReconstructor{
 		orderedBlocks: make([]*blockWithHeader, 0, len(sbb)),
-		bodies:        make(map[[32]byte]*pb.ExecutionPayloadBody),
+		bodies:        make(map[[32]byte]*pb.ExecutionPayloadBodyV1),
 	}
 	for i := range sbb {
 		if err := r.addToBatch(sbb[i]); err != nil {
@@ -156,7 +156,7 @@ func computeRanges(hbns []hashBlockNumber) []byRangeReq {
 }
 
 func (r *blindedBlockReconstructor) requestBodiesByRange(ctx context.Context, client RPCClient, method string, req byRangeReq) error {
-	result := make([]*pb.ExecutionPayloadBody, 0)
+	result := make([]*pb.ExecutionPayloadBodyV1, 0)
 	if err := client.CallContext(ctx, &result, method, hexutil.EncodeUint64(req.start), hexutil.EncodeUint64(req.count)); err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (r *blindedBlockReconstructor) requestBodiesByHash(ctx context.Context, cli
 		}
 		hashes = append(hashes, h)
 	}
-	result := make([]*pb.ExecutionPayloadBody, 0)
+	result := make([]*pb.ExecutionPayloadBodyV1, 0)
 	if err := client.CallContext(ctx, &result, method, hashes); err != nil {
 		return nil, err
 	}

--- a/beacon-chain/execution/payload_body_test.go
+++ b/beacon-chain/execution/payload_body_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
-func payloadToBody(t *testing.T, ed interfaces.ExecutionData) *pb.ExecutionPayloadBody {
-	body := &pb.ExecutionPayloadBody{}
+func payloadToBody(t *testing.T, ed interfaces.ExecutionData) *pb.ExecutionPayloadBodyV1 {
+	body := &pb.ExecutionPayloadBodyV1{}
 	txs, err := ed.Transactions()
 	require.NoError(t, err)
 	wd, err := ed.Withdrawals()
@@ -118,7 +118,7 @@ func TestPayloadBodiesViaUnblinder(t *testing.T) {
 	t.Run("mix of non-empty and empty", func(t *testing.T) {
 		cli, srv := newMockEngine(t)
 		srv.register(GetPayloadBodiesByHashV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{
 				payloadToBody(t, fx.denebBlock.blinded.header),
 				payloadToBody(t, fx.emptyDenebBlock.blinded.header),
 			}
@@ -259,11 +259,11 @@ func TestReconstructBlindedBlockBatchFallbackToRange(t *testing.T) {
 		cli, srv := newMockEngine(t)
 		fx := testBlindedBlockFixtures(t)
 		srv.register(GetPayloadBodiesByHashV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{nil, nil}
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{nil, nil}
 			mockWriteResult(t, w, msg, executionPayloadBodies)
 		})
 		srv.register(GetPayloadBodiesByRangeV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{nil, nil}
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{nil, nil}
 			mockWriteResult(t, w, msg, executionPayloadBodies)
 		})
 		toUnblind := []interfaces.ReadOnlySignedBeaconBlock{
@@ -279,11 +279,11 @@ func TestReconstructBlindedBlockBatchFallbackToRange(t *testing.T) {
 		cli, srv := newMockEngine(t)
 		fx := testBlindedBlockFixtures(t)
 		srv.register(GetPayloadBodiesByHashV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{nil, nil}
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{nil, nil}
 			mockWriteResult(t, w, msg, executionPayloadBodies)
 		})
 		srv.register(GetPayloadBodiesByRangeV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{
 				payloadToBody(t, fx.denebBlock.blinded.header),
 				payloadToBody(t, fx.emptyDenebBlock.blinded.header),
 			}
@@ -300,7 +300,7 @@ func TestReconstructBlindedBlockBatchFallbackToRange(t *testing.T) {
 		cli, srv := newMockEngine(t)
 		fx := testBlindedBlockFixtures(t)
 		srv.register(GetPayloadBodiesByHashV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{nil, nil, nil}
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{nil, nil, nil}
 			mockWriteResult(t, w, msg, executionPayloadBodies)
 		})
 		srv.register(GetPayloadBodiesByRangeV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
@@ -310,7 +310,7 @@ func TestReconstructBlindedBlockBatchFallbackToRange(t *testing.T) {
 			// Return first 2 blocks by number, which are contiguous.
 			if start == fx.denebBlock.blinded.header.BlockNumber() {
 				require.Equal(t, uint64(2), count)
-				executionPayloadBodies := []*pb.ExecutionPayloadBody{
+				executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{
 					payloadToBody(t, fx.denebBlock.blinded.header),
 					payloadToBody(t, fx.emptyDenebBlock.blinded.header),
 				}
@@ -320,7 +320,7 @@ func TestReconstructBlindedBlockBatchFallbackToRange(t *testing.T) {
 			// Assume it's the second request
 			require.Equal(t, fx.afterSkipDeneb.blinded.header.BlockNumber(), start)
 			require.Equal(t, uint64(1), count)
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{
 				payloadToBody(t, fx.afterSkipDeneb.blinded.header),
 			}
 			mockWriteResult(t, w, msg, executionPayloadBodies)
@@ -344,7 +344,7 @@ func TestReconstructBlindedBlockBatchDenebAndBeyond(t *testing.T) {
 		cli, srv := newMockEngine(t)
 		fx := testBlindedBlockFixtures(t)
 		srv.register(GetPayloadBodiesByHashV1, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
-			executionPayloadBodies := []*pb.ExecutionPayloadBody{payloadToBody(t, fx.denebBlock.blinded.header), payloadToBody(t, fx.electra.blinded.header), payloadToBody(t, fx.fulu.blinded.header)}
+			executionPayloadBodies := []*pb.ExecutionPayloadBodyV1{payloadToBody(t, fx.denebBlock.blinded.header), payloadToBody(t, fx.electra.blinded.header), payloadToBody(t, fx.fulu.blinded.header)}
 			mockWriteResult(t, w, msg, executionPayloadBodies)
 		})
 		blinded := []interfaces.ReadOnlySignedBeaconBlock{

--- a/changelog/syjn99_chore-el-request-cleanup.md
+++ b/changelog/syjn99_chore-el-request-cleanup.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Remove obsolete `*Requests` fields in `ExecutionPayloadBody` (used in Engine API).

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -360,20 +360,17 @@ type GetPayloadV6ResponseJson struct {
 	ExecutionRequests     []hexutil.Bytes            `json:"executionRequests"`
 }
 
+// ExecutionPayloadBodyV1 represents the engine API ExecutionPayloadV1 type.
+type ExecutionPayloadBodyV1 struct {
+	Transactions []hexutil.Bytes `json:"transactions"`
+	Withdrawals  []*Withdrawal   `json:"withdrawals"`
+}
+
 // ExecutionPayloadBodyV2 represents the engine API ExecutionPayloadBodyV2 type (Amsterdam).
 type ExecutionPayloadBodyV2 struct {
 	Transactions    []hexutil.Bytes `json:"transactions"`
 	Withdrawals     []*Withdrawal   `json:"withdrawals"`
 	BlockAccessList *hexutil.Bytes  `json:"blockAccessList"`
-}
-
-// ExecutionPayloadBody represents the engine API ExecutionPayloadV1 or ExecutionPayloadV2 type.
-type ExecutionPayloadBody struct {
-	Transactions          []hexutil.Bytes          `json:"transactions"`
-	Withdrawals           []*Withdrawal            `json:"withdrawals"`
-	WithdrawalRequests    []WithdrawalRequestV1    `json:"withdrawalRequests"`
-	DepositRequests       []DepositRequestV1       `json:"depositRequests"`
-	ConsolidationRequests []ConsolidationRequestV1 `json:"consolidationRequests"`
 }
 
 type ExecutionPayloadDenebJSON struct {

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -393,40 +393,6 @@ type ExecutionPayloadDenebJSON struct {
 	Withdrawals   []*Withdrawal   `json:"withdrawals"`
 }
 
-// DepositRequestV1 represents an execution engine DepositRequestV1 value
-// https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#depositrequestv1
-type DepositRequestV1 struct {
-	// pubkey: DATA, 48 Bytes
-	PubKey *BlsPubkey `json:"pubkey"`
-	// withdrawalCredentials: DATA, 32 Bytes
-	WithdrawalCredentials *common.Hash `json:"withdrawalCredentials"`
-	// amount: QUANTITY, 64 Bits
-	Amount *hexutil.Uint64 `json:"amount"`
-	// signature: DATA, 96 Bytes
-	Signature *BlsSig `json:"signature"`
-	// index: QUANTITY, 64 Bits
-	Index *hexutil.Uint64 `json:"index"`
-}
-
-func (r DepositRequestV1) Validate() error {
-	if r.PubKey == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'pubkey' for DepositRequestV1")
-	}
-	if r.WithdrawalCredentials == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'withdrawalCredentials' for DepositRequestV1")
-	}
-	if r.Amount == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'amount' for DepositRequestV1")
-	}
-	if r.Signature == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'signature' for DepositRequestV1")
-	}
-	if r.Index == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'index' for DepositRequestV1")
-	}
-	return nil
-}
-
 // ConsolidationRequestV1 represents an execution engine ConsolidationRequestV1 value
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#consolidationrequestv1
 type ConsolidationRequestV1 struct {
@@ -987,48 +953,6 @@ func (e *ExecutionPayloadDeneb) MarshalJSON() ([]byte, error) {
 		BlobGasUsed:   &blobGasUsed,
 		ExcessBlobGas: &excessBlobGas,
 	})
-}
-
-func JsonDepositRequestsToProto(j []DepositRequestV1) ([]*DepositRequest, error) {
-	reqs := make([]*DepositRequest, len(j))
-
-	for i := range j {
-		req := j[i]
-		if err := req.Validate(); err != nil {
-			return nil, err
-		}
-		reqs[i] = &DepositRequest{
-			Pubkey:                req.PubKey.Bytes(),
-			WithdrawalCredentials: req.WithdrawalCredentials.Bytes(),
-			Amount:                uint64(*req.Amount),
-			Signature:             req.Signature.Bytes(),
-			Index:                 uint64(*req.Index),
-		}
-	}
-
-	return reqs, nil
-}
-
-func ProtoDepositRequestsToJson(reqs []*DepositRequest) []DepositRequestV1 {
-	j := make([]DepositRequestV1, len(reqs))
-	for i := range reqs {
-		r := reqs[i]
-		pk := BlsPubkey{}
-		copy(pk[:], r.Pubkey)
-		creds := common.BytesToHash(r.WithdrawalCredentials)
-		amt := hexutil.Uint64(r.Amount)
-		sig := BlsSig{}
-		copy(sig[:], r.Signature)
-		idx := hexutil.Uint64(r.Index)
-		j[i] = DepositRequestV1{
-			PubKey:                &pk,
-			WithdrawalCredentials: &creds,
-			Amount:                &amt,
-			Signature:             &sig,
-			Index:                 &idx,
-		}
-	}
-	return j
 }
 
 func JsonConsolidationRequestsToProto(j []ConsolidationRequestV1) ([]*ConsolidationRequest, error) {

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -393,30 +393,6 @@ type ExecutionPayloadDenebJSON struct {
 	Withdrawals   []*Withdrawal   `json:"withdrawals"`
 }
 
-// ConsolidationRequestV1 represents an execution engine ConsolidationRequestV1 value
-// https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#consolidationrequestv1
-type ConsolidationRequestV1 struct {
-	// sourceAddress: DATA, 20 Bytes
-	SourceAddress *common.Address `json:"sourceAddress"`
-	// sourcePubkey: DATA, 48 Bytes
-	SourcePubkey *BlsPubkey `json:"sourcePubkey"`
-	// targetPubkey: DATA, 48 Bytes
-	TargetPubkey *BlsPubkey `json:"targetPubkey"`
-}
-
-func (r ConsolidationRequestV1) Validate() error {
-	if r.SourceAddress == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'sourceAddress' for ConsolidationRequestV1")
-	}
-	if r.SourcePubkey == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'sourcePubkey' for ConsolidationRequestV1")
-	}
-	if r.TargetPubkey == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'targetPubkey' for ConsolidationRequestV1")
-	}
-	return nil
-}
-
 // MarshalJSON --
 func (e *ExecutionPayload) MarshalJSON() ([]byte, error) {
 	transactions := make([]hexutil.Bytes, len(e.Transactions))
@@ -953,42 +929,6 @@ func (e *ExecutionPayloadDeneb) MarshalJSON() ([]byte, error) {
 		BlobGasUsed:   &blobGasUsed,
 		ExcessBlobGas: &excessBlobGas,
 	})
-}
-
-func JsonConsolidationRequestsToProto(j []ConsolidationRequestV1) ([]*ConsolidationRequest, error) {
-	reqs := make([]*ConsolidationRequest, len(j))
-
-	for i := range j {
-		req := j[i]
-		if err := req.Validate(); err != nil {
-			return nil, err
-		}
-		reqs[i] = &ConsolidationRequest{
-			SourceAddress: req.SourceAddress.Bytes(),
-			SourcePubkey:  req.SourcePubkey.Bytes(),
-			TargetPubkey:  req.TargetPubkey.Bytes(),
-		}
-	}
-
-	return reqs, nil
-}
-
-func ProtoConsolidationRequestsToJson(reqs []*ConsolidationRequest) []ConsolidationRequestV1 {
-	j := make([]ConsolidationRequestV1, len(reqs))
-	for i := range reqs {
-		r := reqs[i]
-		spk := BlsPubkey{}
-		copy(spk[:], r.SourcePubkey)
-		tpk := BlsPubkey{}
-		copy(tpk[:], r.TargetPubkey)
-		address := common.BytesToAddress(r.SourceAddress)
-		j[i] = ConsolidationRequestV1{
-			SourceAddress: &address,
-			SourcePubkey:  &spk,
-			TargetPubkey:  &tpk,
-		}
-	}
-	return j
 }
 
 func (e *ExecutionPayloadDenebWithValueAndBlobsBundle) UnmarshalJSON(enc []byte) error {

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -393,27 +393,6 @@ type ExecutionPayloadDenebJSON struct {
 	Withdrawals   []*Withdrawal   `json:"withdrawals"`
 }
 
-// WithdrawalRequestV1 represents an execution engine WithdrawalRequestV1 value
-// https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#withdrawalrequestv1
-type WithdrawalRequestV1 struct {
-	SourceAddress   *common.Address `json:"sourceAddress"`
-	ValidatorPubkey *BlsPubkey      `json:"validatorPubkey"`
-	Amount          *hexutil.Uint64 `json:"amount"`
-}
-
-func (r WithdrawalRequestV1) Validate() error {
-	if r.SourceAddress == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'sourceAddress' for WithdrawalRequestV1")
-	}
-	if r.ValidatorPubkey == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'validatorPubkey' for WithdrawalRequestV1")
-	}
-	if r.Amount == nil {
-		return errors.Wrap(errJsonNilField, "missing required field 'amount' for WithdrawalRequestV1")
-	}
-	return nil
-}
-
 // DepositRequestV1 represents an execution engine DepositRequestV1 value
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#depositrequestv1
 type DepositRequestV1 struct {
@@ -1047,41 +1026,6 @@ func ProtoDepositRequestsToJson(reqs []*DepositRequest) []DepositRequestV1 {
 			Amount:                &amt,
 			Signature:             &sig,
 			Index:                 &idx,
-		}
-	}
-	return j
-}
-
-func JsonWithdrawalRequestsToProto(j []WithdrawalRequestV1) ([]*WithdrawalRequest, error) {
-	reqs := make([]*WithdrawalRequest, len(j))
-
-	for i := range j {
-		req := j[i]
-		if err := req.Validate(); err != nil {
-			return nil, err
-		}
-		reqs[i] = &WithdrawalRequest{
-			SourceAddress:   req.SourceAddress.Bytes(),
-			ValidatorPubkey: req.ValidatorPubkey.Bytes(),
-			Amount:          uint64(*req.Amount),
-		}
-	}
-
-	return reqs, nil
-}
-
-func ProtoWithdrawalRequestsToJson(reqs []*WithdrawalRequest) []WithdrawalRequestV1 {
-	j := make([]WithdrawalRequestV1, len(reqs))
-	for i := range reqs {
-		r := reqs[i]
-		pk := BlsPubkey{}
-		amt := hexutil.Uint64(r.Amount)
-		copy(pk[:], r.ValidatorPubkey)
-		address := common.BytesToAddress(r.SourceAddress)
-		j[i] = WithdrawalRequestV1{
-			SourceAddress:   &address,
-			ValidatorPubkey: &pk,
-			Amount:          &amt,
 		}
 	}
 	return j

--- a/proto/engine/v1/json_marshal_unmarshal_test.go
+++ b/proto/engine/v1/json_marshal_unmarshal_test.go
@@ -607,9 +607,6 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		// Expect no transaction objects in the unmarshaled data.
 		require.Equal(t, 0, len(payloadPb.Transactions))
 	})
-	t.Run("execution bundle electra with deneb payload, blob data, and execution requests", func(t *testing.T) {
-		// TODO #14351: update this test when geth updates
-	})
 
 	t.Run("ExecutionPayloadDenebAndBlobsBundleV2 SSZ marshaling", func(t *testing.T) {
 		payload := &enginev1.ExecutionPayloadDeneb{
@@ -703,7 +700,7 @@ func TestPayloadIDBytes_MarshalUnmarshalJSON(t *testing.T) {
 }
 
 func TestExecutionPayloadBody_MarshalUnmarshalJSON(t *testing.T) {
-	pBody := &enginev1.ExecutionPayloadBody{
+	pBody := &enginev1.ExecutionPayloadBodyV1{
 		Transactions: []hexutil.Bytes{[]byte("random1"), []byte("random2"), []byte("random3")},
 		Withdrawals: []*enginev1.Withdrawal{
 			{
@@ -722,7 +719,7 @@ func TestExecutionPayloadBody_MarshalUnmarshalJSON(t *testing.T) {
 	}
 	enc, err := json.Marshal(pBody)
 	require.NoError(t, err)
-	res := &enginev1.ExecutionPayloadBody{}
+	res := &enginev1.ExecutionPayloadBodyV1{}
 	err = json.Unmarshal(enc, res)
 	require.NoError(t, err)
 	require.DeepEqual(t, pBody, res)


### PR DESCRIPTION
**What type of PR is this?**

> Other: Cleanup

**What does this PR do? Why is it needed?**

This PR properly modifies `ExecutionPayloadBodyV1` as per spec ([execution-apis](https://github.com/ethereum/execution-apis/blob/abe638ccc84418c82b2db3f88523b4f7385b7f7f/src/engine/shanghai.md#executionpayloadbodyv1)). Now all execution requests are contained in the beacon block body, so the current codebase reflects some old discussions regarding Engine API + Execution Requests before Prague.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
