### PR TITLE
Fix unbounded growth of engine_exchangeCapabilities requested method list

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -369,20 +369,31 @@ func (s *Service) ExchangeCapabilities(ctx context.Context) ([]string, error) {
 	ctx, span := trace.StartSpan(ctx, "powchain.engine-api-client.ExchangeCapabilities")
 	defer span.End()
 
+	capacity := len(supportedEngineEndpoints)
 	if params.ElectraEnabled() {
-		supportedEngineEndpoints = append(supportedEngineEndpoints, electraEngineEndpoints...)
+		capacity += len(electraEngineEndpoints)
 	}
-
 	if params.FuluEnabled() {
-		supportedEngineEndpoints = append(supportedEngineEndpoints, fuluEngineEndpoints...)
+		capacity += len(fuluEngineEndpoints)
 	}
-
 	if params.GloasEnabled() {
-		supportedEngineEndpoints = append(supportedEngineEndpoints, gloasEngineEndpoints...)
+		capacity += len(gloasEngineEndpoints)
 	}
 
-	elSupportedEndpointsSlice := make([]string, len(supportedEngineEndpoints))
-	if err := s.rpcClient.CallContext(ctx, &elSupportedEndpointsSlice, ExchangeCapabilities, supportedEngineEndpoints); err != nil {
+	endpoints := make([]string, 0, capacity)
+	endpoints = append(endpoints, supportedEngineEndpoints...)
+	if params.ElectraEnabled() {
+		endpoints = append(endpoints, electraEngineEndpoints...)
+	}
+	if params.FuluEnabled() {
+		endpoints = append(endpoints, fuluEngineEndpoints...)
+	}
+	if params.GloasEnabled() {
+		endpoints = append(endpoints, gloasEngineEndpoints...)
+	}
+
+	elSupportedEndpointsSlice := make([]string, 0, len(endpoints))
+	if err := s.rpcClient.CallContext(ctx, &elSupportedEndpointsSlice, ExchangeCapabilities, endpoints); err != nil {
 		return nil, handleRPCError(err)
 	}
 
@@ -392,7 +403,7 @@ func (s *Service) ExchangeCapabilities(ctx context.Context) ([]string, error) {
 	}
 
 	unsupported := make([]string, 0)
-	for _, method := range supportedEngineEndpoints {
+	for _, method := range endpoints {
 		if !elSupportedEndpoints[method] {
 			unsupported = append(unsupported, method)
 		}

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -2527,6 +2527,69 @@ func Test_ExchangeCapabilities(t *testing.T) {
 	})
 }
 
+func Test_ExchangeCapabilities_StableAcrossCalls(t *testing.T) {
+	// Enable all forks so the fork-specific endpoint branches in
+	// ExchangeCapabilities are exercised on every call.
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	// Capture the engine method list the EL receives on each call.
+	var requested [][]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		defer func() {
+			require.NoError(t, r.Body.Close())
+		}()
+
+		var req struct {
+			Params [][]string `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.Equal(t, 1, len(req.Params))
+		requested = append(requested, req.Params[0])
+
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  []string{},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+
+	ctx := t.Context()
+	rpcClient, err := rpc.DialHTTP(srv.URL)
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	service := &Service{}
+	service.rpcClient = rpcClient
+
+	_, err = service.ExchangeCapabilities(ctx)
+	require.NoError(t, err)
+	_, err = service.ExchangeCapabilities(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(requested))
+	// The requested method list must be identical between calls: the set of
+	// engine methods Prysm supports does not change at runtime.
+	require.Equal(t, len(requested[0]), len(requested[1]), "engine method list grew between calls")
+	for i := range requested[0] {
+		require.Equal(t, requested[0][i], requested[1][i])
+	}
+
+	// And the list must contain no duplicate method names.
+	seen := make(map[string]bool, len(requested[1]))
+	for _, m := range requested[1] {
+		require.Equal(t, false, seen[m], "duplicate engine method requested: %s", m)
+		seen[m] = true
+	}
+}
+
 func mockSummary(t *testing.T, exists []bool) func(uint64) bool {
 	hi, err := filesystem.NewBlobStorageSummary(params.BeaconConfig().DenebForkEpoch, exists)
 	require.NoError(t, err)

--- a/changelog/prestonvanloon_fix-exchange-capabilities-log-growth.md
+++ b/changelog/prestonvanloon_fix-exchange-capabilities-log-growth.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed `engine_exchangeCapabilities` requesting an ever-growing list of engine methods. Fork-specific endpoints were appended to a shared slice on every execution client reconnect, causing the "Connected execution client does not support some requested engine methods" warning to grow unbounded with duplicate entries.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

`ExchangeCapabilities` appends the fork-specific engine endpoints (Electra/Fulu/Gloas) to the **package-level** `supportedEngineEndpoints` slice on every invocation:

```go
if params.FuluEnabled() {
    supportedEngineEndpoints = append(supportedEngineEndpoints, fuluEngineEndpoints...)
}
```

`ExchangeCapabilities` is called from `pollConnectionStatus` on every execution-client (re)connection, and `pollConnectionStatus` is re-invoked from the run loop on every failed `eth1HeadTicker` header fetch (and via `retryExecutionClientConnection` from several error paths). Each call therefore re-appends the fork endpoints to the shared slice, so the slice grows without bound.

Because the requested-but-unsupported set is then computed from that ever-growing slice, the resulting warning grows on every reconnect:

```
WARN execution: Connected execution client does not support some requested engine methods
  methods=[engine_getBlobsV3 engine_getBlobsV3 engine_getBlobsV3 ... (hundreds)]
```

This is most visible on execution clients that don't yet implement `engine_getBlobsV3`/`engine_getBlobsV2`, and on nodes that reconnect to the EL frequently.

The fix builds a fresh local endpoint list on each call instead of mutating the shared package-level slice. The set of requested engine methods is now stable across calls, so the warning is constant-length (and duplicate-free) rather than monotonically growing. The shared `supportedEngineEndpoints` slice is left read-only.

**Other notes for review**

Testing plan: added `Test_ExchangeCapabilities_StableAcrossCalls`, which enables all forks, captures the engine-method list the EL receives via a stub HTTP handler, calls `ExchangeCapabilities` twice, and asserts the two requested method lists are identical and contain no duplicates. The test fails on the previous code (`22` methods on the first call, `32` on the second) and passes with this change. The full `//beacon-chain/execution:go_default_test` package passes.

This change only affects the request list sent to the EL and the warning log; it does not change which capabilities are cached or how they are used. The warning will still appear once per reconnect when the EL genuinely lacks a requested method — it simply no longer accumulates.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).
