### PR TITLE
Handle closed event channels in async Debounce

### DIFF
--- a/async/debounce.go
+++ b/async/debounce.go
@@ -17,7 +17,10 @@ func Debounce(ctx context.Context, interval time.Duration, eventsChan <-chan any
 	for {
 		select {
 		// Wait until an event is triggered.
-		case event := <-eventsChan:
+		case event, ok := <-eventsChan:
+			if !ok {
+				return
+			}
 			timer = time.NewTimer(interval)
 		loop:
 			for {
@@ -25,7 +28,10 @@ func Debounce(ctx context.Context, interval time.Duration, eventsChan <-chan any
 				// If another event is received before the interval has passed, store
 				// it and reset the timer.
 				select {
-				case event = <-eventsChan:
+				case event, ok = <-eventsChan:
+					if !ok {
+						return
+					}
 					// Reset timer.
 					timer.Stop()
 					timer = time.NewTimer(interval)

--- a/async/debounce_test.go
+++ b/async/debounce_test.go
@@ -60,6 +60,29 @@ func TestDebounce_CtxClosing(t *testing.T) {
 	})
 }
 
+func TestDebounce_EventsChannelClosing(t *testing.T) {
+	eventsChan := make(chan any, 100)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan struct{})
+	timesHandled := int32(0)
+	go func() {
+		defer close(done)
+		async.Debounce(ctx, time.Second, eventsChan, func(event any) {
+			atomic.AddInt32(&timesHandled, 1)
+		})
+	}()
+
+	close(eventsChan)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Debounce should return after events channel is closed")
+	}
+	assert.Equal(t, int32(0), atomic.LoadInt32(&timesHandled), "Wrong number of handled calls")
+}
+
 func TestDebounce_SingleHandlerInvocation(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		eventsChan := make(chan any, 100)

--- a/changelog/haoshengzhen-debounce-closed-channel.md
+++ b/changelog/haoshengzhen-debounce-closed-channel.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Prevent `async.Debounce` from processing zero-value events after its input channel closes.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**


> Bug fix


**What does this PR do? Why is it needed?**

This PR updates `async.Debounce` to return when its input events channel is closed.

Previously, receiving from a closed channel produced the zero value immediately. That could keep the debounce loop alive and eventually call the handler with a zero-value event instead of exiting. The fix checks the receive `ok` value in both event receive paths and returns when the channel is closed.

A regression test was added to cover the closed-channel case and verify that the handler is not called.


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

Testing performed:

- `go test ./async -run TestDebounce_EventsChannelClosing -count=1`
- `go test ./async -count=1`
- `gofmt`
- `git diff --check`
- 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
