### PR TITLE
Reject empty Gloas block access lists

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
@@ -36,6 +36,9 @@ func (vs *Server) storeExecutionPayloadEnvelope(
 	}
 
 	payload := extractExecutionPayloadGloas(local)
+	if err := validateExecutionPayloadGloas(payload); err != nil {
+		return err
+	}
 
 	parentRoot := sBlk.Block().ParentRoot()
 	envelope := &ethpb.ExecutionPayloadEnvelope{
@@ -63,6 +66,16 @@ func (vs *Server) storeExecutionPayloadEnvelope(
 		Envelope:    envelope,
 		DataColumns: roSidecars,
 	})
+	return nil
+}
+
+func validateExecutionPayloadGloas(payload *enginev1.ExecutionPayloadGloas) error {
+	if payload == nil {
+		return errors.New("execution payload is nil")
+	}
+	if len(payload.BlockAccessList) == 0 {
+		return errors.New("execution payload block access list cannot be empty")
+	}
 	return nil
 }
 
@@ -127,6 +140,9 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 	if slots.ToEpoch(envSlot) < params.BeaconConfig().GloasForkEpoch {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"execution payload envelopes are not supported before Gloas fork (slot %d)", envSlot)
+	}
+	if err := validateExecutionPayloadGloas(req.Message.Payload); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	beaconBlockRoot := bytesutil.ToBytes32(req.Message.BeaconBlockRoot)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope_test.go
@@ -24,15 +24,16 @@ func testGloasBlock(t *testing.T) (*consensusblocks.GetPayloadResponse, interfac
 	t.Helper()
 
 	payload := &enginev1.ExecutionPayloadGloas{
-		ParentHash:    make([]byte, 32),
-		FeeRecipient:  make([]byte, 20),
-		StateRoot:     make([]byte, 32),
-		ReceiptsRoot:  make([]byte, 32),
-		LogsBloom:     make([]byte, 256),
-		PrevRandao:    make([]byte, 32),
-		BaseFeePerGas: make([]byte, 32),
-		BlockHash:     make([]byte, 32),
-		ExtraData:     make([]byte, 0),
+		ParentHash:      make([]byte, 32),
+		FeeRecipient:    make([]byte, 20),
+		StateRoot:       make([]byte, 32),
+		ReceiptsRoot:    make([]byte, 32),
+		LogsBloom:       make([]byte, 256),
+		PrevRandao:      make([]byte, 32),
+		BaseFeePerGas:   make([]byte, 32),
+		BlockHash:       make([]byte, 32),
+		ExtraData:       make([]byte, 0),
+		BlockAccessList: []byte{0xc0},
 	}
 	ed, err := consensusblocks.WrappedExecutionPayloadGloas(payload)
 	require.NoError(t, err)
@@ -61,17 +62,27 @@ func TestStoreExecutionPayloadEnvelope(t *testing.T) {
 	require.Equal(t, sBlk.Block().Slot(), contents.Envelope.Payload.SlotNumber)
 }
 
+func TestStoreExecutionPayloadEnvelope_RejectsEmptyBlockAccessList(t *testing.T) {
+	local, sBlk := testGloasBlock(t)
+	local.ExecutionData.Proto().(*enginev1.ExecutionPayloadGloas).BlockAccessList = nil
+
+	vs := &Server{ExecutionPayloadEnvelopeCache: cache.NewExecutionPayloadEnvelopeCache()}
+	err := vs.storeExecutionPayloadEnvelope(sBlk, local)
+	require.ErrorContains(t, "block access list cannot be empty", err)
+}
+
 func TestExtractExecutionPayloadGloas(t *testing.T) {
 	payload := &enginev1.ExecutionPayloadGloas{
-		ParentHash:    make([]byte, 32),
-		FeeRecipient:  make([]byte, 20),
-		StateRoot:     make([]byte, 32),
-		ReceiptsRoot:  make([]byte, 32),
-		LogsBloom:     make([]byte, 256),
-		PrevRandao:    make([]byte, 32),
-		BaseFeePerGas: make([]byte, 32),
-		BlockHash:     make([]byte, 32),
-		ExtraData:     make([]byte, 0),
+		ParentHash:      make([]byte, 32),
+		FeeRecipient:    make([]byte, 20),
+		StateRoot:       make([]byte, 32),
+		ReceiptsRoot:    make([]byte, 32),
+		LogsBloom:       make([]byte, 256),
+		PrevRandao:      make([]byte, 32),
+		BaseFeePerGas:   make([]byte, 32),
+		BlockHash:       make([]byte, 32),
+		ExtraData:       make([]byte, 0),
+		BlockAccessList: []byte{0xc0},
 	}
 	ed, err := consensusblocks.WrappedExecutionPayloadGloas(payload)
 	require.NoError(t, err)
@@ -183,16 +194,17 @@ func TestPublishExecutionPayloadEnvelope_Success(t *testing.T) {
 	req := &ethpb.SignedExecutionPayloadEnvelope{
 		Message: &ethpb.ExecutionPayloadEnvelope{
 			Payload: &enginev1.ExecutionPayloadGloas{
-				ParentHash:    make([]byte, 32),
-				FeeRecipient:  make([]byte, 20),
-				StateRoot:     make([]byte, 32),
-				ReceiptsRoot:  make([]byte, 32),
-				LogsBloom:     make([]byte, 256),
-				PrevRandao:    make([]byte, 32),
-				BaseFeePerGas: make([]byte, 32),
-				BlockHash:     make([]byte, 32),
-				ExtraData:     make([]byte, 0),
-				SlotNumber:    1,
+				ParentHash:      make([]byte, 32),
+				FeeRecipient:    make([]byte, 20),
+				StateRoot:       make([]byte, 32),
+				ReceiptsRoot:    make([]byte, 32),
+				LogsBloom:       make([]byte, 256),
+				PrevRandao:      make([]byte, 32),
+				BaseFeePerGas:   make([]byte, 32),
+				BlockHash:       make([]byte, 32),
+				ExtraData:       make([]byte, 0),
+				BlockAccessList: []byte{0xc0},
+				SlotNumber:      1,
 			},
 			ExecutionRequests:     &enginev1.ExecutionRequestsGloas{},
 			BuilderIndex:          0,
@@ -208,6 +220,21 @@ func TestPublishExecutionPayloadEnvelope_Success(t *testing.T) {
 	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
 	require.Equal(t, 1, len(broadcaster.BroadcastMessages))
 	require.Equal(t, 1, receiver.calls)
+}
+
+func TestPublishExecutionPayloadEnvelope_RejectsEmptyBlockAccessList(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	vs := &Server{}
+	_, err := vs.PublishExecutionPayloadEnvelope(t.Context(), &ethpb.SignedExecutionPayloadEnvelope{
+		Message: &ethpb.ExecutionPayloadEnvelope{
+			Payload: &enginev1.ExecutionPayloadGloas{SlotNumber: 1},
+		},
+	})
+	require.ErrorContains(t, "block access list cannot be empty", err)
 }
 
 func TestPublishExecutionPayloadEnvelope_ImportFailureIsAborted(t *testing.T) {
@@ -226,16 +253,17 @@ func TestPublishExecutionPayloadEnvelope_ImportFailureIsAborted(t *testing.T) {
 	req := &ethpb.SignedExecutionPayloadEnvelope{
 		Message: &ethpb.ExecutionPayloadEnvelope{
 			Payload: &enginev1.ExecutionPayloadGloas{
-				ParentHash:    make([]byte, 32),
-				FeeRecipient:  make([]byte, 20),
-				StateRoot:     make([]byte, 32),
-				ReceiptsRoot:  make([]byte, 32),
-				LogsBloom:     make([]byte, 256),
-				PrevRandao:    make([]byte, 32),
-				BaseFeePerGas: make([]byte, 32),
-				BlockHash:     make([]byte, 32),
-				ExtraData:     make([]byte, 0),
-				SlotNumber:    1,
+				ParentHash:      make([]byte, 32),
+				FeeRecipient:    make([]byte, 20),
+				StateRoot:       make([]byte, 32),
+				ReceiptsRoot:    make([]byte, 32),
+				LogsBloom:       make([]byte, 256),
+				PrevRandao:      make([]byte, 32),
+				BaseFeePerGas:   make([]byte, 32),
+				BlockHash:       make([]byte, 32),
+				ExtraData:       make([]byte, 0),
+				BlockAccessList: []byte{0xc0},
+				SlotNumber:      1,
 			},
 			ExecutionRequests:     &enginev1.ExecutionRequestsGloas{},
 			BeaconBlockRoot:       make([]byte, 32),

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -80,6 +80,21 @@ type ExecutionBlock struct {
 	BlockAccessList hexutil.Bytes            `json:"blockAccessList"`
 }
 
+func decodeBlockAccessList(raw any) ([]byte, error) {
+	balStr, ok := raw.(string)
+	if !ok {
+		return nil, errors.New("expected `blockAccessList` field to be a string")
+	}
+	balBytes, err := hexutil.Decode(balStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not decode blockAccessList hex")
+	}
+	if len(balBytes) == 0 {
+		return nil, errors.New("blockAccessList cannot be empty")
+	}
+	return balBytes, nil
+}
+
 func (e *ExecutionBlock) MarshalJSON() ([]byte, error) {
 	decoded := make(map[string]any)
 	encodedHeader, err := e.Header.MarshalJSON()
@@ -130,13 +145,9 @@ func (e *ExecutionBlock) UnmarshalJSON(enc []byte) error {
 	e.TotalDifficulty, _ = decoded["totalDifficulty"].(string)
 
 	if raw, exists := decoded["blockAccessList"]; exists && raw != nil {
-		balStr, ok := raw.(string)
-		if !ok {
-			return errors.New("expected `blockAccessList` field to be a string")
-		}
-		balBytes, err := hexutil.Decode(balStr)
+		balBytes, err := decodeBlockAccessList(raw)
 		if err != nil {
-			return errors.Wrap(err, "could not decode blockAccessList hex")
+			return err
 		}
 		e.BlockAccessList = balBytes
 	}
@@ -1506,6 +1517,9 @@ func (e *ExecutionBundleGloas) UnmarshalJSON(enc []byte) error {
 
 	if dec.ExecutionPayload.BlockAccessList == nil {
 		return errors.New("missing required field 'blockAccessList' for ExecutionPayload")
+	}
+	if len(*dec.ExecutionPayload.BlockAccessList) == 0 {
+		return errors.New("blockAccessList cannot be empty")
 	}
 	e.Payload.BlockAccessList = *dec.ExecutionPayload.BlockAccessList
 	e.Payload.SlotNumber = primitives.Slot(*dec.ExecutionPayload.SlotNumber)

--- a/proto/engine/v1/json_marshal_unmarshal_test.go
+++ b/proto/engine/v1/json_marshal_unmarshal_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -723,6 +724,51 @@ func TestExecutionPayloadBody_MarshalUnmarshalJSON(t *testing.T) {
 	err = json.Unmarshal(enc, res)
 	require.NoError(t, err)
 	require.DeepEqual(t, pBody, res)
+}
+
+func TestExecutionBundleGloas_UnmarshalJSONRejectsEmptyBlockAccessList(t *testing.T) {
+	hash := common.BytesToHash([]byte("hash"))
+	addr := common.BytesToAddress([]byte("feeRecipient"))
+	logsBloom := hexutil.Bytes(bytesutil.PadTo([]byte("logs"), fieldparams.LogsBloomLength))
+	slotNumber := hexutil.Uint64(1)
+	payload := &enginev1.GetPayloadV6ResponseJson{
+		ExecutionPayload: &enginev1.ExecutionPayloadGloasJSON{
+			ParentHash:      &hash,
+			FeeRecipient:    &addr,
+			StateRoot:       &hash,
+			ReceiptsRoot:    &hash,
+			LogsBloom:       &logsBloom,
+			PrevRandao:      &hash,
+			BlockNumber:     (*hexutil.Uint64)(&slotNumber),
+			GasLimit:        (*hexutil.Uint64)(&slotNumber),
+			GasUsed:         (*hexutil.Uint64)(&slotNumber),
+			Timestamp:       (*hexutil.Uint64)(&slotNumber),
+			ExtraData:       hexutil.Bytes{},
+			BaseFeePerGas:   "0x1",
+			BlobGasUsed:     (*hexutil.Uint64)(&slotNumber),
+			ExcessBlobGas:   (*hexutil.Uint64)(&slotNumber),
+			BlockHash:       &hash,
+			Transactions:    []hexutil.Bytes{},
+			Withdrawals:     []*enginev1.Withdrawal{},
+			BlockAccessList: new(hexutil.Bytes),
+			SlotNumber:      (*hexutil.Uint64)(&slotNumber),
+		},
+		BlockValue:        "0x0",
+		ExecutionRequests: []hexutil.Bytes{},
+	}
+	enc, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	res := &enginev1.ExecutionBundleGloas{}
+	err = json.Unmarshal(enc, res)
+	require.ErrorContains(t, "blockAccessList cannot be empty", err)
+}
+
+func TestExecutionBlock_UnmarshalJSONRejectsEmptyBlockAccessList(t *testing.T) {
+	block := strings.Replace(blockNoTxJson, `,"transactionsRoot"`, `,"blockAccessList":"0x","transactionsRoot"`, 1)
+	res := &enginev1.ExecutionBlock{}
+	err := json.Unmarshal([]byte(block), res)
+	require.ErrorContains(t, "blockAccessList cannot be empty", err)
 }
 
 func TestExecutionBlock_MarshalUnmarshalJSON_MainnetBlock(t *testing.T) {


### PR DESCRIPTION
## What changed

This rejects zero-length Gloas block access lists before Prysm caches or publishes an execution payload envelope, and while decoding Gloas engine JSON payloads. A zero-length BAL serializes as `0x`, which ELs reject as invalid RLP; the valid empty RLP list encoding is `0xc0`.

The guard is applied in:
- `ExecutionBundleGloas` JSON decoding
- `ExecutionBlock` JSON decoding
- self-built execution payload envelope caching
- `PublishExecutionPayloadEnvelope` request validation

## Why

On `glamsterdam-devnet-6`, block `0xe52da835...f491fa` at slot 13961 / execution block 12609 was imported successfully through non-Prysm paths, but Prysm-connected ELs rejected the replayed/published payload envelope with BAL decode failures:

- Besu: `Invalid block access list encoding`
- Geth: `failed to decode BAL: EOF`

The Prysm-side logs showed the beacon node processing the same payload envelope while sending an empty BAL (`0x`) to the EL, which explains the EL-specific rejection without requiring the original built block to be globally invalid.

## Tests

- `go test ./proto/engine/v1`
- `go test ./beacon-chain/rpc/prysm/v1alpha1/validator -run 'Test(StoreExecutionPayloadEnvelope|ExtractExecutionPayloadGloas|PublishExecutionPayloadEnvelope)'`\n\nI also tried `go test ./proto/engine/v1 ./beacon-chain/rpc/prysm/v1alpha1/validator`; `proto/engine/v1` passed, while the full validator package hit unrelated existing failures in stream/duties tests and a `Bitvector32` go-cmp panic.\n\n## Note\n\nAI-assisted investigation and patch by @lodekeeper.