### PR TITLE
Drain pending Gloas data columns for our own proposed block

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -259,6 +259,7 @@ go_test(
         "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/operation:go_default_library",
+        "//beacon-chain/core/feed/state:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/peerdas:go_default_library",
         "//beacon-chain/core/signing:go_default_library",

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -343,6 +343,7 @@ func (s *Service) Start() {
 	async.RunEvery(s.ctx, 30*time.Second, s.pruneDataColumnCache)
 
 	go s.prunePendingGloasColumns()
+	go s.processPendingGloasColumnsRoutine()
 
 	if !params.FuluEnabled() {
 		return

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -15,6 +17,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/logging"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -277,6 +280,42 @@ func (s *Service) hasPendingGloasColumns(root [fieldparams.RootLength]byte) bool
 	defer s.pendingGloasColumnsLock.RUnlock()
 	_, ok := s.pendingGloasColumns[root]
 	return ok
+}
+
+// processPendingGloasColumnsRoutine drains pending Gloas columns once their block
+// is processed. Blocks we propose ourselves are imported via the RPC path and never
+// re-enter the gossip/by-root ingest paths that drain the queue, so the columns peers
+// gossip back to us (queued while the block was not yet seen) would otherwise be lost.
+func (s *Service) processPendingGloasColumnsRoutine() {
+	ch := make(chan *feed.Event, 1)
+	sub := s.cfg.stateNotifier.StateFeed().Subscribe(ch)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type != statefeed.BlockProcessed {
+				continue
+			}
+			data, ok := ev.Data.(*statefeed.BlockProcessedData)
+			if !ok || data == nil || data.SignedBlock == nil || data.SignedBlock.IsNil() {
+				continue
+			}
+			if data.SignedBlock.Version() < version.Gloas {
+				continue
+			}
+			// Initial sync imports via the batch path (which also emits this event) and has
+			// no gossip-queued columns; draining there would needlessly re-broadcast.
+			if s.cfg.initialSync != nil && s.cfg.initialSync.Syncing() {
+				continue
+			}
+			s.processPendingGloasColumns(s.ctx, data.BlockRoot, data.SignedBlock)
+		case <-sub.Err():
+			return
+		case <-s.ctx.Done():
+			return
+		}
+	}
 }
 
 // prunePendingGloasColumns removes stale entries every slot.

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -309,7 +309,7 @@ func (s *Service) processPendingGloasColumnsRoutine() {
 			if s.cfg.initialSync != nil && s.cfg.initialSync.Syncing() {
 				continue
 			}
-			s.processPendingGloasColumns(s.ctx, data.BlockRoot, data.SignedBlock)
+			go s.processPendingGloasColumns(s.ctx, data.BlockRoot, data.SignedBlock)
 		case <-sub.Err():
 			return
 		case <-s.ctx.Done():

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
 	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
@@ -526,6 +528,67 @@ func TestPendingGloasColumns(t *testing.T) {
 		require.Equal(t, false, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
 		// Nothing valid was processed, so nothing is re-broadcast.
 		require.Equal(t, false, p.BroadcastCalled.Load())
+	})
+
+	t.Run("routine drains pending columns on BlockProcessed", func(t *testing.T) {
+		err := kzg.Start()
+		require.NoError(t, err)
+
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		ctx := t.Context()
+
+		p := p2ptest.NewTestP2P(t)
+		dcs := filesystem.NewEphemeralDataColumnStorage(t)
+		notifier := mock.NewSimpleStateNotifier()
+
+		sidecar, signedBlock := gloasFixture(t)
+		blockRoot, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+
+		s := &Service{
+			cfg: &config{
+				p2p:               p,
+				clock:             clock,
+				dataColumnStorage: dcs,
+				stateNotifier:     notifier,
+			},
+			ctx:                 ctx,
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+		}
+
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+		require.NoError(t, err)
+		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+		require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
+
+		go s.processPendingGloasColumnsRoutine()
+
+		// Resend until the subscription is live and the routine drains the queue.
+		ev := &feed.Event{
+			Type: statefeed.BlockProcessed,
+			Data: &statefeed.BlockProcessedData{
+				Slot:        signedBlock.Block().Slot(),
+				BlockRoot:   blockRoot,
+				SignedBlock: signedBlock,
+			},
+		}
+		drained := false
+		for range 200 {
+			notifier.StateFeed().Send(ev)
+			if !s.hasPendingGloasColumns(blockRoot) {
+				drained = true
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		require.Equal(t, true, drained)
+		require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
 	})
 
 	t.Run("no entry is no-op", func(t *testing.T) {

--- a/changelog/potuz_receive-self-columns.md
+++ b/changelog/potuz_receive-self-columns.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Drain pending Gloas data column sidecars on block processing so columns gossiped back for our own proposed block are imported and the payload is marked available.


### PR DESCRIPTION
Our own proposed block is imported via the RPC path (ProposeBeaconBlock -> ReceiveBlock) and never re-enters the gossip/by-root ingest paths that drain pending Gloas columns. Columns peers reconstruct and gossip back to us arrive before our local import, get queued as "block not yet seen", and are never drained -- so the payload's data columns are declared unavailable at slot end.

Subscribe sync to the statefeed BlockProcessed event (which fires on every import path, including our own block) and drain the pending Gloas columns for the processed root. Gated on regular sync to avoid needless work on the initial-sync batch path.
