### PR TITLE
Fall back to finalized dependent root when the fork-choice head is pruned

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -802,7 +802,19 @@ func (s *Store) dependentRoot(epoch primitives.Epoch) ([32]byte, error) {
 	if s.headNode != nil {
 		headRoot = s.headNode.root
 	}
-	return s.dependentRootForEpoch(headRoot, epoch)
+	root, err := s.dependentRootForEpoch(headRoot, epoch)
+	if errors.Is(err, ErrNilNode) {
+		// The head, or an ancestor on the way back to the requested epoch, is no
+		// longer in forkchoice because it was pruned past the finalized checkpoint.
+		// This happens when DependentRoot is queried for an epoch at/before
+		// finalization -- e.g. the ePBS head_v2 payload-update event firing across
+		// a finalization boundary, where the head slot comes from a separately
+		// cached head. The dependent root for a finalized epoch is fixed, so fall
+		// back to the finalized dependent root instead of returning ErrNilNode,
+		// which would otherwise silently drop the caller's head event.
+		return s.finalizedDependentRoot, nil
+	}
+	return root, err
 }
 
 func (s *Store) dependentRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -803,15 +803,11 @@ func (s *Store) dependentRoot(epoch primitives.Epoch) ([32]byte, error) {
 		headRoot = s.headNode.root
 	}
 	root, err := s.dependentRootForEpoch(headRoot, epoch)
-	if errors.Is(err, ErrNilNode) {
-		// The head, or an ancestor on the way back to the requested epoch, is no
-		// longer in forkchoice because it was pruned past the finalized checkpoint.
-		// This happens when DependentRoot is queried for an epoch at/before
-		// finalization -- e.g. the ePBS head_v2 payload-update event firing across
-		// a finalization boundary, where the head slot comes from a separately
-		// cached head. The dependent root for a finalized epoch is fixed, so fall
-		// back to the finalized dependent root instead of returning ErrNilNode,
-		// which would otherwise silently drop the caller's head event.
+	if errors.Is(err, ErrNilNode) && epoch == s.finalizedCheckpoint.Epoch {
+		// The walk hit a node pruned past the finalized checkpoint.
+		// finalizedDependentRoot is the dependent root for the finalized epoch only,
+		// so substitute it for that epoch alone; for any other epoch the missing node
+		// is a real error, not a value we can safely replace.
 		return s.finalizedDependentRoot, nil
 	}
 	return root, err

--- a/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
@@ -602,26 +602,45 @@ func TestStore_TargetRootForEpoch(t *testing.T) {
 	require.Equal(t, blk1.Root(), dependent)
 }
 
-func TestStore_DependentRoot_PrunedHeadFallsBackToFinalized(t *testing.T) {
-	ctx := t.Context()
-	f := setup(1, 1)
-	// Insert one block so the store is initialised with a real node.
-	state, blk, err := prepareForkchoiceState(ctx, params.BeaconConfig().SlotsPerEpoch, [32]byte{'a'}, params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 1, 1)
-	require.NoError(t, err)
-	require.NoError(t, f.InsertNode(ctx, state, blk))
+func TestStore_DependentRoot_PrunedHead(t *testing.T) {
+	// A stale/pruned head makes the dependent-root walk return ErrNilNode. dependentRoot
+	// substitutes finalizedDependentRoot only for the finalized epoch; for any other
+	// epoch the error must surface. Regression for the dropped ePBS head_v2 event.
+	const finalizedEpoch = 3
+	finalizedDependentRoot := [32]byte{'x'}
 
-	s := f.store
-	s.finalizedDependentRoot = [32]byte{'x'}
-	// Reproduce the prune / stale-head race: the head references a node that is no
-	// longer in forkchoice (pruned past the finalized checkpoint). Before the fix,
-	// dependentRoot returned ErrNilNode here, which the ePBS head_v2 payload-update
-	// path surfaced as "Could not notify event feed of head_v2 payload update" and
-	// silently dropped the event. It must instead fall back to the finalized
-	// dependent root.
-	s.headNode = &Node{root: [32]byte{'z'}, slot: 5 * params.BeaconConfig().SlotsPerEpoch}
-	dependent, err := f.DependentRoot(5)
-	require.NoError(t, err)
-	require.Equal(t, [32]byte{'x'}, dependent)
+	staleHeadStore := func(t *testing.T) *ForkChoice {
+		ctx := t.Context()
+		f := setup(finalizedEpoch, finalizedEpoch)
+		state, blk, err := prepareForkchoiceState(ctx, params.BeaconConfig().SlotsPerEpoch, [32]byte{'a'}, params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, finalizedEpoch, finalizedEpoch)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertNode(ctx, state, blk))
+
+		s := f.store
+		s.finalizedDependentRoot = finalizedDependentRoot
+		// Head points at a root not in forkchoice (pruned), so the walk returns ErrNilNode.
+		s.headNode = &Node{root: [32]byte{'z'}, slot: finalizedEpoch * params.BeaconConfig().SlotsPerEpoch}
+		return f
+	}
+
+	t.Run("finalized epoch falls back to finalizedDependentRoot", func(t *testing.T) {
+		f := staleHeadStore(t)
+		dependent, err := f.DependentRoot(finalizedEpoch)
+		require.NoError(t, err)
+		require.Equal(t, finalizedDependentRoot, dependent)
+	})
+
+	t.Run("epoch after finalized surfaces the missing node", func(t *testing.T) {
+		f := staleHeadStore(t)
+		_, err := f.DependentRoot(finalizedEpoch + 2)
+		require.ErrorIs(t, err, ErrNilNode)
+	})
+
+	t.Run("epoch before finalized does not return finalizedDependentRoot", func(t *testing.T) {
+		f := staleHeadStore(t)
+		_, err := f.DependentRoot(finalizedEpoch - 2)
+		require.ErrorIs(t, err, ErrNilNode)
+	})
 }
 
 func TestStore_DependentRootForEpoch(t *testing.T) {

--- a/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
@@ -602,6 +602,28 @@ func TestStore_TargetRootForEpoch(t *testing.T) {
 	require.Equal(t, blk1.Root(), dependent)
 }
 
+func TestStore_DependentRoot_PrunedHeadFallsBackToFinalized(t *testing.T) {
+	ctx := t.Context()
+	f := setup(1, 1)
+	// Insert one block so the store is initialised with a real node.
+	state, blk, err := prepareForkchoiceState(ctx, params.BeaconConfig().SlotsPerEpoch, [32]byte{'a'}, params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, state, blk))
+
+	s := f.store
+	s.finalizedDependentRoot = [32]byte{'x'}
+	// Reproduce the prune / stale-head race: the head references a node that is no
+	// longer in forkchoice (pruned past the finalized checkpoint). Before the fix,
+	// dependentRoot returned ErrNilNode here, which the ePBS head_v2 payload-update
+	// path surfaced as "Could not notify event feed of head_v2 payload update" and
+	// silently dropped the event. It must instead fall back to the finalized
+	// dependent root.
+	s.headNode = &Node{root: [32]byte{'z'}, slot: 5 * params.BeaconConfig().SlotsPerEpoch}
+	dependent, err := f.DependentRoot(5)
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{'x'}, dependent)
+}
+
 func TestStore_DependentRootForEpoch(t *testing.T) {
 	ctx := t.Context()
 	f := setup(1, 1)

--- a/changelog/satushh_fix-dependent-root-finalized-fallback.md
+++ b/changelog/satushh_fix-dependent-root-finalized-fallback.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fall back to `finalizedDependentRoot` when the fork-choice head has been pruned past the finalized checkpoint, so the ePBS `head_v2` payload-update event is no longer dropped with `Could not notify event feed of head_v2 payload update` across a finalization boundary. The fallback is scoped to the finalized epoch, the only epoch whose dependent root equals `finalizedDependentRoot`; for any other epoch the pruned-node error still surfaces instead of returning a wrong root.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

- `DependentRoot` walks back from the fork-choice head, so when the head (or an ancestor) has been pruned past the finalized checkpoint the walk returns `ErrNilNode`, which dropped the ePBS `head_v2` payload-update event across finalization boundaries. 
- Fall back to `finalizedDependentRoot`, scoped to the finalized epoch (the only epoch that value is correct for); newer and older epochs still surface the error. 
- Adds regression tests for the finalized epoch and the epochs above and below it.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
