### PR TITLE
`notifyNewHeadEvent`: Fix error when it is called for zero head slot

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -334,11 +334,6 @@ func (s *Service) notifyNewHeadEvent(
 	newHeadStateRoot,
 	newHeadRoot []byte,
 ) error {
-	// No-op: Return early if there's no parent block.
-	if newHeadSlot <= 0 {
-		return nil
-	}
-
 	currEpoch := slots.ToEpoch(newHeadSlot)
 	previousDutyDependentRoot, currentDutyDependentRoot, err := s.headEventDependentRoots(currEpoch)
 	if err != nil {
@@ -380,11 +375,6 @@ func (s *Service) notifyNewHeadV2Event(
 	newHeadStateRoot, newHeadRoot [32]byte,
 	headVersion int,
 ) error {
-	// No-op: Return early if there's no parent block.
-	if newHeadSlot <= 0 {
-		return nil
-	}
-
 	currEpoch := slots.ToEpoch(newHeadSlot)
 	currentEpochDependentRoot, nextEpochDependentRoot, err := s.headEventDependentRoots(currEpoch)
 	if err != nil {
@@ -458,6 +448,11 @@ func (s *Service) headEventDependentRoots(currEpoch primitives.Epoch) (previousD
 // headEpochTransition reports whether the head at newHeadSlot crossed an epoch boundary
 // relative to its parent block.
 func (s *Service) headEpochTransition(newHeadSlot primitives.Slot, newHeadRoot [32]byte) (bool, error) {
+	// Consider the head to be an epoch transition if it is the genesis block.
+	if newHeadSlot == 0 {
+		return true, nil
+	}
+
 	parentRoot, err := s.ParentRoot(newHeadRoot)
 	if err != nil {
 		return false, errors.Wrap(err, "could not obtain parent root in forkchoice")

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -334,6 +334,11 @@ func (s *Service) notifyNewHeadEvent(
 	newHeadStateRoot,
 	newHeadRoot []byte,
 ) error {
+	// No-op: Return early if there's no parent block.
+	if newHeadSlot <= 0 {
+		return nil
+	}
+
 	currEpoch := slots.ToEpoch(newHeadSlot)
 	previousDutyDependentRoot, currentDutyDependentRoot, err := s.headEventDependentRoots(currEpoch)
 	if err != nil {
@@ -375,6 +380,11 @@ func (s *Service) notifyNewHeadV2Event(
 	newHeadStateRoot, newHeadRoot [32]byte,
 	headVersion int,
 ) error {
+	// No-op: Return early if there's no parent block.
+	if newHeadSlot <= 0 {
+		return nil
+	}
+
 	currEpoch := slots.ToEpoch(newHeadSlot)
 	currentEpochDependentRoot, nextEpochDependentRoot, err := s.headEventDependentRoots(currEpoch)
 	if err != nil {

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -183,6 +183,18 @@ func Test_notifyNewHeadEvent(t *testing.T) {
 		}
 		require.DeepSSZEqual(t, wanted, eventHead)
 	})
+
+	t.Run("no-op when head slot is zero", func(t *testing.T) {
+		srv := testServiceWithDB(t)
+		newHeadStateRoot, newHeadRoot := [32]byte{}, [32]byte{}
+		notifier := srv.cfg.StateNotifier.(*mock.MockStateNotifier)
+
+		require.NoError(t, srv.notifyNewHeadEvent(t.Context(), 0, newHeadStateRoot[:], newHeadRoot[:]))
+
+		events := notifier.ReceivedEvents()
+		require.Equal(t, 0, len(events))
+	})
+
 	t.Run("non_genesis_values", func(t *testing.T) {
 		bState, _ := util.DeterministicGenesisState(t, 10)
 		genesisRoot := [32]byte{1}
@@ -325,6 +337,18 @@ func Test_notifyNewHeadV2Event(t *testing.T) {
 		require.NotNil(t, headV2)
 		return headV2
 	}
+
+	t.Run("no-op when head slot is zero", func(t *testing.T) {
+		srv, events, newHeadStateRoot, newHeadRoot := setupHeadV2Service(t, 1)
+		require.NoError(t, srv.notifyNewHeadV2Event(t.Context(), 0, newHeadStateRoot, newHeadRoot, version.Gloas))
+
+		// Ensure no events were emitted
+		select {
+		case e := <-events:
+			t.Fatalf("unexpected event: %v", e)
+		default:
+		}
+	})
 
 	t.Run("dependent roots fall back to genesis block root on underflow", func(t *testing.T) {
 		srv, events, newHeadStateRoot, newHeadRoot := setupHeadV2Service(t, 1)

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -184,15 +184,31 @@ func Test_notifyNewHeadEvent(t *testing.T) {
 		require.DeepSSZEqual(t, wanted, eventHead)
 	})
 
-	t.Run("no-op when head slot is zero", func(t *testing.T) {
+	t.Run("zero head slot", func(t *testing.T) {
 		srv := testServiceWithDB(t)
-		newHeadStateRoot, newHeadRoot := [32]byte{}, [32]byte{}
+		srv.SetGenesisTime(time.Now())
 		notifier := srv.cfg.StateNotifier.(*mock.MockStateNotifier)
-
+		srv.originBlockRoot = [32]byte{1}
+		st, blk, err := prepareForkchoiceState(t.Context(), 0, [32]byte{}, [32]byte{}, [32]byte{}, &ethpb.Checkpoint{}, &ethpb.Checkpoint{})
+		require.NoError(t, err)
+		require.NoError(t, srv.cfg.ForkChoiceStore.InsertNode(t.Context(), st, blk))
+		newHeadStateRoot := [32]byte{2}
+		newHeadRoot := [32]byte{3}
 		require.NoError(t, srv.notifyNewHeadEvent(t.Context(), 0, newHeadStateRoot[:], newHeadRoot[:]))
-
 		events := notifier.ReceivedEvents()
-		require.Equal(t, 0, len(events))
+		require.Equal(t, 1, len(events))
+
+		eventHead, ok := events[0].Data.(*ethpbv1.EventHead)
+		require.Equal(t, true, ok)
+		wanted := &ethpbv1.EventHead{
+			Slot:                      0,
+			Block:                     newHeadRoot[:],
+			State:                     newHeadStateRoot[:],
+			EpochTransition:           true,
+			PreviousDutyDependentRoot: srv.originBlockRoot[:],
+			CurrentDutyDependentRoot:  srv.originBlockRoot[:],
+		}
+		require.DeepSSZEqual(t, wanted, eventHead)
 	})
 
 	t.Run("non_genesis_values", func(t *testing.T) {
@@ -338,16 +354,20 @@ func Test_notifyNewHeadV2Event(t *testing.T) {
 		return headV2
 	}
 
-	t.Run("no-op when head slot is zero", func(t *testing.T) {
-		srv, events, newHeadStateRoot, newHeadRoot := setupHeadV2Service(t, 1)
+	t.Run("zero head slot", func(t *testing.T) {
+		srv, events, newHeadStateRoot, newHeadRoot := setupHeadV2Service(t, 0)
 		require.NoError(t, srv.notifyNewHeadV2Event(t.Context(), 0, newHeadStateRoot, newHeadRoot, version.Gloas))
-
-		// Ensure no events were emitted
-		select {
-		case e := <-events:
-			t.Fatalf("unexpected event: %v", e)
-		default:
+		wantedV2 := &statefeed.HeadV2Data{
+			Slot:                      0,
+			Block:                     newHeadRoot,
+			State:                     newHeadStateRoot,
+			EpochTransition:           true,
+			CurrentEpochDependentRoot: srv.originBlockRoot,
+			NextEpochDependentRoot:    srv.originBlockRoot,
+			PayloadStatus:             statefeed.PayloadStatusFull,
+			Version:                   version.Gloas,
 		}
+		require.DeepEqual(t, wantedV2, requireSingleHeadV2(t, events))
 	})
 
 	t.Run("dependent roots fall back to genesis block root on underflow", func(t *testing.T) {

--- a/changelog/syjn99_no-op-head-event.md
+++ b/changelog/syjn99_no-op-head-event.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- No-op when `notifyNewHeadEvent` is called with zero head slot.

--- a/changelog/syjn99_no-op-head-event.md
+++ b/changelog/syjn99_no-op-head-event.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- No-op when `notifyNewHeadEvent` is called with zero head slot.

--- a/changelog/syjn99_zero-head-slot-event.md
+++ b/changelog/syjn99_zero-head-slot-event.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix error when `notifyNewHead(V2)Event` is called with zero head slot.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Everytime we run a new devnet, we'll probably see this log:

```
[2026-06-30 07:00:07.23] ERROR blockchain: Could not notify event feed of new chain head_v2 error=could not obtain parent slot in forkchoice: invalid nil or unknown node
```

This is because `notifyNewHeadEvent` is also emitted when `headSlot == 0`. This PR handles this edge case by fixing `headEpochTransition`.
**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
