### PR TITLE
Skip payload attribute computation while syncing

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -324,6 +324,10 @@ func (s *Service) pruneInvalidBlock(ctx context.Context, root, parentRoot, paren
 func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState, slot primitives.Slot, headRoot []byte, headFull bool) payloadattribute.Attributer {
 	emptyAttri := payloadattribute.EmptyWithVersion(st.Version())
 
+	if !s.inRegularSync() {
+		return emptyAttri
+	}
+
 	// If it is an epoch boundary then process slots to get the right
 	// shuffling before checking if the proposer is tracked. Otherwise
 	// perform this check before. This is cheap as the NSC has already been updated.

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -231,12 +231,10 @@ func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessCon
 	if !s.isNewHead(cfg.headRoot, full) {
 		return
 	}
-	if s.inRegularSync() {
-		proposingSlot := s.CurrentSlot() + 1
-		attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
-		if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
-			return
-		}
+	proposingSlot := s.CurrentSlot() + 1
+	attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
+	if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
+		return
 	}
 	if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState, full); err != nil {
 		log.WithError(err).Error("Could not save head")

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -231,10 +231,12 @@ func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessCon
 	if !s.isNewHead(cfg.headRoot, full) {
 		return
 	}
-	proposingSlot := s.CurrentSlot() + 1
-	attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
-	if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
-		return
+	if s.inRegularSync() {
+		proposingSlot := s.CurrentSlot() + 1
+		attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
+		if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
+			return
+		}
 	}
 	if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState, full); err != nil {
 		log.WithError(err).Error("Could not save head")

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -47,10 +47,6 @@ func (s *Service) getFCUArgs(cfg *postBlockProcessConfig) (*fcuConfig, error) {
 		return nil, err
 	}
 
-	if !s.inRegularSync() {
-		return fcuArgs, nil
-	}
-
 	fcuArgs.attributes = s.getPayloadAttribute(cfg.ctx, fcuArgs.headState, fcuArgs.proposingSlot, cfg.headRoot[:], true)
 	return fcuArgs, nil
 }

--- a/beacon-chain/blockchain/process_block_helpers_test.go
+++ b/beacon-chain/blockchain/process_block_helpers_test.go
@@ -128,10 +128,11 @@ func TestSaveHeadIfNeeded_NotSynced_SkipsPayloadAttribute(t *testing.T) {
 	postState, _, err := prepareForkchoiceState(ctx, 3, [32]byte{'c'}, headRoot, [32]byte{}, ojc, ojc)
 	require.NoError(t, err)
 
-	// Sanity: the override conditions hold, so the synced path would skip the save.
+	// Not in regular sync: the attribute is empty even though the proposer is
+	// tracked and the override conditions hold, so the save below must proceed.
 	proposingSlot := service.CurrentSlot() + 1
 	attr := service.getPayloadAttribute(ctx, postState, proposingSlot, headRoot[:], false)
-	require.Equal(t, false, attr.IsEmpty())
+	require.Equal(t, true, attr.IsEmpty())
 	require.Equal(t, true, service.shouldOverrideFCU(headRoot, proposingSlot))
 
 	// Old head and new head block plumbing so saveHead can complete.

--- a/beacon-chain/blockchain/process_block_helpers_test.go
+++ b/beacon-chain/blockchain/process_block_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
 )
 
 // When the current head is unchanged, saveHeadIfNeeded must return immediately
@@ -90,4 +91,64 @@ func TestSaveHeadIfNeeded_ProposingAndOverride_SkipsSave(t *testing.T) {
 	cfg := &postBlockProcessConfig{ctx: ctx, headRoot: headRoot, postState: postState}
 	service.saveHeadIfNeeded(ctx, cfg)
 	require.Equal(t, true, service.head == nil)
+}
+
+type notSyncedChecker struct{}
+
+func (notSyncedChecker) Synced() bool { return false }
+
+func TestSaveHeadIfNeeded_NotSynced_SkipsPayloadAttribute(t *testing.T) {
+	resetCfg := features.InitWithReset(&features.Flags{PrepareAllPayloads: true})
+	defer resetCfg()
+
+	service, tr := minimalTestService(t)
+	ctx, fcs := tr.ctx, tr.fcs
+	service.cfg.SyncChecker = notSyncedChecker{}
+
+	// Service clock: current slot == 2, so the proposing slot is 3.
+	service.SetGenesisTime(time.Now().Add(-time.Duration(2*params.BeaconConfig().SecondsPerSlot) * time.Second))
+
+	parentRoot := [32]byte{'a'}
+	headRoot := [32]byte{'b'}
+	ojc := &ethpb.Checkpoint{}
+	st, ro, err := prepareForkchoiceState(ctx, 1, parentRoot, [32]byte{}, [32]byte{}, ojc, ojc)
+	require.NoError(t, err)
+	require.NoError(t, fcs.InsertNode(ctx, st, ro))
+	st, ro, err = prepareForkchoiceState(ctx, 2, headRoot, parentRoot, [32]byte{}, ojc, ojc)
+	require.NoError(t, err)
+	require.NoError(t, fcs.InsertNode(ctx, st, ro))
+
+	// Forkchoice clock: the head node (slot 2) is from the current slot and arrived
+	// late, so ForkChoiceStore.ShouldOverrideFCU() returns true.
+	fcs.SetGenesisTime(time.Now().Add(-29 * time.Second))
+	fcHead, err := fcs.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, headRoot, fcHead)
+
+	postState, _, err := prepareForkchoiceState(ctx, 3, [32]byte{'c'}, headRoot, [32]byte{}, ojc, ojc)
+	require.NoError(t, err)
+
+	// Sanity: the override conditions hold, so the synced path would skip the save.
+	proposingSlot := service.CurrentSlot() + 1
+	attr := service.getPayloadAttribute(ctx, postState, proposingSlot, headRoot[:], false)
+	require.Equal(t, false, attr.IsEmpty())
+	require.Equal(t, true, service.shouldOverrideFCU(headRoot, proposingSlot))
+
+	// Old head and new head block plumbing so saveHead can complete.
+	oldBlock := util.SaveBlock(t, ctx, service.cfg.BeaconDB, util.NewBeaconBlock())
+	oldRoot, err := oldBlock.Block().HashTreeRoot()
+	require.NoError(t, err)
+	service.head = &head{root: oldRoot, block: oldBlock, state: postState}
+
+	newHeadSignedBlock := util.NewBeaconBlock()
+	newHeadSignedBlock.Block.Slot = 2
+	newHeadSignedBlock.Block.ParentRoot = oldRoot[:]
+	wsb := util.SaveBlock(t, ctx, service.cfg.BeaconDB, newHeadSignedBlock)
+	roblock, err := blocks.NewROBlockWithRoot(wsb, headRoot)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.BeaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 2, Root: headRoot[:]}))
+
+	cfg := &postBlockProcessConfig{ctx: ctx, roblock: roblock, headRoot: headRoot, postState: postState}
+	service.saveHeadIfNeeded(ctx, cfg)
+	require.Equal(t, headRoot, service.head.root)
 }

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -226,11 +226,11 @@ func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROEx
 		}
 	}
 
-	proposingSlot := s.CurrentSlot() + 1
-	attr := s.getPayloadAttribute(ctx, st, proposingSlot, headRoot[:], true)
 	if !s.inRegularSync() {
 		return nil
 	}
+	proposingSlot := s.CurrentSlot() + 1
+	attr := s.getPayloadAttribute(ctx, st, proposingSlot, headRoot[:], true)
 	go func() {
 		pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, attr)
 		if err != nil {

--- a/changelog/terence_skip-payload-attribute-while-syncing.md
+++ b/changelog/terence_skip-payload-attribute-while-syncing.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Skip payload attribute computation in `saveHeadIfNeeded` while syncing. Computing attributes with a head state far behind the wall clock processed thousands of slots per synced block, slowing initial sync to ~0.1 blocks/s.
+- Skip payload attribute computation while the node is syncing, gated inside `getPayloadAttribute`. Computing attributes with a state far behind the wall clock processed thousands of slots per block, slowing sync to ~0.1 blocks/s.

--- a/changelog/terence_skip-payload-attribute-while-syncing.md
+++ b/changelog/terence_skip-payload-attribute-while-syncing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Skip payload attribute computation in `saveHeadIfNeeded` while syncing. Computing attributes with a head state far behind the wall clock processed thousands of slots per synced block, slowing initial sync to ~0.1 blocks/s.


### PR DESCRIPTION
Per review, the gate is now inside `getPayloadAttribute` itself: it returns an empty attribute when the node is not in regular sync, instead of replaying a state that can be thousands of slots behind the wall clock