### PR TITLE
SSZ-QL: Return list/bitlist  length in BeaconSate and BeaconBlock query endpoints

### DIFF
--- a/beacon-chain/rpc/prysm/beacon/ssz_query.go
+++ b/beacon-chain/rpc/prysm/beacon/ssz_query.go
@@ -1,6 +1,7 @@
 package beacon
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,7 +86,7 @@ func (s *Server) QueryBeaconState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, offset, length, err := query.CalculateOffsetAndLength(info, path)
+	finalInfo, offset, length, err := query.CalculateOffsetAndLength(info, path)
 	if err != nil {
 		httputil.HandleError(w, "Could not calculate offset and length for path '"+req.Query+"': "+err.Error(), http.StatusInternalServerError)
 		return
@@ -97,9 +98,21 @@ func (s *Server) QueryBeaconState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var result []byte
+	if path.Length {
+		n, err := finalInfo.LengthValue()
+		if err != nil {
+			httputil.HandleError(w, "Invalid query '"+req.Query+"': "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		result = binary.LittleEndian.AppendUint64(nil, n)
+	} else {
+		result = encodedState[offset : offset+length]
+	}
+
 	response := &sszquerypb.SSZQueryResponse{
 		Root:   stateRoot,
-		Result: encodedState[offset : offset+length],
+		Result: result,
 	}
 
 	responseSsz, err := response.MarshalSSZ()
@@ -170,7 +183,7 @@ func (s *Server) QueryBeaconBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, offset, length, err := query.CalculateOffsetAndLength(info, path)
+	finalInfo, offset, length, err := query.CalculateOffsetAndLength(info, path)
 	if err != nil {
 		httputil.HandleError(w, "Could not calculate offset and length for path '"+req.Query+"': "+err.Error(), http.StatusInternalServerError)
 		return
@@ -188,6 +201,18 @@ func (s *Server) QueryBeaconBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var result []byte
+	if path.Length {
+		n, err := finalInfo.LengthValue()
+		if err != nil {
+			httputil.HandleError(w, "Invalid query '"+req.Query+"': "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		result = binary.LittleEndian.AppendUint64(nil, n)
+	} else {
+		result = encodedBlock[offset : offset+length]
+	}
+
 	var response ssz.Marshaler
 	if req.IncludeProof {
 		proof, err := getSSZQueryProof(info, path)
@@ -197,7 +222,7 @@ func (s *Server) QueryBeaconBlock(w http.ResponseWriter, r *http.Request) {
 		}
 		response = &sszquerypb.SSZQueryResponseWithProof{
 			Root:   blockRoot[:],
-			Result: encodedBlock[offset : offset+length],
+			Result: result,
 			Proof: &sszquerypb.SSZQueryProof{
 				Leaf:   proof.Leaf,
 				Gindex: uint64(proof.Index),
@@ -207,7 +232,7 @@ func (s *Server) QueryBeaconBlock(w http.ResponseWriter, r *http.Request) {
 	} else {
 		response = &sszquerypb.SSZQueryResponse{
 			Root:   blockRoot[:],
-			Result: encodedBlock[offset : offset+length],
+			Result: result,
 		}
 	}
 	responseSsz, err := response.MarshalSSZ()

--- a/beacon-chain/rpc/prysm/beacon/ssz_query.go
+++ b/beacon-chain/rpc/prysm/beacon/ssz_query.go
@@ -92,12 +92,6 @@ func (s *Server) QueryBeaconState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	encodedState, err := st.MarshalSSZ()
-	if err != nil {
-		httputil.HandleError(w, "Could not marshal state to SSZ: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	var result []byte
 	if path.Length {
 		n, err := finalInfo.LengthValue()
@@ -107,6 +101,11 @@ func (s *Server) QueryBeaconState(w http.ResponseWriter, r *http.Request) {
 		}
 		result = binary.LittleEndian.AppendUint64(nil, n)
 	} else {
+		encodedState, err := st.MarshalSSZ()
+		if err != nil {
+			httputil.HandleError(w, "Could not marshal state to SSZ: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 		result = encodedState[offset : offset+length]
 	}
 
@@ -189,12 +188,6 @@ func (s *Server) QueryBeaconBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	encodedBlock, err := signedBlock.Block().MarshalSSZ()
-	if err != nil {
-		httputil.HandleError(w, "Could not marshal block to SSZ: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	blockRoot, err := block.HashTreeRoot()
 	if err != nil {
 		httputil.HandleError(w, "Could not compute block root: "+err.Error(), http.StatusInternalServerError)
@@ -210,6 +203,11 @@ func (s *Server) QueryBeaconBlock(w http.ResponseWriter, r *http.Request) {
 		}
 		result = binary.LittleEndian.AppendUint64(nil, n)
 	} else {
+		encodedBlock, err := signedBlock.Block().MarshalSSZ()
+		if err != nil {
+			httputil.HandleError(w, "Could not marshal block to SSZ: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 		result = encodedBlock[offset : offset+length]
 	}
 

--- a/beacon-chain/rpc/prysm/beacon/ssz_query_test.go
+++ b/beacon-chain/rpc/prysm/beacon/ssz_query_test.go
@@ -95,6 +95,14 @@ func TestQueryBeaconState(t *testing.T) {
 				return b
 			}(),
 		},
+		{
+			path: "len(validators)",
+			expectedValue: func() []byte {
+				b := make([]byte, 8)
+				binary.LittleEndian.PutUint64(b, uint64(len(st.Validators())))
+				return b
+			}(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -168,6 +176,18 @@ func TestQueryBeaconStateInvalidRequest(t *testing.T) {
 			path:        ".non_existent_field",
 			code:        http.StatusInternalServerError,
 			errorString: "Could not calculate offset and length for path",
+		},
+		{
+			name:        "len() on a non-collection field",
+			stateId:     "head",
+			path:        "len(slot)",
+			errorString: "only supported for List and Bitlist",
+		},
+		{
+			name:        "len() on an non-collection field with index",
+			stateId:     "head",
+			path:        "len(validators[0])",
+			errorString: "only supported for List and Bitlist",
 		},
 		{
 			name:    "empty state ID",
@@ -345,6 +365,40 @@ func TestQueryBeaconBlock(t *testing.T) {
 			expectedValue: func() []byte {
 				b, err := att.MarshalSSZ()
 				require.NoError(t, err)
+				return b
+			}(),
+		},
+		{
+			name:         "len(body.attestations)",
+			path:         "len(body.attestations)",
+			includeProof: false,
+			block: func() interfaces.ReadOnlySignedBeaconBlock {
+				b := util.NewBeaconBlock()
+				b.Block.Body.Attestations = []*eth.Attestation{att, att}
+				sb, err := blocks.NewSignedBeaconBlock(b)
+				require.NoError(t, err)
+				return sb
+			}(),
+			expectedValue: func() []byte {
+				b := make([]byte, 8)
+				binary.LittleEndian.PutUint64(b, 2)
+				return b
+			}(),
+		},
+		{
+			name:         "len(body.attestations)",
+			path:         "len(body.attestations)",
+			includeProof: true,
+			block: func() interfaces.ReadOnlySignedBeaconBlock {
+				b := util.NewBeaconBlock()
+				b.Block.Body.Attestations = []*eth.Attestation{att, att}
+				sb, err := blocks.NewSignedBeaconBlock(b)
+				require.NoError(t, err)
+				return sb
+			}(),
+			expectedValue: func() []byte {
+				b := make([]byte, 8)
+				binary.LittleEndian.PutUint64(b, 2)
 				return b
 			}(),
 		},

--- a/changelog/fernantho_sszql-len-query.md
+++ b/changelog/fernantho_sszql-len-query.md
@@ -1,0 +1,2 @@
+### Added
+- SSZ-QL: support `len()` queries on the BeaconState and BeaconBlock query endpoints, returning the runtime length of a List (element count) or Bitlist (bit count) as an 8-byte little-endian value.

--- a/encoding/ssz/query/query_test.go
+++ b/encoding/ssz/query/query_test.go
@@ -344,6 +344,67 @@ func TestCalculateOffsetAndLength(t *testing.T) {
 	})
 }
 
+func TestLengthValue(t *testing.T) {
+	t.Run("returns runtime length for List and Bitlist", func(t *testing.T) {
+		info, err := query.AnalyzeObject(createVariableTestContainer())
+		require.NoError(t, err)
+
+		tests := []struct {
+			name     string
+			path     string
+			expected uint64
+		}{
+			{name: "list of uint64", path: ".field_list_uint64", expected: 5},
+			{name: "list of containers", path: ".field_list_container", expected: 3},
+			{name: "list of bytes32", path: ".field_list_bytes32", expected: 3},
+			{name: "nested list of uint64", path: ".nested.field_list_uint64", expected: 5},
+			{name: "bitlist (counted in bits)", path: ".bitlist_field", expected: 256},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				path, err := query.ParsePath(tt.path)
+				require.NoError(t, err)
+
+				finalInfo, _, _, err := query.CalculateOffsetAndLength(info, path)
+				require.NoError(t, err)
+
+				n, err := finalInfo.LengthValue()
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, n, "Expected length to be %d", tt.expected)
+			})
+		}
+	})
+
+	t.Run("errors for non-List/Bitlist types", func(t *testing.T) {
+		info, err := query.AnalyzeObject(createFixedTestContainer())
+		require.NoError(t, err)
+
+		paths := []struct {
+			name string
+			path string
+		}{
+			{name: "vector", path: ".vector_field"},
+			{name: "bitvector", path: ".bitvector64_field"},
+			{name: "basic uint64", path: ".field_uint64"},
+			{name: "container", path: ".nested"},
+		}
+
+		for _, tt := range paths {
+			t.Run(tt.name, func(t *testing.T) {
+				path, err := query.ParsePath(tt.path)
+				require.NoError(t, err)
+
+				finalInfo, _, _, err := query.CalculateOffsetAndLength(info, path)
+				require.NoError(t, err)
+
+				_, err = finalInfo.LengthValue()
+				require.ErrorContains(t, "only supported for List and Bitlist", err)
+			})
+		}
+	})
+}
+
 func TestHashTreeRoot(t *testing.T) {
 	tests := []struct {
 		name string

--- a/encoding/ssz/query/ssz_info.go
+++ b/encoding/ssz/query/ssz_info.go
@@ -72,6 +72,25 @@ func (info *SszInfo) Size() uint64 {
 	}
 }
 
+// LengthValue returns the runtime length of a List (counted in elements) or a Bitlist
+// (counted in bits). len() queries are only valid for these two types; any other type
+// returns an error. The value is populated during AnalyzeObject, so it reflects the
+// analyzed instance rather than the type's limit.
+func (info *SszInfo) LengthValue() (uint64, error) {
+	if info == nil {
+		return 0, errors.New("SszInfo is nil")
+	}
+
+	switch info.sszType {
+	case List:
+		return info.listInfo.Length(), nil
+	case Bitlist:
+		return info.bitlistInfo.Length(), nil
+	default:
+		return 0, fmt.Errorf("len() is only supported for List and Bitlist types, got %s", info.sszType)
+	}
+}
+
 func (info *SszInfo) ContainerInfo() (*containerInfo, error) {
 	if info == nil {
 		return nil, errors.New("SszInfo is nil")


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR wires `List`/`Bitlist` length information into the BeaconBlock and BeaconState SSZ-QL endpoints. A `len(...)` query now returns the collection 's runtime length i.e. the element count for `List` or the bit count for a `Bitlist`, encoded as an 8-byte little-endian `uint64` in the response result.

Previously the `len(...)` parsed into the query path but never acted upon. This PR completes that path so SSZ-QL users can retrieve the length value. The new `LengthValue()` method on `SszInfo` class returns this information. 

**Which issues(s) does this PR fix?**
Part of https://github.com/OffchainLabs/prysm/issues/15587

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
