### PR TITLE
Check shouldOverrideFCU before computing payload attribute

### DIFF
--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -232,9 +232,11 @@ func (s *Service) saveHeadIfNeeded(ctx context.Context, cfg *postBlockProcessCon
 		return
 	}
 	proposingSlot := s.CurrentSlot() + 1
-	attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
-	if !attr.IsEmpty() && s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
-		return
+	if s.shouldOverrideFCU(cfg.headRoot, proposingSlot) {
+		attr := s.getPayloadAttribute(ctx, cfg.postState, proposingSlot, cfg.headRoot[:], full)
+		if !attr.IsEmpty() {
+			return
+		}
 	}
 	if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState, full); err != nil {
 		log.WithError(err).Error("Could not save head")

--- a/changelog/terence_reorder-fcu-override-check.md
+++ b/changelog/terence_reorder-fcu-override-check.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Check `shouldOverrideFCU` before computing payload attributes in `saveHeadIfNeeded`, avoiding expensive part


### PR DESCRIPTION
Reorders `saveHeadIfNeeded` to run the cheap `shouldOverrideFCU` forkchoice check before `getPayloadAttribute`, which copies the state and can replay slots