### PR TITLE
Resolve payload attestation committee against the slot-covering state

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -54,6 +54,7 @@ type ChainService struct {
 	DB                          db.Database
 	State                       state.BeaconState
 	HeadStateErr                error
+	PtcLookupStateErr           error
 	Block                       interfaces.ReadOnlySignedBeaconBlock
 	VerifyBlkDescendantErr      error
 	stateNotifier               statefeed.Notifier
@@ -916,6 +917,9 @@ func (c *ChainService) ReceivePayloadAttestationMessage(_ context.Context, _ *et
 
 // PtcLookupState implements the same method in the chain service.
 func (c *ChainService) PtcLookupState(_ context.Context, _ [32]byte, _ primitives.Slot) (state.ReadOnlyBeaconState, error) {
+	if c.PtcLookupStateErr != nil {
+		return nil, c.PtcLookupStateErr
+	}
 	if c.State == nil {
 		return nil, nil
 	}

--- a/beacon-chain/sync/subscriber_payload_attestation.go
+++ b/beacon-chain/sync/subscriber_payload_attestation.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"google.golang.org/protobuf/proto"
 )
@@ -30,9 +31,12 @@ func (s *Service) payloadAttestationSubscriber(ctx context.Context, msg proto.Me
 		return err
 	}
 
-	st, err := s.cfg.chain.HeadStateReadOnly(ctx)
+	st, err := s.cfg.chain.PtcLookupState(ctx, bytesutil.ToBytes32(a.Data.BeaconBlockRoot), a.Data.Slot)
 	if err != nil {
 		return err
+	}
+	if st == nil {
+		return nil
 	}
 	idx, err := gloas.PayloadCommitteeIndex(ctx, st, a.Data.Slot, a.ValidatorIndex)
 	if err != nil {

--- a/beacon-chain/sync/subscriber_payload_attestation_test.go
+++ b/beacon-chain/sync/subscriber_payload_attestation_test.go
@@ -56,13 +56,13 @@ func TestPayloadAttestationSubscriber_NoPool(t *testing.T) {
 	require.NoError(t, s.payloadAttestationSubscriber(t.Context(), msg))
 }
 
-func TestPayloadAttestationSubscriber_HeadStateError(t *testing.T) {
-	headErr := errors.New("head state unavailable")
+func TestPayloadAttestationSubscriber_StateLookupError(t *testing.T) {
+	lookupErr := errors.New("state lookup failed")
 	s := &Service{
 		payloadAttestationCache: &cache.PayloadAttestationCache{},
 		cfg: &config{
 			chain: &mock.ChainService{
-				HeadStateErr: headErr,
+				PtcLookupStateErr: lookupErr,
 			},
 			payloadAttestationPool: payloadattestation.NewPool(),
 			operationNotifier:      &mock.MockOperationNotifier{},
@@ -76,7 +76,29 @@ func TestPayloadAttestationSubscriber_HeadStateError(t *testing.T) {
 		},
 		Signature: make([]byte, 96),
 	}
-	require.ErrorIs(t, s.payloadAttestationSubscriber(t.Context(), msg), headErr)
+	require.ErrorIs(t, s.payloadAttestationSubscriber(t.Context(), msg), lookupErr)
+}
+
+func TestPayloadAttestationSubscriber_NoCoveringState(t *testing.T) {
+	pool := payloadattestation.NewPool()
+	s := &Service{
+		payloadAttestationCache: &cache.PayloadAttestationCache{},
+		cfg: &config{
+			chain:                  &mock.ChainService{},
+			payloadAttestationPool: pool,
+			operationNotifier:      &mock.MockOperationNotifier{},
+		},
+	}
+	msg := &ethpb.PayloadAttestationMessage{
+		ValidatorIndex: 0,
+		Data: &ethpb.PayloadAttestationData{
+			BeaconBlockRoot: make([]byte, 32),
+			Slot:            0,
+		},
+		Signature: make([]byte, 96),
+	}
+	require.NoError(t, s.payloadAttestationSubscriber(t.Context(), msg))
+	require.Equal(t, 0, len(pool.PendingPayloadAttestations(0)))
 }
 
 func TestPayloadAttestationSubscriber_ValidatorInPTC(t *testing.T) {

--- a/changelog/terence_payload-attestation-covering-state.md
+++ b/changelog/terence_payload-attestation-covering-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Resolve the payload attestation committee against the slot-covering state so lagging nodes don't drop valid votes.


### PR DESCRIPTION
payloadAttestationSubscriber computed the PTC committee index from the head state, which on a lagging node errors (ptc window out of range) and drops the vote. Use PtcLookupState — the same slot-covering state the gossip validation path uses — and skip cleanly when none is available