### PR TITLE
Resolve payload attestation committee against the slot-covering state

### DIFF
--- a/beacon-chain/cache/committee_disabled.go
+++ b/beacon-chain/cache/committee_disabled.go
@@ -13,7 +13,7 @@ import (
 
 // FakeCommitteeCache is a struct with 1 queue for looking up shuffled indices list by seed.
 type FakeCommitteeCache struct {
-	Wg  sync.WaitGroup
+	Wg sync.WaitGroup
 	Sf singleflight.Group
 }
 

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -4033,7 +4033,7 @@ func TestGetPayloadAttestationData(t *testing.T) {
 			HeadFetcher:           chainService,
 			TimeFetcher:           chainService,
 			OptimisticModeFetcher: chainService,
-			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService},
+			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService},
 		}
 
 		request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/validator/payload_attestation_data/{slot}", nil)
@@ -4065,7 +4065,7 @@ func TestGetPayloadAttestationData(t *testing.T) {
 			HeadFetcher:           chainService,
 			TimeFetcher:           chainService,
 			OptimisticModeFetcher: chainService,
-			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService},
+			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService},
 		}
 
 		request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/validator/payload_attestation_data/{slot}", nil)
@@ -4099,7 +4099,7 @@ func TestGetPayloadAttestationData(t *testing.T) {
 			HeadFetcher:           chainService,
 			TimeFetcher:           chainService,
 			OptimisticModeFetcher: chainService,
-			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService},
+			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService},
 		}
 
 		request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/validator/payload_attestation_data/{slot}", nil)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation_test.go
@@ -52,7 +52,7 @@ func TestPayloadAttestationData_OK(t *testing.T) {
 		TimeFetcher:       chain,
 		HeadFetcher:       chain,
 		ForkchoiceFetcher: chain,
-		CoreService:       &core.Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain},
+		CoreService:       &core.Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain},
 	}
 
 	resp, err := vs.PayloadAttestationData(t.Context(), &ethpb.PayloadAttestationDataRequest{Slot: slot})

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -87,7 +87,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		if full {
 			payloadStr = "full"
 		}
-		parentSlot, err :=vs.CoreService.ChainInfoFetcher.RecentBlockSlot(parentRoot)
+		parentSlot, err := vs.CoreService.ChainInfoFetcher.RecentBlockSlot(parentRoot)
 		if err != nil {
 			return nil, err
 		}

--- a/beacon-chain/sync/subscriber_payload_attestation.go
+++ b/beacon-chain/sync/subscriber_payload_attestation.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"google.golang.org/protobuf/proto"
 )
@@ -36,9 +37,12 @@ func (s *Service) processPayloadAttestationMessage(ctx context.Context, a *eth.P
 		return err
 	}
 
-	st, err := s.cfg.chain.HeadStateReadOnly(ctx)
+	st, err := s.cfg.chain.PtcLookupState(ctx, bytesutil.ToBytes32(a.Data.BeaconBlockRoot), a.Data.Slot)
 	if err != nil {
 		return err
+	}
+	if st == nil {
+		return nil
 	}
 	idx, err := gloas.PayloadCommitteeIndex(ctx, st, a.Data.Slot, a.ValidatorIndex)
 	if err != nil {

--- a/beacon-chain/sync/subscriber_payload_attestation_test.go
+++ b/beacon-chain/sync/subscriber_payload_attestation_test.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"errors"
 	"testing"
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
@@ -56,15 +55,13 @@ func TestPayloadAttestationSubscriber_NoPool(t *testing.T) {
 	require.NoError(t, s.payloadAttestationSubscriber(t.Context(), msg))
 }
 
-func TestPayloadAttestationSubscriber_HeadStateError(t *testing.T) {
-	headErr := errors.New("head state unavailable")
+func TestPayloadAttestationSubscriber_NoCoveringState(t *testing.T) {
+	pool := payloadattestation.NewPool()
 	s := &Service{
 		payloadAttestationCache: &cache.PayloadAttestationCache{},
 		cfg: &config{
-			chain: &mock.ChainService{
-				HeadStateErr: headErr,
-			},
-			payloadAttestationPool: payloadattestation.NewPool(),
+			chain:                  &mock.ChainService{},
+			payloadAttestationPool: pool,
 			operationNotifier:      &mock.MockOperationNotifier{},
 		},
 	}
@@ -76,7 +73,8 @@ func TestPayloadAttestationSubscriber_HeadStateError(t *testing.T) {
 		},
 		Signature: make([]byte, 96),
 	}
-	require.ErrorIs(t, s.payloadAttestationSubscriber(t.Context(), msg), headErr)
+	require.NoError(t, s.payloadAttestationSubscriber(t.Context(), msg))
+	require.Equal(t, 0, len(pool.PendingPayloadAttestations(0)))
 }
 
 func TestPayloadAttestationSubscriber_ValidatorInPTC(t *testing.T) {

--- a/changelog/terence_payload-attestation-process-covering-state.md
+++ b/changelog/terence_payload-attestation-process-covering-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Resolve the payload attestation committee against the slot-covering state instead of the head state, skipping cleanly when no covering state is available.

--- a/validator/client/beacon-api/get_beacon_block_test.go
+++ b/validator/client/beacon-api/get_beacon_block_test.go
@@ -1511,7 +1511,7 @@ func TestGetBeaconBlock_GloasRejectsJSONWithPayload(t *testing.T) {
 	).Return(
 		[]byte("{}"),
 		http.Header{
-			"Content-Type":                       []string{"application/json"},
+			"Content-Type":                     []string{"application/json"},
 			api.ExecutionPayloadIncludedHeader: []string{"true"},
 		},
 		nil,


### PR DESCRIPTION
`processPayloadAttestationMessage` resolved the PTC committee index from the head state, which on a lagging node errored with `ptc window out of range` and silently dropped the vote. It now uses `PtcLookupState` — the same slot-covering state the gossip validation path uses — and skips cleanly when no covering state is available.