### PR TITLE
Emit proposer_preferences SSE event for locally submitted preferences

### DIFF
--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -4569,6 +4569,7 @@ func TestSubmitSignedProposerPreferences_OK(t *testing.T) {
 		TimeFetcher:              &mockChain.ChainService{Slot: &currentSlot},
 		P2P:                      &p2pmock.MockBroadcaster{},
 		ProposerPreferencesCache: c,
+		OperationNotifier:        (&mockChain.ChainService{}).OperationNotifier(),
 	}
 
 	s := &Server{V1Alpha1Server: v1alpha1Server}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -97,6 +99,11 @@ func (vs *Server) SubmitSignedProposerPreferences(
 			FeeRecipient:   bytesutil.ToBytes20(msg.Message.FeeRecipient),
 			TargetGasLimit: msg.Message.TargetGasLimit,
 		}, proposalSlot)
+
+		vs.OperationNotifier.OperationFeed().Send(&feed.Event{
+			Type: opfeed.ProposerPreferencesReceived,
+			Data: &opfeed.ProposerPreferencesReceivedData{Data: msg},
+		})
 		broadcast++
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_preferences_test.go
@@ -30,6 +30,7 @@ func TestSubmitSignedProposerPreferences_OK(t *testing.T) {
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:              chain,
+		OperationNotifier:        chain.OperationNotifier(),
 		P2P:                      p2p,
 		ProposerPreferencesCache: cache,
 	}
@@ -72,6 +73,7 @@ func TestSubmitSignedProposerPreferences_Multiple(t *testing.T) {
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:              chain,
+		OperationNotifier:        chain.OperationNotifier(),
 		P2P:                      p2p,
 		ProposerPreferencesCache: c,
 	}
@@ -132,6 +134,7 @@ func TestSubmitSignedProposerPreferences_DuplicateSlot(t *testing.T) {
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:              chain,
+		OperationNotifier:        chain.OperationNotifier(),
 		P2P:                      p2p,
 		ProposerPreferencesCache: c,
 	}
@@ -168,6 +171,7 @@ func TestSubmitSignedProposerPreferences_InvalidEpoch(t *testing.T) {
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:              chain,
+		OperationNotifier:        chain.OperationNotifier(),
 		P2P:                      &p2pmock.MockBroadcaster{},
 		ProposerPreferencesCache: cache.NewProposerPreferencesCache(),
 	}
@@ -210,6 +214,7 @@ func TestSubmitSignedProposerPreferences_CurrentEpochFutureSlot(t *testing.T) {
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:              chain,
+		OperationNotifier:        chain.OperationNotifier(),
 		P2P:                      p2p,
 		ProposerPreferencesCache: cache,
 	}
@@ -246,6 +251,7 @@ func TestSubmitSignedProposerPreferences_Syncing(t *testing.T) {
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: true},
 		TimeFetcher:              chain,
+		OperationNotifier:        chain.OperationNotifier(),
 		P2P:                      &p2pmock.MockBroadcaster{},
 		ProposerPreferencesCache: cache.NewProposerPreferencesCache(),
 	}
@@ -284,6 +290,7 @@ func TestSubmitSignedProposerPreferences_BroadcastsForProposalEpoch(t *testing.T
 	vs := &Server{
 		SyncChecker:              &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:              chain,
+		OperationNotifier:        chain.OperationNotifier(),
 		P2P:                      p2p,
 		ProposerPreferencesCache: cache.NewProposerPreferencesCache(),
 	}

--- a/changelog/terence_gloas-proposer-preferences-sse.md
+++ b/changelog/terence_gloas-proposer-preferences-sse.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Emit the `proposer_preferences` SSE event for locally submitted preferences, not only those received over gossip.


### PR DESCRIPTION
The `proposer_preferences` SSE event only fired from the gossip-receive path, so a node never emitted its own validators' preferences (gossip doesn't loop back to the publisher). Builders and relays consuming a single node's event stream therefore missed that node's proposers' preferences; this also emits the event when preferences are submitted locally via the validator client.