### PR TITLE
Fix attestation ideal rewards for Electra balances

### DIFF
--- a/beacon-chain/rpc/eth/rewards/handlers.go
+++ b/beacon-chain/rpc/eth/rewards/handlers.go
@@ -271,31 +271,34 @@ func idealAttRewards(
 	bal *precompute.Balance,
 	vals []*precompute.Validator,
 ) ([]structs.IdealAttestationReward, bool) {
-	idealValsCount := uint64(16)
-	minIdealBalance := uint64(17)
-	maxIdealBalance := minIdealBalance + idealValsCount - 1
-	idealRewards := make([]structs.IdealAttestationReward, 0, idealValsCount)
-	idealVals := make([]*precompute.Validator, 0, idealValsCount)
 	increment := params.BeaconConfig().EffectiveBalanceIncrement
-	for i := minIdealBalance; i <= maxIdealBalance; i++ {
-		for _, v := range vals {
-			if v.CurrentEpochEffectiveBalance/1e9 == i {
-				effectiveBalance := i * increment
-				idealVals = append(idealVals, &precompute.Validator{
-					IsActivePrevEpoch:            true,
-					IsSlashed:                    false,
-					CurrentEpochEffectiveBalance: effectiveBalance,
-					IsPrevEpochSourceAttester:    true,
-					IsPrevEpochTargetAttester:    true,
-					IsPrevEpochHeadAttester:      true,
-				})
-				idealRewards = append(idealRewards, structs.IdealAttestationReward{
-					EffectiveBalance: strconv.FormatUint(effectiveBalance, 10),
-					Inactivity:       strconv.FormatUint(0, 10),
-				})
-				break
-			}
+	effectiveBalances := make([]uint64, 0, len(vals))
+	seen := make(map[uint64]bool, len(vals))
+	for _, v := range vals {
+		effectiveBalance := v.CurrentEpochEffectiveBalance
+		if effectiveBalance <= params.BeaconConfig().EjectionBalance || effectiveBalance%increment != 0 || seen[effectiveBalance] {
+			continue
 		}
+		seen[effectiveBalance] = true
+		effectiveBalances = append(effectiveBalances, effectiveBalance)
+	}
+	slices.Sort(effectiveBalances)
+
+	idealRewards := make([]structs.IdealAttestationReward, 0, len(effectiveBalances))
+	idealVals := make([]*precompute.Validator, 0, len(effectiveBalances))
+	for _, effectiveBalance := range effectiveBalances {
+		idealVals = append(idealVals, &precompute.Validator{
+			IsActivePrevEpoch:            true,
+			IsSlashed:                    false,
+			CurrentEpochEffectiveBalance: effectiveBalance,
+			IsPrevEpochSourceAttester:    true,
+			IsPrevEpochTargetAttester:    true,
+			IsPrevEpochHeadAttester:      true,
+		})
+		idealRewards = append(idealRewards, structs.IdealAttestationReward{
+			EffectiveBalance: strconv.FormatUint(effectiveBalance, 10),
+			Inactivity:       strconv.FormatUint(0, 10),
+		})
 	}
 	deltas, err := altair.AttestationsDelta(st, bal, idealVals)
 	if err != nil {

--- a/beacon-chain/rpc/eth/rewards/handlers.go
+++ b/beacon-chain/rpc/eth/rewards/handlers.go
@@ -272,14 +272,19 @@ func idealAttRewards(
 	vals []*precompute.Validator,
 ) ([]structs.IdealAttestationReward, bool) {
 	increment := params.BeaconConfig().EffectiveBalanceIncrement
-	effectiveBalances := make([]uint64, 0, len(vals))
-	seen := make(map[uint64]bool, len(vals))
+	maxIdealRewards := int((params.BeaconConfig().MaxEffectiveBalanceElectra - params.BeaconConfig().EjectionBalance) / increment)
+	capacity := min(len(vals), maxIdealRewards)
+	effectiveBalances := make([]uint64, 0, capacity)
+	seen := make(map[uint64]struct{}, capacity)
 	for _, v := range vals {
 		effectiveBalance := v.CurrentEpochEffectiveBalance
-		if effectiveBalance <= params.BeaconConfig().EjectionBalance || effectiveBalance%increment != 0 || seen[effectiveBalance] {
+		if effectiveBalance <= params.BeaconConfig().EjectionBalance || effectiveBalance%increment != 0 {
 			continue
 		}
-		seen[effectiveBalance] = true
+		if _, ok := seen[effectiveBalance]; ok {
+			continue
+		}
+		seen[effectiveBalance] = struct{}{}
 		effectiveBalances = append(effectiveBalances, effectiveBalance)
 	}
 	slices.Sort(effectiveBalances)

--- a/beacon-chain/rpc/eth/rewards/handlers_test.go
+++ b/beacon-chain/rpc/eth/rewards/handlers_test.go
@@ -852,6 +852,80 @@ func TestAttestationRewards(t *testing.T) {
 	})
 }
 
+func TestAttestationRewards_IdealRewardsIncludesCompoundingValidatorEffectiveBalance(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.AltairForkEpoch = 1
+	cfg.ElectraForkEpoch = 1
+	params.OverrideBeaconConfig(cfg)
+	helpers.ClearCache()
+
+	st, err := util.NewBeaconStateElectra()
+	require.NoError(t, err)
+	require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch*3-1))
+
+	blsKey, err := bls.RandKey()
+	require.NoError(t, err)
+	withdrawalCredentials := make([]byte, 32)
+	withdrawalCredentials[0] = params.BeaconConfig().CompoundingWithdrawalPrefixByte
+	validators := []*eth.Validator{
+		{
+			PublicKey:             blsKey.PublicKey().Marshal(),
+			WithdrawalCredentials: withdrawalCredentials,
+			ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
+			WithdrawableEpoch:     params.BeaconConfig().FarFutureEpoch,
+			EffectiveBalance:      params.BeaconConfig().MaxEffectiveBalanceElectra,
+		},
+	}
+	require.NoError(t, st.SetValidators(validators))
+	require.NoError(t, st.SetBalances([]uint64{params.BeaconConfig().MaxEffectiveBalanceElectra}))
+	require.NoError(t, st.SetInactivityScores(make([]uint64, len(validators))))
+	participation := []byte{0b111}
+	require.NoError(t, st.SetCurrentParticipationBits(participation))
+	require.NoError(t, st.SetPreviousParticipationBits(participation))
+
+	blkRoot, err := st.LatestBlockHeader().HashTreeRoot()
+	require.NoError(t, err)
+	currentSlot := params.BeaconConfig().SlotsPerEpoch * 3
+	mockChainService := &mock.ChainService{OptimisticRoots: map[[32]byte]bool{blkRoot: true}, Slot: &currentSlot}
+	s := &Server{
+		Stater: &testutil.MockStater{StatesBySlot: map[primitives.Slot]state.BeaconState{
+			params.BeaconConfig().SlotsPerEpoch*3 - 1: st,
+		}},
+		TimeFetcher:           mockChainService,
+		OptimisticModeFetcher: mockChainService,
+		FinalizationFetcher:   mockChainService,
+	}
+
+	url := "http://only.the.epoch.number.at.the.end.is.important/1"
+	request := httptest.NewRequest("POST", url, nil)
+	request.SetPathValue("epoch", "1")
+	writer := httptest.NewRecorder()
+	writer.Body = &bytes.Buffer{}
+
+	s.AttestationRewards(writer, request)
+	require.Equal(t, http.StatusOK, writer.Code)
+	resp := &structs.AttestationRewardsResponse{}
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+
+	wantedEffectiveBalance := strconv.FormatUint(params.BeaconConfig().MaxEffectiveBalanceElectra, 10)
+	var idealReward *structs.IdealAttestationReward
+	for i := range resp.Data.IdealRewards {
+		if resp.Data.IdealRewards[i].EffectiveBalance == wantedEffectiveBalance {
+			idealReward = &resp.Data.IdealRewards[i]
+			break
+		}
+	}
+	require.NotNil(t, idealReward, "ideal_rewards should include a row for a 2048 ETH compounding validator effective balance")
+	assert.Equal(t, "20035008", idealReward.Head)
+	assert.Equal(t, "20035008", idealReward.Source)
+	assert.Equal(t, "37207872", idealReward.Target)
+	assert.Equal(t, "0", idealReward.Inactivity)
+	assert.NotEqual(t, "0", idealReward.Head)
+	assert.NotEqual(t, "0", idealReward.Source)
+	assert.NotEqual(t, "0", idealReward.Target)
+}
+
 func TestSyncCommitteeRewards(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig()

--- a/changelog/pvl_fix-attestation-ideal-rewards-electra.md
+++ b/changelog/pvl_fix-attestation-ideal-rewards-electra.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed the attestation rewards API `ideal_rewards` response for Electra compounding validators with effective balances above 32 ETH.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes the attestation rewards API `ideal_rewards` response for Electra compounding validators with effective balances above 32 ETH.

Previously, `idealAttRewards` only generated rows for hard-coded 17–32 ETH effective balance buckets. Electra compounding validators can have effective balances up to 2048 ETH, so those validators were omitted from `ideal_rewards`.

This PR updates ideal reward generation to derive distinct effective-balance buckets from the requested validators and sort them before calculating rewards. It also adds a regression test for a 2048 ETH compounding validator with exact expected reward values.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).
