### PR TITLE
Avoid redundant blob copy in KZG batch verify path

### DIFF
--- a/beacon-chain/blockchain/kzg/validation.go
+++ b/beacon-chain/blockchain/kzg/validation.go
@@ -40,7 +40,7 @@ func Verify(blobSidecars ...blocks.ROBlob) error {
 	cmts := make([]GoKZG.KZGCommitment, len(blobSidecars))
 	proofs := make([]GoKZG.KZGProof, len(blobSidecars))
 	for i, sidecar := range blobSidecars {
-		blobs[i] = *bytesToBlob(sidecar.Blob)
+		copy(blobs[i][:], sidecar.Blob)
 		cmts[i] = bytesToCommitment(sidecar.KzgCommitment)
 		proofs[i] = bytesToKZGProof(sidecar.KzgProof)
 	}

--- a/changelog/satushh_kzg-batch-blob-copy.md
+++ b/changelog/satushh_kzg-batch-blob-copy.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Avoid a redundant 128 KiB blob copy and heap allocation in the KZG batch verification path by copying each blob directly into the preallocated destination.


### PR DESCRIPTION
**What type of PR is this?**

other

**What does this PR do? Why is it needed?**

Avoid redundant blob copy and heap allocation in the KZG batch verification path

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
