### PR TITLE
Set KZG commitments on Gloas sidecars fetched by RPC before validating them

### DIFF
--- a/beacon-chain/sync/backfill/BUILD.bazel
+++ b/beacon-chain/sync/backfill/BUILD.bazel
@@ -91,6 +91,7 @@ go_test(
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/dbval:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
         "//runtime/interop:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",

--- a/beacon-chain/sync/backfill/columns.go
+++ b/beacon-chain/sync/backfill/columns.go
@@ -209,6 +209,10 @@ func (v *validatingColumnRequest) countedValidation(cd blocks.RODataColumn) erro
 	if !expected.remaining.Has(cd.Index()) {
 		return nil
 	}
+	// Gloas sidecars carry no commitments on the wire; seed them from the block's bid before reading them.
+	if cd.IsGloas() {
+		cd.SetBidCommitments(expected.commitments)
+	}
 	comms, err := cd.KzgCommitments()
 	if err != nil {
 		return err

--- a/beacon-chain/sync/backfill/columns_test.go
+++ b/beacon-chain/sync/backfill/columns_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
@@ -866,6 +867,46 @@ func TestValidatingColumnRequest_CountedValidation(t *testing.T) {
 		// Verify that remaining.Unset was called (column 0 should be removed)
 		require.Equal(t, false, remaining.Has(0), "column 0 should be removed from remaining after validation")
 		require.Equal(t, 0, remaining.Count(), "remaining should be empty")
+	})
+
+	t.Run("gloas sidecar seeds bid commitments from block", func(t *testing.T) {
+		blockRoot := [32]byte{0x02}
+		commitment := make([]byte, 48)
+		commitment[0] = 0xaa
+
+		roCol, err := blocks.NewRODataColumnGloas(&ethpb.DataColumnSidecarGloas{
+			Index:           0,
+			Slot:            100,
+			BeaconBlockRoot: blockRoot[:],
+		})
+		require.NoError(t, err)
+
+		colStore := filesystem.NewEphemeralDataColumnStorage(t)
+		p2p := p2ptest.NewTestP2P(t)
+		remaining := peerdas.NewColumnIndicesFromSlice([]uint64{0})
+		bisector := newColumnBisector(func(peer.ID, string, error) {})
+		sr := func(primitives.Slot) bool { return true }
+		vcr := &validatingColumnRequest{
+			columnSync: &columnSync{
+				columnBatch: &columnBatch{
+					toDownload: map[[32]byte]*toDownload{
+						roCol.BlockRoot(): {
+							remaining:   remaining,
+							commitments: [][]byte{commitment},
+						},
+					},
+				},
+				store:   das.NewLazilyPersistentStoreColumn(colStore, testNewDataColumnsVerifier(), p2p.NodeID(), 1, bisector, sr),
+				current: primitives.Slot(200),
+				peer:    mockPeer,
+			},
+			bisector: bisector,
+		}
+
+		// Without seeding the bid commitments, KzgCommitments() would error for gloas.
+		err = vcr.countedValidation(roCol)
+		require.NoError(t, err)
+		require.Equal(t, false, remaining.Has(0), "column 0 should be removed from remaining after validation")
 	})
 }
 

--- a/changelog/aarshkshah1992_backfill-gloas-column-commitments.md
+++ b/changelog/aarshkshah1992_backfill-gloas-column-commitments.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Backfill now seeds Gloas data column sidecars with their block's bid KZG commitments before validation, so Gloas columns no longer fail with `errNotFuluDataColumn`.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR ensures we set the KZG commitments  on Gloas sidecars fetched via RPC for backfill before we verify them.
Without this fix, all Gloas sidecars fetched for backfill will fail validation.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
