### PR TITLE
Make FullBeatsEmpty fork-agnostic

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -558,7 +558,7 @@ func (f *ForkChoice) FullBeatsEmpty(root [32]byte) bool {
 		return false
 	}
 	if slots.ToEpoch(en.node.slot) < params.BeaconConfig().GloasForkEpoch {
-		return false
+		return true // pre-gloas blocks always carry their payload
 	}
 	pn := f.store.choosePayloadContent(en.node)
 	return pn != nil && pn.full

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -557,9 +557,6 @@ func (f *ForkChoice) FullBeatsEmpty(root [32]byte) bool {
 	if en == nil || en.node == nil {
 		return false
 	}
-	if slots.ToEpoch(en.node.slot) < params.BeaconConfig().GloasForkEpoch {
-		return true // pre-gloas blocks always carry their payload
-	}
 	pn := f.store.choosePayloadContent(en.node)
 	return pn != nil && pn.full
 }

--- a/changelog/terence_full-beats-empty-pre-gloas.md
+++ b/changelog/terence_full-beats-empty-pre-gloas.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Return true from `FullBeatsEmpty` for pre-gloas blocks so head payload status is saved consistently across all head update paths.

--- a/changelog/terence_full-beats-empty-pre-gloas.md
+++ b/changelog/terence_full-beats-empty-pre-gloas.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Return true from `FullBeatsEmpty` for pre-gloas blocks so head payload status is saved consistently across all head update paths.
+- Make `FullBeatsEmpty` fork-agnostic so pre-gloas heads report a full payload consistently across all head update paths.


### PR DESCRIPTION
`FullBeatsEmpty` returned `false` for pre-gloas blocks, but pre-gloas blocks always carry their payload, so head saves were inconsistent: `UpdateAndSaveHeadWithBalances` saved `full = false` pre-gloas while the post-block FCU path and the `FullHead`-derived paths saved `true`, letting a same-root save spuriously register as a head change.

Rather than special-case the fork, this drops the slot/epoch branch entirely: `choosePayloadContent` already resolves to the full node pre-gloas (all pre-gloas votes carry `payloadStatus = true` so weight accrues to the full node, and pre-gloas children build on it), so the helper now works the same across forks.