### PR TITLE
Add missing execution_payload_bid gossip REJECT checks

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -87,12 +87,24 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyBuilderActive(st); err != nil {
 		return pubsub.ValidationReject, err
 	}
+	// [REJECT] the builder version is PAYLOAD_BUILDER_VERSION.
+	if err := v.VerifyBuilderVersion(st); err != nil {
+		return pubsub.ValidationReject, err
+	}
 	// [REJECT] bid.execution_payment is zero.
 	if err := v.VerifyExecutionPaymentZero(); err != nil {
 		return pubsub.ValidationReject, err
 	}
 	// [REJECT] bid.fee_recipient matches the fee_recipient from the proposer's SignedProposerPreferences associated with bid.slot.
 	if err := v.VerifyFeeRecipientMatches(pref.FeeRecipient[:]); err != nil {
+		return pubsub.ValidationReject, err
+	}
+	// [REJECT] len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block.
+	if err := v.VerifyBlobKzgCommitmentsLimit(); err != nil {
+		return pubsub.ValidationReject, err
+	}
+	// [REJECT] bid.prev_randao == get_randao_mix(parent_state, get_current_epoch(parent_state)).
+	if err := v.VerifyPrevRandao(st); err != nil {
 		return pubsub.ValidationReject, err
 	}
 	if err := v.VerifySignature(st); err != nil {

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -143,6 +143,24 @@ func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
 			wantError: true,
 		},
 		{
+			name:      "builder wrong version",
+			verifier:  mockExecutionPayloadBidVerifier{errBuilderVersion: errors.New("not a payload builder")},
+			result:    pubsub.ValidationReject,
+			wantError: true,
+		},
+		{
+			name:      "too many blob commitments",
+			verifier:  mockExecutionPayloadBidVerifier{errBlobKzgCommitments: errors.New("too many commitments")},
+			result:    pubsub.ValidationReject,
+			wantError: true,
+		},
+		{
+			name:      "wrong prev randao",
+			verifier:  mockExecutionPayloadBidVerifier{errPrevRandao: errors.New("wrong prev randao")},
+			result:    pubsub.ValidationReject,
+			wantError: true,
+		},
+		{
 			name:      "slot not higher than parent",
 			verifier:  mockExecutionPayloadBidVerifier{errSlotHigherThanParent: errors.New("slot not higher than parent")},
 			result:    pubsub.ValidationReject,
@@ -311,8 +329,11 @@ func TestExecutionPayloadBidSubscriber_NilMessage(t *testing.T) {
 type mockExecutionPayloadBidVerifier struct {
 	errCurrentOrNextSlot    error
 	errBuilderActive        error
+	errBuilderVersion       error
 	errExecutionPayment     error
 	errFeeRecipientMismatch error
+	errBlobKzgCommitments   error
+	errPrevRandao           error
 	errGasLimitIncompatible error
 	errParentBlockRootSeen  error
 	errSlotHigherThanParent error
@@ -331,12 +352,24 @@ func (m *mockExecutionPayloadBidVerifier) VerifyBuilderActive(state.ReadOnlyBeac
 	return m.errBuilderActive
 }
 
+func (m *mockExecutionPayloadBidVerifier) VerifyBuilderVersion(state.ReadOnlyBeaconState) error {
+	return m.errBuilderVersion
+}
+
 func (m *mockExecutionPayloadBidVerifier) VerifyExecutionPaymentZero() error {
 	return m.errExecutionPayment
 }
 
 func (m *mockExecutionPayloadBidVerifier) VerifyFeeRecipientMatches([]byte) error {
 	return m.errFeeRecipientMismatch
+}
+
+func (m *mockExecutionPayloadBidVerifier) VerifyBlobKzgCommitmentsLimit() error {
+	return m.errBlobKzgCommitments
+}
+
+func (m *mockExecutionPayloadBidVerifier) VerifyPrevRandao(state.ReadOnlyBeaconState) error {
+	return m.errPrevRandao
 }
 
 func (m *mockExecutionPayloadBidVerifier) VerifyGasLimitTargetCompatible(uint64, uint64) error {

--- a/beacon-chain/verification/execution_payload_bid.go
+++ b/beacon-chain/verification/execution_payload_bid.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
 
@@ -15,8 +18,11 @@ import (
 var ExecutionPayloadBidGossipRequirements = []Requirement{
 	RequireBidCurrentOrNextSlot,
 	RequireBidBuilderActive,
+	RequireBidBuilderVersionValid,
 	RequireBidExecutionPaymentZero,
 	RequireBidFeeRecipientMatches,
+	RequireBidBlobKzgCommitmentsLimit,
+	RequireBidPrevRandaoValid,
 	RequireBidParentBlockRootSeen,
 	RequireBidSlotHigherThanParent,
 	RequireBidParentBlockHashValid,
@@ -29,16 +35,23 @@ var ExecutionPayloadBidGossipRequirements = []Requirement{
 var GossipExecutionPayloadBidRequirements = requirementList(ExecutionPayloadBidGossipRequirements)
 
 var (
-	ErrBidSlotNotCurrentOrNext    = errors.New("bid slot is not current or next")
-	ErrBidBuilderNotActive        = errors.New("builder is not active")
-	ErrBidExecutionPaymentNonZero = errors.New("execution payment is non-zero")
-	ErrBidFeeRecipientMismatch    = errors.New("fee recipient does not match proposer preferences")
-	ErrBidGasLimitIncompatible    = errors.New("bid gas limit is incompatible with parent and target")
-	ErrBidParentBlockRootNotSeen  = errors.New("parent block root not seen")
-	ErrBidSlotNotHigherThanParent = errors.New("bid slot is not higher than parent block slot")
-	ErrBidParentBlockHashMismatch = errors.New("parent block hash does not match forkchoice")
-	ErrBidBuilderCannotCover      = errors.New("builder cannot cover bid")
+	ErrBidSlotNotCurrentOrNext      = errors.New("bid slot is not current or next")
+	ErrBidBuilderNotActive          = errors.New("builder is not active")
+	ErrBidBuilderVersionInvalid     = errors.New("builder is not a payload builder")
+	ErrBidExecutionPaymentNonZero   = errors.New("execution payment is non-zero")
+	ErrBidFeeRecipientMismatch      = errors.New("fee recipient does not match proposer preferences")
+	ErrBidTooManyBlobKzgCommitments = errors.New("bid has too many blob KZG commitments")
+	ErrBidPrevRandaoMismatch        = errors.New("bid prev randao does not match state randao mix")
+	ErrBidGasLimitIncompatible      = errors.New("bid gas limit is incompatible with parent and target")
+	ErrBidParentBlockRootNotSeen    = errors.New("parent block root not seen")
+	ErrBidSlotNotHigherThanParent   = errors.New("bid slot is not higher than parent block slot")
+	ErrBidParentBlockHashMismatch   = errors.New("parent block hash does not match forkchoice")
+	ErrBidBuilderCannotCover        = errors.New("builder cannot cover bid")
 )
+
+// payloadBuilderVersion is PAYLOAD_BUILDER_VERSION: the builder version byte
+// required for an execution payload builder (EIP-7732).
+const payloadBuilderVersion = 0
 
 var _ ExecutionPayloadBidVerifier = &BidVerifier{}
 
@@ -78,6 +91,60 @@ func (v *BidVerifier) VerifyBuilderActive(st state.ReadOnlyBeaconState) (err err
 	}
 	if !active {
 		return fmt.Errorf("%w: builder=%d", ErrBidBuilderNotActive, bid.BuilderIndex())
+	}
+	return nil
+}
+
+// VerifyBuilderVersion verifies the bid builder's version is PAYLOAD_BUILDER_VERSION.
+func (v *BidVerifier) VerifyBuilderVersion(st state.ReadOnlyBeaconState) (err error) {
+	defer v.record(RequireBidBuilderVersionValid, &err)
+
+	bid, err := v.b.Bid()
+	if err != nil {
+		return errors.Wrap(err, "failed to get bid")
+	}
+	builder, err := st.Builder(bid.BuilderIndex())
+	if err != nil {
+		return errors.Wrap(err, "failed to get builder")
+	}
+	if len(builder.Version) == 0 || builder.Version[0] != payloadBuilderVersion {
+		return fmt.Errorf("%w: builder=%d version=%x", ErrBidBuilderVersionInvalid, bid.BuilderIndex(), builder.Version)
+	}
+	return nil
+}
+
+// VerifyBlobKzgCommitmentsLimit verifies the bid blob KZG commitment count does
+// not exceed the per-block limit for the bid's slot.
+func (v *BidVerifier) VerifyBlobKzgCommitmentsLimit() (err error) {
+	defer v.record(RequireBidBlobKzgCommitmentsLimit, &err)
+
+	bid, err := v.b.Bid()
+	if err != nil {
+		return errors.Wrap(err, "failed to get bid")
+	}
+	maxBlobs := uint64(params.BeaconConfig().MaxBlobsPerBlockAtEpoch(slots.ToEpoch(bid.Slot())))
+	if count := bid.BlobKzgCommitmentCount(); count > maxBlobs {
+		return fmt.Errorf("%w: got %d max %d", ErrBidTooManyBlobKzgCommitments, count, maxBlobs)
+	}
+	return nil
+}
+
+// VerifyPrevRandao verifies the bid prev_randao matches the state's RANDAO mix
+// for the current epoch.
+func (v *BidVerifier) VerifyPrevRandao(st state.ReadOnlyBeaconState) (err error) {
+	defer v.record(RequireBidPrevRandaoValid, &err)
+
+	bid, err := v.b.Bid()
+	if err != nil {
+		return errors.Wrap(err, "failed to get bid")
+	}
+	mix, err := helpers.RandaoMix(st, slots.ToEpoch(st.Slot()))
+	if err != nil {
+		return errors.Wrap(err, "failed to get randao mix")
+	}
+	prevRandao := bid.PrevRandao()
+	if !bytes.Equal(prevRandao[:], mix) {
+		return fmt.Errorf("%w: bid=%#x state=%#x", ErrBidPrevRandaoMismatch, prevRandao, mix)
 	}
 	return nil
 }

--- a/beacon-chain/verification/execution_payload_bid_test.go
+++ b/beacon-chain/verification/execution_payload_bid_test.go
@@ -252,16 +252,23 @@ func TestBidVerifier_VerifyBuilderVersion(t *testing.T) {
 
 func TestBidVerifier_VerifyBlobKzgCommitmentsLimit(t *testing.T) {
 	maxBlobs := params.BeaconConfig().MaxBlobsPerBlockAtEpoch(slots.ToEpoch(1))
+	commitments := func(n int) [][]byte {
+		c := make([][]byte, n)
+		for i := range c {
+			c[i] = bytes.Repeat([]byte{0x01}, 48)
+		}
+		return c
+	}
 
 	atLimit := testSignedExecutionPayloadBid(t, 1)
-	atLimit.Message.BlobKzgCommitments = make([][]byte, maxBlobs)
+	atLimit.Message.BlobKzgCommitments = commitments(maxBlobs)
 	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(atLimit)
 	require.NoError(t, err)
 	verifier := &BidVerifier{results: newResults(RequireBidBlobKzgCommitmentsLimit), b: wrapped}
 	require.NoError(t, verifier.VerifyBlobKzgCommitmentsLimit())
 
 	overLimit := testSignedExecutionPayloadBid(t, 1)
-	overLimit.Message.BlobKzgCommitments = make([][]byte, maxBlobs+1)
+	overLimit.Message.BlobKzgCommitments = commitments(maxBlobs + 1)
 	wrapped, err = blocks.WrappedROSignedExecutionPayloadBid(overLimit)
 	require.NoError(t, err)
 	verifier = &BidVerifier{results: newResults(RequireBidBlobKzgCommitmentsLimit), b: wrapped}

--- a/beacon-chain/verification/execution_payload_bid_test.go
+++ b/beacon-chain/verification/execution_payload_bid_test.go
@@ -232,6 +232,60 @@ func TestBidVerifier_VerifySignature(t *testing.T) {
 	require.ErrorIs(t, verifier.VerifySignature(st), signing.ErrSigFailedToVerify)
 }
 
+func TestBidVerifier_VerifyBuilderVersion(t *testing.T) {
+	signed := testSignedExecutionPayloadBid(t, 1)
+	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signed)
+	require.NoError(t, err)
+
+	payloadBuilder := newBidState(t, 1, func(s *ethpb.BeaconStateGloas) {
+		s.Builders = []*ethpb.Builder{{Version: []byte{0}, WithdrawableEpoch: params.BeaconConfig().FarFutureEpoch}}
+	})
+	verifier := &BidVerifier{results: newResults(RequireBidBuilderVersionValid), b: wrapped}
+	require.NoError(t, verifier.VerifyBuilderVersion(payloadBuilder))
+
+	nonPayloadBuilder := newBidState(t, 1, func(s *ethpb.BeaconStateGloas) {
+		s.Builders = []*ethpb.Builder{{Version: []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte}, WithdrawableEpoch: params.BeaconConfig().FarFutureEpoch}}
+	})
+	verifier = &BidVerifier{results: newResults(RequireBidBuilderVersionValid), b: wrapped}
+	require.ErrorIs(t, verifier.VerifyBuilderVersion(nonPayloadBuilder), ErrBidBuilderVersionInvalid)
+}
+
+func TestBidVerifier_VerifyBlobKzgCommitmentsLimit(t *testing.T) {
+	maxBlobs := params.BeaconConfig().MaxBlobsPerBlockAtEpoch(slots.ToEpoch(1))
+
+	atLimit := testSignedExecutionPayloadBid(t, 1)
+	atLimit.Message.BlobKzgCommitments = make([][]byte, maxBlobs)
+	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(atLimit)
+	require.NoError(t, err)
+	verifier := &BidVerifier{results: newResults(RequireBidBlobKzgCommitmentsLimit), b: wrapped}
+	require.NoError(t, verifier.VerifyBlobKzgCommitmentsLimit())
+
+	overLimit := testSignedExecutionPayloadBid(t, 1)
+	overLimit.Message.BlobKzgCommitments = make([][]byte, maxBlobs+1)
+	wrapped, err = blocks.WrappedROSignedExecutionPayloadBid(overLimit)
+	require.NoError(t, err)
+	verifier = &BidVerifier{results: newResults(RequireBidBlobKzgCommitmentsLimit), b: wrapped}
+	require.ErrorIs(t, verifier.VerifyBlobKzgCommitmentsLimit(), ErrBidTooManyBlobKzgCommitments)
+}
+
+func TestBidVerifier_VerifyPrevRandao(t *testing.T) {
+	signed := testSignedExecutionPayloadBid(t, 1)
+	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signed)
+	require.NoError(t, err)
+
+	matching := newBidState(t, 1, func(s *ethpb.BeaconStateGloas) {
+		s.RandaoMixes[0] = bytes.Repeat([]byte{0x04}, 32)
+	})
+	verifier := &BidVerifier{results: newResults(RequireBidPrevRandaoValid), b: wrapped}
+	require.NoError(t, verifier.VerifyPrevRandao(matching))
+
+	mismatching := newBidState(t, 1, func(s *ethpb.BeaconStateGloas) {
+		s.RandaoMixes[0] = bytes.Repeat([]byte{0x09}, 32)
+	})
+	verifier = &BidVerifier{results: newResults(RequireBidPrevRandaoValid), b: wrapped}
+	require.ErrorIs(t, verifier.VerifyPrevRandao(mismatching), ErrBidPrevRandaoMismatch)
+}
+
 func testSignedExecutionPayloadBid(t *testing.T, slot primitives.Slot) *ethpb.SignedExecutionPayloadBid {
 	t.Helper()
 

--- a/beacon-chain/verification/interface.go
+++ b/beacon-chain/verification/interface.go
@@ -102,8 +102,11 @@ type NewSignedProposerPreferencesVerifier func(p *ethpb.SignedProposerPreference
 type ExecutionPayloadBidVerifier interface {
 	VerifyCurrentOrNextSlot() error
 	VerifyBuilderActive(state.ReadOnlyBeaconState) error
+	VerifyBuilderVersion(state.ReadOnlyBeaconState) error
 	VerifyExecutionPaymentZero() error
 	VerifyFeeRecipientMatches([]byte) error
+	VerifyBlobKzgCommitmentsLimit() error
+	VerifyPrevRandao(state.ReadOnlyBeaconState) error
 	VerifyParentBlockRootSeen(func([32]byte) bool) error
 	VerifyBidSlotHigherThanParent(parentSlot primitives.Slot) error
 	VerifyParentBlockHash(func([32]byte) ([32]byte, error)) error

--- a/beacon-chain/verification/requirements.go
+++ b/beacon-chain/verification/requirements.go
@@ -42,8 +42,11 @@ const (
 	// Execution payload bid specific.
 	RequireBidCurrentOrNextSlot
 	RequireBidBuilderActive
+	RequireBidBuilderVersionValid
 	RequireBidExecutionPaymentZero
 	RequireBidFeeRecipientMatches
+	RequireBidBlobKzgCommitmentsLimit
+	RequireBidPrevRandaoValid
 	RequireBidGasLimitCompatible
 	RequireBidParentBlockRootSeen
 	RequireBidSlotHigherThanParent

--- a/beacon-chain/verification/result.go
+++ b/beacon-chain/verification/result.go
@@ -73,10 +73,16 @@ func (r Requirement) String() string {
 		return "RequireBidCurrentOrNextSlot"
 	case RequireBidBuilderActive:
 		return "RequireBidBuilderActive"
+	case RequireBidBuilderVersionValid:
+		return "RequireBidBuilderVersionValid"
 	case RequireBidExecutionPaymentZero:
 		return "RequireBidExecutionPaymentZero"
 	case RequireBidFeeRecipientMatches:
 		return "RequireBidFeeRecipientMatches"
+	case RequireBidBlobKzgCommitmentsLimit:
+		return "RequireBidBlobKzgCommitmentsLimit"
+	case RequireBidPrevRandaoValid:
+		return "RequireBidPrevRandaoValid"
 	case RequireBidGasLimitCompatible:
 		return "RequireBidGasLimitCompatible"
 	case RequireBidParentBlockRootSeen:

--- a/changelog/terence_gloas-bid-gossip-checks.md
+++ b/changelog/terence_gloas-bid-gossip-checks.md
@@ -1,0 +1,3 @@
+### Added
+
+- Gloas: reject `execution_payload_bid` gossip when the builder version is not `PAYLOAD_BUILDER_VERSION`, the blob KZG commitment count exceeds the per-slot limit, or `prev_randao` does not match the RANDAO mix.


### PR DESCRIPTION
Implements the three `execution_payload_bid` gossip `[REJECT]` conditions that were missing per consensus-specs v1.7.0-alpha.11: the builder version must equal `PAYLOAD_BUILDER_VERSION`, the blob KZG commitment count must not exceed the per-slot limit, and `prev_randao` must match the state's RANDAO mix.