### PR TITLE
Fall back to a cached P2P bid when the local payload is unavailable in Gloas block production

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
@@ -56,6 +57,27 @@ func (vs *Server) setExecutionPayloadBid(
 	}
 
 	return true, nil
+}
+
+// setP2PBidFallback uses a cached P2P bid when the local EL self-build is unavailable.
+func (vs *Server) setP2PBidFallback(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, parentFull bool) error {
+	if vs.HighestBidCache == nil {
+		return errors.New("highest bid cache is nil")
+	}
+	slot := sBlk.Block().Slot()
+	parentRoot := sBlk.Block().ParentRoot()
+	parentHash, err := vs.getParentBlockHash(ctx, head, slot, parentRoot, parentFull)
+	if err != nil {
+		return errors.Wrap(err, "could not get parent block hash")
+	}
+	cached, ok := vs.HighestBidCache.Get(slot, bytesutil.ToBytes32(parentHash), parentRoot)
+	if !ok {
+		return errors.New("no cached P2P bid available")
+	}
+	if err := sBlk.SetSignedExecutionPayloadBid(cached); err != nil {
+		return errors.Wrap(err, "could not set cached P2P execution payload bid")
+	}
+	return nil
 }
 
 // winningP2PBid returns a cached P2P bid if one exists and exceeds the local EL value.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
@@ -33,13 +33,18 @@ func (vs *Server) buildBlockGloas(ctx context.Context, sBlk interfaces.SignedBea
 	})
 
 	// local is our self-build candidate and the baseline for comparing incoming bids.
+	var selfBuilt bool
 	local, err := vs.getLocalPayload(ctx, sBlk.Block(), head, parentFull)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get local payload: %v", err)
-	}
-	selfBuilt, err := vs.setExecutionPayloadBid(ctx, sBlk, local, local.OverrideBuilder || skipBuilder)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not set execution payload bid: %v", err)
+		log.WithError(err).Warn("Could not get local payload, falling back to P2P bid")
+		if fbErr := vs.setP2PBidFallback(ctx, sBlk, head, parentFull); fbErr != nil {
+			return nil, status.Errorf(codes.Internal, "Could not get local payload and no P2P bid fallback: %v", fbErr)
+		}
+	} else {
+		selfBuilt, err = vs.setExecutionPayloadBid(ctx, sBlk, local, local.OverrideBuilder || skipBuilder)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not set execution payload bid: %v", err)
+		}
 	}
 
 	wg.Wait()

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
@@ -1,0 +1,103 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	chainMock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+)
+
+func TestSetP2PBidFallback_UsesCachedBid(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	parentBlockHash := bytesutil.ToBytes32([]byte("parent-block-hash"))
+	parentRoot := bytesutil.ToBytes32([]byte("parent-root"))
+	slot := primitives.Slot(100)
+
+	blockHash := bytesutil.ToBytes32([]byte("block-hash"))
+	st, err := util.NewBeaconStateGloas(func(state *ethpb.BeaconStateGloas) error {
+		state.LatestExecutionPayloadBid.BlockHash = blockHash[:]
+		state.LatestExecutionPayloadBid.ParentBlockHash = parentBlockHash[:]
+		return nil
+	})
+	require.NoError(t, err)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	p2pBid := &ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			Slot:                  slot,
+			ParentBlockHash:       parentBlockHash[:],
+			ParentBlockRoot:       parentRoot[:],
+			BlockHash:             make([]byte, 32),
+			BuilderIndex:          7,
+			Value:                 1000,
+			ExecutionPayment:      500,
+			FeeRecipient:          make([]byte, 20),
+			GasLimit:              30_000_000,
+			PrevRandao:            make([]byte, 32),
+			BlobKzgCommitments:    [][]byte{},
+			ExecutionRequestsRoot: make([]byte, 32),
+		},
+		Signature: make([]byte, 96),
+	}
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	bidCache.SetIfHigher(p2pBid)
+
+	vs := &Server{HighestBidCache: bidCache, ForkchoiceFetcher: &chainMock.ChainService{}}
+
+	require.NoError(t, vs.setP2PBidFallback(context.Background(), sBlk, st, false))
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.NotNil(t, signedBid)
+	require.Equal(t, primitives.BuilderIndex(7), signedBid.Message.BuilderIndex)
+	require.Equal(t, primitives.Gwei(1000), signedBid.Message.Value)
+}
+
+func TestSetP2PBidFallback_NoCachedBidErrors(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	parentRoot := bytesutil.ToBytes32([]byte("parent-root"))
+	parentBlockHash := bytesutil.ToBytes32([]byte("parent-block-hash"))
+	st, err := util.NewBeaconStateGloas(func(state *ethpb.BeaconStateGloas) error {
+		state.LatestExecutionPayloadBid.ParentBlockHash = parentBlockHash[:]
+		return nil
+	})
+	require.NoError(t, err)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       primitives.Slot(100),
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	vs := &Server{HighestBidCache: cache.NewHighestExecutionPayloadBidCache(), ForkchoiceFetcher: &chainMock.ChainService{}}
+
+	err = vs.setP2PBidFallback(context.Background(), sBlk, st, false)
+	require.ErrorContains(t, "no cached P2P bid", err)
+}

--- a/changelog/terence_gloas-local-block-fallback.md
+++ b/changelog/terence_gloas-local-block-fallback.md
@@ -1,0 +1,3 @@
+### Added
+
+- Gloas block production falls back to a cached P2P execution payload bid when the local EL self-build is unavailable.


### PR DESCRIPTION
In Gloas block production, when getLocalPayload fails (e.g. the EL engine times out), use a cached P2P execution payload bid instead of aborting the proposal. The proposal still fails if no cached bid exists, since the bid field is mandatory.