### PR TITLE
Emit payload_attributes SSE event after the Gloas fork

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -179,7 +179,7 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 			"payloadID": fmt.Sprintf("%#x", bytesutil.Trunc(payloadID[:])),
 		}).Info("Forkchoice updated with payload attributes for proposal")
 		s.cfg.PayloadIDCache.Set(nextSlot, arg.headRoot, true, pId)
-		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), arg.headBlock, arg.headRoot, nextSlot)
+		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), arg.headBlock, arg.headRoot, nextSlot, arg.attributes)
 	} else if hasAttr && payloadID == nil && !features.Get().PrepareAllPayloads {
 		log.WithFields(logrus.Fields{
 			"blockHash": fmt.Sprintf("%#x", headPayload.BlockHash()),
@@ -190,17 +190,15 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 	return payloadID, nil
 }
 
-func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot) {
+func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot, attr payloadattribute.Attributer) {
 	// If we're syncing a block in the past and init-sync is still running, we shouldn't fire this event.
 	if !s.cfg.SyncChecker.Synced() {
 		return
 	}
-	// the fcu args have differing amounts of completeness based on the code path,
-	// and there is work we only want to do if a client is actually listening to the events beacon api endpoint.
-	// temporary solution: just fire a blank event and fill in the details in the api handler.
+	// Carry the attribute already sent to the engine so the SSE value matches it exactly; the handler fills the remaining scalar fields lazily.
 	f.Send(&feed.Event{
 		Type: statefeed.PayloadAttributes,
-		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalSlot: nextSlot},
+		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalSlot: nextSlot, Attributer: attr},
 	})
 }
 

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	payloadattribute "github.com/OffchainLabs/prysm/v7/consensus-types/payload-attribute"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
@@ -202,10 +203,12 @@ func (s *Service) latePayloadTasks(ctx context.Context) {
 	}
 	var pId [8]byte
 	copy(pId[:], pid[:])
+
 	s.cfg.PayloadIDCache.Set(currentSlot+1, hr, false, pId)
+	s.firePayloadAttributesEventForHead(hr, currentSlot+1)
 }
 
-func (s *Service) fcuFromReorgData(hr [32]byte, hash [32]byte, full bool, attr payloadattribute.Attributer, proposingSlot primitives.Slot) {
+func (s *Service) fcuFromReorgData(headBlock interfaces.ReadOnlySignedBeaconBlock, hr [32]byte, hash [32]byte, full bool, attr payloadattribute.Attributer, proposingSlot primitives.Slot) {
 	pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, hash, attr)
 	if err != nil {
 		log.WithError(err).Error("Could not update forkchoice with engine")
@@ -219,6 +222,23 @@ func (s *Service) fcuFromReorgData(hr [32]byte, hash [32]byte, full bool, attr p
 	var pId [8]byte
 	copy(pId[:], pid[:])
 	s.cfg.PayloadIDCache.Set(proposingSlot, hr, full, pId)
+
+	if !attr.IsEmpty() {
+		s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, hr, proposingSlot)
+	}
+}
+
+func (s *Service) firePayloadAttributesEventForHead(headRoot [32]byte, proposingSlot primitives.Slot) {
+	s.headLock.RLock()
+	var headBlock interfaces.ReadOnlySignedBeaconBlock
+	if s.head != nil && s.head.root == headRoot {
+		headBlock = s.head.block
+	}
+	s.headLock.RUnlock()
+	if headBlock == nil {
+		return
+	}
+	s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, proposingSlot)
 }
 
 // This saves head and prunes atts from the pool only if the head is new and if we are either

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -203,9 +203,8 @@ func (s *Service) latePayloadTasks(ctx context.Context) {
 	}
 	var pId [8]byte
 	copy(pId[:], pid[:])
-
 	s.cfg.PayloadIDCache.Set(currentSlot+1, hr, false, pId)
-	s.firePayloadAttributesEventForHead(hr, currentSlot+1)
+	s.firePayloadAttributesEventForHead(hr, currentSlot+1, attr)
 }
 
 func (s *Service) fcuFromReorgData(headBlock interfaces.ReadOnlySignedBeaconBlock, hr [32]byte, hash [32]byte, full bool, attr payloadattribute.Attributer, proposingSlot primitives.Slot) {
@@ -224,11 +223,11 @@ func (s *Service) fcuFromReorgData(headBlock interfaces.ReadOnlySignedBeaconBloc
 	s.cfg.PayloadIDCache.Set(proposingSlot, hr, full, pId)
 
 	if !attr.IsEmpty() {
-		s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, hr, proposingSlot)
+		s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, hr, proposingSlot, attr)
 	}
 }
 
-func (s *Service) firePayloadAttributesEventForHead(headRoot [32]byte, proposingSlot primitives.Slot) {
+func (s *Service) firePayloadAttributesEventForHead(headRoot [32]byte, proposingSlot primitives.Slot, attr payloadattribute.Attributer) {
 	s.headLock.RLock()
 	var headBlock interfaces.ReadOnlySignedBeaconBlock
 	if s.head != nil && s.head.root == headRoot {
@@ -238,7 +237,7 @@ func (s *Service) firePayloadAttributesEventForHead(headRoot [32]byte, proposing
 	if headBlock == nil {
 		return
 	}
-	s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, proposingSlot)
+	s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, proposingSlot, attr)
 }
 
 // This saves head and prunes atts from the pool only if the head is new and if we are either

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -396,7 +396,7 @@ func TestFcuFromReorgData_CachesPayloadID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, attr.IsEmpty())
 
-	s.fcuFromReorgData(headRoot, headHash, false, attr, proposingSlot)
+	s.fcuFromReorgData(nil, headRoot, headHash, false, attr, proposingSlot)
 
 	require.LogsDoNotContain(t, logHook, "Could not update forkchoice with engine")
 	cachedPid, has := s.cfg.PayloadIDCache.PayloadID(proposingSlot, headRoot, false)
@@ -413,7 +413,7 @@ func TestFcuFromReorgData_NilPayloadID_NoCache(t *testing.T) {
 	proposingSlot := primitives.Slot(2)
 	attr := payloadattribute.EmptyWithVersion(version.Gloas)
 
-	s.fcuFromReorgData(headRoot, headHash, false, attr, proposingSlot)
+	s.fcuFromReorgData(nil, headRoot, headHash, false, attr, proposingSlot)
 
 	_, has := s.cfg.PayloadIDCache.PayloadID(proposingSlot, headRoot, false)
 	require.Equal(t, false, has)
@@ -431,7 +431,7 @@ func TestFcuFromReorgData_EngineError(t *testing.T) {
 	proposingSlot := primitives.Slot(2)
 	attr := payloadattribute.EmptyWithVersion(version.Gloas)
 
-	s.fcuFromReorgData(headRoot, headHash, false, attr, proposingSlot)
+	s.fcuFromReorgData(nil, headRoot, headHash, false, attr, proposingSlot)
 
 	require.LogsContain(t, logHook, "Could not update forkchoice with engine")
 	_, has := s.cfg.PayloadIDCache.PayloadID(proposingSlot, headRoot, false)

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -155,7 +155,7 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 		}
 		postGloas := slots.ToEpoch(proposingSlot) >= params.BeaconConfig().GloasForkEpoch
 		if postGloas {
-			go s.fcuFromReorgData(newHeadRoot, headHash, full, attr, proposingSlot)
+			go s.fcuFromReorgData(headBlock, newHeadRoot, headHash, full, attr, proposingSlot)
 		} else {
 			fcuArgs := &fcuConfig{
 				headState:     headState,

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -241,7 +241,7 @@ func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROEx
 			var pId [8]byte
 			copy(pId[:], pid[:])
 			s.cfg.PayloadIDCache.Set(proposingSlot, root, true, pId)
-			s.firePayloadAttributesEventForHead(root, proposingSlot)
+			s.firePayloadAttributesEventForHead(root, proposingSlot, attr)
 		}
 	}()
 	if requests := envelope.ExecutionRequests(); requests != nil && len(requests.Deposits) > 0 {

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -241,6 +241,7 @@ func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROEx
 			var pId [8]byte
 			copy(pId[:], pid[:])
 			s.cfg.PayloadIDCache.Set(proposingSlot, root, true, pId)
+			s.firePayloadAttributesEventForHead(root, proposingSlot)
 		}
 	}()
 	if requests := envelope.ExecutionRequests(); requests != nil && len(requests.Deposits) > 0 {

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -869,12 +869,20 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 		return ev, errors.Wrap(err, "could not get head state randado")
 	}
 
-	payload, err := ev.HeadBlock.Block().Body().Execution()
-	if err != nil {
-		return ev, errors.Wrap(err, "could not get execution payload for head block")
+	if ev.HeadBlock.Version() >= version.Gloas {
+		h, err := rost.LatestBlockHash()
+		if err != nil {
+			return ev, errors.Wrap(err, "could not get latest block hash from head state")
+		}
+		ev.ParentBlockHash = h[:]
+	} else {
+		payload, err := ev.HeadBlock.Block().Body().Execution()
+		if err != nil {
+			return ev, errors.Wrap(err, "could not get execution payload for head block")
+		}
+		ev.ParentBlockHash = payload.BlockHash()
+		ev.ParentBlockNumber = payload.BlockNumber()
 	}
-	ev.ParentBlockHash = payload.BlockHash()
-	ev.ParentBlockNumber = payload.BlockNumber()
 
 	t, err := slots.StartTime(rost.GenesisTime(), ev.ProposalSlot)
 	if err != nil {

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -864,11 +864,6 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 
 	ev.ProposerIndex = proposerIndex
 
-	randao, err := helpers.RandaoMix(rost, pse)
-	if err != nil {
-		return ev, errors.Wrap(err, "could not get head state randado")
-	}
-
 	if ev.HeadBlock.Version() >= version.Gloas {
 		h, err := rost.LatestBlockHash()
 		if err != nil {
@@ -882,6 +877,15 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 		}
 		ev.ParentBlockHash = payload.BlockHash()
 		ev.ParentBlockNumber = payload.BlockNumber()
+	}
+
+	if ev.Attributer != nil && !ev.Attributer.IsEmpty() {
+		return ev, nil
+	}
+
+	randao, err := helpers.RandaoMix(rost, pse)
+	if err != nil {
+		return ev, errors.Wrap(err, "could not get head state randado")
 	}
 
 	t, err := slots.StartTime(rost.GenesisTime(), ev.ProposalSlot)

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -728,68 +728,70 @@ func TestFillEventData(t *testing.T) {
 		require.NoError(t, err)
 		require.DeepEqual(t, alreadyFilled, result)
 	})
-	t.Run("Electra PartialData_ShouldFetchHeadStateAndBlock", func(t *testing.T) {
-		st, err := util.NewBeaconStateElectra()
-		require.NoError(t, err)
-		valCount := 10
-		setActiveValidators(t, st, valCount)
-		inactivityScores := make([]uint64, valCount)
-		for i := range inactivityScores {
-			inactivityScores[i] = 10
-		}
-		require.NoError(t, st.SetInactivityScores(inactivityScores))
-		b, err := blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlockElectra(&eth.SignedBeaconBlockElectra{}))
-		require.NoError(t, err)
-		attributor, err := payloadattribute.New(&enginev1.PayloadAttributes{
-			Timestamp: uint64(time.Now().Unix()),
-		})
-		require.NoError(t, err)
-		headRoot, err := b.Block().HashTreeRoot()
-		require.NoError(t, err)
-		// Create an event data object missing certain fields:
-		partial := payloadattribute.EventData{
-			ProposalSlot: 42,         // different epoch from current slot
-			Attributer:   attributor, // Must be Bellatrix or later
-			HeadBlock:    b,
-			HeadRoot:     headRoot,
-		}
-		currentSlot := primitives.Slot(0)
-		// to avoid slot processing
-		require.NoError(t, st.SetSlot(currentSlot+1))
-		mockChainService := &mockChain.ChainService{
-			Root:  make([]byte, 32),
-			State: st,
-			Block: b,
-			Slot:  &currentSlot,
-		}
-
-		stategen := mock.NewService()
-		stategen.AddStateForRoot(st, headRoot)
-		stn := mockChain.NewEventFeedWrapper()
-		opn := mockChain.NewEventFeedWrapper()
-		srv := &Server{
-			StateNotifier:          &mockChain.SimpleNotifier{Feed: stn},
-			OperationNotifier:      &mockChain.SimpleNotifier{Feed: opn},
-			HeadFetcher:            mockChainService,
-			ChainInfoFetcher:       mockChainService,
-			TrackedValidatorsCache: cache.NewTrackedValidatorsCache(),
-			EventWriteTimeout:      testEventWriteTimeout,
-			StateGen:               stategen,
-		}
-
+	t.Run("Electra PartialData_RecomputesAttributerWhenAbsent", func(t *testing.T) {
+		srv, partial := newPartialFillTestServer(t)
 		filled, err := srv.fillEventData(ctx, partial)
 		require.NoError(t, err, "expected successful fill of partial event data")
 
-		// Verify that fields have been updated from the mock data:
 		require.NotNil(t, filled.HeadBlock, "HeadBlock should be assigned")
 		require.NotEqual(t, [32]byte{}, filled.HeadRoot, "HeadRoot should no longer be zero")
 		require.NotEmpty(t, filled.ParentBlockHash, "ParentBlockHash should be filled")
 		require.Equal(t, uint64(0), filled.ParentBlockNumber, "ParentBlockNumber must match mock block")
-
-		// Check that a valid Attributer was set:
 		require.NotNil(t, filled.Attributer, "Should have a valid payload attributes object")
 		require.Equal(t, false, filled.Attributer.IsEmpty(), "Attributer should not be empty after fill")
+		require.NotEqual(t, version.Bellatrix, filled.Attributer.Version(), "recomputed Attributer should match the head state version")
 	})
+	t.Run("Electra PartialData_PreservesProvidedAttributer", func(t *testing.T) {
+		srv, partial := newPartialFillTestServer(t)
+		// The blockchain package now supplies the attribute it already sent to the engine; fillEventData
+		// must keep it verbatim and only fill the scalar fields, never recompute it.
+		attributor, err := payloadattribute.New(&enginev1.PayloadAttributes{Timestamp: uint64(time.Now().Unix())})
+		require.NoError(t, err)
+		partial.Attributer = attributor
+
+		filled, err := srv.fillEventData(ctx, partial)
+		require.NoError(t, err)
+		require.NotEmpty(t, filled.ParentBlockHash, "ParentBlockHash should still be filled")
+		require.Equal(t, attributor, filled.Attributer, "provided Attributer should be preserved")
+		require.Equal(t, version.Bellatrix, filled.Attributer.Version(), "preserved Attributer keeps its version; a recompute on Electra state would be Deneb-versioned")
+	})
+}
+
+func newPartialFillTestServer(t *testing.T) (*Server, payloadattribute.EventData) {
+	st, err := util.NewBeaconStateElectra()
+	require.NoError(t, err)
+	valCount := 10
+	setActiveValidators(t, st, valCount)
+	inactivityScores := make([]uint64, valCount)
+	for i := range inactivityScores {
+		inactivityScores[i] = 10
+	}
+	require.NoError(t, st.SetInactivityScores(inactivityScores))
+	b, err := blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlockElectra(&eth.SignedBeaconBlockElectra{}))
+	require.NoError(t, err)
+	headRoot, err := b.Block().HashTreeRoot()
+	require.NoError(t, err)
+	currentSlot := primitives.Slot(0)
+	require.NoError(t, st.SetSlot(currentSlot+1)) // avoid slot processing on the source state
+	mockChainService := &mockChain.ChainService{
+		Root:  make([]byte, 32),
+		State: st,
+		Block: b,
+		Slot:  &currentSlot,
+	}
+	stategen := mock.NewService()
+	stategen.AddStateForRoot(st, headRoot)
+	srv := &Server{
+		StateNotifier:          &mockChain.SimpleNotifier{Feed: mockChain.NewEventFeedWrapper()},
+		OperationNotifier:      &mockChain.SimpleNotifier{Feed: mockChain.NewEventFeedWrapper()},
+		HeadFetcher:            mockChainService,
+		ChainInfoFetcher:       mockChainService,
+		TrackedValidatorsCache: cache.NewTrackedValidatorsCache(),
+		EventWriteTimeout:      testEventWriteTimeout,
+		StateGen:               stategen,
+	}
+	// ProposalSlot sits in a later epoch than the head to exercise slot processing.
+	return srv, payloadattribute.EventData{ProposalSlot: 42, HeadBlock: b, HeadRoot: headRoot}
 }
 
 func setActiveValidators(t *testing.T, st state.BeaconState, count int) {

--- a/changelog/terence_gloas-payload-attributes-sse.md
+++ b/changelog/terence_gloas-payload-attributes-sse.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Emit the `payload_attributes` SSE event after the Gloas fork; it previously stopped at the fork boundary because the Gloas forkchoice-update path did not fire it.


### PR DESCRIPTION
The `payload_attributes` event only fired from the pre-Gloas `notifyForkchoiceUpdate` path, so the stream went silent the moment Gloas activated — which blocks external builders and relays that drive payload building off this event. This fires it from the Gloas envelope and forkchoice-update paths, and sources the parent execution block hash from the head state for Gloas blocks (the payload lives in the envelope, not the block body).