### PR TITLE
Submit block to winning builder before the broadcast error check

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -346,15 +346,15 @@ func (vs *Server) ProposeBeaconBlock(ctx context.Context, req *ethpb.GenericSign
 			return nil, status.Errorf(codes.Internal, "Could not broadcast/receive sidecars: %v", err)
 		}
 	}
-	if err := <-errChan; err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not broadcast/receive block: %v", err)
-	}
 
-	// Submit to the winning builder so it reveals the envelope when its bid won.
 	if block.Version() >= version.Gloas {
 		if src, builderURL := vs.bidSourceForSlot(block.Block().Slot()); src == bidSourceBuilderAPI {
 			go vs.submitBlockToBuilder(block, builderURL)
 		}
+	}
+
+	if err := <-errChan; err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not broadcast/receive block: %v", err)
 	}
 
 	return &ethpb.ProposeResponse{BlockRoot: root[:]}, nil

--- a/changelog/terence_builder-submit-before-receive-error.md
+++ b/changelog/terence_builder-submit-before-receive-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Submit the signed block to the winning builder even when local block processing fails after broadcast.


### PR DESCRIPTION
ProposeBeaconBlock returned on a broadcast/receive error before reaching the builder submission, so a block that was already broadcast to gossip but failed local processing never reached the winning builder and the envelope was never revealed. The submission now runs before the error check.