### PR TITLE
Accept builder preferences without the builder endpoint flag

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/builder_preferences.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/builder_preferences.go
@@ -19,7 +19,8 @@ func (vs *Server) SubmitBuilderPreferences(ctx context.Context, req *ethpb.Submi
 	if req == nil || req.Request == nil {
 		return nil, status.Error(codes.InvalidArgument, "builder preferences request is empty")
 	}
-	if vs.BlockBuilder == nil || !vs.BlockBuilder.Configured() {
+	// Not gated on Configured(), gloas builders are dialed per URL from the request auth rather than the endpoint flag.
+	if vs.BlockBuilder == nil {
 		return nil, status.Error(codes.FailedPrecondition, "builder is not configured")
 	}
 	pubkey := bytesutil.ToBytes48(req.ValidatorPubkey)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/builder_preferences_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/builder_preferences_test.go
@@ -34,8 +34,17 @@ func TestServer_SubmitBuilderPreferences(t *testing.T) {
 		require.ErrorContains(t, "request is empty", err)
 	})
 
-	t.Run("builder not configured errors", func(t *testing.T) {
+	t.Run("succeeds without the builder endpoint flag", func(t *testing.T) {
 		vs := &Server{BlockBuilder: &builderTest.MockBuilderService{HasConfigured: false}}
+		_, err := vs.SubmitBuilderPreferences(t.Context(), req)
+		require.NoError(t, err)
+		v, ok := vs.maxExecutionPayments.Load(pubkey)
+		require.Equal(t, true, ok)
+		require.Equal(t, uint64(1000), v.(uint64))
+	})
+
+	t.Run("nil block builder errors", func(t *testing.T) {
+		vs := &Server{}
 		_, err := vs.SubmitBuilderPreferences(t.Context(), req)
 		require.ErrorContains(t, "builder is not configured", err)
 	})

--- a/changelog/terence_submit-builder-preferences-flagless.md
+++ b/changelog/terence_submit-builder-preferences-flagless.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Accept builder preference submissions without the `--http-mev-relay` flag, gloas builders are dialed per URL from the request auth.


### PR DESCRIPTION
`SubmitBuilderPreferences` was gated on the legacy `--http-mev-relay` flag via `Configured()`, while the gloas bid path already dials builders per URL from the request auth. Flag-less deployments rejected every preference push with `FailedPrecondition`, so `maxExecutionPayments` stayed empty and payment-carrying bids were discarded.