### PR TITLE
Dedupe Gloas pending-column downscore to once per peer per root

### DIFF
--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -294,11 +294,18 @@ func (s *Service) pruneStaleGloasColumns(currentSlot primitives.Slot) {
 		if e.slot+1 >= currentSlot {
 			continue
 		}
+		// Dedupe forwarders: a peer that relayed many columns for one root is downscored once, not per column.
+		seen := make(map[peer.ID]struct{})
 		peers := make([]peer.ID, 0, fieldparams.NumberOfColumns)
 		for _, pe := range e.columns {
-			if pe != nil {
-				peers = append(peers, pe.peer)
+			if pe == nil {
+				continue
 			}
+			if _, ok := seen[pe.peer]; ok {
+				continue
+			}
+			seen[pe.peer] = struct{}{}
+			peers = append(peers, pe.peer)
 		}
 		pruned = append(pruned, prunedRoot{root: r, peers: peers})
 		delete(s.pendingGloasColumns, r)

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -581,10 +581,10 @@ func TestPendingGloasColumns(t *testing.T) {
 
 		scorer := p.Peers().Scorers().BadResponsesScorer()
 
-		// One increment per fabricated column.
+		// One increment for the fabricated root even though the peer forwarded three columns.
 		evilCount, err := scorer.Count("evilpeer")
 		require.NoError(t, err)
-		require.Equal(t, 3, evilCount)
+		require.Equal(t, 1, evilCount)
 
 		// The peer on the known (orphaned) root is untouched.
 		_, err = scorer.Count("honestpeer")

--- a/changelog/terence_gloas-dedup-pending-column-downscore.md
+++ b/changelog/terence_gloas-dedup-pending-column-downscore.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Downscore a Gloas data column forwarder at most once per orphaned block root instead of once per column.


### PR DESCRIPTION
Under blob load a Gloas data column can be queued before its block arrives. If the block is still missing when the pending entry is pruned, every queued column's forwarder is downscored once per column. A single peer that relayed many columns for one block then takes up to 128 hits and instantly blows past the bad responses threshold of 5. That disconnects an otherwise healthy peer, and under sustained load it cascades into losing most peers. This change downscores each forwarder at most once per orphaned root.