### PR TITLE
Batch verify builder deposit request signatures

### DIFF
--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -14,8 +14,16 @@ import (
 
 // ProcessBuilderDepositRequests applies each builder deposit request in order.
 func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, requests []*enginev1.BuilderDepositRequest) error {
-	for _, request := range requests {
-		if err := processBuilderDepositRequest(st, request); err != nil {
+	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(ctx, requests)
+	if err != nil {
+		return err
+	}
+	badSig := make([]bool, len(requests))
+	for _, i := range invalid {
+		badSig[i] = true
+	}
+	for i, request := range requests {
+		if err := processBuilderDepositRequest(st, request, !badSig[i]); err != nil {
 			return errors.Wrap(err, "could not process builder deposit request")
 		}
 	}
@@ -49,7 +57,7 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 //	            epoch = get_current_epoch(state)
 //	            builder.withdrawable_epoch = epoch + MIN_BUILDER_WITHDRAWABILITY_DELAY
 //	</spec>
-func processBuilderDepositRequest(st state.BeaconState, request *enginev1.BuilderDepositRequest) error {
+func processBuilderDepositRequest(st state.BeaconState, request *enginev1.BuilderDepositRequest, sigValid bool) error {
 	if request == nil {
 		return errors.New("nil builder deposit request")
 	}
@@ -73,11 +81,7 @@ func processBuilderDepositRequest(st state.BeaconState, request *enginev1.Builde
 		return nil
 	}
 
-	valid, err := helpers.IsValidBuilderDepositSignature(request)
-	if err != nil {
-		return errors.Wrap(err, "could not verify builder deposit signature")
-	}
-	if !valid {
+	if !sigValid {
 		return nil
 	}
 

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -14,13 +14,26 @@ import (
 
 // ProcessBuilderDepositRequests applies each builder deposit request in order.
 func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, requests []*enginev1.BuilderDepositRequest) error {
-	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(ctx, requests)
+	// Topups to an existing builder skip signature verification per spec, so only batch-verify
+	// deposits that would register a new builder.
+	newDeposits := make([]*enginev1.BuilderDepositRequest, 0, len(requests))
+	newIdx := make([]int, 0, len(requests))
+	for i, request := range requests {
+		if request == nil {
+			continue
+		}
+		if _, isBuilder := st.BuilderIndexByPubkey(bytesutil.ToBytes48(request.Pubkey)); !isBuilder {
+			newDeposits = append(newDeposits, request)
+			newIdx = append(newIdx, i)
+		}
+	}
+	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(ctx, newDeposits)
 	if err != nil {
 		return err
 	}
 	badSig := make([]bool, len(requests))
-	for _, i := range invalid {
-		badSig[i] = true
+	for _, j := range invalid {
+		badSig[newIdx[j]] = true
 	}
 	for i, request := range requests {
 		if err := processBuilderDepositRequest(st, request, !badSig[i]); err != nil {

--- a/beacon-chain/core/gloas/builder_deposit_request_test.go
+++ b/beacon-chain/core/gloas/builder_deposit_request_test.go
@@ -38,7 +38,7 @@ func TestProcessBuilderDepositRequest_NewBuilderValidSignature(t *testing.T) {
 	req := signedBuilderDepositRequest(t, sk, cred, 1234)
 
 	st := newGloasState(t, nil, nil)
-	require.NoError(t, processBuilderDepositRequest(st, req))
+	require.NoError(t, processBuilderDepositRequest(st, req, true))
 
 	idx, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, true, ok)
@@ -56,10 +56,9 @@ func TestProcessBuilderDepositRequest_NewBuilderInvalidSignatureIgnored(t *testi
 	require.NoError(t, err)
 	cred := builderWithdrawalCredentials()
 	req := signedBuilderDepositRequest(t, sk, cred, 1234)
-	req.Signature = make([]byte, 96) // invalidate
 
 	st := newGloasState(t, nil, nil)
-	require.NoError(t, processBuilderDepositRequest(st, req))
+	require.NoError(t, processBuilderDepositRequest(st, req, false))
 
 	_, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, false, ok)
@@ -84,13 +83,93 @@ func TestProcessBuilderDepositRequest_ExistingBuilderTopsUpNoSignatureCheck(t *t
 		Amount:                200,
 		Signature:             make([]byte, 96), // not checked for top-up
 	}
-	require.NoError(t, processBuilderDepositRequest(st, req))
+	require.NoError(t, processBuilderDepositRequest(st, req, false))
 
 	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
 	require.Equal(t, true, ok)
 	builder, err := st.Builder(idx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(205), uint64(builder.Balance))
+}
+
+func TestProcessBuilderDepositRequests_BatchMixedValidInvalidAndTopUp(t *testing.T) {
+	cred := builderWithdrawalCredentials()
+	skValid, err := bls.RandKey()
+	require.NoError(t, err)
+	skInvalid, err := bls.RandKey()
+	require.NoError(t, err)
+	skExisting, err := bls.RandKey()
+	require.NoError(t, err)
+	existingPubkey := skExisting.PublicKey().Marshal()
+
+	builders := []*ethpb.Builder{{
+		Pubkey:            existingPubkey,
+		Version:           []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           5,
+		WithdrawableEpoch: params.BeaconConfig().FarFutureEpoch,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	invalidReq := signedBuilderDepositRequest(t, skInvalid, cred, 1234)
+	invalidReq.Signature = make([]byte, 96)
+	reqs := []*enginev1.BuilderDepositRequest{
+		signedBuilderDepositRequest(t, skValid, cred, 1000),
+		invalidReq,
+		{Pubkey: existingPubkey, WithdrawalCredentials: cred[:], Amount: 200, Signature: make([]byte, 96)},
+	}
+	require.NoError(t, ProcessBuilderDepositRequests(t.Context(), st, reqs))
+
+	_, ok := st.BuilderIndexByPubkey(toBytes48(skValid.PublicKey().Marshal()))
+	require.Equal(t, true, ok)
+	_, ok = st.BuilderIndexByPubkey(toBytes48(skInvalid.PublicKey().Marshal()))
+	require.Equal(t, false, ok)
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(existingPubkey))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(205), uint64(builder.Balance))
+}
+
+func TestProcessBuilderDepositRequests_DuplicatePubkeyValidThenTopUp(t *testing.T) {
+	cred := builderWithdrawalCredentials()
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+
+	st := newGloasState(t, nil, nil)
+	reqs := []*enginev1.BuilderDepositRequest{
+		signedBuilderDepositRequest(t, sk, cred, 1000),
+		// top-up: bad signature is fine
+		{Pubkey: sk.PublicKey().Marshal(), WithdrawalCredentials: cred[:], Amount: 500, Signature: make([]byte, 96)},
+	}
+	require.NoError(t, ProcessBuilderDepositRequests(t.Context(), st, reqs))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(sk.PublicKey().Marshal()))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1500), uint64(builder.Balance))
+}
+
+func TestProcessBuilderDepositRequests_DuplicatePubkeyInvalidThenValidRegisters(t *testing.T) {
+	cred := builderWithdrawalCredentials()
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+
+	st := newGloasState(t, nil, nil)
+	invalidReq := signedBuilderDepositRequest(t, sk, cred, 1000)
+	invalidReq.Signature = make([]byte, 96)
+	reqs := []*enginev1.BuilderDepositRequest{
+		invalidReq,
+		signedBuilderDepositRequest(t, sk, cred, 700),
+	}
+	require.NoError(t, ProcessBuilderDepositRequests(t.Context(), st, reqs))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(sk.PublicKey().Marshal()))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(700), uint64(builder.Balance))
 }
 
 func builderWithdrawalCredentialsAt(b byte) []byte {

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -91,6 +91,7 @@ go_test(
         "//crypto/bls:go_default_library",
         "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//runtime/version:go_default_library",
         "//testing/assert:go_default_library",

--- a/beacon-chain/core/helpers/deposit.go
+++ b/beacon-chain/core/helpers/deposit.go
@@ -143,38 +143,6 @@ func IsValidDepositSignature(data *ethpb.Deposit_Data) (bool, error) {
 	return true, nil
 }
 
-// IsValidBuilderDepositSignature returns whether a builder deposit request's
-// proof-of-possession signature is valid under DOMAIN_BUILDER_DEPOSIT.
-//
-//	<spec fn="is_valid_builder_deposit_signature" fork="gloas" hash="a4b72f03">
-//	def is_valid_builder_deposit_signature(request: BuilderDepositRequest) -> bool:
-//	    deposit_message = DepositMessage(
-//	        pubkey=request.pubkey,
-//	        withdrawal_credentials=request.withdrawal_credentials,
-//	        amount=request.amount,
-//	    )
-//	    domain = compute_domain(DOMAIN_BUILDER_DEPOSIT)
-//	    signing_root = compute_signing_root(deposit_message, domain)
-//	    return bls.Verify(request.pubkey, signing_root, request.signature)
-//	</spec>
-func IsValidBuilderDepositSignature(request *enginev1.BuilderDepositRequest) (bool, error) {
-	domain, err := signing.ComputeDomain(params.BeaconConfig().DomainBuilderDeposit, nil, nil)
-	if err != nil {
-		return false, err
-	}
-	data := &ethpb.Deposit_Data{
-		PublicKey:             request.Pubkey,
-		WithdrawalCredentials: request.WithdrawalCredentials,
-		Amount:                request.Amount,
-		Signature:             request.Signature,
-	}
-	if err := verifyDepositDataSigningRoot(data, domain); err != nil {
-		log.WithError(err).Debug("Skipping builder deposit: could not verify deposit data signature")
-		return false, nil
-	}
-	return true, nil
-}
-
 // BatchVerifyBuilderDepositRequestSignatures returns the indices of builder deposit
 // requests with invalid proof-of-possession signatures.
 func BatchVerifyBuilderDepositRequestSignatures(ctx context.Context, requests []*enginev1.BuilderDepositRequest) ([]int, error) {

--- a/beacon-chain/core/helpers/deposit.go
+++ b/beacon-chain/core/helpers/deposit.go
@@ -175,6 +175,91 @@ func IsValidBuilderDepositSignature(request *enginev1.BuilderDepositRequest) (bo
 	return true, nil
 }
 
+// BatchVerifyBuilderDepositRequestSignatures returns the indices of builder deposit
+// requests with invalid proof-of-possession signatures.
+func BatchVerifyBuilderDepositRequestSignatures(ctx context.Context, requests []*enginev1.BuilderDepositRequest) ([]int, error) {
+	if len(requests) == 0 {
+		return nil, nil
+	}
+	domain, err := signing.ComputeDomain(params.BeaconConfig().DomainBuilderDeposit, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return verifyBuilderDepositRequestsDC(ctx, requests, domain)
+}
+
+func verifyBuilderDepositRequestDataWithDomain(ctx context.Context, reqs []*enginev1.BuilderDepositRequest, domain []byte) error {
+	if len(reqs) == 0 {
+		return nil
+	}
+	pks := make([]bls.PublicKey, len(reqs))
+	sigs := make([][]byte, len(reqs))
+	msgs := make([][32]byte, len(reqs))
+	for i, req := range reqs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if req == nil {
+			return errors.New("nil builder deposit request")
+		}
+		pk, err := bls.PublicKeyFromBytes(req.Pubkey)
+		if err != nil {
+			return err
+		}
+		pks[i] = pk
+		sigs[i] = req.Signature
+		sr, err := signing.ComputeSigningRoot(&ethpb.DepositMessage{
+			PublicKey:             req.Pubkey,
+			WithdrawalCredentials: req.WithdrawalCredentials,
+			Amount:                req.Amount,
+		}, domain)
+		if err != nil {
+			return err
+		}
+		msgs[i] = sr
+	}
+	verify, err := bls.VerifyMultipleSignatures(sigs, msgs, pks)
+	if err != nil {
+		return errors.Errorf("could not verify multiple signatures: %v", err)
+	}
+	if !verify {
+		return errors.New("one or more builder deposit signatures did not verify")
+	}
+	return nil
+}
+
+// verifyBuilderDepositRequestsDC localizes invalid signatures by divide-and-conquer. A non-nil
+// verify error means the subtree has at least one bad signature, not a block-level failure: bad
+// signatures only skip the deposit (see process_builder_deposit_request). Real aborts (ctx
+// cancellation) propagate via the ctx.Err guards.
+func verifyBuilderDepositRequestsDC(ctx context.Context, reqs []*enginev1.BuilderDepositRequest, domain []byte) ([]int, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(reqs) == 0 {
+		return nil, nil
+	}
+	if err := verifyBuilderDepositRequestDataWithDomain(ctx, reqs, domain); err == nil {
+		return nil, nil
+	}
+	if len(reqs) == 1 {
+		return []int{0}, nil
+	}
+	mid := len(reqs) / 2
+	left, err := verifyBuilderDepositRequestsDC(ctx, reqs[:mid], domain)
+	if err != nil {
+		return nil, err
+	}
+	right, err := verifyBuilderDepositRequestsDC(ctx, reqs[mid:], domain)
+	if err != nil {
+		return nil, err
+	}
+	for i := range right {
+		right[i] += mid
+	}
+	return append(left, right...), nil
+}
+
 // VerifyDeposit verifies the deposit data and signature given the beacon state and deposit information
 func VerifyDeposit(beaconState state.ReadOnlyBeaconState, deposit *ethpb.Deposit) error {
 	// Verify Merkle proof of deposit and deposit trie root.

--- a/beacon-chain/core/helpers/deposit_test.go
+++ b/beacon-chain/core/helpers/deposit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/container/trie"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
@@ -177,4 +178,85 @@ func TestBatchVerifyPendingDepositsSignatures_InvalidSignature(t *testing.T) {
 	verified, err := helpers.BatchVerifyPendingDepositsSignatures(t.Context(), []*ethpb.PendingDeposit{pendingDeposit})
 	require.NoError(t, err)
 	require.Equal(t, false, verified)
+}
+
+func makeValidBuilderDepositRequest(t *testing.T, amount uint64) *enginev1.BuilderDepositRequest {
+	t.Helper()
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	domain, err := signing.ComputeDomain(params.BeaconConfig().DomainBuilderDeposit, nil, nil)
+	require.NoError(t, err)
+	wc := make([]byte, 32)
+	sr, err := signing.ComputeSigningRoot(&ethpb.DepositMessage{
+		PublicKey:             sk.PublicKey().Marshal(),
+		WithdrawalCredentials: wc,
+		Amount:                amount,
+	}, domain)
+	require.NoError(t, err)
+	return &enginev1.BuilderDepositRequest{
+		Pubkey:                sk.PublicKey().Marshal(),
+		WithdrawalCredentials: wc,
+		Amount:                amount,
+		Signature:             sk.Sign(sr[:]).Marshal(),
+	}
+}
+
+func makeInvalidBuilderDepositRequest(t *testing.T, amount uint64) *enginev1.BuilderDepositRequest {
+	t.Helper()
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	return &enginev1.BuilderDepositRequest{
+		Pubkey:                sk.PublicKey().Marshal(),
+		WithdrawalCredentials: make([]byte, 32),
+		Amount:                amount,
+		Signature:             make([]byte, 96),
+	}
+}
+
+func TestBatchVerifyBuilderDepositRequestSignatures_Empty(t *testing.T) {
+	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(t.Context(), nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(invalid))
+}
+
+func TestBatchVerifyBuilderDepositRequestSignatures_AllValid(t *testing.T) {
+	reqs := []*enginev1.BuilderDepositRequest{
+		makeValidBuilderDepositRequest(t, 100),
+		makeValidBuilderDepositRequest(t, 200),
+		makeValidBuilderDepositRequest(t, 300),
+	}
+	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(t.Context(), reqs)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(invalid))
+}
+
+func TestBatchVerifyBuilderDepositRequestSignatures_MixedDC(t *testing.T) {
+	reqs := []*enginev1.BuilderDepositRequest{
+		makeInvalidBuilderDepositRequest(t, 1),
+		makeValidBuilderDepositRequest(t, 2),
+		makeValidBuilderDepositRequest(t, 3),
+		makeInvalidBuilderDepositRequest(t, 4),
+		makeValidBuilderDepositRequest(t, 5),
+		makeValidBuilderDepositRequest(t, 6),
+		makeInvalidBuilderDepositRequest(t, 7),
+		makeValidBuilderDepositRequest(t, 8),
+	}
+	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(t.Context(), reqs)
+	require.NoError(t, err)
+	require.DeepEqual(t, []int{0, 3, 6}, invalid)
+}
+
+func TestBatchVerifyBuilderDepositRequestSignatures_MultipleBadAcrossSubtrees(t *testing.T) {
+	const n = 128
+	reqs := make([]*enginev1.BuilderDepositRequest, n)
+	for i := range n {
+		reqs[i] = makeValidBuilderDepositRequest(t, uint64(i+1))
+	}
+	badIdxs := []int{5, 47, 99, 120}
+	for _, idx := range badIdxs {
+		reqs[idx] = makeInvalidBuilderDepositRequest(t, uint64(idx+1))
+	}
+	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(t.Context(), reqs)
+	require.NoError(t, err)
+	require.DeepEqual(t, badIdxs, invalid)
 }

--- a/changelog/terence_batch-verify-builder-deposits.md
+++ b/changelog/terence_batch-verify-builder-deposits.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Batch-verify builder deposit request signatures in `ProcessBuilderDepositRequests` instead of one BLS verification per request.


### PR DESCRIPTION
The batch signature-verification code is the same divide-and-conquer logic as the deposit-request version that #17012 removes; the only difference is this wires it into `ProcessBuilderDepositRequests` against `BuilderDepositRequest` under `DOMAIN_BUILDER_DEPOSIT`, replacing the previous one-BLS-verification-per-request path.