### PR TITLE
making ssz the default for payload attestations

### DIFF
--- a/api/rest/BUILD.bazel
+++ b/api/rest/BUILD.bazel
@@ -31,6 +31,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//api:go_default_library",
+        "//network/httputil:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
     ],

--- a/api/rest/rest_handler.go
+++ b/api/rest/rest_handler.go
@@ -164,10 +164,12 @@ func (c *handler) GetSSZ(ctx context.Context, endpoint string) ([]byte, http.Hea
 
 	// non-2XX codes are a failure
 	if !strings.HasPrefix(httpResp.Status, "2") {
-		decoder := json.NewDecoder(bytes.NewBuffer(body))
+		if !strings.Contains(contentType, api.JsonMediaType) {
+			return nil, nil, &httputil.DefaultJsonError{Code: httpResp.StatusCode, Message: string(body)}
+		}
 		errorJson := &httputil.DefaultJsonError{}
-		if err = decoder.Decode(errorJson); err != nil {
-			return nil, nil, fmt.Errorf("HTTP request for %s unsuccessful (%d: %s)", httpResp.Request.URL.Redacted(), httpResp.StatusCode, string(body))
+		if err = json.NewDecoder(bytes.NewBuffer(body)).Decode(errorJson); err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL.Redacted())
 		}
 		return nil, nil, errorJson
 	}
@@ -270,10 +272,12 @@ func (c *handler) PostSSZ(
 
 	// non-2XX codes are a failure
 	if !strings.HasPrefix(httpResp.Status, "2") {
-		decoder := json.NewDecoder(bytes.NewBuffer(body))
+		if !strings.Contains(contentType, api.JsonMediaType) {
+			return nil, nil, &httputil.DefaultJsonError{Code: httpResp.StatusCode, Message: string(body)}
+		}
 		errorJson := &httputil.DefaultJsonError{}
-		if err = decoder.Decode(errorJson); err != nil {
-			return nil, nil, fmt.Errorf("HTTP request for %s unsuccessful (%d: %s)", httpResp.Request.URL.Redacted(), httpResp.StatusCode, string(body))
+		if err = json.NewDecoder(bytes.NewBuffer(body)).Decode(errorJson); err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL.Redacted())
 		}
 		return nil, nil, errorJson
 	}

--- a/api/rest/rest_handler_test.go
+++ b/api/rest/rest_handler_test.go
@@ -1,11 +1,16 @@
 package rest
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v7/api"
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
 
@@ -22,4 +27,54 @@ func TestHandler_ErrorsRedactCredentials(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, false, strings.Contains(err.Error(), secret), "error leaked credentials: %s", err.Error())
 	require.Equal(t, true, strings.Contains(err.Error(), "eth:xxxxx"), "error missing redacted host: %s", err.Error())
+}
+
+// A plain-text (non-JSON) error body — e.g. the 415 produced by content-type negotiation —
+// must still surface as a typed DefaultJsonError carrying the status code, so callers can
+// react to it (e.g. fall back to JSON).
+func TestPostSSZ_NonJSONErrorBodyIsTyped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// http.Error writes a text/plain body.
+		http.Error(w, "Unsupported media type: application/octet-stream", http.StatusUnsupportedMediaType)
+	}))
+	defer srv.Close()
+
+	c := NewHandler(http.Client{}, srv.URL)
+	_, _, err := c.PostSSZ(context.Background(), "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01}))
+	require.NotNil(t, err)
+	errJson := &httputil.DefaultJsonError{}
+	require.Equal(t, true, errors.As(err, &errJson), "expected DefaultJsonError, got %T", err)
+	require.Equal(t, http.StatusUnsupportedMediaType, errJson.Code)
+}
+
+func TestGetSSZ_NonJSONErrorBodyIsTyped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Not Acceptable", http.StatusNotAcceptable)
+	}))
+	defer srv.Close()
+
+	c := NewHandler(http.Client{}, srv.URL)
+	_, _, err := c.GetSSZ(context.Background(), "/eth/v1/test")
+	require.NotNil(t, err)
+	errJson := &httputil.DefaultJsonError{}
+	require.Equal(t, true, errors.As(err, &errJson), "expected DefaultJsonError, got %T", err)
+	require.Equal(t, http.StatusNotAcceptable, errJson.Code)
+}
+
+// A JSON error body is decoded into the typed error's fields.
+func TestPostSSZ_JSONErrorBodyIsDecoded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", api.JsonMediaType)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":400,"message":"bad request"}`))
+	}))
+	defer srv.Close()
+
+	c := NewHandler(http.Client{}, srv.URL)
+	_, _, err := c.PostSSZ(context.Background(), "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01}))
+	require.NotNil(t, err)
+	errJson := &httputil.DefaultJsonError{}
+	require.Equal(t, true, errors.As(err, &errJson), "expected DefaultJsonError, got %T", err)
+	require.Equal(t, http.StatusBadRequest, errJson.Code)
+	require.Equal(t, "bad request", errJson.Message)
 }

--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -953,7 +953,7 @@ func (s *Service) beaconEndpoints(
 			template: "/eth/v1/beacon/pool/payload_attestations",
 			name:     namespace + ".ListPayloadAttestations",
 			middleware: []middleware.Middleware{
-				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
+				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
 				middleware.AcceptEncodingHeaderHandler(),
 			},
 			handler: server.ListPayloadAttestations,
@@ -963,7 +963,7 @@ func (s *Service) beaconEndpoints(
 			template: "/eth/v1/beacon/pool/payload_attestations",
 			name:     namespace + ".SubmitPayloadAttestations",
 			middleware: []middleware.Middleware{
-				middleware.ContentTypeHandler([]string{api.JsonMediaType}),
+				middleware.ContentTypeHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
 				middleware.AcceptEncodingHeaderHandler(),
 			},

--- a/changelog/james-prysm_payload-attestations-ssz-route.md
+++ b/changelog/james-prysm_payload-attestations-ssz-route.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Accept SSZ (`application/octet-stream`) request bodies on `POST /eth/v1/beacon/pool/payload_attestations`. The handler already decoded SSZ, but the route only registered JSON so SSZ submissions were rejected with 415.
+- Allow SSZ responses on `GET /eth/v1/beacon/pool/payload_attestations`. The handler already supported SSZ, but the route's Accept negotiation only allowed JSON, making the SSZ response unreachable.
+
+### Changed
+
+- Validator client submits payload attestations as SSZ by default, falling back to JSON if the beacon node returns 415.
+- Validator client requests `payload_attestation_data` as SSZ, decoding either an SSZ or JSON response.

--- a/validator/client/beacon-api/payload_attestation.go
+++ b/validator/client/beacon-api/payload_attestation.go
@@ -5,20 +5,37 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 )
 
+const payloadAttestationsEndpoint = "/eth/v1/beacon/pool/payload_attestations"
+
 func (c *beaconApiValidatorClient) payloadAttestationData(ctx context.Context, slot primitives.Slot) (*ethpb.PayloadAttestationData, error) {
 	endpoint := fmt.Sprintf("/eth/v1/validator/payload_attestation_data/%d", slot)
-	var resp structs.GetPayloadAttestationDataResponse
-	if err := c.handler.Get(ctx, endpoint, &resp); err != nil {
+	// Prefer SSZ; GetSSZ negotiates and the server may answer JSON, which we decode below.
+	data, header, err := c.handler.GetSSZ(ctx, endpoint)
+	if err != nil {
 		return nil, errors.Wrap(err, "could not get execution payload attestation data")
+	}
+	if strings.Contains(header.Get("Content-Type"), api.OctetStreamMediaType) {
+		d := &ethpb.PayloadAttestationData{}
+		if err := d.UnmarshalSSZ(data); err != nil {
+			return nil, errors.Wrap(err, "could not unmarshal ssz payload attestation data")
+		}
+		return d, nil
+	}
+	var resp structs.GetPayloadAttestationDataResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, errors.Wrap(err, "could not decode payload attestation data")
 	}
 	if resp.Data == nil {
 		return nil, errors.New("payload attestation data is nil")
@@ -30,11 +47,26 @@ func (c *beaconApiValidatorClient) submitPayloadAttestation(ctx context.Context,
 	if msg == nil || msg.Data == nil {
 		return errors.New("payload attestation message is nil")
 	}
-	jsonMsg := structs.PayloadAttestationMessageFromConsensus(msg)
-	body, err := json.Marshal([]*structs.PayloadAttestationMessage{jsonMsg})
+	headers := map[string]string{api.VersionHeader: version.String(version.Gloas)}
+
+	// Prefer SSZ; fall back to JSON if the beacon node does not accept octet-stream request bodies.
+	// The SSZ body is the List[PayloadAttestationMessage] encoding, here a single fixed-size element.
+	sszBody, err := msg.MarshalSSZ()
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal payload attestation message ssz")
+	}
+	if _, _, err = c.handler.PostSSZ(ctx, payloadAttestationsEndpoint, headers, bytes.NewBuffer(sszBody)); err == nil {
+		return nil
+	}
+	errJson := &httputil.DefaultJsonError{}
+	if !errors.As(err, &errJson) || errJson.Code != http.StatusUnsupportedMediaType {
+		return err
+	}
+	log.WithError(err).Warn("Beacon node does not accept SSZ payload attestations, falling back to JSON")
+
+	jsonBody, err := json.Marshal([]*structs.PayloadAttestationMessage{structs.PayloadAttestationMessageFromConsensus(msg)})
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal payload attestation message")
 	}
-	headers := map[string]string{api.VersionHeader: version.String(version.Gloas)}
-	return c.handler.Post(ctx, "/eth/v1/beacon/pool/payload_attestations", headers, bytes.NewBuffer(body), nil)
+	return c.handler.Post(ctx, payloadAttestationsEndpoint, headers, bytes.NewBuffer(jsonBody), nil)
 }

--- a/validator/client/beacon-api/payload_attestation_test.go
+++ b/validator/client/beacon-api/payload_attestation_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -23,35 +25,55 @@ import (
 func TestPayloadAttestationData(t *testing.T) {
 	ctx := t.Context()
 	slot := uint64(42)
-	beaconBlockRoot := hexutil.Encode(testhelpers.FillByteSlice(32, 0xab))
+	beaconBlockRoot := testhelpers.FillByteSlice(32, 0xab)
+	endpoint := fmt.Sprintf("/eth/v1/validator/payload_attestation_data/%d", slot)
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	handler := mock.NewMockHandler(ctrl)
+	jsonHeader := http.Header{"Content-Type": []string{api.JsonMediaType}}
+	sszHeader := http.Header{"Content-Type": []string{api.OctetStreamMediaType}}
 
-	resp := structs.GetPayloadAttestationDataResponse{}
-	handler.EXPECT().Get(
-		gomock.Any(),
-		fmt.Sprintf("/eth/v1/validator/payload_attestation_data/%d", slot),
-		&resp,
-	).Return(nil).SetArg(2, structs.GetPayloadAttestationDataResponse{
+	jsonResp, err := json.Marshal(structs.GetPayloadAttestationDataResponse{
 		Version: version.String(version.Gloas),
 		Data: &structs.PayloadAttestationData{
-			BeaconBlockRoot:   beaconBlockRoot,
+			BeaconBlockRoot:   hexutil.Encode(beaconBlockRoot),
 			Slot:              fmt.Sprintf("%d", slot),
 			PayloadPresent:    true,
 			BlobDataAvailable: false,
 		},
-	}).Times(1)
-
-	client := &beaconApiValidatorClient{handler: handler}
-	data, err := client.payloadAttestationData(ctx, primitives.Slot(slot))
+	})
 	require.NoError(t, err)
-	require.NotNil(t, data)
-	assert.Equal(t, primitives.Slot(slot), data.Slot)
-	assert.Equal(t, beaconBlockRoot, hexutil.Encode(data.BeaconBlockRoot))
-	assert.Equal(t, true, data.PayloadPresent)
-	assert.Equal(t, false, data.BlobDataAvailable)
+
+	sszResp, err := (&ethpb.PayloadAttestationData{
+		BeaconBlockRoot:   beaconBlockRoot,
+		Slot:              primitives.Slot(slot),
+		PayloadPresent:    true,
+		BlobDataAvailable: false,
+	}).MarshalSSZ()
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name   string
+		body   []byte
+		header http.Header
+	}{
+		{name: "json response", body: jsonResp, header: jsonHeader},
+		{name: "ssz response", body: sszResp, header: sszHeader},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			handler := mock.NewMockHandler(ctrl)
+			handler.EXPECT().GetSSZ(gomock.Any(), endpoint).Return(tt.body, tt.header, nil).Times(1)
+
+			client := &beaconApiValidatorClient{handler: handler}
+			data, err := client.payloadAttestationData(ctx, primitives.Slot(slot))
+			require.NoError(t, err)
+			require.NotNil(t, data)
+			assert.Equal(t, primitives.Slot(slot), data.Slot)
+			assert.Equal(t, hexutil.Encode(beaconBlockRoot), hexutil.Encode(data.BeaconBlockRoot))
+			assert.Equal(t, true, data.PayloadPresent)
+			assert.Equal(t, false, data.BlobDataAvailable)
+		})
+	}
 }
 
 func TestPayloadAttestationData_NilData(t *testing.T) {
@@ -60,7 +82,8 @@ func TestPayloadAttestationData_NilData(t *testing.T) {
 	defer ctrl.Finish()
 	handler := mock.NewMockHandler(ctrl)
 
-	handler.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	jsonHeader := http.Header{"Content-Type": []string{api.JsonMediaType}}
+	handler.EXPECT().GetSSZ(gomock.Any(), gomock.Any()).Return([]byte("{}"), jsonHeader, nil).Times(1)
 
 	client := &beaconApiValidatorClient{handler: handler}
 	_, err := client.payloadAttestationData(ctx, 1)
@@ -73,7 +96,7 @@ func TestPayloadAttestationData_EndpointError(t *testing.T) {
 	defer ctrl.Finish()
 	handler := mock.NewMockHandler(ctrl)
 
-	handler.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("boom")).Times(1)
+	handler.EXPECT().GetSSZ(gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("boom")).Times(1)
 
 	client := &beaconApiValidatorClient{handler: handler}
 	_, err := client.payloadAttestationData(ctx, 1)
@@ -91,59 +114,63 @@ func TestSubmitPayloadAttestation(t *testing.T) {
 		},
 		Signature: testhelpers.FillByteSlice(96, 0x22),
 	}
-
-	validBody, err := json.Marshal([]*structs.PayloadAttestationMessage{{
-		ValidatorIndex: "7",
-		Data: &structs.PayloadAttestationData{
-			BeaconBlockRoot:   hexutil.Encode(testhelpers.FillByteSlice(32, 0x11)),
-			Slot:              "99",
-			PayloadPresent:    true,
-			BlobDataAvailable: true,
-		},
-		Signature: hexutil.Encode(testhelpers.FillByteSlice(96, 0x22)),
-	}})
+	sszBody, err := msg.MarshalSSZ()
 	require.NoError(t, err)
+	jsonBody, err := json.Marshal([]*structs.PayloadAttestationMessage{structs.PayloadAttestationMessageFromConsensus(msg)})
+	require.NoError(t, err)
+	headers := map[string]string{api.VersionHeader: version.String(version.Gloas)}
 
-	tests := []struct {
-		name          string
-		msg           *ethpb.PayloadAttestationMessage
-		endpointError error
-		endpointCall  int
-		expectErr     string
-	}{
-		{name: "valid", msg: msg, endpointCall: 1},
-		{name: "nil message", msg: nil, expectErr: "payload attestation message is nil"},
-		{name: "nil data", msg: &ethpb.PayloadAttestationMessage{ValidatorIndex: 1}, expectErr: "payload attestation message is nil"},
-		{name: "endpoint error", msg: msg, endpointError: errors.New("bad request"), endpointCall: 1, expectErr: "bad request"},
-	}
+	t.Run("valid sends SSZ", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		handler := mock.NewMockHandler(ctrl)
+		handler.EXPECT().PostSSZ(
+			gomock.Any(),
+			payloadAttestationsEndpoint,
+			headers,
+			bytes.NewBuffer(sszBody),
+		).Return(nil, nil, nil).Times(1)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			handler := mock.NewMockHandler(ctrl)
+		client := &beaconApiValidatorClient{handler: handler}
+		require.NoError(t, client.submitPayloadAttestation(t.Context(), msg))
+	})
 
-			var body []byte
-			if tt.msg != nil && tt.msg.Data != nil {
-				body = validBody
-			}
+	t.Run("falls back to JSON on 415", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		handler := mock.NewMockHandler(ctrl)
+		handler.EXPECT().PostSSZ(gomock.Any(), payloadAttestationsEndpoint, gomock.Any(), gomock.Any()).
+			Return(nil, nil, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"}).Times(1)
+		handler.EXPECT().Post(
+			gomock.Any(),
+			payloadAttestationsEndpoint,
+			headers,
+			bytes.NewBuffer(jsonBody),
+			nil,
+		).Return(nil).Times(1)
 
-			headers := map[string]string{api.VersionHeader: version.String(version.Gloas)}
-			handler.EXPECT().Post(
-				gomock.Any(),
-				"/eth/v1/beacon/pool/payload_attestations",
-				headers,
-				bytes.NewBuffer(body),
-				nil,
-			).Return(tt.endpointError).Times(tt.endpointCall)
+		client := &beaconApiValidatorClient{handler: handler}
+		require.NoError(t, client.submitPayloadAttestation(t.Context(), msg))
+	})
 
-			client := &beaconApiValidatorClient{handler: handler}
-			err := client.submitPayloadAttestation(t.Context(), tt.msg)
-			if tt.expectErr != "" {
-				require.ErrorContains(t, tt.expectErr, err)
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
+	t.Run("non-415 error does not fall back", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		handler := mock.NewMockHandler(ctrl)
+		handler.EXPECT().PostSSZ(gomock.Any(), payloadAttestationsEndpoint, gomock.Any(), gomock.Any()).
+			Return(nil, nil, errors.New("bad request")).Times(1)
+
+		client := &beaconApiValidatorClient{handler: handler}
+		require.ErrorContains(t, "bad request", client.submitPayloadAttestation(t.Context(), msg))
+	})
+
+	t.Run("nil message", func(t *testing.T) {
+		client := &beaconApiValidatorClient{}
+		require.ErrorContains(t, "payload attestation message is nil", client.submitPayloadAttestation(t.Context(), nil))
+	})
+
+	t.Run("nil data", func(t *testing.T) {
+		client := &beaconApiValidatorClient{}
+		require.ErrorContains(t, "payload attestation message is nil", client.submitPayloadAttestation(t.Context(), &ethpb.PayloadAttestationMessage{ValidatorIndex: 1}))
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**
 Feature


**What does this PR do? Why is it needed?**

- Accept SSZ on `POST /eth/v1/beacon/pool/payload_attestations`
- Allow SSZ on `GET /eth/v1/beacon/pool/payload_attestations`. 
- Validator client submits payload attestations as SSZ by default, falling back to JSON if the beacon node returns 415.
- Validator client requests `payload_attestation_data` as SSZ by default

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
