### PR TITLE
Avoid slice clone when only counting consensus children in forkchoice

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -123,6 +123,14 @@ func (s *Store) allConsensusChildren(n *Node) []*Node {
 	return en.children
 }
 
+// hasConsensusChildren reports whether any consensus block builds on the given node.
+// It avoids the allocation allConsensusChildren makes when only the count is needed.
+func (s *Store) hasConsensusChildren(n *Node) bool {
+	en := s.emptyNodeByRoot[n.root]
+	fn, ok := s.fullNodeByRoot[n.root]
+	return len(en.children) > 0 || (ok && len(fn.children) > 0)
+}
+
 // setNodeAndParentValidated sets the current node and all the ancestors as validated (i.e. non-optimistic).
 func (s *Store) setNodeAndParentValidated(ctx context.Context, pn *PayloadNode) error {
 	if ctx.Err() != nil {
@@ -230,7 +238,7 @@ func (s *Store) updateBestDescendantConsensusNode(ctx context.Context, n *Node, 
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if len(s.allConsensusChildren(n)) == 0 {
+	if !s.hasConsensusChildren(n) {
 		n.bestDescendant = nil
 		return nil
 	}

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 )
 
-func setupGloas(t *testing.T, justified, finalized primitives.Epoch) *ForkChoice {
+func setupGloas(t testing.TB, justified, finalized primitives.Epoch) *ForkChoice {
 	t.Helper()
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig()
@@ -1923,4 +1923,48 @@ func TestProcessAttestation_SameSlotPayloadVote(t *testing.T) {
 	require.Equal(t, 2, len(f.votes))
 	require.Equal(t, rootA, f.votes[1].nextRoot)
 	require.Equal(t, true, f.votes[1].nextPayloadStatus)
+}
+
+// BenchmarkConsensusChildrenLen compares the older length-only use of
+// allConsensusChildren (which clones+appends a slice) against hasConsensusChildren
+// on a node that has both an empty child and a full child.
+//
+// goos: darwin, goarch: arm64, cpu: Apple M4 Pro
+// BenchmarkConsensusChildrenLen/allConsensusChildren-14   39.17 ns/op   24 B/op   2 allocs/op
+// BenchmarkConsensusChildrenLen/hasConsensusChildren-14   12.09 ns/op    0 B/op   0 allocs/op
+func BenchmarkConsensusChildrenLen(b *testing.B) {
+	f := setupGloas(b, 0, 0)
+	ctx := b.Context()
+
+	rootA, blockHashA := indexToHash(1), indexToHash(100)
+	st, blk, err := prepareGloasForkchoiceState(ctx, 1, rootA, params.BeaconConfig().ZeroHash, blockHashA, params.BeaconConfig().ZeroHash, 0, 0)
+	require.NoError(b, err)
+	require.NoError(b, f.InsertNode(ctx, st, blk))
+	pe, err := prepareGloasForkchoicePayload(rootA)
+	require.NoError(b, err)
+	require.NoError(b, f.InsertPayload(pe))
+
+	// Block B builds on (A, empty); block C builds on (A, full).
+	st, blk, err = prepareGloasForkchoiceState(ctx, 2, indexToHash(2), rootA, indexToHash(200), indexToHash(999), 0, 0)
+	require.NoError(b, err)
+	require.NoError(b, f.InsertNode(ctx, st, blk))
+	st, blk, err = prepareGloasForkchoiceState(ctx, 3, indexToHash(3), rootA, indexToHash(201), blockHashA, 0, 0)
+	require.NoError(b, err)
+	require.NoError(b, f.InsertNode(ctx, st, blk))
+
+	s := f.store
+	n := s.emptyNodeByRoot[rootA].node
+
+	b.Run("allConsensusChildren", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = len(s.allConsensusChildren(n)) == 0
+		}
+	})
+	b.Run("hasConsensusChildren", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = !s.hasConsensusChildren(n)
+		}
+	})
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -341,7 +341,7 @@ func (s *Store) tips() ([][32]byte, []primitives.Slot) {
 	var slots []primitives.Slot
 
 	for root, n := range s.emptyNodeByRoot {
-		if len(s.allConsensusChildren(n.node)) == 0 {
+		if !s.hasConsensusChildren(n.node) {
 			roots = append(roots, root)
 			slots = append(slots, n.node.slot)
 		}

--- a/changelog/satushh_forkchoice-has-consensus-children.md
+++ b/changelog/satushh_forkchoice-has-consensus-children.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Avoid cloning a slice just to count it in the Gloas fork-choice best-descendant walk: `updateBestDescendantConsensusNode` and `tips` now use a `hasConsensusChildren` helper instead of `len(allConsensusChildren(...))`, removing a per-node heap allocation.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

- The Gloas best-descendant walk and tips() called `len(allConsensusChildren(n)) == 0`, which clones+appends a slice just to read its length: once per node, every `Head()` computation. 
- Add a zero-alloc `hasConsensusChildren` helper for the count-only call sites.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
