### PR TITLE
Emit execution_payload_bid event on the beacon node event stream

### DIFF
--- a/api/server/structs/endpoints_events.go
+++ b/api/server/structs/endpoints_events.go
@@ -135,6 +135,11 @@ type ProposerPreferencesEvent struct {
 	Data    *SignedProposerPreferences `json:"data"`
 }
 
+type ExecutionPayloadBidEvent struct {
+	Version string                     `json:"version"`
+	Data    *SignedExecutionPayloadBid `json:"data"`
+}
+
 type ExecutionPayloadAvailableEvent struct {
 	Slot      string `json:"slot"`
 	BlockRoot string `json:"block_root"`

--- a/beacon-chain/core/feed/operation/events.go
+++ b/beacon-chain/core/feed/operation/events.go
@@ -56,6 +56,9 @@ const (
 
 	// ProposerPreferencesReceived is sent after signed proposer preferences are received from gossip or rpc.
 	ProposerPreferencesReceived = 15
+
+	// ExecutionPayloadBidReceived is sent after a signed execution payload bid is received from gossip that passes validation rules.
+	ExecutionPayloadBidReceived = 16
 )
 
 // UnAggregatedAttReceivedData is the data sent with UnaggregatedAttReceived events.
@@ -141,4 +144,9 @@ type ExecutionPayloadGossipReceivedData struct {
 // ProposerPreferencesReceivedData is the data sent with ProposerPreferencesReceived events.
 type ProposerPreferencesReceivedData struct {
 	Data *ethpb.SignedProposerPreferences
+}
+
+// ExecutionPayloadBidReceivedData is the data sent with ExecutionPayloadBidReceived events.
+type ExecutionPayloadBidReceivedData struct {
+	Bid *ethpb.SignedExecutionPayloadBid
 }

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -130,6 +130,7 @@ var opsFeedEventTopics = map[feed.EventType]string{
 	operation.PayloadAttestationMessageReceived: PayloadAttestationMessageTopic,
 	operation.ProposerPreferencesReceived:       ProposerPreferencesTopic,
 	operation.ExecutionPayloadGossipReceived:    ExecutionPayloadGossipTopic,
+	operation.ExecutionPayloadBidReceived:       ExecutionPayloadBidTopic,
 }
 
 var stateFeedEventTopics = map[feed.EventType]string{
@@ -145,11 +146,7 @@ var stateFeedEventTopics = map[feed.EventType]string{
 	statefeed.ExecutionPayloadProcessed:   ExecutionPayloadTopic,
 }
 
-var topicsForStateFeed = func() map[string]bool {
-	m := topicsForFeed(stateFeedEventTopics)
-	m[ExecutionPayloadBidTopic] = true
-	return m
-}()
+var topicsForStateFeed = topicsForFeed(stateFeedEventTopics)
 var topicsForOpsFeed = topicsForFeed(opsFeedEventTopics)
 
 func topicsForFeed(em map[feed.EventType]string) map[string]bool {
@@ -501,6 +498,8 @@ func topicForEvent(event *feed.Event) string {
 		return PayloadAttestationMessageTopic
 	case *operation.ProposerPreferencesReceivedData:
 		return ProposerPreferencesTopic
+	case *operation.ExecutionPayloadBidReceivedData:
+		return ExecutionPayloadBidTopic
 	case *statefeed.ExecutionPayloadAvailableData:
 		return ExecutionPayloadAvailableTopic
 	case *statefeed.ExecutionPayloadProcessedData:
@@ -693,6 +692,14 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 			return jsonMarshalReader(eventName, &structs.ProposerPreferencesEvent{
 				Version: version.String(params.GetNetworkScheduleEntry(epoch).VersionEnum),
 				Data:    structs.SignedProposerPreferencesFromConsensus(v.Data),
+			})
+		}, nil
+	case *operation.ExecutionPayloadBidReceivedData:
+		return func() io.Reader {
+			epoch := slots.ToEpoch(v.Bid.Message.Slot)
+			return jsonMarshalReader(eventName, &structs.ExecutionPayloadBidEvent{
+				Version: version.String(params.GetNetworkScheduleEntry(epoch).VersionEnum),
+				Data:    structs.SignedExecutionPayloadBidFromConsensus(v.Bid),
 			})
 		}, nil
 	case *statefeed.ExecutionPayloadAvailableData:

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"context"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -142,6 +144,10 @@ func (s *Service) executionPayloadBidSubscriber(_ context.Context, msg proto.Mes
 		return errNilMessage
 	}
 	s.setHighestExecutionPayloadBid(signedBid)
+	s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
+		Type: opfeed.ExecutionPayloadBidReceived,
+		Data: &opfeed.ExecutionPayloadBidReceivedData{Bid: signedBid},
+	})
 	return nil
 }
 

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -288,6 +288,7 @@ func TestExecutionPayloadBidSubscriber_WrongMessage(t *testing.T) {
 
 func TestExecutionPayloadBidSubscriber_HappyPath(t *testing.T) {
 	s := &Service{
+		cfg:                             &config{operationNotifier: &mock.MockOperationNotifier{}},
 		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
 	}
 	signedBid := util.GenerateTestSignedExecutionPayloadBid(1)

--- a/changelog/terence_gloas-execution-payload-bid-event.md
+++ b/changelog/terence_gloas-execution-payload-bid-event.md
@@ -1,0 +1,3 @@
+### Added
+
+- Emit the `execution_payload_bid` event on the beacon node event stream when a builder bid is received from gossip; the topic was previously subscribable but never produced.


### PR DESCRIPTION
The `execution_payload_bid` SSE topic was registered as subscribable but had no producer, so subscribers never received anything. This emits it from the gossip subscriber once a bid passes validation, mirroring how `proposer_preferences` is wired, so builders and relays can observe bids over the event stream.