### PR TITLE
Ignore unverifiable execution payload bids on gossip instead of rejecting

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -31,7 +32,7 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 		return pubsub.ValidationIgnore, nil
 	}
 
-	ctx, span := trace.StartSpan(ctx, "sync.validateExecutionPayloadBidGossip")
+	_, span := trace.StartSpan(ctx, "sync.validateExecutionPayloadBidGossip")
 	defer span.End()
 
 	if msg.Topic == nil {
@@ -68,13 +69,13 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyCurrentOrNextSlot(); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	st, err := s.cfg.chain.HeadStateReadOnly(ctx)
-	if err != nil {
-		return pubsub.ValidationIgnore, err
+	parentBlockRoot := bid.ParentBlockRoot()
+	st := transition.NextSlotStateReadOnly(parentBlockRoot[:], bid.Slot())
+	if st == nil {
+		return pubsub.ValidationIgnore, nil
 	}
 	// [IGNORE] matching SignedProposerPreferences seen, keyed on the proposer
 	// dep root anchored to bid.parent_block_root.
-	parentBlockRoot := bid.ParentBlockRoot()
 	dependentRoot, err := s.proposerDependentRoot(parentBlockRoot, bid.Slot())
 	if err != nil {
 		return pubsub.ValidationIgnore, err

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -71,7 +71,7 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	}
 	parentBlockRoot := bid.ParentBlockRoot()
 	st := transition.NextSlotStateReadOnly(parentBlockRoot[:], bid.Slot())
-	if st == nil {
+	if st == nil || st.Slot() != bid.Slot() {
 		return pubsub.ValidationIgnore, nil
 	}
 	// [IGNORE] matching SignedProposerPreferences seen, keyed on the proposer

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -510,7 +510,7 @@ func setupExecutionPayloadBidService(t *testing.T) (*Service, *pubsub.Message, *
 		ForkchoiceBlockHashes: map[[32]byte][32]byte{[32]byte{0x02}: [32]byte{0x01}},
 		ForkchoiceGasLimits:   map[[32]byte]uint64{[32]byte{0x02}: 1},
 	}
-	require.NoError(t, transition.UpdateNextSlotCache(ctx, chainService.Root, state))
+	require.NoError(t, transition.UpdateNextSlotCache(context.Background(), chainService.Root, state))
 	s := &Service{
 		seenExecutionPayloadBidCache:    newSlotAwareCache(10),
 		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -10,6 +10,7 @@ import (
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
@@ -274,6 +275,24 @@ func TestValidateExecutionPayloadBidGossip_HappyPath(t *testing.T) {
 	require.DeepEqual(t, signedBid, got)
 }
 
+func TestValidateExecutionPayloadBidGossip_NextSlotStateMissIgnored(t *testing.T) {
+	ctx := context.Background()
+	s, msg, _ := setupExecutionPayloadBidService(t)
+	// errPrevRandao would reject if reached, but a next-slot-cache miss for the bid's parent must ignore first.
+	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
+		errPrevRandao: errors.New("wrong prev randao"),
+	})
+	// Evict the bid's parent (0x02) from the next-slot cache.
+	other, err := util.NewBeaconStateGloas()
+	require.NoError(t, err)
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x07}, 32), other))
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x08}, 32), other))
+
+	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+}
+
 func TestValidateExecutionPayloadBidGossip_FeeRecipientMismatch(t *testing.T) {
 	ctx := context.Background()
 	s, msg, _ := setupExecutionPayloadBidService(t)
@@ -484,12 +503,14 @@ func setupExecutionPayloadBidService(t *testing.T) (*Service, *pubsub.Message, *
 		Genesis:    time.Now(),
 		State:      state,
 		TargetRoot: genesisRoot,
+		Root:       bytesutil.PadTo([]byte{0x02}, 32),
 		ForkchoiceRoots: map[[32]byte]bool{
 			[32]byte{0x02}: true,
 		},
 		ForkchoiceBlockHashes: map[[32]byte][32]byte{[32]byte{0x02}: [32]byte{0x01}},
 		ForkchoiceGasLimits:   map[[32]byte]uint64{[32]byte{0x02}: 1},
 	}
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, chainService.Root, state))
 	s := &Service{
 		seenExecutionPayloadBidCache:    newSlotAwareCache(10),
 		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),

--- a/changelog/terence_gloas-bid-prev-randao-gossip.md
+++ b/changelog/terence_gloas-bid-prev-randao-gossip.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Ignore execution payload bids that cannot be verified against the current head state instead of rejecting them.


### PR DESCRIPTION
The execution payload bid gossip validator rejected and penalized the sender whenever the bid did not verify against the current head state, which on glamsterdam-devnet-6 drove Prysm into a gossip score death spiral and off the canonical chain. It now ignores rather than rejects any bid whose parent block root is neither the current head nor the proposer head, and logs the ignored case at debug.