### PR TITLE
Fix builder exits processed metric increment

### DIFF
--- a/beacon-chain/core/gloas/builder_exit.go
+++ b/beacon-chain/core/gloas/builder_exit.go
@@ -29,5 +29,9 @@ func InitiateBuilderExit(s state.BeaconState, builderIndex primitives.BuilderInd
 	}
 	currentEpoch := slots.ToEpoch(s.Slot())
 	builder.WithdrawableEpoch = currentEpoch + params.BeaconConfig().MinBuilderWithdrawabilityDelay
-	return s.UpdateBuilderAtIndex(builderIndex, builder)
+	if err := s.UpdateBuilderAtIndex(builderIndex, builder); err != nil {
+		return err
+	}
+	builderExitsProcessedTotal.Inc()
+	return nil
 }

--- a/changelog/satushh_fix-builder-exits-metric.md
+++ b/changelog/satushh_fix-builder-exits-metric.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Increment the `builder_exits_processed_total` metric when a builder exit is initiated. The counter was defined but never incremented, so it always reported zero.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Increment the `builder_exits_processed_total` metric when a builder exit is initiated as it was defined but never incremented.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
