### PR TITLE
Move peer-scoring of invalid block signatures to gossip caller

### DIFF
--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -174,7 +174,7 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	// Process the block if the clock jitter is less than MAXIMUM_GOSSIP_CLOCK_DISPARITY.
 	// Otherwise queue it for processing in the right slot.
 	if isBlockQueueable(genesisTime, blk.Block().Slot(), receivedTime) {
-		if res, err := s.verifyPendingBlockSignature(ctx, blk, blockRoot); err != nil {
+		if res, err := s.verifyPendingBlockSignature(ctx, pid, blk, blockRoot); err != nil {
 			log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not verify block signature")
 			return res, err
 		}
@@ -192,7 +192,7 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 
 	// Handle block when the parent is unknown.
 	if !s.cfg.chain.HasBlock(ctx, blk.Block().ParentRoot()) {
-		if res, err := s.verifyPendingBlockSignature(ctx, blk, blockRoot); err != nil {
+		if res, err := s.verifyPendingBlockSignature(ctx, pid, blk, blockRoot); err != nil {
 			log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not verify block signature")
 			return res, err
 		}
@@ -208,7 +208,7 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationIgnore, err
 	}
 	if res, err := s.validateExecutionPayloadBidParentSeen(ctx, blk.Block()); res == pubsub.ValidationIgnore {
-		if sigRes, sigErr := s.verifyPendingBlockSignature(ctx, blk, blockRoot); sigErr != nil {
+		if sigRes, sigErr := s.verifyPendingBlockSignature(ctx, pid, blk, blockRoot); sigErr != nil {
 			log.WithError(sigErr).WithFields(getBlockFields(blk)).Debug("Could not verify block signature")
 			return sigRes, sigErr
 		}
@@ -233,6 +233,10 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 
 	err = s.validateBeaconBlock(ctx, blk, blockRoot)
 	if err != nil {
+		if errors.Is(err, blocks.ErrInvalidSignature) {
+			s.downscorePeer(pid, "invalidBlockSignature")
+			return pubsub.ValidationReject, err
+		}
 		if s.hasBadBlock(blockRoot) || errors.Is(err, blocks.ErrInvalidProposerIndex) {
 			log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not validate beacon block")
 			return pubsub.ValidationReject, err
@@ -330,9 +334,6 @@ func (s *Service) validatePhase0Block(ctx context.Context, blk interfaces.ReadOn
 		return nil, err
 	}
 	if err := blocks.VerifyBlockSignatureUsingCurrentFork(verifyingState, blk, blockRoot); err != nil {
-		if errors.Is(err, blocks.ErrInvalidSignature) {
-			s.setBadBlock(ctx, blockRoot)
-		}
 		return nil, err
 	}
 	idx, err := helpers.BeaconProposerIndexAtSlot(ctx, verifyingState, blk.Block().Slot())
@@ -480,7 +481,7 @@ func (s *Service) validateBellatrixBeaconBlock(ctx context.Context, verifyingSta
 }
 
 // Verifies the signature of the pending block with respect to the current head state.
-func (s *Service) verifyPendingBlockSignature(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock, blkRoot [32]byte) (pubsub.ValidationResult, error) {
+func (s *Service) verifyPendingBlockSignature(ctx context.Context, pid peer.ID, blk interfaces.ReadOnlySignedBeaconBlock, blkRoot [32]byte) (pubsub.ValidationResult, error) {
 	roState, err := s.cfg.chain.HeadStateReadOnly(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore, err
@@ -491,7 +492,9 @@ func (s *Service) verifyPendingBlockSignature(ctx context.Context, blk interface
 		return pubsub.ValidationIgnore, err
 	}
 	if err := blocks.VerifyBlockSignatureUsingCurrentFork(roState, blk, blkRoot); err != nil {
-		s.setBadBlock(ctx, blkRoot)
+		if errors.Is(err, blocks.ErrInvalidSignature) {
+			s.downscorePeer(pid, "invalidBlockSignature")
+		}
 		return pubsub.ValidationReject, err
 	}
 	return pubsub.ValidationAccept, nil

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -125,9 +125,10 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 	}
 }
 
-func TestValidateBeaconBlockPubSub_InvalidSignature_MarksBlockAsBad(t *testing.T) {
+func TestValidateBeaconBlockPubSub_InvalidSignature_DownscoresPeer(t *testing.T) {
 	db := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
+	attacker := p2ptest.NewTestP2P(t)
 	ctx := t.Context()
 	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
 	parentBlock := util.NewBeaconBlock()
@@ -144,7 +145,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature_MarksBlockAsBad(t *testing.T
 	msg.Block.ParentRoot = bRoot[:]
 	msg.Block.Slot = 1
 	msg.Block.ProposerIndex = proposerIdx
-	badPrivKeyIdx := proposerIdx + 1 // We generate a valid signature from a wrong private key which fails to verify
+	badPrivKeyIdx := proposerIdx + 1
 	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
 	require.NoError(t, err)
 
@@ -176,12 +177,6 @@ func TestValidateBeaconBlockPubSub_InvalidSignature_MarksBlockAsBad(t *testing.T
 	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
 	defer opSub.Unsubscribe()
 
-	blockRoot, err := msg.Block.HashTreeRoot()
-	require.NoError(t, err)
-
-	// Verify block is not marked as bad initially
-	assert.Equal(t, false, r.hasBadBlock(blockRoot), "block should not be marked as bad initially")
-
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
@@ -195,19 +190,18 @@ func TestValidateBeaconBlockPubSub_InvalidSignature_MarksBlockAsBad(t *testing.T
 			Topic: &topic,
 		},
 	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+	res, err := r.validateBeaconBlockPubSub(ctx, attacker.PeerID(), m)
 	require.ErrorContains(t, "invalid signature", err)
-	result := res == pubsub.ValidationReject
-	assert.Equal(t, true, result)
+	assert.Equal(t, pubsub.ValidationReject, res)
 
-	// Verify block is now marked as bad after invalid signature
-	assert.Equal(t, true, r.hasBadBlock(blockRoot), "block should be marked as bad after invalid signature")
+	count, err := p.Peers().Scorers().BadResponsesScorer().Count(attacker.PeerID())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "peer should be downscored on invalid signature")
 
 	select {
 	case event := <-opChannel:
 		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
 	default:
-		// this case is needed, otherwise the test will never finish
 	}
 }
 
@@ -1341,9 +1335,8 @@ func TestValidateBeaconBlockPubSub_InvalidParentBlock(t *testing.T) {
 	r.cfg.clock = startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
 
 	res, err = r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "has an invalid parent", err)
-	// Expect block with bad parent to fail too
-	assert.Equal(t, res, pubsub.ValidationReject, "block with invalid parent should be ignored")
+	require.ErrorContains(t, "unknown parent for block", err)
+	assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
 
 	select {
 	case event := <-opChannel:

--- a/changelog/terence_move-peer-scoring-invalid-block-sig.md
+++ b/changelog/terence_move-peer-scoring-invalid-block-sig.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move peer-scoring of invalid block signatures to the gossip caller.


### PR DESCRIPTION
Invalid block signatures were handled inside the per-fork validation helpers, which marked the block bad. This moves that handling up to the gossip caller, which already holds the sending peer's ID: an invalid signature now downscores that peer and rejects the message, keeping the gossip peer-scoring in one place