### PR TITLE
Add Gloas builder service execution payload bid and signed block methods

### DIFF
--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -27,6 +27,8 @@ type BlockBuilder interface {
 	SubmitBlindedBlock(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, v1.BlobsBundler, error)
 	SubmitBlindedBlockPostFulu(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock) error
 	GetHeader(ctx context.Context, slot primitives.Slot, parentHash [32]byte, pubKey [48]byte) (builder.SignedBid, error)
+	GetExecutionPayloadBid(ctx context.Context, slot primitives.Slot, parentHash, parentRoot [32]byte, proposerPubkey [48]byte, auths []*ethpb.SignedRequestAuthV1) (*ethpb.SignedExecutionPayloadBid, error)
+	SubmitSignedBeaconBlock(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock) error
 	RegisterValidator(ctx context.Context, reg []*ethpb.SignedValidatorRegistrationV1) error
 	RegistrationByValidatorID(ctx context.Context, id primitives.ValidatorIndex) (*ethpb.ValidatorRegistrationV1, error)
 	SubmitBuilderPreferences(ctx context.Context, validatorPubkey [48]byte, req *ethpb.BuilderPreferencesRequestV1) error
@@ -117,6 +119,45 @@ func (s *Service) SubmitBlindedBlockPostFulu(ctx context.Context, b interfaces.R
 	}
 
 	return s.c.SubmitBlindedBlockPostFulu(ctx, b)
+}
+
+// GetExecutionPayloadBid requests a SignedExecutionPayloadBid from the builder for the given slot.
+func (s *Service) GetExecutionPayloadBid(ctx context.Context, slot primitives.Slot, parentHash, parentRoot [32]byte, proposerPubkey [48]byte, auths []*ethpb.SignedRequestAuthV1) (*ethpb.SignedExecutionPayloadBid, error) {
+	ctx, span := trace.StartSpan(ctx, "builder.GetExecutionPayloadBid")
+	defer span.End()
+	if s.c == nil {
+		tracing.AnnotateError(span, ErrNoBuilder)
+		return nil, ErrNoBuilder
+	}
+	auth := authForBuilder(auths, s.c.NodeURL())
+	if auth == nil {
+		log.WithField("builderUrl", s.c.NodeURL()).WithField("authCount", len(auths)).
+			Warn("No request auth signed for this builder; sending bid request without auth")
+	}
+	bid, err := s.c.GetExecutionPayloadBid(ctx, slot, parentHash, parentRoot, proposerPubkey, auth)
+	tracing.AnnotateError(span, err)
+	return bid, err
+}
+
+// authForBuilder returns the request auth signed for the given builder URL, or nil if none match.
+func authForBuilder(auths []*ethpb.SignedRequestAuthV1, url string) *ethpb.SignedRequestAuthV1 {
+	for _, a := range auths {
+		if string(a.GetMessage().GetData()) == url {
+			return a
+		}
+	}
+	return nil
+}
+
+// SubmitSignedBeaconBlock sends a signed Gloas beacon block to the builder so it can reveal the envelope.
+func (s *Service) SubmitSignedBeaconBlock(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock) error {
+	ctx, span := trace.StartSpan(ctx, "builder.SubmitSignedBeaconBlock")
+	defer span.End()
+	if s.c == nil {
+		tracing.AnnotateError(span, ErrNoBuilder)
+		return ErrNoBuilder
+	}
+	return s.c.SubmitSignedBeaconBlock(ctx, b)
 }
 
 // SubmitBuilderPreferences submits a proposer's per-builder preferences ahead of the bid request.

--- a/beacon-chain/builder/service_test.go
+++ b/beacon-chain/builder/service_test.go
@@ -66,4 +66,24 @@ func Test_BuilderMethodsWithouClient(t *testing.T) {
 
 	err = s.RegisterValidator(t.Context(), nil)
 	assert.ErrorContains(t, ErrNoBuilder.Error(), err)
+
+	_, err = s.GetExecutionPayloadBid(t.Context(), 0, [32]byte{}, [32]byte{}, [48]byte{}, nil)
+	assert.ErrorContains(t, ErrNoBuilder.Error(), err)
+
+	err = s.SubmitSignedBeaconBlock(t.Context(), nil)
+	assert.ErrorContains(t, ErrNoBuilder.Error(), err)
+}
+
+func Test_authForBuilder(t *testing.T) {
+	mk := func(url string) *eth.SignedRequestAuthV1 {
+		return &eth.SignedRequestAuthV1{Message: &eth.RequestAuthV1{Data: []byte(url)}}
+	}
+	auths := []*eth.SignedRequestAuthV1{mk("https://a.example.com"), mk("https://b.example.com")}
+
+	got := authForBuilder(auths, "https://b.example.com")
+	require.NotNil(t, got)
+	assert.DeepEqual(t, []byte("https://b.example.com"), got.GetMessage().GetData())
+
+	assert.Equal(t, (*eth.SignedRequestAuthV1)(nil), authForBuilder(auths, "https://c.example.com"))
+	assert.Equal(t, (*eth.SignedRequestAuthV1)(nil), authForBuilder(nil, "https://a.example.com"))
 }

--- a/beacon-chain/builder/testing/mock.go
+++ b/beacon-chain/builder/testing/mock.go
@@ -40,6 +40,9 @@ type MockBuilderService struct {
 	ErrGetHeader                  error
 	ErrRegisterValidator          error
 	ErrSubmitBuilderPreferences   error
+	ErrGetExecutionPayloadBid     error
+	ErrSubmitSignedBeaconBlock    error
+	ExecutionPayloadBid           *ethpb.SignedExecutionPayloadBid
 	Cfg                           *Config
 }
 
@@ -121,6 +124,16 @@ func (s *MockBuilderService) RegisterValidator(context.Context, []*ethpb.SignedV
 // SubmitBuilderPreferences for mocking.
 func (s *MockBuilderService) SubmitBuilderPreferences(_ context.Context, _ [48]byte, _ *ethpb.BuilderPreferencesRequestV1) error {
 	return s.ErrSubmitBuilderPreferences
+}
+
+// GetExecutionPayloadBid for mocking.
+func (s *MockBuilderService) GetExecutionPayloadBid(_ context.Context, _ primitives.Slot, _, _ [32]byte, _ [48]byte, _ []*ethpb.SignedRequestAuthV1) (*ethpb.SignedExecutionPayloadBid, error) {
+	return s.ExecutionPayloadBid, s.ErrGetExecutionPayloadBid
+}
+
+// SubmitSignedBeaconBlock for mocking.
+func (s *MockBuilderService) SubmitSignedBeaconBlock(_ context.Context, _ interfaces.ReadOnlySignedBeaconBlock) error {
+	return s.ErrSubmitSignedBeaconBlock
 }
 
 // SubmitBlindedBlockPostFulu for mocking.

--- a/changelog/terence_gloas-builder-service-bid.md
+++ b/changelog/terence_gloas-builder-service-bid.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add `GetExecutionPayloadBid` and `SubmitSignedBeaconBlock` to the beacon node builder service, wrapping the Gloas builder API client and selecting the per-builder request auth.


### PR DESCRIPTION
Adds `GetExecutionPayloadBid` and `SubmitSignedBeaconBlock` to the beacon node builder service, wrapping the Gloas builder API client from #16984 and selecting the request auth signed for the configured builder. Carved out of #16961; unblocks the Gloas bid-selection path in proposer block production.