### PR TITLE
Seed bid KZG commitments on Gloas columns in by-root sync verification

### DIFF
--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -81,7 +81,6 @@ func FetchDataColumnSidecars(
 	slotByRoot := make(map[[fieldparams.RootLength]byte]primitives.Slot, blockCount)
 	storedIndicesByRoot := make(map[[fieldparams.RootLength]byte]map[uint64]bool, blockCount)
 
-	commitmentsByRoot := make(map[[fieldparams.RootLength]byte][][]byte, blockCount)
 	blockByRoot := make(map[[fieldparams.RootLength]byte]blocks.ROBlock, blockCount)
 
 	for _, roBlock := range roBlocks {
@@ -102,7 +101,6 @@ func FetchDataColumnSidecars(
 		incompleteRoots[root] = true
 		slotByRoot[root] = slot
 		slotsWithCommitments[slot] = true
-		commitmentsByRoot[root] = commitments
 		blockByRoot[root] = roBlock
 
 		storedIndices := params.Storage.Summary(root).Stored()
@@ -127,7 +125,7 @@ func FetchDataColumnSidecars(
 	}
 
 	// Request direct sidecars from peers.
-	directSidecarsByRoot, err := requestDirectSidecarsFromPeers(params, slotByRoot, requestedIndices, slotsWithCommitments, storedIndicesByRoot, incompleteRoots, commitmentsByRoot, blockByRoot)
+	directSidecarsByRoot, err := requestDirectSidecarsFromPeers(params, slotByRoot, requestedIndices, slotsWithCommitments, storedIndicesByRoot, incompleteRoots, blockByRoot)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "request direct sidecars from peers")
 	}
@@ -146,7 +144,7 @@ func FetchDataColumnSidecars(
 	}
 
 	// Request all possible indirect sidecars from peers which are neither stored nor in `directSidecarsByRoot`
-	indirectSidecarsByRoot, err := requestIndirectSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, storedIndicesByRoot, directSidecarsByRoot, requestedIndices, incompleteRoots, commitmentsByRoot, blockByRoot)
+	indirectSidecarsByRoot, err := requestIndirectSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, storedIndicesByRoot, directSidecarsByRoot, requestedIndices, incompleteRoots, blockByRoot)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "request all sidecars from peers")
 	}
@@ -237,7 +235,6 @@ func requestDirectSidecarsFromPeers(
 	slotsWithCommitments map[primitives.Slot]bool,
 	storedIndicesByRoot map[[fieldparams.RootLength]byte]map[uint64]bool,
 	incompleteRoots map[[fieldparams.RootLength]byte]bool,
-	commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte,
 	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 ) (map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn, error) {
 	start := time.Now()
@@ -295,9 +292,6 @@ func requestDirectSidecarsFromPeers(
 		// Fetch the sidecars from the chosen peers.
 		roDataColumnsByPeer := fetchDataColumnSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, indicesByRootByPeerToQuery)
 
-		// Set bid commitments on Gloas columns before verification.
-		setBidCommitments(commitmentsByRoot, roDataColumnsByPeer)
-
 		// Verify the received data column sidecars.
 		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(params.P2P, params.NewVerifier, blockByRoot, roDataColumnsByPeer)
 		if err != nil {
@@ -348,7 +342,6 @@ func requestIndirectSidecarsFromPeers(
 	alreadyAvailableByRoot map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn,
 	requestedIndices map[uint64]bool,
 	roots map[[fieldparams.RootLength]byte]bool,
-	commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte,
 	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 ) (map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn, error) {
 	start := time.Now()
@@ -417,9 +410,6 @@ func requestIndirectSidecarsFromPeers(
 
 		// Fetch the sidecars from the chosen peers.
 		roDataColumnsByPeer := fetchDataColumnSidecarsFromPeers(p, slotByRoot, slotsWithCommitments, indicesByRootByPeerToQuery)
-
-		// Set bid commitments on Gloas columns before verification.
-		setBidCommitments(commitmentsByRoot, roDataColumnsByPeer)
 
 		// Verify the received data column sidecars.
 		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(p.P2P, p.NewVerifier, blockByRoot, roDataColumnsByPeer)
@@ -1011,6 +1001,22 @@ func verifyByRootDataColumnSidecars(
 	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 	roDataColumns []blocks.RODataColumn,
 ) ([]blocks.VerifiedRODataColumn, error) {
+	// Gloas sidecars carry no commitments; seed them from the block's bid before the Fulu verifier runs.
+	for i := range roDataColumns {
+		if !roDataColumns[i].IsGloas() {
+			continue
+		}
+		block, ok := blockByRoot[roDataColumns[i].BlockRoot()]
+		if !ok {
+			return nil, fmt.Errorf("no local block for sidecar root %#x: %w", roDataColumns[i].BlockRoot(), ErrSidecarHeaderMismatch)
+		}
+		commitments, err := block.Block().Body().BlobKzgCommitments()
+		if err != nil {
+			return nil, errors.Wrap(err, "get bid blob kzg commitments")
+		}
+		roDataColumns[i].SetBidCommitments(commitments)
+	}
+
 	verifier := newVerifier(roDataColumns, verification.ByRootRequestDataColumnSidecarRequirements)
 
 	if err := verifier.ValidFields(); err != nil {
@@ -1042,23 +1048,6 @@ func verifyByRootDataColumnSidecars(
 	}
 
 	return verifiedRoDataColumns, nil
-}
-
-// setBidCommitments sets bid KZG commitments on Gloas data columns so verification can proceed.
-func setBidCommitments(commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte, columnsByPeer map[goPeer.ID][]blocks.RODataColumn) {
-	if len(commitmentsByRoot) == 0 {
-		return
-	}
-	for _, columns := range columnsByPeer {
-		for i := range columns {
-			if !columns[i].IsGloas() {
-				continue
-			}
-			if comms, ok := commitmentsByRoot[columns[i].BlockRoot()]; ok {
-				columns[i].SetBidCommitments(comms)
-			}
-		}
-	}
 }
 
 // computeIndicesByRootByPeer returns a peers->root->indices map only for

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -1119,49 +1119,39 @@ func TestComputeTotalCount(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestSetBidCommitments(t *testing.T) {
+func TestVerifyByRootDataColumnSidecars_SeedsGloasBidCommitments(t *testing.T) {
 	root := [fieldparams.RootLength]byte{1}
-	comms := [][]byte{{0xaa}, {0xbb}}
+	commitments := [][]byte{{0xaa}, {0xbb}}
 
-	// Fulu column should be untouched.
-	fuluDC := &ethpb.DataColumnSidecar{
-		SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
-			Header: &ethpb.BeaconBlockHeader{
-				ParentRoot: make([]byte, 32),
-				StateRoot:  make([]byte, 32),
-				BodyRoot:   make([]byte, 32),
-			},
-			Signature: make([]byte, 96),
-		},
-	}
-	fuluCol := blocks.NewRODataColumnNoVerify(fuluDC)
+	// Gloas block whose bid carries the commitments.
+	pb := util.NewBeaconBlockGloas()
+	pb.Block.Body.SignedExecutionPayloadBid.Message.BlobKzgCommitments = commitments
+	signedBlock, err := blocks.NewSignedBeaconBlock(pb)
+	require.NoError(t, err)
+	roBlock, err := blocks.NewROBlockWithRoot(signedBlock, root)
+	require.NoError(t, err)
+	blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{root: roBlock}
 
-	// Gloas column should get commitments set.
-	gloasDC := &ethpb.DataColumnSidecarGloas{
-		Index:           5,
-		BeaconBlockRoot: root[:],
-		Column:          [][]byte{make([]byte, 2048)},
-		KzgProofs:       [][]byte{make([]byte, 48)},
+	newVerifier := func(_ []blocks.RODataColumn, _ []verification.Requirement) verification.DataColumnsVerifier {
+		return &verification.MockDataColumnsVerifier{}
 	}
-	gloasCol, err := blocks.NewRODataColumnGloasWithRoot(gloasDC, root)
+
+	gloasSidecar := &ethpb.DataColumnSidecarGloas{Index: 5, BeaconBlockRoot: root[:]}
+	gloasColumn, err := blocks.NewRODataColumnGloasWithRoot(gloasSidecar, root)
 	require.NoError(t, err)
 
-	pid := peer.ID("test-peer")
-	columnsByPeer := map[peer.ID][]blocks.RODataColumn{
-		pid: {fuluCol, gloasCol},
-	}
-	commitmentsByRoot := map[[fieldparams.RootLength]byte][][]byte{
-		root: comms,
-	}
+	t.Run("seeds commitments from the local block", func(t *testing.T) {
+		columns := []blocks.RODataColumn{gloasColumn}
+		_, err := verifyByRootDataColumnSidecars(newVerifier, blockByRoot, columns)
+		require.NoError(t, err)
 
-	setBidCommitments(commitmentsByRoot, columnsByPeer)
+		got, err := columns[0].KzgCommitments()
+		require.NoError(t, err)
+		require.Equal(t, len(commitments), len(got))
+	})
 
-	// Fulu column should not have bid commitments.
-	_, err = columnsByPeer[pid][0].KzgCommitments()
-	require.NoError(t, err)
-
-	// Gloas column should now have bid commitments.
-	got, err := columnsByPeer[pid][1].KzgCommitments()
-	require.NoError(t, err)
-	require.Equal(t, 2, len(got))
+	t.Run("errors when the block is not local", func(t *testing.T) {
+		_, err := verifyByRootDataColumnSidecars(newVerifier, map[[fieldparams.RootLength]byte]blocks.ROBlock{}, []blocks.RODataColumn{gloasColumn})
+		require.ErrorIs(t, err, ErrSidecarHeaderMismatch)
+	})
 }

--- a/changelog/terence_gloas-column-verify-seed-commitments.md
+++ b/changelog/terence_gloas-column-verify-seed-commitments.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Seed bid KZG commitments on Gloas data column sidecars during by-root sync verification so column verification can proceed.


### PR DESCRIPTION
`verifyByRootDataColumnSidecars` seeds Gloas columns with their block's bid KZG commitments before verifying — sourced from the `blockByRoot` map it already uses for header matching — otherwise they fail the Fulu verifier. Also drops the now-redundant precomputed commitments map that seeded the same values upstream.