### PR TITLE
make builder ssz the default

### DIFF
--- a/beacon-chain/builder/option.go
+++ b/beacon-chain/builder/option.go
@@ -14,12 +14,12 @@ type Option func(s *Service) error
 // FlagOptions for builder service flag configurations.
 func FlagOptions(c *cli.Context) ([]Option, error) {
 	endpoint := c.String(flags.MevRelayEndpoint.Name)
-	sszEnabled := c.Bool(flags.EnableBuilderSSZ.Name)
+	sszDisabled := c.Bool(flags.DisableBuilderSSZ.Name)
 	var client *builder.Client
 	if endpoint != "" {
 		var opts []builder.ClientOpt
-		if sszEnabled {
-			log.Info("Using APIs with SSZ enabled")
+		if !sszDisabled {
+			log.Info("Using Builder APIs with SSZ enabled")
 			opts = append(opts, builder.WithSSZ())
 		}
 		var err error

--- a/changelog/james-prysm_builder-ssz-default.md
+++ b/changelog/james-prysm_builder-ssz-default.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Builder API requests and responses now use SSZ encoding by default. Use `--disable-builder-ssz` to fall back to JSON.
+- Deprecated `--enable-builder-ssz` (alias `--builder-ssz`); SSZ is now the default for builder setups, so the flag is a no-op.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -29,11 +29,10 @@ var (
 		Value: "",
 	}
 
-	// EnableBuilderSSZ enables Builder APIs to send and receive in SSZ format
-	EnableBuilderSSZ = &cli.BoolFlag{
-		Name:    "enable-builder-ssz",
-		Aliases: []string{"builder-ssz"},
-		Usage:   "Enables Builder APIs to send and receive in SSZ format",
+	// DisableBuilderSSZ turns off SSZ encoding for Builder APIs, falling back to JSON.
+	DisableBuilderSSZ = &cli.BoolFlag{
+		Name:  "disable-builder-ssz",
+		Usage: "Disables SSZ encoding for Builder API requests and responses, using JSON instead.",
 	}
 
 	// PostponeShutdownForProposals delays a graceful shutdown while a connected

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -90,7 +90,7 @@ var appFlags = []cli.Flag{
 	flags.MinBuilderDiff,
 	flags.BeaconDBPruning,
 	flags.PrunerRetentionEpochs,
-	flags.EnableBuilderSSZ,
+	flags.DisableBuilderSSZ,
 	cmd.MinimalConfigFlag,
 	cmd.E2EConfigFlag,
 	cmd.RPCMaxPageSizeFlag,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -145,7 +145,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.MinBuilderBid,
 			flags.MinBuilderDiff,
 			flags.SuggestedFeeRecipient,
-			flags.EnableBuilderSSZ,
+			flags.DisableBuilderSSZ,
 		},
 	},
 	{ // Flags relevant to syncing the beacon chain.

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -34,6 +34,12 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableBuilderSSZ = &cli.BoolFlag{
+		Name:    "enable-builder-ssz",
+		Aliases: []string{"builder-ssz"},
+		Usage:   deprecatedUsage,
+		Hidden:  true,
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.
@@ -52,4 +58,5 @@ var upcomingDeprecation = []cli.Flag{
 // and therefore cannot be added to deprecatedFlags
 var deprecatedBeaconFlags = []cli.Flag{
 	deprecatedDisableLastEpochTargets,
+	deprecatedEnableBuilderSSZ,
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

builder ssz should be the default now that we are well into pectra

adds `--disable-builder-ssz` and deprecates `--enable-builder-ssz`

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
