### PR TITLE
Fail fast on data column availability check for past-slot blocks during sync

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -1009,6 +1009,12 @@ func (s *Service) areDataColumnsAvailable(
 		return nil
 	}
 
+	// During catch-up (past slot) columns arrive via range requests, not gossip, so the
+	// subscription wait below would never make progress. Fail fast and let the caller refetch.
+	if slot < currentSlot {
+		return errors.Errorf("data columns unavailable for slot %d root %#x: missing %v", slot, root, helpers.SortedPrettySliceFromMap(missing))
+	}
+
 	if s.startWaitingDataColumnSidecars != nil {
 		s.startWaitingDataColumnSidecars <- true
 	}

--- a/changelog/terence_sync-da-columns-no-wait.md
+++ b/changelog/terence_sync-da-columns-no-wait.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Don't block on the gossip data column availability wait for past-slot blocks/envelopes during sync; fail fast so the caller refetches.


### PR DESCRIPTION
areDataColumnsAvailable blocks on a subscription fed by gossip storage writes. During sync that channel never fires for historical roots (columns arrive via range requests, already saved before import), so the wait could only end on context expiry. This skips the wait for past-slot blocks and envelopes, returning an error so the caller refetches instead of blocking the import path. The live path (current/future slot) is unchanged.