### PR TITLE
Fall back to Builder-API bids when the local payload is unavailable

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -132,6 +132,42 @@ func effectiveBidValue(bid *ethpb.SignedExecutionPayloadBid, maxExecutionPayment
 	return bid.Message.Value + payment
 }
 
+// Returns the proposer's max execution payment alongside the bid so callers compare values with the same clamp.
+func (vs *Server) builderBidForProposal(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, parentHash [32]byte, auths []*ethpb.SignedRequestAuthV1) (*ethpb.SignedExecutionPayloadBid, string, uint64) {
+	if vs.BlockBuilder == nil || len(auths) == 0 {
+		return nil, "", 0
+	}
+	val, err := head.ValidatorAtIndexReadOnly(sBlk.Block().ProposerIndex())
+	if err != nil {
+		log.WithError(err).Error("Could not get proposer for builder bid request")
+		return nil, "", 0
+	}
+	parentGasLimit, err := vs.ForkchoiceFetcher.GasLimit(sBlk.Block().ParentRoot())
+	if err != nil {
+		log.WithError(err).Error("Could not get parent gas limit for builder bid request")
+		return nil, "", 0
+	}
+	pubkey := val.PublicKey()
+	var maxExecutionPayment uint64
+	if v, ok := vs.maxExecutionPayments.Load(pubkey); ok {
+		maxExecutionPayment, _ = v.(uint64)
+	}
+	pref := vs.proposerPreferenceForProposal(ctx, head, sBlk.Block().Slot(), sBlk.Block().ProposerIndex())
+	feeRecipient := pref.FeeRecipientOrDefault()
+	bid, url := vs.getBuilderExecutionPayloadBid(ctx, head, &builderBidQuery{
+		slot:           sBlk.Block().Slot(),
+		parentRoot:     sBlk.Block().ParentRoot(),
+		parentHash:     parentHash,
+		pubkey:         pubkey,
+		maxPayment:     maxExecutionPayment,
+		feeRecipient:   feeRecipient[:],
+		parentGasLimit: parentGasLimit,
+		targetGasLimit: pref.GasLimitOr(parentGasLimit),
+		auths:          auths,
+	})
+	return bid, url, maxExecutionPayment
+}
+
 // builderBidQuery carries the proposal context builder bids are requested and validated against.
 type builderBidQuery struct {
 	slot           primitives.Slot
@@ -291,25 +327,45 @@ func (vs *Server) submitBlockToBuilder(block interfaces.ReadOnlySignedBeaconBloc
 	}
 }
 
-// setP2PBidFallback uses a cached P2P bid when the local EL self-build is unavailable.
-func (vs *Server) setP2PBidFallback(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, parentFull bool) error {
-	if vs.HighestBidCache == nil {
-		return errors.New("highest bid cache is nil")
-	}
+// setRemoteBidFallback uses the best cached P2P or Builder-API bid when the local EL self-build is unavailable.
+func (vs *Server) setRemoteBidFallback(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, parentFull, skipBuilder bool, auths []*ethpb.SignedRequestAuthV1) (bidSource, string, error) {
 	slot := sBlk.Block().Slot()
 	parentRoot := sBlk.Block().ParentRoot()
 	parentHash, err := vs.getParentBlockHash(ctx, head, slot, parentRoot, parentFull)
 	if err != nil {
-		return errors.Wrap(err, "could not get parent block hash")
+		return bidSourceSelfBuild, "", errors.Wrap(err, "could not get parent block hash")
 	}
-	cached, ok := vs.HighestBidCache.Get(slot, bytesutil.ToBytes32(parentHash), parentRoot)
-	if !ok {
-		return errors.New("no cached P2P bid available")
+	ph := bytesutil.ToBytes32(parentHash)
+
+	var chosen *ethpb.SignedExecutionPayloadBid
+	var chosenURL string
+	src := bidSourceP2P
+	if vs.HighestBidCache != nil {
+		if cached, ok := vs.HighestBidCache.Get(slot, ph, parentRoot); ok {
+			chosen = cached
+		}
 	}
-	if err := sBlk.SetSignedExecutionPayloadBid(cached); err != nil {
-		return errors.Wrap(err, "could not set cached P2P execution payload bid")
+	var builderBid *ethpb.SignedExecutionPayloadBid
+	var builderURL string
+	var maxPayment uint64
+	// skip_mev_boost suppresses Builder-API solicitation but not P2P bids, which arrive regardless.
+	if !skipBuilder {
+		builderBid, builderURL, maxPayment = vs.builderBidForProposal(ctx, sBlk, head, ph, auths)
 	}
-	return nil
+	if builderBid != nil && (chosen == nil || effectiveBidValue(builderBid, maxPayment) > effectiveBidValue(chosen, maxPayment)) {
+		chosen, chosenURL, src = builderBid, builderURL, bidSourceBuilderAPI
+	}
+	if chosen == nil {
+		return bidSourceSelfBuild, "", errors.New("no cached P2P or builder bid available")
+	}
+	if err := sBlk.SetSignedExecutionPayloadBid(chosen); err != nil {
+		return bidSourceSelfBuild, "", errors.Wrap(err, "could not set remote execution payload bid")
+	}
+	log.WithFields(logrus.Fields{
+		"slot":  slot,
+		"value": uint64(effectiveBidValue(chosen, maxPayment)),
+	}).Infof("Chose %s execution payload bid without local payload", src)
+	return src, chosenURL, nil
 }
 
 func (vs *Server) cachedP2PBid(sBlk interfaces.SignedBeaconBlock, local *consensusblocks.GetPayloadResponse) *ethpb.SignedExecutionPayloadBid {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
@@ -37,42 +37,19 @@ func (vs *Server) buildBlockGloas(ctx context.Context, sBlk interfaces.SignedBea
 	var selfBuilt bool
 	local, err := vs.getLocalPayload(ctx, sBlk.Block(), head, parentFull)
 	if err != nil {
-		log.WithError(err).Warn("Could not get local payload, falling back to P2P bid")
-		if fbErr := vs.setP2PBidFallback(ctx, sBlk, head, parentFull); fbErr != nil {
-			return nil, status.Errorf(codes.Internal, "Could not get local payload and no P2P bid fallback: %v", fbErr)
+		log.WithError(err).Warn("Could not get local payload, falling back to remote bids")
+		src, builderURL, fbErr := vs.setRemoteBidFallback(ctx, sBlk, head, parentFull, skipBuilder, builderRequestAuths)
+		if fbErr != nil {
+			return nil, status.Errorf(codes.Internal, "Could not get local payload and no remote bid fallback: %v", fbErr)
 		}
+		vs.recordBidSource(sBlk.Block().Slot(), src, builderURL)
 	} else {
 		selfBuildOnly := local.OverrideBuilder || skipBuilder
 		var builderBid *ethpb.SignedExecutionPayloadBid
 		var builderURL string
 		var maxExecutionPayment uint64
-		if !selfBuildOnly && len(builderRequestAuths) > 0 {
-			val, valErr := head.ValidatorAtIndexReadOnly(sBlk.Block().ProposerIndex())
-			parentGasLimit, glErr := vs.ForkchoiceFetcher.GasLimit(sBlk.Block().ParentRoot())
-			switch {
-			case valErr != nil:
-				log.WithError(valErr).Error("Could not get proposer for builder bid request")
-			case glErr != nil:
-				log.WithError(glErr).Error("Could not get parent gas limit for builder bid request")
-			default:
-				pubkey := val.PublicKey()
-				if v, ok := vs.maxExecutionPayments.Load(pubkey); ok {
-					maxExecutionPayment, _ = v.(uint64)
-				}
-				pref := vs.proposerPreferenceForProposal(ctx, head, sBlk.Block().Slot(), sBlk.Block().ProposerIndex())
-				feeRecipient := pref.FeeRecipientOrDefault()
-				builderBid, builderURL = vs.getBuilderExecutionPayloadBid(ctx, head, &builderBidQuery{
-					slot:           sBlk.Block().Slot(),
-					parentRoot:     sBlk.Block().ParentRoot(),
-					parentHash:     bytesutil.ToBytes32(local.ExecutionData.ParentHash()),
-					pubkey:         pubkey,
-					maxPayment:     maxExecutionPayment,
-					feeRecipient:   feeRecipient[:],
-					parentGasLimit: parentGasLimit,
-					targetGasLimit: pref.GasLimitOr(parentGasLimit),
-					auths:          builderRequestAuths,
-				})
-			}
+		if !selfBuildOnly {
+			builderBid, builderURL, maxExecutionPayment = vs.builderBidForProposal(ctx, sBlk, head, bytesutil.ToBytes32(local.ExecutionData.ParentHash()), builderRequestAuths)
 		}
 		src, bidErr := vs.setExecutionPayloadBid(ctx, sBlk, local, builderBid, maxExecutionPayment, selfBuildOnly)
 		if bidErr != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
@@ -5,9 +5,13 @@ import (
 	"testing"
 
 	chainMock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	beaconbuilder "github.com/OffchainLabs/prysm/v7/beacon-chain/builder"
+	builderTest "github.com/OffchainLabs/prysm/v7/beacon-chain/builder/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -64,7 +68,10 @@ func TestSetP2PBidFallback_UsesCachedBid(t *testing.T) {
 
 	vs := &Server{HighestBidCache: bidCache, ForkchoiceFetcher: &chainMock.ChainService{}}
 
-	require.NoError(t, vs.setP2PBidFallback(context.Background(), sBlk, st, false))
+	src, url, err := vs.setRemoteBidFallback(context.Background(), sBlk, st, false, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, bidSourceP2P, src)
+	require.Equal(t, "", url)
 
 	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
 	require.NoError(t, err)
@@ -98,6 +105,86 @@ func TestSetP2PBidFallback_NoCachedBidErrors(t *testing.T) {
 
 	vs := &Server{HighestBidCache: cache.NewHighestExecutionPayloadBidCache(), ForkchoiceFetcher: &chainMock.ChainService{}}
 
-	err = vs.setP2PBidFallback(context.Background(), sBlk, st, false)
-	require.ErrorContains(t, "no cached P2P bid", err)
+	_, _, err = vs.setRemoteBidFallback(context.Background(), sBlk, st, false, false, nil)
+	require.ErrorContains(t, "no cached P2P or builder bid", err)
+}
+
+func TestSetRemoteBidFallback_BuilderBidWins(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	parentBlockHash := bytesutil.ToBytes32([]byte("parent-block-hash"))
+	parentRoot := bytesutil.ToBytes32([]byte("parent-root"))
+	slot := primitives.Slot(100)
+
+	st, err := util.NewBeaconStateGloas(func(state *ethpb.BeaconStateGloas) error {
+		state.LatestExecutionPayloadBid.ParentBlockHash = parentBlockHash[:]
+		state.Validators = []*ethpb.Validator{{PublicKey: make([]byte, 48), WithdrawalCredentials: make([]byte, 32)}}
+		return nil
+	})
+	require.NoError(t, err)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	newFallbackBid := func(builderIndex primitives.BuilderIndex, value primitives.Gwei) *ethpb.SignedExecutionPayloadBid {
+		return util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
+			Message: &ethpb.ExecutionPayloadBid{
+				Slot:            slot,
+				ParentBlockHash: parentBlockHash[:],
+				ParentBlockRoot: parentRoot[:],
+				BuilderIndex:    builderIndex,
+				Value:           value,
+				GasLimit:        30_000_000,
+			},
+		})
+	}
+
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	bidCache.SetIfHigher(newFallbackBid(7, 1000))
+
+	vs := &Server{
+		HighestBidCache:          bidCache,
+		ForkchoiceFetcher:        &chainMock.ChainService{ForkchoiceGasLimits: map[[32]byte]uint64{parentRoot: 30_000_000}},
+		ProposerPreferencesCache: cache.NewProposerPreferencesCache(),
+		BlockBuilder:             &builderTest.MockBuilderService{PayloadBids: []beaconbuilder.PayloadBid{{BuilderURL: "http://builder", Bid: newFallbackBid(9, 1500)}}},
+		NewExecutionPayloadBidVerifier: func(interfaces.ROSignedExecutionPayloadBid, []verification.Requirement) verification.ExecutionPayloadBidVerifier {
+			return &fakeBidVerifier{}
+		},
+	}
+
+	src, url, err := vs.setRemoteBidFallback(context.Background(), sBlk, st, false, false, []*ethpb.SignedRequestAuthV1{{}})
+	require.NoError(t, err)
+	require.Equal(t, bidSourceBuilderAPI, src)
+	require.Equal(t, "http://builder", url)
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.Equal(t, primitives.BuilderIndex(9), signedBid.Message.BuilderIndex)
+	require.Equal(t, primitives.Gwei(1500), signedBid.Message.Value)
+
+	// skip_mev_boost suppresses the Builder-API query, so the P2P bid wins instead.
+	skipBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+	src, url, err = vs.setRemoteBidFallback(context.Background(), skipBlk, st, false, true, []*ethpb.SignedRequestAuthV1{{}})
+	require.NoError(t, err)
+	require.Equal(t, bidSourceP2P, src)
+	require.Equal(t, "", url)
+	signedBid, err = skipBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.Equal(t, primitives.BuilderIndex(7), signedBid.Message.BuilderIndex)
 }

--- a/changelog/terence_builder-api-local-payload-fallback.md
+++ b/changelog/terence_builder-api-local-payload-fallback.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fall back to Builder-API bids in addition to cached P2P bids when the local payload is unavailable during Gloas block production.


### PR DESCRIPTION
When `getLocalPayload` fails, Gloas block production only consulted the cached P2P bid even with valid builder request auths in hand, because the builder query took its parent hash from the local payload. The fallback now queries authed builders using `getParentBlockHash`, picks the best of the cached P2P and Builder-API bids, and records the bid source so a winning builder still receives the signed block