### PR TITLE
Request data column sidecars needed to validate a payload envelope

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -48,6 +48,7 @@ type ForkchoiceFetcher interface {
 	UpdateHead(context.Context, primitives.Slot)
 	HighestReceivedBlockSlot() primitives.Slot
 	HighestReceivedBlockRoot() [32]byte
+	HasNode([32]byte) bool
 	HasFullNode([32]byte) bool
 	PayloadEarly([32]byte) (bool, bool)
 	FullBeatsEmpty([32]byte) bool

--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@ -63,6 +63,13 @@ func (s *Service) GasLimit(root [32]byte) (uint64, error) {
 	return s.cfg.ForkChoiceStore.GasLimit(root)
 }
 
+// HasNode returns the corresponding value from forkchoice
+func (s *Service) HasNode(root [32]byte) bool {
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
+	return s.cfg.ForkChoiceStore.HasNode(root)
+}
+
 // HasFullNode returns the corresponding value from forkchoice
 func (s *Service) HasFullNode(root [32]byte) bool {
 	s.cfg.ForkChoiceStore.RLock()

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -769,6 +769,17 @@ func (s *ChainService) HighestReceivedBlockRoot() [32]byte {
 	return [32]byte{}
 }
 
+// HasNode mocks the same method in the chain service
+func (s *ChainService) HasNode(root [32]byte) bool {
+	if s.ForkChoiceStore != nil {
+		return s.ForkChoiceStore.HasNode(root)
+	}
+	if s.ForkchoiceRoots != nil {
+		return s.ForkchoiceRoots[root]
+	}
+	return false
+}
+
 // HasFullNode mocks the same method in the chain service
 func (s *ChainService) HasFullNode(root [32]byte) bool {
 	if s.ForkChoiceStore != nil {

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -764,9 +764,11 @@ func Test_validateGloasCommitteeIndex(t *testing.T) {
 				mc.ForkchoiceRoots = map[[32]byte]bool{blockRoot32: true}
 			}
 			s := &Service{
+				ctx: t.Context(),
 				cfg: &config{
-					chain: mc,
-					p2p:   p2ptest.NewTestP2P(t),
+					chain:    mc,
+					p2p:      p2ptest.NewTestP2P(t),
+					beaconDB: dbtest.SetupDB(t),
 				},
 				badPayloadCache: lruwrpr.New(10),
 			}

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -88,9 +88,12 @@ func (s *Service) requestPayloadEnvelope(root [32]byte) {
 // requestDataColumnsForEnvelope fetches and stores the data column sidecars needed to
 // validate the envelope for root, if the block carries commitments and we are missing them.
 func (s *Service) requestDataColumnsForEnvelope(root [32]byte) {
+	if !s.cfg.chain.HasNode(root) {
+		return
+	}
 	blk, err := s.cfg.beaconDB.Block(s.ctx, root)
 	if err != nil {
-		log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Debug("Could not fetch block for payload envelope data columns")
+		log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Error("Could not fetch block for payload envelope data columns")
 		return
 	}
 	if err := consensusblocks.BeaconBlockIsNil(blk); err != nil {
@@ -110,7 +113,7 @@ const maxPayloadEnvelopeFetchAttempts = 3
 
 func (s *Service) fetchPayloadEnvelope(root [32]byte) {
 	// Validating the envelope requires the block's data column sidecars; fetch any we are missing.
-	s.requestDataColumnsForEnvelope(root)
+	go s.requestDataColumnsForEnvelope(root)
 
 	bestPeers := s.getBestPeers()
 	if len(bestPeers) == 0 {

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -85,9 +85,33 @@ func (s *Service) requestPayloadEnvelope(root [32]byte) {
 	})
 }
 
+// requestDataColumnsForEnvelope fetches and stores the data column sidecars needed to
+// validate the envelope for root, if the block carries commitments and we are missing them.
+func (s *Service) requestDataColumnsForEnvelope(root [32]byte) {
+	blk, err := s.cfg.beaconDB.Block(s.ctx, root)
+	if err != nil {
+		log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Debug("Could not fetch block for payload envelope data columns")
+		return
+	}
+	if err := consensusblocks.BeaconBlockIsNil(blk); err != nil {
+		return
+	}
+	roBlock, err := consensusblocks.NewROBlockWithRoot(blk, root)
+	if err != nil {
+		log.WithError(err).Debug("Could not wrap block for payload envelope data columns")
+		return
+	}
+	if err := s.requestAndSaveMissingDataColumnSidecars([]consensusblocks.ROBlock{roBlock}); err != nil {
+		log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Debug("Could not fetch data column sidecars for payload envelope")
+	}
+}
+
 const maxPayloadEnvelopeFetchAttempts = 3
 
 func (s *Service) fetchPayloadEnvelope(root [32]byte) {
+	// Validating the envelope requires the block's data column sidecars; fetch any we are missing.
+	s.requestDataColumnsForEnvelope(root)
+
 	bestPeers := s.getBestPeers()
 	if len(bestPeers) == 0 {
 		return

--- a/changelog/potuz_request-columns-for-envelope.md
+++ b/changelog/potuz_request-columns-for-envelope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Request the data column sidecars needed to validate a payload envelope when we do not already have them.


### PR DESCRIPTION
Fetch and store the block's data column sidecars before receiving its payload envelope, so the envelope's data-availability check does not fail or stall on missing columns.
