### PR TITLE
Dedup locks

### DIFF
--- a/beacon-chain/cache/subnet_ids.go
+++ b/beacon-chain/cache/subnet_ids.go
@@ -18,7 +18,6 @@ type subnetIDs struct {
 	aggregator        *lru.Cache
 	aggregatorLock    sync.RWMutex
 	persistentSubnets *cache.Cache
-	subnetsLock       sync.RWMutex
 }
 
 // SubnetIDs for attester and aggregator.
@@ -94,9 +93,6 @@ func (s *subnetIDs) GetAggregatorSubnetIDs(slot primitives.Slot) []uint64 {
 // GetPersistentSubnets retrieves the persistent subnet and expiration time of that validator's
 // subscription.
 func (s *subnetIDs) GetPersistentSubnets() ([]uint64, bool, time.Time) {
-	s.subnetsLock.RLock()
-	defer s.subnetsLock.RUnlock()
-
 	id, duration, ok := s.persistentSubnets.GetWithExpiration(subnetKey)
 	if !ok {
 		return []uint64{}, ok, time.Time{}
@@ -107,9 +103,6 @@ func (s *subnetIDs) GetPersistentSubnets() ([]uint64, bool, time.Time) {
 // GetAllSubnets retrieves all the non-expired subscribed subnets of all the validators
 // in the cache.
 func (s *subnetIDs) GetAllSubnets() []uint64 {
-	s.subnetsLock.RLock()
-	defer s.subnetsLock.RUnlock()
-
 	itemsMap := s.persistentSubnets.Items()
 	var committees []uint64
 
@@ -125,9 +118,6 @@ func (s *subnetIDs) GetAllSubnets() []uint64 {
 // AddPersistentCommittee adds the relevant committee for that particular validator along with its
 // expiration period.
 func (s *subnetIDs) AddPersistentCommittee(comIndex []uint64, duration time.Duration) {
-	s.subnetsLock.Lock()
-	defer s.subnetsLock.Unlock()
-
 	s.persistentSubnets.Set(subnetKey, comIndex, duration)
 }
 
@@ -145,7 +135,5 @@ func (s *subnetIDs) EmptyAllCaches() {
 	s.aggregator.Purge()
 	s.aggregatorLock.Unlock()
 
-	s.subnetsLock.Lock()
 	s.persistentSubnets.Flush()
-	s.subnetsLock.Unlock()
 }

--- a/beacon-chain/cache/sync_committee_head_state.go
+++ b/beacon-chain/cache/sync_committee_head_state.go
@@ -1,8 +1,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -13,7 +11,6 @@ import (
 // SyncCommitteeHeadStateCache for the latest head state requested by a sync committee participant.
 type SyncCommitteeHeadStateCache struct {
 	cache *lru.Cache
-	lock  sync.RWMutex
 }
 
 // NewSyncCommitteeHeadState initializes a LRU cache for `SyncCommitteeHeadState` with size of 1.
@@ -24,8 +21,6 @@ func NewSyncCommitteeHeadState() *SyncCommitteeHeadStateCache {
 
 // Put `slot` as key and `state` as value onto the cache.
 func (c *SyncCommitteeHeadStateCache) Put(slot primitives.Slot, st state.BeaconState) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	// Make sure that the provided state is non nil
 	// and is of the correct type.
 	if st == nil || st.IsNil() {
@@ -42,8 +37,6 @@ func (c *SyncCommitteeHeadStateCache) Put(slot primitives.Slot, st state.BeaconS
 
 // Get `state` using `slot` as key. Return nil if nothing is found.
 func (c *SyncCommitteeHeadStateCache) Get(slot primitives.Slot) (state.BeaconState, error) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	val, exists := c.cache.Get(slot)
 	if !exists {
 		return nil, ErrNotFound

--- a/beacon-chain/state/stategen/hot_state_cache.go
+++ b/beacon-chain/state/stategen/hot_state_cache.go
@@ -1,8 +1,6 @@
 package stategen
 
 import (
-	"sync"
-
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	lru "github.com/hashicorp/golang-lru"
@@ -27,7 +25,6 @@ var (
 // hotStateCache is used to store the processed beacon state after finalized check point.
 type hotStateCache struct {
 	cache *lru.Cache
-	lock  sync.RWMutex
 }
 
 // newHotStateCache initializes the map and underlying cache.
@@ -40,8 +37,6 @@ func newHotStateCache() *hotStateCache {
 // Get returns a cached response via input block root, if any.
 // The response is copied by default.
 func (c *hotStateCache) get(blockRoot [32]byte) state.BeaconState {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	item, exists := c.cache.Get(blockRoot)
 
 	if exists && item != nil {
@@ -62,8 +57,6 @@ func (c *hotStateCache) ByBlockRoot(r [32]byte) (state.BeaconState, error) {
 
 // GetWithoutCopy returns a non-copied cached response via input block root.
 func (c *hotStateCache) getWithoutCopy(blockRoot [32]byte) state.BeaconState {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	item, exists := c.cache.Get(blockRoot)
 	if exists && item != nil {
 		hotStateCacheHit.Inc()
@@ -75,21 +68,15 @@ func (c *hotStateCache) getWithoutCopy(blockRoot [32]byte) state.BeaconState {
 
 // put the response in the cache.
 func (c *hotStateCache) put(blockRoot [32]byte, state state.BeaconState) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	c.cache.Add(blockRoot, state)
 }
 
 // has returns true if the key exists in the cache.
 func (c *hotStateCache) has(blockRoot [32]byte) bool {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	return c.cache.Contains(blockRoot)
 }
 
 // delete deletes the key exists in the cache.
 func (c *hotStateCache) delete(blockRoot [32]byte) bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	return c.cache.Remove(blockRoot)
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -161,9 +161,7 @@ type Service struct {
 	seenDataColumnCache                  *slotAwareCache
 	pendingGloasColumnsLock              sync.RWMutex
 	pendingGloasColumns                  map[[32]byte]*pendingGloasEntry
-	seenAggregatedAttestationLock        sync.RWMutex
 	seenAggregatedAttestationCache       *lru.Cache
-	seenUnAggregatedAttestationLock      sync.RWMutex
 	seenUnAggregatedAttestationCache     *lru.Cache
 	seenExitCache                        *lru.Cache
 	seenProposerSlashingCache            *lru.Cache

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -153,12 +153,10 @@ type Service struct {
 	chainStarted                         *atomic.Bool
 	validateBlockLock                    sync.RWMutex
 	rateLimiter                          *limiter
-	seenBlockLock                        sync.RWMutex
 	seenBlockCache                       *lru.Cache
 	seenPayloadEnvelopeCache             *lru.Cache
 	seenExecutionPayloadBidCache         *slotAwareCache
 	highestExecutionPayloadBidCache      *cache.HighestExecutionPayloadBidCache
-	seenBlobLock                         sync.RWMutex
 	seenBlobCache                        *lru.Cache
 	seenDataColumnCache                  *slotAwareCache
 	pendingGloasColumnsLock              sync.RWMutex
@@ -167,20 +165,14 @@ type Service struct {
 	seenAggregatedAttestationCache       *lru.Cache
 	seenUnAggregatedAttestationLock      sync.RWMutex
 	seenUnAggregatedAttestationCache     *lru.Cache
-	seenExitLock                         sync.RWMutex
 	seenExitCache                        *lru.Cache
-	seenProposerSlashingLock             sync.RWMutex
 	seenProposerSlashingCache            *lru.Cache
 	seenAttesterSlashingLock             sync.RWMutex
 	seenAttesterSlashingCache            map[uint64]bool
-	seenSyncMessageLock                  sync.RWMutex
 	seenSyncMessageCache                 *lru.Cache
-	seenSyncContributionLock             sync.RWMutex
 	seenSyncContributionCache            *lru.Cache
 	badBlockCache                        *lru.Cache
-	badBlockLock                         sync.RWMutex
 	badPayloadCache                      *lru.Cache
-	badPayloadLock                       sync.RWMutex
 	syncContributionBitsOverlapLock      sync.RWMutex
 	syncContributionBitsOverlapCache     *lru.Cache
 	signatureChan                        chan *signatureVerifier

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -258,10 +258,6 @@ func (s *Service) validateBlockInAttestation(ctx context.Context, satt ethpb.Sig
 // Returns true if the node has received aggregate for the aggregator with index and target epoch.
 func (s *Service) hasSeenAggregatorIndexEpoch(epoch primitives.Epoch, aggregatorIndex primitives.ValidatorIndex) bool {
 	b := append(bytesutil.Bytes32(uint64(epoch)), bytesutil.Bytes32(uint64(aggregatorIndex))...)
-
-	s.seenAggregatedAttestationLock.RLock()
-	defer s.seenAggregatedAttestationLock.RUnlock()
-
 	_, seen := s.seenAggregatedAttestationCache.Get(string(b))
 	return seen
 }
@@ -270,16 +266,8 @@ func (s *Service) hasSeenAggregatorIndexEpoch(epoch primitives.Epoch, aggregator
 // Returns true if this is the first time seeing this aggregator index and epoch.
 func (s *Service) setAggregatorIndexEpochSeen(epoch primitives.Epoch, aggregatorIndex primitives.ValidatorIndex) bool {
 	b := append(bytesutil.Bytes32(uint64(epoch)), bytesutil.Bytes32(uint64(aggregatorIndex))...)
-
-	s.seenAggregatedAttestationLock.Lock()
-	defer s.seenAggregatedAttestationLock.Unlock()
-
-	_, seen := s.seenAggregatedAttestationCache.Get(string(b))
-	if seen {
-		return false
-	}
-	s.seenAggregatedAttestationCache.Add(string(b), true)
-	return true
+	found, _ := s.seenAggregatedAttestationCache.ContainsOrAdd(string(b), true)
+	return !found
 }
 
 // This validates the bitfield is correct and aggregator's index in state is within the beacon committee.

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -425,9 +425,6 @@ func generateUnaggregatedAttCacheKey(att eth.Att) (string, error) {
 
 // Returns true if the attestation was already seen for the participating validator for the slot.
 func (s *Service) hasSeenUnaggregatedAtt(key string) bool {
-	s.seenUnAggregatedAttestationLock.RLock()
-	defer s.seenUnAggregatedAttestationLock.RUnlock()
-
 	_, seen := s.seenUnAggregatedAttestationCache.Get(key)
 	return seen
 }
@@ -435,14 +432,8 @@ func (s *Service) hasSeenUnaggregatedAtt(key string) bool {
 // Set an incoming attestation as seen for the participating validator for the slot.
 // Returns false if the attestation was already seen.
 func (s *Service) setSeenUnaggregatedAtt(key string) bool {
-	s.seenUnAggregatedAttestationLock.Lock()
-	defer s.seenUnAggregatedAttestationLock.Unlock()
-	_, seen := s.seenUnAggregatedAttestationCache.Get(key)
-	if seen {
-		return false
-	}
-	s.seenUnAggregatedAttestationCache.Add(key, true)
-	return true
+	found, _ := s.seenUnAggregatedAttestationCache.ContainsOrAdd(key, true)
+	return !found
 }
 
 // hasBlockAndState returns true if the beacon node knows about a block and associated state in the

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -487,8 +487,6 @@ func (s *Service) verifyPendingBlockSignature(ctx context.Context, pid peer.ID, 
 
 // Returns true if the block is not the first block proposed for the proposer for the slot.
 func (s *Service) hasSeenBlockIndexSlot(slot primitives.Slot, proposerIdx primitives.ValidatorIndex) bool {
-	s.seenBlockLock.RLock()
-	defer s.seenBlockLock.RUnlock()
 	b := append(bytesutil.Bytes32(uint64(slot)), bytesutil.Bytes32(uint64(proposerIdx))...)
 	_, seen := s.seenBlockCache.Get(string(b))
 	return seen
@@ -496,8 +494,6 @@ func (s *Service) hasSeenBlockIndexSlot(slot primitives.Slot, proposerIdx primit
 
 // Set block proposer index and slot as seen for incoming blocks.
 func (s *Service) setSeenBlockIndexSlot(slot primitives.Slot, proposerIdx primitives.ValidatorIndex) {
-	s.seenBlockLock.Lock()
-	defer s.seenBlockLock.Unlock()
 	b := append(bytesutil.Bytes32(uint64(slot)), bytesutil.Bytes32(uint64(proposerIdx))...)
 	s.seenBlockCache.Add(string(b), true)
 }
@@ -507,24 +503,18 @@ func (s *Service) hasBadBlock(root [32]byte) bool {
 	if features.BlacklistedBlock(root) {
 		return true
 	}
-	s.badBlockLock.RLock()
-	defer s.badBlockLock.RUnlock()
 	_, seen := s.badBlockCache.Get(string(root[:]))
 	return seen
 }
 
 // Returns true if the payload for the given block root is marked as bad.
 func (s *Service) hasBadPayload(root [32]byte) bool {
-	s.badPayloadLock.RLock()
-	defer s.badPayloadLock.RUnlock()
 	_, seen := s.badPayloadCache.Get(string(root[:]))
 	return seen
 }
 
 // Set bad payload in the cache.
 func (s *Service) setBadPayload(ctx context.Context, root [32]byte) {
-	s.badPayloadLock.Lock()
-	defer s.badPayloadLock.Unlock()
 	if ctx.Err() != nil {
 		return
 	}
@@ -534,8 +524,6 @@ func (s *Service) setBadPayload(ctx context.Context, root [32]byte) {
 
 // Set bad block in the cache.
 func (s *Service) setBadBlock(ctx context.Context, root [32]byte) {
-	s.badBlockLock.Lock()
-	defer s.badBlockLock.Unlock()
 	if ctx.Err() != nil { // Do not mark block as bad if it was due to context error.
 		return
 	}

--- a/beacon-chain/sync/validate_blob.go
+++ b/beacon-chain/sync/validate_blob.go
@@ -143,8 +143,6 @@ func (s *Service) validateBlob(ctx context.Context, pid peer.ID, msg *pubsub.Mes
 
 // Returns true if the blob with the same slot, proposer index, and blob index has been seen before.
 func (s *Service) hasSeenBlobIndex(slot primitives.Slot, proposerIndex primitives.ValidatorIndex, index uint64) bool {
-	s.seenBlobLock.RLock()
-	defer s.seenBlobLock.RUnlock()
 	b := append(bytesutil.Bytes32(uint64(slot)), bytesutil.Bytes32(uint64(proposerIndex))...)
 	b = append(b, bytesutil.Bytes32(index)...)
 	_, seen := s.seenBlobCache.Get(string(b))
@@ -153,8 +151,6 @@ func (s *Service) hasSeenBlobIndex(slot primitives.Slot, proposerIndex primitive
 
 // Sets the blob with the same slot, proposer index, and blob index as seen.
 func (s *Service) setSeenBlobIndex(slot primitives.Slot, proposerIndex primitives.ValidatorIndex, index uint64) {
-	s.seenBlobLock.Lock()
-	defer s.seenBlobLock.Unlock()
 	b := append(bytesutil.Bytes32(uint64(slot)), bytesutil.Bytes32(uint64(proposerIndex))...)
 	b = append(b, bytesutil.Bytes32(index)...)
 	s.seenBlobCache.Add(string(b), true)

--- a/beacon-chain/sync/validate_proposer_slashing.go
+++ b/beacon-chain/sync/validate_proposer_slashing.go
@@ -79,15 +79,11 @@ func (s *Service) validateProposerSlashing(ctx context.Context, pid peer.ID, msg
 
 // Returns true if the node has already received a valid proposer slashing received for the proposer with index
 func (s *Service) hasSeenProposerSlashingIndex(i primitives.ValidatorIndex) bool {
-	s.seenProposerSlashingLock.RLock()
-	defer s.seenProposerSlashingLock.RUnlock()
 	_, seen := s.seenProposerSlashingCache.Get(i)
 	return seen
 }
 
 // Set proposer slashing index in proposer slashing cache.
 func (s *Service) setProposerSlashingIndexSeen(i primitives.ValidatorIndex) {
-	s.seenProposerSlashingLock.Lock()
-	defer s.seenProposerSlashingLock.Unlock()
 	s.seenProposerSlashingCache.Add(i, true)
 }

--- a/beacon-chain/sync/validate_sync_committee_message.go
+++ b/beacon-chain/sync/validate_sync_committee_message.go
@@ -128,8 +128,6 @@ func (s *Service) markSyncCommitteeMessagesSeen(committeeIndices []primitives.Co
 
 // Returns true if the node has received sync committee for the validator with index and slot.
 func (s *Service) hasSeenSyncMessageIndexSlot(ctx context.Context, m *ethpb.SyncCommitteeMessage, subCommitteeIndex uint64) bool {
-	s.seenSyncMessageLock.RLock()
-	defer s.seenSyncMessageLock.RUnlock()
 	rt, seen := s.seenSyncMessageCache.Get(seenSyncCommitteeKey(m.Slot, m.ValidatorIndex, subCommitteeIndex))
 	if !seen {
 		// return early if this is the first message
@@ -157,8 +155,6 @@ func (s *Service) hasSeenSyncMessageIndexSlot(ctx context.Context, m *ethpb.Sync
 
 // Set sync committee message validator index and slot as seen.
 func (s *Service) setSeenSyncMessageIndexSlot(m *ethpb.SyncCommitteeMessage, subCommitteeIndex uint64) {
-	s.seenSyncMessageLock.Lock()
-	defer s.seenSyncMessageLock.Unlock()
 	key := seenSyncCommitteeKey(m.Slot, m.ValidatorIndex, subCommitteeIndex)
 	s.seenSyncMessageCache.Add(key, [32]byte(m.BlockRoot))
 }

--- a/beacon-chain/sync/validate_sync_contribution_proof.go
+++ b/beacon-chain/sync/validate_sync_contribution_proof.go
@@ -297,9 +297,6 @@ func (s *Service) rejectInvalidSyncAggregateSignature(m *ethpb.SignedContributio
 
 // Returns true if the node has received sync contribution for the aggregator with index, slot and subcommittee index.
 func (s *Service) hasSeenSyncContributionIndexSlot(slot primitives.Slot, aggregatorIndex primitives.ValidatorIndex, subComIdx primitives.CommitteeIndex) bool {
-	s.seenSyncContributionLock.RLock()
-	defer s.seenSyncContributionLock.RUnlock()
-
 	b := append(bytesutil.Bytes32(uint64(aggregatorIndex)), bytesutil.Bytes32(uint64(slot))...)
 	b = append(b, bytesutil.Bytes32(uint64(subComIdx))...)
 	_, seen := s.seenSyncContributionCache.Get(string(b))
@@ -308,8 +305,6 @@ func (s *Service) hasSeenSyncContributionIndexSlot(slot primitives.Slot, aggrega
 
 // Set sync contributor's aggregate index, slot and subcommittee index as seen.
 func (s *Service) setSyncContributionIndexSlotSeen(slot primitives.Slot, aggregatorIndex primitives.ValidatorIndex, subComIdx primitives.CommitteeIndex) {
-	s.seenSyncContributionLock.Lock()
-	defer s.seenSyncContributionLock.Unlock()
 	b := append(bytesutil.Bytes32(uint64(aggregatorIndex)), bytesutil.Bytes32(uint64(slot))...)
 	b = append(b, bytesutil.Bytes32(uint64(subComIdx))...)
 	s.seenSyncContributionCache.Add(string(b), true)

--- a/beacon-chain/sync/validate_voluntary_exit.go
+++ b/beacon-chain/sync/validate_voluntary_exit.go
@@ -87,15 +87,11 @@ func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 
 // Returns true if the node has already received a valid exit request for the validator with index `i`.
 func (s *Service) hasSeenExitIndex(i primitives.ValidatorIndex) bool {
-	s.seenExitLock.RLock()
-	defer s.seenExitLock.RUnlock()
 	_, seen := s.seenExitCache.Get(i)
 	return seen
 }
 
 // Set exit request index `i` in seen exit request cache.
 func (s *Service) setExitIndexSeen(i primitives.ValidatorIndex) {
-	s.seenExitLock.Lock()
-	defer s.seenExitLock.Unlock()
 	s.seenExitCache.Add(i, true)
 }

--- a/changelog/syjn99_dedup-locks.md
+++ b/changelog/syjn99_dedup-locks.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Dedup redundant locks in codebase.

--- a/validator/client/aggregator_selector.go
+++ b/validator/client/aggregator_selector.go
@@ -44,7 +44,6 @@ type attSelectionKey struct {
 // localSelector computes selection proofs using the local keymanager.
 type localSelector struct {
 	v          *validator
-	dedupLock  sync.Mutex
 	dedupCache *lru.Cache
 	proofLock  sync.Mutex
 	proofCache map[attSelectionKey][]byte
@@ -113,13 +112,8 @@ func (p *localSelector) AttestationSelectionProof(ctx context.Context, slot prim
 
 func (p *localSelector) ClaimAggregateSlot(slot primitives.Slot, committeeIndex primitives.CommitteeIndex) bool {
 	k := validatorSubnetSubscriptionKey(slot, committeeIndex)
-	p.dedupLock.Lock()
-	defer p.dedupLock.Unlock()
-	if p.dedupCache.Contains(k) {
-		return false
-	}
-	p.dedupCache.Add(k, true)
-	return true
+	found, _ := p.dedupCache.ContainsOrAdd(k, true)
+	return !found
 }
 
 type syncSelectionProof struct {


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

This PR removes **obviously** redundant locks. As #13723 explains, `lru.Cache` has internal synchronization mechanism. In our codebase, it is quite frequent to use mutex explicitly with `lru.Cache`. 

Also for some cases, it 1) seeks for the value and 2) if it doesn't have, add a new key. This can be deduped with `ContainsOrAdd` which is atomic.

**Which issues(s) does this PR fix?**

Fixes #13723

**Other notes for review**

Each commit is separated by removed locks. Some commits contain reason for this.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
