### PR TITLE
Cleanup: Use stdlib functions

### DIFF
--- a/api/client/builder/types.go
+++ b/api/client/builder/types.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
@@ -107,21 +106,6 @@ func (s Uint256) MarshalText() ([]byte, error) {
 		return nil, errors.Wrapf(errInvalidUint256, "value=%s", s.Int)
 	}
 	return []byte(s.String()), nil
-}
-
-// Uint64String is a custom type that allows marshalling from text to uint64 and vice versa.
-type Uint64String uint64
-
-// UnmarshalText takes a byte array and unmarshals the text in Uint64String.
-func (s *Uint64String) UnmarshalText(t []byte) error {
-	u, err := strconv.ParseUint(string(t), 10, 64)
-	*s = Uint64String(u)
-	return err
-}
-
-// MarshalText returns a byte representation of the text from Uint64String.
-func (s Uint64String) MarshalText() ([]byte, error) {
-	return fmt.Appendf(nil, "%d", s), nil
 }
 
 // VersionResponse is a JSON representation of a field in the builder API header response.

--- a/beacon-chain/cache/depositsnapshot/BUILD.bazel
+++ b/beacon-chain/cache/depositsnapshot/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
     deps = [
         "//beacon-chain/cache:go_default_library",
         "//config/fieldparams:go_default_library",
-        "//container/slice:go_default_library",
         "//container/trie:go_default_library",
         "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",

--- a/beacon-chain/cache/depositsnapshot/merkle_tree.go
+++ b/beacon-chain/cache/depositsnapshot/merkle_tree.go
@@ -1,7 +1,8 @@
 package depositsnapshot
 
 import (
-	"github.com/OffchainLabs/prysm/v7/container/slice"
+	"slices"
+
 	"github.com/OffchainLabs/prysm/v7/container/trie"
 	"github.com/OffchainLabs/prysm/v7/crypto/hash"
 	"github.com/OffchainLabs/prysm/v7/math"
@@ -110,7 +111,7 @@ func generateProof(tree MerkleTreeNode, index uint64, depth uint64) ([32]byte, [
 		}
 		depth--
 	}
-	proof = slice.Reverse(proof)
+	slices.Reverse(proof)
 	return node.GetRoot(), proof
 }
 

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -248,7 +248,7 @@ func SlashValidator(
 		return nil, err
 	}
 	validator.Slashed = true
-	maxWithdrawableEpoch := primitives.MaxEpoch(validator.WithdrawableEpoch, currentEpoch+params.BeaconConfig().EpochsPerSlashingsVector)
+	maxWithdrawableEpoch := max(validator.WithdrawableEpoch, currentEpoch+params.BeaconConfig().EpochsPerSlashingsVector)
 	validator.WithdrawableEpoch = maxWithdrawableEpoch
 
 	if err := s.UpdateValidatorAtIndex(slashedIdx, validator); err != nil {

--- a/beacon-chain/p2p/gossip_topic_mappings.go
+++ b/beacon-chain/p2p/gossip_topic_mappings.go
@@ -1,7 +1,9 @@
 package p2p
 
 import (
+	"maps"
 	"reflect"
+	"slices"
 
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -113,11 +115,7 @@ func gossipMessage(topic string) proto.Message {
 // AllTopics returns all topics stored in our
 // gossip mapping.
 func AllTopics() []string {
-	var topics []string
-	for k := range gossipTopicMappings {
-		topics = append(topics, k)
-	}
-	return topics
+	return slices.Collect(maps.Keys(gossipTopicMappings))
 }
 
 // GossipTypeMapping is the inverse of GossipTopicMappings so that an arbitrary protobuf message

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -896,7 +896,7 @@ func (s *Service) ValidatorActiveSetChanges(
 			activatedKeys = append(activatedKeys, publicKey[:])
 		}
 
-		maxWithdrawableEpoch := primitives.MaxEpoch(validator.WithdrawableEpoch(), requestedEpoch+slashingsVector)
+		maxWithdrawableEpoch := max(validator.WithdrawableEpoch(), requestedEpoch+slashingsVector)
 
 		if validator.Slashed() && validator.WithdrawableEpoch() == maxWithdrawableEpoch {
 			publicKey := validator.PublicKey()

--- a/changelog/syjn99_cleanup-stdlib-deadcode.md
+++ b/changelog/syjn99_cleanup-stdlib-deadcode.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Remove dead code and adopt stdlib equivalents: drop unused `container/slice` helpers and the builder's unused `Uint64String` type, and use builtin `max`/`slices`/`maps` in place of hand-rolled helpers.

--- a/cmd/validator/wallet/recover.go
+++ b/cmd/validator/wallet/recover.go
@@ -2,8 +2,9 @@ package wallet
 
 import (
 	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -123,11 +124,7 @@ func inputMnemonic(cliCtx *cli.Context) (mnemonicPhrase string, err error) {
 		"italian":             wordlists.Italian,
 		"spanish":             wordlists.Spanish,
 	}
-	languages := make([]string, 0)
-	for k := range allowedLanguages {
-		languages = append(languages, k)
-	}
-	sort.Strings(languages)
+	languages := slices.Sorted(maps.Keys(allowedLanguages))
 	selectedLanguage, err := prompt.ValidatePrompt(
 		os.Stdin,
 		fmt.Sprintf("Enter the language of your seed phrase: %s", strings.Join(languages, ", ")),

--- a/consensus-types/primitives/epoch.go
+++ b/consensus-types/primitives/epoch.go
@@ -14,14 +14,6 @@ var _ fssz.Unmarshaler = (*Epoch)(nil)
 // Epoch represents a single epoch.
 type Epoch uint64
 
-// MaxEpoch compares two epochs and returns the greater one.
-func MaxEpoch(a, b Epoch) Epoch {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Mul multiplies epoch by x.
 // In case of arithmetic issues (overflow/underflow/div by zero) panic is thrown.
 func (e Epoch) Mul(x uint64) Epoch {

--- a/consensus-types/primitives/epoch_test.go
+++ b/consensus-types/primitives/epoch_test.go
@@ -7,15 +7,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	mathprysm "github.com/OffchainLabs/prysm/v7/math"
-	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
-
-func TestMaxEpoch(t *testing.T) {
-	require.Equal(t, primitives.Epoch(0), primitives.MaxEpoch(0, 0))
-	require.Equal(t, primitives.Epoch(1), primitives.MaxEpoch(1, 0))
-	require.Equal(t, primitives.Epoch(1), primitives.MaxEpoch(0, 1))
-	require.Equal(t, primitives.Epoch(1000), primitives.MaxEpoch(100, 1000))
-}
 
 func TestEpoch_Mul(t *testing.T) {
 	tests := []struct {

--- a/container/slice/BUILD.bazel
+++ b/container/slice/BUILD.bazel
@@ -18,6 +18,5 @@ go_test(
     deps = [
         ":go_default_library",
         "//consensus-types/primitives:go_default_library",
-        "//testing/require:go_default_library",
     ],
 )

--- a/container/slice/slice.go
+++ b/container/slice/slice.go
@@ -2,7 +2,6 @@ package slice
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -107,19 +106,6 @@ func SetUint64(a []uint64) []uint64 {
 	return cleanedIndices
 }
 
-// IsUint64Sorted verifies if a uint64 slice is sorted in ascending order.
-func IsUint64Sorted(a []uint64) bool {
-	if len(a) == 0 || len(a) == 1 {
-		return true
-	}
-	for i := 1; i < len(a); i++ {
-		if a[i-1] > a[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // NotUint64 returns the uint64 in slice b that are
 // not in slice a with time complexity of approximately
 // O(n) leveraging a map to check for element existence
@@ -137,11 +123,6 @@ func NotUint64(a, b []uint64) []uint64 {
 		}
 	}
 	return set
-}
-
-// IsInUint64 returns true if a is in b and False otherwise.
-func IsInUint64(a uint64, b []uint64) bool {
-	return slices.Contains(b, a)
 }
 
 // IntersectionInt64 of any number of int64 slices with time
@@ -218,11 +199,6 @@ func NotInt64(a, b []int64) []int64 {
 		}
 	}
 	return set
-}
-
-// IsInInt64 returns true if a is in b and False otherwise.
-func IsInInt64(a int64, b []int64) bool {
-	return slices.Contains(b, a)
 }
 
 // UnionByteSlices returns the all elements between sets of byte slices.
@@ -345,38 +321,6 @@ func NotSlot(a, b []primitives.Slot) []primitives.Slot {
 		}
 	}
 	return set
-}
-
-// IsInSlots returns true if a is in b and False otherwise.
-func IsInSlots(a primitives.Slot, b []primitives.Slot) bool {
-	return slices.Contains(b, a)
-}
-
-// Unique returns an array with duplicates filtered based on the type given
-func Unique[T comparable](a []T) []T {
-	if len(a) <= 1 {
-		return a
-	}
-	found := map[T]bool{}
-	result := make([]T, len(a))
-	end := 0
-	for i := range a {
-		if !found[a[i]] {
-			found[a[i]] = true
-			result[end] = a[i]
-			end += 1
-		}
-	}
-	return result[:end]
-}
-
-// Reverse reverses any slice in place
-// Taken from https://github.com/faiface/generics/blob/8cf65f0b43803410724d8c671cb4d328543ba07d/examples/sliceutils/sliceutils.go
-func Reverse[E any](s []E) []E {
-	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-		s[i], s[j] = s[j], s[i]
-	}
-	return s
 }
 
 // VerifyMaxLength takes a slice and a maximum length and validates the length.

--- a/container/slice/slice_test.go
+++ b/container/slice/slice_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/container/slice"
-	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
 
 func TestSubsetUint64(t *testing.T) {
@@ -71,24 +70,6 @@ func TestIntersectionUint64(t *testing.T) {
 		}
 		if !reflect.DeepEqual(setC, tt.setC) {
 			t.Errorf("slice modified, got %v, want %v", setC, tt.setC)
-		}
-	}
-}
-
-func TestIsSortedUint64(t *testing.T) {
-	testCases := []struct {
-		setA []uint64
-		out  bool
-	}{
-		{[]uint64{1, 2, 3}, true},
-		{[]uint64{3, 1, 3}, false},
-		{[]uint64{1}, true},
-		{[]uint64{}, true},
-	}
-	for _, tt := range testCases {
-		result := slice.IsUint64Sorted(tt.setA)
-		if result != tt.out {
-			t.Errorf("got %v, want %v", result, tt.out)
 		}
 	}
 }
@@ -262,46 +243,6 @@ func TestNotInt64(t *testing.T) {
 		result := slice.NotInt64(tt.setA, tt.setB)
 		if !reflect.DeepEqual(result, tt.out) {
 			t.Errorf("got %d, want %d", result, tt.out)
-		}
-	}
-}
-
-func TestIsInUint64(t *testing.T) {
-	testCases := []struct {
-		a      uint64
-		b      []uint64
-		result bool
-	}{
-		{0, []uint64{}, false},
-		{0, []uint64{0}, true},
-		{4, []uint64{2, 3, 5, 4, 6}, true},
-		{100, []uint64{2, 3, 5, 4, 6}, false},
-	}
-	for _, tt := range testCases {
-		result := slice.IsInUint64(tt.a, tt.b)
-		if result != tt.result {
-			t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
-				tt.a, tt.b, result, tt.result)
-		}
-	}
-}
-
-func TestIsInInt64(t *testing.T) {
-	testCases := []struct {
-		a      int64
-		b      []int64
-		result bool
-	}{
-		{0, []int64{}, false},
-		{0, []int64{0}, true},
-		{4, []int64{2, 3, 5, 4, 6}, true},
-		{100, []int64{2, 3, 5, 4, 6}, false},
-	}
-	for _, tt := range testCases {
-		result := slice.IsInInt64(tt.a, tt.b)
-		if result != tt.result {
-			t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
-				tt.a, tt.b, result, tt.result)
 		}
 	}
 }
@@ -560,53 +501,5 @@ func TestNotSlot(t *testing.T) {
 		if !reflect.DeepEqual(result, tt.out) {
 			t.Errorf("got %d, want %d", result, tt.out)
 		}
-	}
-}
-
-func TestIsInSlots(t *testing.T) {
-	testCases := []struct {
-		a      primitives.Slot
-		b      []primitives.Slot
-		result bool
-	}{
-		{0, []primitives.Slot{}, false},
-		{0, []primitives.Slot{0}, true},
-		{4, []primitives.Slot{2, 3, 5, 4, 6}, true},
-		{100, []primitives.Slot{2, 3, 5, 4, 6}, false},
-	}
-	for _, tt := range testCases {
-		result := slice.IsInSlots(tt.a, tt.b)
-		if result != tt.result {
-			t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
-				tt.a, tt.b, result, tt.result)
-		}
-	}
-}
-
-func TestUnique(t *testing.T) {
-	t.Run("string", func(t *testing.T) {
-		result := slice.Unique[string]([]string{"a", "b", "a"})
-		require.DeepEqual(t, []string{"a", "b"}, result)
-	})
-	t.Run("uint64", func(t *testing.T) {
-		result := slice.Unique[uint64]([]uint64{1, 2, 1})
-		require.DeepEqual(t, []uint64{1, 2}, result)
-	})
-}
-
-func TestReverse(t *testing.T) {
-	tests := []struct {
-		value [][32]byte
-		want  [][32]byte
-	}{
-		{[][32]byte{}, [][32]byte{}},
-		{[][32]byte{{'A'}, {'B'}, {'C'}, {'D'}},
-			[][32]byte{{'D'}, {'C'}, {'B'}, {'A'}}},
-		{[][32]byte{{1}, {2}, {3}, {4}},
-			[][32]byte{{4}, {3}, {2}, {1}}},
-	}
-	for _, tt := range tests {
-		b := slice.Reverse(tt.value)
-		require.DeepEqual(t, tt.want, b)
 	}
 }

--- a/testing/endtoend/evaluators/slashing.go
+++ b/testing/endtoend/evaluators/slashing.go
@@ -3,6 +3,7 @@ package evaluators
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -197,7 +198,7 @@ func proposeDoubleBlock(_ *e2eTypes.EvaluationContext, conns ...*grpc.ClientConn
 
 	var proposerIndex primitives.ValidatorIndex
 	for i, duty := range duties.CurrentEpochDuties {
-		if slice.IsInSlots(chainHead.HeadSlot-1, duty.ProposerSlots) {
+		if slices.Contains(duty.ProposerSlots, chainHead.HeadSlot-1) {
 			proposerIndex = primitives.ValidatorIndex(i)
 			break
 		}


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Remove dead code and adopt stdlib equivalents: drop unused `container/slice` helpers and the builder's unused `Uint64String` type, and use builtin `max`/`slices`/`maps` in place of hand-rolled helpers.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
