### PR TITLE
refactor marking fields as dirty

### DIFF
--- a/beacon-chain/state/state-native/progressive_ssz_test.go
+++ b/beacon-chain/state/state-native/progressive_ssz_test.go
@@ -2,9 +2,11 @@ package state_native
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/OffchainLabs/go-bitfield"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/fieldtrie"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stateutil"
@@ -323,6 +325,57 @@ func TestHashTreeRoot_ProgressiveSSZFieldTrieRebuild(t *testing.T) {
 	require.Equal(t, false, st.rebuildTrie[types.Balances])
 	require.Equal(t, fieldtrie.MerkleModeProgressive, st.stateFieldLeaves[types.Validators].MerkleMode())
 	require.Equal(t, fieldtrie.MerkleModeProgressive, st.stateFieldLeaves[types.Balances].MerkleMode())
+}
+
+func TestHashTreeRoot_ProgressiveSSZApplyToEveryValidatorMarksDirtyOnError(t *testing.T) {
+	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	defer reset()
+
+	st := newGloasStateForProgressiveSSZTests(t)
+	initialRoot, err := st.HashTreeRoot(context.Background())
+	require.NoError(t, err)
+
+	expectedErr := errors.New("stop after partial validator update")
+	err = st.ApplyToEveryValidator(func(idx int, val state.ReadOnlyValidator) (*ethpb.Validator, error) {
+		if idx == 0 {
+			updated := val.Copy()
+			updated.EffectiveBalance++
+			return updated, nil
+		}
+		return nil, expectedErr
+	})
+	require.ErrorIs(t, err, expectedErr)
+	require.Equal(t, true, st.dirtyFields[types.Validators])
+	require.DeepEqual(t, []uint64{0}, st.dirtyIndices[types.Validators])
+
+	root, err := st.HashTreeRoot(context.Background())
+	require.NoError(t, err)
+	require.DeepNotSSZEqual(t, initialRoot, root)
+	require.Equal(t, progressiveRootFromScratch(t, st), root)
+	require.Equal(t, 0, len(st.dirtyIndices[types.Validators]))
+}
+
+func TestHashTreeRoot_ProgressiveSSZDecreaseWithdrawalBalancesMarksDirtyOnError(t *testing.T) {
+	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	defer reset()
+
+	st := newGloasStateForProgressiveSSZTests(t)
+	initialRoot, err := st.HashTreeRoot(context.Background())
+	require.NoError(t, err)
+
+	err = st.DecreaseWithdrawalBalances([]*enginev1.Withdrawal{
+		{ValidatorIndex: primitives.ValidatorIndex(1), Amount: 5},
+		nil,
+	})
+	require.ErrorContains(t, "withdrawal is nil", err)
+	require.Equal(t, true, st.dirtyFields[types.Balances])
+	require.DeepEqual(t, []uint64{1}, st.dirtyIndices[types.Balances])
+
+	root, err := st.HashTreeRoot(context.Background())
+	require.NoError(t, err)
+	require.DeepNotSSZEqual(t, initialRoot, root)
+	require.Equal(t, progressiveRootFromScratch(t, st), root)
+	require.Equal(t, 0, len(st.dirtyIndices[types.Balances]))
 }
 
 func TestHashTreeRoot_ProgressiveSSZCopy(t *testing.T) {

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -599,6 +599,16 @@ func (b *BeaconState) DecreaseWithdrawalBalances(withdrawals []*enginev1.Withdra
 		balanceIndices []uint64
 		builderIndices []uint64
 	)
+	defer func() {
+		if len(balanceIndices) > 0 {
+			b.markFieldAsDirty(types.Balances)
+			b.addDirtyIndices(types.Balances, balanceIndices)
+		}
+		if len(builderIndices) > 0 {
+			b.markFieldAsDirty(types.Builders)
+			b.addDirtyIndices(types.Builders, builderIndices)
+		}
+	}()
 
 	for _, withdrawal := range withdrawals {
 		if withdrawal == nil {
@@ -626,15 +636,6 @@ func (b *BeaconState) DecreaseWithdrawalBalances(withdrawals []*enginev1.Withdra
 			return pkgerrors.Wrap(err, "could not update balances")
 		}
 		balanceIndices = append(balanceIndices, uint64(withdrawal.ValidatorIndex))
-	}
-
-	if len(balanceIndices) > 0 {
-		b.markFieldAsDirty(types.Balances)
-		b.addDirtyIndices(types.Balances, balanceIndices)
-	}
-	if len(builderIndices) > 0 {
-		b.markFieldAsDirty(types.Builders)
-		b.addDirtyIndices(types.Builders, builderIndices)
 	}
 
 	return nil

--- a/beacon-chain/state/state-native/setters_validator.go
+++ b/beacon-chain/state/state-native/setters_validator.go
@@ -32,6 +32,16 @@ func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
 // validator registry.
 func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val state.ReadOnlyValidator) (*ethpb.Validator, error)) error {
 	var changedVals []uint64
+	defer func() {
+		if len(changedVals) == 0 {
+			return
+		}
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		b.markFieldAsDirty(types.Validators)
+		b.addDirtyIndices(types.Validators, changedVals)
+	}()
+
 	l := b.validatorsMultiValue.Len(b)
 	for i := range l {
 		v, err := b.validatorsMultiValue.At(b, uint64(i))
@@ -44,21 +54,14 @@ func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val state.ReadOnlyVa
 			return err
 		}
 		if newVal != nil {
-			changedVals = append(changedVals, uint64(i))
 			compactValidator := stateutil.CompactValidatorFromProto(newVal)
 			if err := b.validatorsMultiValue.UpdateAt(b, uint64(i), compactValidator); err != nil {
 				return errors.Wrapf(err, "could not update validator at index %d", i)
 			}
+			changedVals = append(changedVals, uint64(i))
 		}
 	}
 
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	if len(changedVals) > 0 {
-		b.markFieldAsDirty(types.Validators)
-		b.addDirtyIndices(types.Validators, changedVals)
-	}
 	return nil
 }
 


### PR DESCRIPTION
refactoring marking some state fields as dirty to work correctly in case of an error in the loops when updating an entry. 
previously the fields and indices were marked as dirty only when the loops finishes (without errors). but in case of an error we won't mark them dirty. this fixes that.