### PR TITLE
Deprecate flags: `--enable-db-backup-webhook`, `--slasher-rpc-provider`, `--slasher-tls-cert`.

### DIFF
--- a/changelog/syjn99_deprecate-flags.md
+++ b/changelog/syjn99_deprecate-flags.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Deprecate legacy `--enable-db-backup-webhook`, `--slasher-rpc-provider`, and `--slasher-tls-cert` flags.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -47,12 +47,6 @@ var (
 		Usage: "Data directory for the databases.",
 		Value: DefaultDataDir(),
 	}
-	// EnableBackupWebhookFlag for users to trigger db backups via an HTTP webhook.
-	EnableBackupWebhookFlag = &cli.BoolFlag{
-		Name: "enable-db-backup-webhook",
-		Usage: `Serves HTTP handler to initiate database backups.
-		The handler is served on the monitoring port at path /db/backup.`,
-	}
 	// EnableTracingFlag defines a flag to enable OpenTelemetry tracing.
 	EnableTracingFlag = &cli.BoolFlag{
 		Name:  "enable-tracing",

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -75,17 +75,6 @@ var (
 		Usage: "RPC port exposed by a validator client.",
 		Value: 7000,
 	}
-	// SlasherRPCProviderFlag defines a slasher node RPC endpoint.
-	SlasherRPCProviderFlag = &cli.StringFlag{
-		Name:  "slasher-rpc-provider",
-		Usage: "Slasher node RPC provider endpoint.",
-		Value: "127.0.0.1:4002",
-	}
-	// SlasherCertFlag defines a flag for the slasher node's TLS certificate.
-	SlasherCertFlag = &cli.StringFlag{
-		Name:  "slasher-tls-cert",
-		Usage: "Certificate for secure slasher gRPC. Pass this and the tls-key flag in order to use gRPC securely.",
-	}
 	// DisablePenaltyRewardLogFlag defines the ability to not log reward/penalty information during deployment
 	DisablePenaltyRewardLogFlag = &cli.BoolFlag{
 		Name:  "disable-rewards-penalties-logging",

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -68,8 +68,6 @@ var appFlags = []cli.Flag{
 	flags.HTTPServerCorsDomain,
 	flags.DisableAccountMetricsFlag,
 	flags.MonitoringPortFlag,
-	flags.SlasherRPCProviderFlag,
-	flags.SlasherCertFlag,
 	flags.WalletPasswordFileFlag,
 	flags.WalletDirFlag,
 	flags.GraffitiFileFlag,
@@ -91,7 +89,6 @@ var appFlags = []cli.Flag{
 	////////////////////
 	cmd.DisableMonitoringFlag,
 	cmd.MonitoringHostFlag,
-	cmd.EnableBackupWebhookFlag,
 	cmd.MinimalConfigFlag,
 	cmd.E2EConfigFlag,
 	cmd.VerbosityFlag,

--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -60,7 +60,6 @@ var appHelpFlagGroups = []flagGroup{
 			flags.WalletPasswordFileFlag,
 			cmd.ClearDB,
 			cmd.ForceClearDB,
-			cmd.EnableBackupWebhookFlag,
 			cmd.EnableTracingFlag,
 			cmd.TracingProcessNameFlag,
 			cmd.TracingEndpointFlag,
@@ -129,13 +128,6 @@ var appHelpFlagGroups = []flagGroup{
 			flags.Web3SignerURLFlag,
 			flags.Web3SignerPublicValidatorKeysFlag,
 			flags.Web3SignerKeyFileFlag,
-		},
-	},
-	{
-		Name: "slasher",
-		Flags: []cli.Flag{
-			flags.SlasherRPCProviderFlag,
-			flags.SlasherCertFlag,
 		},
 	},
 	{

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -19,11 +19,29 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableDBBackupWebhook = &cli.BoolFlag{
+		Name:   "enable-db-backup-webhook",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
+	deprecatedSlasherRPCProvider = &cli.StringFlag{
+		Name:   "slasher-rpc-provider",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
+	deprecatedSlasherTLSCert = &cli.StringFlag{
+		Name:   "slasher-tls-cert",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.
 var deprecatedFlags = []cli.Flag{
 	deprecatedHTTPModules,
+	deprecatedEnableDBBackupWebhook,
+	deprecatedSlasherRPCProvider,
+	deprecatedSlasherTLSCert,
 }
 
 var upcomingDeprecation = []cli.Flag{


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Similar to #16973, we have three more flags that are no longer used in any production code. This PR just deprecates them.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
