### PR TITLE
Add Read Only interface to next slot state cache

### DIFF
--- a/beacon-chain/core/transition/trailing_slot_state_cache.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache.go
@@ -34,6 +34,25 @@ var (
 	})
 )
 
+// NextSlotStateReadOnly returns the saved state for the given blockroot.
+// It returns the last updated state if it matches. Otherwise it returns the previously
+// updated state if it matches its root. If no root matches it returns nil.
+// This version returns a ReadoOnlyBeaconState without making a copy.
+func NextSlotStateReadOnly(root []byte, wantedSlot types.Slot) state.ReadOnlyBeaconState {
+	nsc.Lock()
+	defer nsc.Unlock()
+	if bytes.Equal(root, nsc.lastRoot) && nsc.lastState.Slot() <= wantedSlot {
+		nextSlotCacheHit.Inc()
+		return nsc.lastState
+	}
+	if bytes.Equal(root, nsc.prevRoot) && nsc.prevState.Slot() <= wantedSlot {
+		nextSlotCacheHit.Inc()
+		return nsc.prevState
+	}
+	nextSlotCacheMiss.Inc()
+	return nil
+}
+
 // NextSlotState returns the saved state for the given blockroot.
 // It returns the last updated state if it matches. Otherwise it returns the previously
 // updated state if it matches its root. If no root matches it returns nil

--- a/beacon-chain/core/transition/trailing_slot_state_cache_test.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache_test.go
@@ -34,6 +34,40 @@ func TestTrailingSlotState_RoundTrip(t *testing.T) {
 	require.Equal(t, s.Slot(), lastState.Slot())
 }
 
+func TestTrailingSlotStateReadOnly_RoundTrip(t *testing.T) {
+	ctx := t.Context()
+	r := []byte{'a'}
+	require.Equal(t, nil, transition.NextSlotStateReadOnly(r, 0))
+
+	s, _ := util.DeterministicGenesisState(t, 1)
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, r, s))
+	ro := transition.NextSlotStateReadOnly(r, 1)
+	require.NotNil(t, ro)
+	require.Equal(t, primitives.Slot(1), ro.Slot())
+
+	// Cache a second root so the first becomes prevRoot, and confirm both still hit.
+	r2 := []byte{'b'}
+	s2, _ := util.DeterministicGenesisState(t, 1)
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, r2, s2))
+	ro = transition.NextSlotStateReadOnly(r2, 1)
+	require.NotNil(t, ro)
+	require.Equal(t, primitives.Slot(1), ro.Slot())
+	ro = transition.NextSlotStateReadOnly(r, 1)
+	require.NotNil(t, ro)
+	require.Equal(t, primitives.Slot(1), ro.Slot())
+}
+
+func TestTrailingSlotStateReadOnly_StateAdvancedBeyondRequest(t *testing.T) {
+	ctx := t.Context()
+	r := []byte{'a'}
+	require.Equal(t, nil, transition.NextSlotStateReadOnly(r, 0))
+
+	s, _ := util.DeterministicGenesisState(t, 1)
+	assert.NoError(t, s.SetSlot(2))
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, r, s))
+	require.Equal(t, nil, transition.NextSlotStateReadOnly(r, 1))
+}
+
 func TestTrailingSlotState_StateAdvancedBeyondRequest(t *testing.T) {
 	ctx := t.Context()
 	r := []byte{'a'}

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -164,11 +164,11 @@ func ProcessSlotsIfNeeded(ctx context.Context, st state.ReadOnlyBeaconState, par
 	if slot <= st.Slot() {
 		return st, nil
 	}
-	if cached := NextSlotState(parentRoot, slot); cached != nil {
+	if cached := NextSlotStateReadOnly(parentRoot, slot); cached != nil {
 		if cached.Slot() >= slot {
 			return cached, nil
 		}
-		return ProcessSlots(ctx, cached, slot)
+		return ProcessSlots(ctx, cached.Copy(), slot)
 	}
 	return ProcessSlots(ctx, st.Copy(), slot)
 }

--- a/changelog/potuz_nsc_ro.md
+++ b/changelog/potuz_nsc_ro.md
@@ -1,0 +1,2 @@
+### Added
+- Add a NextSlotStateReadOnly interface to allow read-only access to the next slot state.


### PR DESCRIPTION
Also use this interface on ProcessSlotsIfNeeded to avoid a copy. There are other places where this construction can be used but can be added later.
