### PR TITLE
Fix IsOptimisticForRoot validated checkpoint summary recovery

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -498,7 +498,7 @@ func (s *Service) IsOptimisticForRoot(ctx context.Context, root [32]byte) (bool,
 		return false, err
 	}
 	if lastValidated == nil {
-		lastValidated, err = s.recoverStateSummary(ctx, root)
+		lastValidated, err = s.recoverStateSummary(ctx, s.ensureRootNotZeros(bytesutil.ToBytes32(validatedCheckpoint.Root)))
 		if err != nil {
 			return false, err
 		}

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -579,13 +579,45 @@ func TestService_IsOptimisticForRoot_DB_non_canonical(t *testing.T) {
 
 }
 
+func TestService_IsOptimisticForRoot_RecoverLastValidated(t *testing.T) {
+	// Validated checkpoint state summary is missing — recovery must use the
+	// checkpoint root, not the queried root, so the slot comparison is correct.
+	ctx := t.Context()
+	c := testServiceWithDB(t)
+	beaconDB := c.cfg.BeaconDB
+
+	cpBlock := util.NewBeaconBlock()
+	cpBlock.Block.Slot = 1
+	cpRoot, err := cpBlock.Block.HashTreeRoot()
+	require.NoError(t, err)
+	util.SaveBlock(t, ctx, beaconDB, cpBlock)
+	st, _ := util.DeterministicGenesisState(t, 1)
+	require.NoError(t, beaconDB.SaveState(ctx, st, cpRoot))
+	require.NoError(t, beaconDB.SaveLastValidatedCheckpoint(ctx, &ethpb.Checkpoint{Root: cpRoot[:]}))
+
+	qBlock := util.NewBeaconBlock()
+	qBlock.Block.Slot = 2
+	qRoot, err := qBlock.Block.HashTreeRoot()
+	require.NoError(t, err)
+	util.SaveBlock(t, ctx, beaconDB, qBlock)
+	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: qRoot[:], Slot: 2}))
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, qRoot))
+
+	optimistic, err := c.IsOptimisticForRoot(ctx, qRoot)
+	require.NoError(t, err)
+	require.Equal(t, true, optimistic)
+}
+
 func TestService_IsOptimisticForRoot_StateSummaryRecovered(t *testing.T) {
 	ctx := t.Context()
 	c := testServiceWithDB(t)
 	beaconDB := c.cfg.BeaconDB
 	c.head = &head{root: params.BeaconConfig().ZeroHash}
 	b := util.NewBeaconBlock()
-	b.Block.Slot = 10
+	// Use slot 33 (epoch 1) so the function returns early at the
+	// "slots.ToEpoch(ss.Slot) > validatedCheckpoint.Epoch" check (1 > 0),
+	// since this test only verifies that the queried block's state summary is recovered.
+	b.Block.Slot = 33
 	br, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	util.SaveBlock(t, t.Context(), beaconDB, b)
@@ -595,7 +627,7 @@ func TestService_IsOptimisticForRoot_StateSummaryRecovered(t *testing.T) {
 	summ, err := beaconDB.StateSummary(ctx, br)
 	assert.NoError(t, err)
 	assert.NotNil(t, summ)
-	assert.Equal(t, 10, int(summ.Slot))
+	assert.Equal(t, 33, int(summ.Slot))
 	assert.DeepEqual(t, br[:], summ.Root)
 }
 

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -614,20 +614,19 @@ func TestService_IsOptimisticForRoot_StateSummaryRecovered(t *testing.T) {
 	beaconDB := c.cfg.BeaconDB
 	c.head = &head{root: params.BeaconConfig().ZeroHash}
 	b := util.NewBeaconBlock()
-	// Use slot 33 (epoch 1) so the function returns early at the
-	// "slots.ToEpoch(ss.Slot) > validatedCheckpoint.Epoch" check (1 > 0),
-	// since this test only verifies that the queried block's state summary is recovered.
-	b.Block.Slot = 33
+	b.Block.Slot = 10
 	br, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	util.SaveBlock(t, t.Context(), beaconDB, b)
-	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, [32]byte{}))
+	cpRoot := [32]byte{'v'}
+	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: cpRoot[:], Slot: 0}))
+	require.NoError(t, beaconDB.SaveLastValidatedCheckpoint(ctx, &ethpb.Checkpoint{Root: cpRoot[:]}))
 	_, err = c.IsOptimisticForRoot(ctx, br)
 	assert.NoError(t, err)
 	summ, err := beaconDB.StateSummary(ctx, br)
 	assert.NoError(t, err)
 	assert.NotNil(t, summ)
-	assert.Equal(t, 33, int(summ.Slot))
+	assert.Equal(t, 10, int(summ.Slot))
 	assert.DeepEqual(t, br[:], summ.Root)
 }
 

--- a/changelog/satushh_fix-isoptimisticforroot-recovery-root.md
+++ b/changelog/satushh_fix-isoptimisticforroot-recovery-root.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `IsOptimisticForRoot` now recovers the validated checkpoint's state summary using the checkpoint root instead of the queried block's root, so the optimism slot comparison is correct.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Recover the last validated checkpoint state summary using the checkpoint root instead of the queried block root.
Adds regression coverage for the false non-optimistic result when the checkpoint summary is missing.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
