### PR TITLE
Emit correct parent_block_hash in Gloas payload_attributes SSE event

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -178,7 +178,7 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 			"payloadID": fmt.Sprintf("%#x", bytesutil.Trunc(payloadID[:])),
 		}).Info("Forkchoice updated with payload attributes for proposal")
 		s.cfg.PayloadIDCache.Set(nextSlot, arg.headRoot, true, pId)
-		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), arg.headBlock, arg.headRoot, nextSlot, arg.attributes)
+		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), arg.headBlock, arg.headRoot, nextSlot, arg.attributes, nil)
 	} else if hasAttr && payloadID == nil && !features.Get().PrepareAllPayloads {
 		log.WithFields(logrus.Fields{
 			"blockHash": fmt.Sprintf("%#x", headPayload.BlockHash()),
@@ -189,15 +189,15 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 	return payloadID, nil
 }
 
-func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot, attr payloadattribute.Attributer) {
+func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot, attr payloadattribute.Attributer, parentBlockHash []byte) {
 	// If we're syncing a block in the past and init-sync is still running, we shouldn't fire this event.
 	if !s.cfg.SyncChecker.Synced() {
 		return
 	}
-	// Carry the attribute already sent to the engine so the SSE value matches it exactly; the handler fills the remaining scalar fields lazily.
+	// Carry the attribute and parent block hash already sent to the engine so the SSE value matches it exactly; the handler fills the remaining scalar fields lazily.
 	f.Send(&feed.Event{
 		Type: statefeed.PayloadAttributes,
-		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalSlot: nextSlot, Attributer: attr},
+		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalSlot: nextSlot, Attributer: attr, ParentBlockHash: parentBlockHash},
 	})
 }
 

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -217,7 +217,7 @@ func (s *Service) latePayloadTasks(ctx context.Context) {
 	var pId [8]byte
 	copy(pId[:], pid[:])
 	s.cfg.PayloadIDCache.Set(currentSlot+1, hr, false, pId)
-	s.firePayloadAttributesEventForHead(hr, currentSlot+1, attr)
+	s.firePayloadAttributesEventForHead(hr, currentSlot+1, attr, bh[:])
 }
 
 func (s *Service) fcuFromReorgData(headBlock interfaces.ReadOnlySignedBeaconBlock, hr [32]byte, hash [32]byte, full bool, attr payloadattribute.Attributer, proposingSlot primitives.Slot) {
@@ -236,11 +236,11 @@ func (s *Service) fcuFromReorgData(headBlock interfaces.ReadOnlySignedBeaconBloc
 	s.cfg.PayloadIDCache.Set(proposingSlot, hr, full, pId)
 
 	if !attr.IsEmpty() {
-		s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, hr, proposingSlot, attr)
+		s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, hr, proposingSlot, attr, hash[:])
 	}
 }
 
-func (s *Service) firePayloadAttributesEventForHead(headRoot [32]byte, proposingSlot primitives.Slot, attr payloadattribute.Attributer) {
+func (s *Service) firePayloadAttributesEventForHead(headRoot [32]byte, proposingSlot primitives.Slot, attr payloadattribute.Attributer, parentBlockHash []byte) {
 	s.headLock.RLock()
 	var headBlock interfaces.ReadOnlySignedBeaconBlock
 	if s.head != nil && s.head.root == headRoot {
@@ -250,7 +250,7 @@ func (s *Service) firePayloadAttributesEventForHead(headRoot [32]byte, proposing
 	if headBlock == nil {
 		return
 	}
-	s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, proposingSlot, attr)
+	s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, proposingSlot, attr, parentBlockHash)
 }
 
 // This saves head and prunes atts from the pool only if the head is new and if we are either

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -250,7 +250,7 @@ func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROEx
 			var pId [8]byte
 			copy(pId[:], pid[:])
 			s.cfg.PayloadIDCache.Set(proposingSlot, root, true, pId)
-			s.firePayloadAttributesEventForHead(root, proposingSlot, attr)
+			s.firePayloadAttributesEventForHead(root, proposingSlot, attr, blockHash[:])
 		}
 	}()
 	return nil

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -825,7 +825,8 @@ var zeroRoot [32]byte
 // needsFill allows tests to provide filled EventData values. An ordinary event data value fired by the blockchain package will have
 // all of the checked fields empty, so the logical short circuit should hit immediately.
 func needsFill(ev payloadattribute.EventData) bool {
-	return len(ev.ParentBlockHash) == 0 ||
+	return ev.ProposerIndex == 0 ||
+		len(ev.ParentBlockHash) == 0 ||
 		ev.Attributer == nil || ev.Attributer.IsEmpty()
 }
 
@@ -878,19 +879,23 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 
 	ev.ProposerIndex = proposerIndex
 
-	if ev.HeadBlock.Version() >= version.Gloas {
-		h, err := rost.LatestBlockHash()
-		if err != nil {
-			return ev, errors.Wrap(err, "could not get latest block hash from head state")
+	// Real fire sites carry the exact hash sent to the engine's forkchoiceUpdated; only
+	// compute it here as a fallback when it wasn't provided.
+	if len(ev.ParentBlockHash) == 0 {
+		if ev.HeadBlock.Version() >= version.Gloas {
+			h, err := rost.LatestBlockHash()
+			if err != nil {
+				return ev, errors.Wrap(err, "could not get latest block hash from head state")
+			}
+			ev.ParentBlockHash = h[:]
+		} else {
+			payload, err := ev.HeadBlock.Block().Body().Execution()
+			if err != nil {
+				return ev, errors.Wrap(err, "could not get execution payload for head block")
+			}
+			ev.ParentBlockHash = payload.BlockHash()
+			ev.ParentBlockNumber = payload.BlockNumber()
 		}
-		ev.ParentBlockHash = h[:]
-	} else {
-		payload, err := ev.HeadBlock.Block().Body().Execution()
-		if err != nil {
-			return ev, errors.Wrap(err, "could not get execution payload for head block")
-		}
-		ev.ParentBlockHash = payload.BlockHash()
-		ev.ParentBlockNumber = payload.BlockNumber()
 	}
 
 	if ev.Attributer != nil && !ev.Attributer.IsEmpty() {

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -715,6 +715,7 @@ func TestFillEventData(t *testing.T) {
 		})
 		require.NoError(t, err)
 		alreadyFilled := payloadattribute.EventData{
+			ProposerIndex:   7,
 			HeadBlock:       b,
 			HeadRoot:        [32]byte{1, 2, 3},
 			Attributer:      attributor,
@@ -751,6 +752,18 @@ func TestFillEventData(t *testing.T) {
 		require.NotEmpty(t, filled.ParentBlockHash, "ParentBlockHash should still be filled")
 		require.Equal(t, attributor, filled.Attributer, "provided Attributer should be preserved")
 		require.Equal(t, version.Bellatrix, filled.Attributer.Version(), "preserved Attributer keeps its version; a recompute on Electra state would be Deneb-versioned")
+	})
+	t.Run("Electra PreservesProvidedParentBlockHash", func(t *testing.T) {
+		srv, partial := newPartialFillTestServer(t)
+		// The blockchain package carries the exact hash it sent to the engine; fillEventData
+		// must keep it verbatim rather than recompute it from state.
+		provided := make([]byte, 32)
+		provided[0] = 0x9
+		partial.ParentBlockHash = provided
+
+		filled, err := srv.fillEventData(ctx, partial)
+		require.NoError(t, err)
+		require.DeepEqual(t, provided, filled.ParentBlockHash, "provided ParentBlockHash must be preserved, not recomputed")
 	})
 }
 

--- a/changelog/potuz_payload-attributes-sse-parent-hash.md
+++ b/changelog/potuz_payload-attributes-sse-parent-hash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Emit the correct `parent_block_hash` in the Gloas `payload_attributes` SSE event by carrying the exact hash sent to the engine, so it matches for a full head instead of reporting the parent's hash.


### PR DESCRIPTION
For a full head the SSE reported the parent's payload hash instead of the head block's own, diverging from the headBlockHash sent to the engine. Carry the exact engine hash through EventData at each fire site rather than recomputing it (which is both wrong for a full tip and racy at lazy read time).

