### PR TITLE
Check network size before computing subnet topic scoring params

### DIFF
--- a/beacon-chain/p2p/gossip_scoring_params.go
+++ b/beacon-chain/p2p/gossip_scoring_params.go
@@ -179,6 +179,18 @@ func (s *Service) retrieveActiveValidators() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if minAtt := minActiveValidatorsForAttSubnetScoring(); activeVals < minAtt {
+		log.WithFields(logrus.Fields{
+			"activeValidators": activeVals,
+			"required":         minAtt,
+		}).Debug("Network too small to score attestation subnet topics, they will be unscored")
+	}
+	if minSync := minActiveValidatorsForSyncSubnetScoring(); activeVals < minSync {
+		log.WithFields(logrus.Fields{
+			"activeValidators": activeVals,
+			"required":         minSync,
+		}).Debug("Network too small to score sync committee subnet topics, they will be unscored")
+	}
 	// Cache active validator count
 	s.activeValidatorCount = activeVals
 	return activeVals, nil
@@ -301,21 +313,29 @@ func defaultSyncContributionTopicParams() *pubsub.TopicScoreParams {
 	}
 }
 
+// minActiveValidatorsForAttSubnetScoring is the count below which the expected
+// per-subnet message rate truncates to zero and attestation subnet topics cannot be scored.
+func minActiveValidatorsForAttSubnetScoring() uint64 {
+	cfg := params.BeaconConfig()
+	return cfg.AttestationSubnetCount * uint64(cfg.SlotsPerEpoch) * gossipSubD / 2
+}
+
+// minActiveValidatorsForSyncSubnetScoring is the sync committee subnet equivalent.
+func minActiveValidatorsForSyncSubnetScoring() uint64 {
+	return params.BeaconConfig().SyncCommitteeSubnetCount * gossipSubD / 2
+}
+
 func defaultAggregateSubnetTopicParams(activeValidators uint64) *pubsub.TopicScoreParams {
+	// Logged once in retrieveActiveValidators.
+	if activeValidators < minActiveValidatorsForAttSubnetScoring() {
+		return nil
+	}
 	subnetCount := params.BeaconConfig().AttestationSubnetCount
 	// Get weight for each specific subnet.
 	topicWeight := attestationTotalWeight / float64(subnetCount)
 	subnetWeight := activeValidators / subnetCount
-	if subnetWeight == 0 {
-		log.Warn("Subnet weight is 0, skipping initializing topic scoring")
-		return nil
-	}
 	// Determine the amount of validators expected in a subnet in a single slot.
 	numPerSlot := time.Duration(subnetWeight / uint64(params.BeaconConfig().SlotsPerEpoch))
-	if numPerSlot == 0 {
-		log.Warn("Number per slot is 0, skipping initializing topic scoring")
-		return nil
-	}
 	comsPerSlot := committeeCountPerSlot(activeValidators)
 	exceedsThreshold := comsPerSlot >= 2*subnetCount/uint64(params.BeaconConfig().SlotsPerEpoch)
 	firstDecay := time.Duration(1)
@@ -325,10 +345,6 @@ func defaultAggregateSubnetTopicParams(activeValidators uint64) *pubsub.TopicSco
 		meshDecay = 16
 	}
 	rate := numPerSlot * 2 / gossipSubD
-	if rate == 0 {
-		log.Warn("Skipping initializing topic scoring because rate is 0")
-		return nil
-	}
 	// Determine expected first deliveries based on the message rate.
 	firstMessageCap, err := decayLimit(scoreDecay(firstDecay*oneEpochDuration()), float64(rate))
 	if err != nil {
@@ -371,6 +387,10 @@ func defaultAggregateSubnetTopicParams(activeValidators uint64) *pubsub.TopicSco
 }
 
 func defaultSyncSubnetTopicParams(activeValidators uint64) *pubsub.TopicScoreParams {
+	// Logged once in retrieveActiveValidators.
+	if activeValidators < minActiveValidatorsForSyncSubnetScoring() {
+		return nil
+	}
 	subnetCount := params.BeaconConfig().SyncCommitteeSubnetCount
 	// Get weight for each specific subnet.
 	topicWeight := syncCommitteesTotalWeight / float64(subnetCount)
@@ -380,18 +400,10 @@ func defaultSyncSubnetTopicParams(activeValidators uint64) *pubsub.TopicScorePar
 		activeValidators = syncComSize
 	}
 	subnetWeight := activeValidators / subnetCount
-	if subnetWeight == 0 {
-		log.Warn("Subnet weight is 0, skipping initializing topic scoring")
-		return nil
-	}
 	firstDecay := time.Duration(1)
 	meshDecay := time.Duration(4)
 
 	rate := subnetWeight * 2 / gossipSubD
-	if rate == 0 {
-		log.Warn("Skipping initializing topic scoring because rate is 0")
-		return nil
-	}
 	// Determine expected first deliveries based on the message rate.
 	firstMessageCap, err := decayLimit(scoreDecay(firstDecay*oneEpochDuration()), float64(rate))
 	if err != nil {

--- a/changelog/terence_demote-small-network-scoring-logs.md
+++ b/changelog/terence_demote-small-network-scoring-logs.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Check the network size up front when computing subnet topic scoring params, replacing the per-subnet "rate is 0" warning spam with a single debug line that includes the active and required validator counts.


### PR DESCRIPTION
Computing subnet topic scoring params on a network with fewer than AttestationSubnetCount × SlotsPerEpoch × D/2 (= 8192) active validators truncates the expected message rate to zero, so every node logged ~64 "Skipping initializing topic scoring because rate is 0" warnings per topic subscription on small networks.

Check the minimum validator count up front in the subnet param functions and replace the per-subnet warnings with a single debug line (active vs required count) logged once when the active validator count is first cached. Mainnet behavior is unchanged.