### PR TITLE
Clean up Gloas proposer flow logging

### DIFF
--- a/beacon-chain/blockchain/log_helpers.go
+++ b/beacon-chain/blockchain/log_helpers.go
@@ -91,7 +91,7 @@ func logStateTransitionData(b interfaces.ReadOnlyBeaconBlock) error {
 				"blobKzgCommitmentCount": len(bid.BlobKzgCommitments),
 				"payloadHash":            fmt.Sprintf("%#x", bytesutil.Trunc(bid.BlockHash)),
 				"parentHash":             fmt.Sprintf("%#x", bytesutil.Trunc(bid.ParentBlockHash)),
-				"builderIndex":           bid.BuilderIndex,
+				"builderIndex":           logs.BuilderIndexLabel(bid.BuilderIndex),
 			})
 		}
 	}
@@ -140,7 +140,7 @@ func logBlockSyncStatus(block interfaces.ReadOnlyBeaconBlock, blockRoot [32]byte
 		} else if signedBid != nil && signedBid.Message != nil {
 			moreFields["blockHash"] = fmt.Sprintf("%#x", bytesutil.Trunc(signedBid.Message.BlockHash))
 			moreFields["parentHash"] = fmt.Sprintf("%#x", bytesutil.Trunc(signedBid.Message.ParentBlockHash))
-			moreFields["builderIndex"] = signedBid.Message.BuilderIndex
+			moreFields["builderIndex"] = logs.BuilderIndexLabel(signedBid.Message.BuilderIndex)
 		}
 	}
 

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -187,7 +187,7 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 		"blockRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(root[:])),
 		"blockHash":  fmt.Sprintf("%#x", bytesutil.Trunc(execution.BlockHash())),
 		"parentHash": fmt.Sprintf("%#x", bytesutil.Trunc(execution.ParentHash())),
-	}).Info("Processed execution payload envelope")
+	}).Info("Synced execution payload envelope")
 	return nil
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -122,7 +122,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		return nil, errors.Wrap(err, "could not build block in parallel")
 	}
 
-	l.Info("Built block")
+	l.Info("Finished building block")
 	return resp, nil
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -62,7 +62,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	}
 
 	log := log.WithField("slot", req.Slot)
-	log.WithField("sinceSlotStartTime", time.Since(t)).Info("Begin building block")
+	log.WithField("sinceSlotStartTime", time.Since(t)).Info("Building block")
 
 	// A syncing validator should not produce a block.
 	if vs.SyncChecker.Syncing() {
@@ -118,11 +118,11 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	})
 
 	if err != nil {
-		l.WithError(err).Error("Finished building block")
+		l.WithError(err).Error("Could not build block")
 		return nil, errors.Wrap(err, "could not build block in parallel")
 	}
 
-	l.Info("Finished building block")
+	l.Info("Built block")
 	return resp, nil
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -68,9 +68,11 @@ func (vs *Server) setExecutionPayloadBid(
 				return bidSourceSelfBuild, errors.Wrap(err, "could not set remote execution payload bid")
 			}
 			log.WithFields(logrus.Fields{
-				"slot":  sBlk.Block().Slot(),
-				"value": uint64(effectiveBidValue(bestBid, maxExecutionPayment)),
-			}).Infof("Chose %s execution payload bid", src)
+				"slot":      sBlk.Block().Slot(),
+				"source":    src,
+				"builder":   bestBid.Message.BuilderIndex,
+				"valueGwei": uint64(effectiveBidValue(bestBid, maxExecutionPayment)),
+			}).Info("Chose payload bid")
 			return src, nil
 		}
 	}
@@ -91,9 +93,10 @@ func (vs *Server) setExecutionPayloadBid(
 	}
 
 	log.WithFields(logrus.Fields{
-		"slot":  sBlk.Block().Slot(),
-		"value": uint64(primitives.WeiToGwei(local.Bid)),
-	}).Infof("Chose %s execution payload bid", bidSourceSelfBuild)
+		"slot":      sBlk.Block().Slot(),
+		"source":    bidSourceSelfBuild,
+		"valueGwei": uint64(primitives.WeiToGwei(local.Bid)),
+	}).Info("Chose payload bid")
 	return bidSourceSelfBuild, nil
 }
 
@@ -181,11 +184,7 @@ func (vs *Server) getBuilderExecutionPayloadBid(ctx context.Context, head state.
 	}
 
 	if len(bidLog) > 0 {
-		log.WithFields(logrus.Fields{
-			"slot":            q.slot,
-			"bestBuilder":     logs.MaskCredentialsLogging(bestURL),
-			"bestBuilderGwei": uint64(bestValue),
-		}).Infof("Received builder bids: [%s]", strings.Join(bidLog, " | "))
+		log.WithField("slot", q.slot).Debugf("Builder bids: [%s]", strings.Join(bidLog, " | "))
 	}
 
 	if best == nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_attestation.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_attestation.go
@@ -47,11 +47,5 @@ func (vs *Server) getPayloadAttestations(ctx context.Context, head state.BeaconS
 		atts = append(atts, att)
 	}
 
-	log.WithFields(map[string]any{
-		"slot":          head.Slot(),
-		"parentSlot":    parentSlot,
-		"parentRoot":    blockParentRoot,
-		"selectedCount": len(atts),
-	}).Debug("Selected payload attestations for block proposal")
 	return atts
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
@@ -14,6 +15,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	"github.com/OffchainLabs/prysm/v7/io/logs"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -126,6 +128,7 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 ) (*emptypb.Empty, error) {
 	ctx, span := trace.StartSpan(ctx, "ProposerServer.PublishExecutionPayloadEnvelope")
 	defer span.End()
+	start := time.Now()
 
 	signed, blobs, kzgProofs, err := vs.resolveEnvelopeToPublish(req)
 	if err != nil {
@@ -147,10 +150,10 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 
 	log := log.WithFields(logrus.Fields{
 		"slot":            envSlot,
-		"builderIndex":    signed.Message.BuilderIndex,
+		"builderIndex":    logs.BuilderIndexLabel(signed.Message.BuilderIndex),
 		"beaconBlockRoot": fmt.Sprintf("%#x", beaconBlockRoot[:8]),
 	})
-	log.Info("Publishing signed execution payload envelope")
+	log.Debug("Publishing execution payload envelope")
 
 	// Broadcast sidecars BEFORE receiving the envelope so the DA check sees them. Stateless publishes
 	// carry blobs+proofs (this node may not have them cached); stateful publishes rely on the cache.
@@ -182,7 +185,7 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 		return nil, status.Errorf(codes.Aborted, "failed to receive execution payload envelope: %v", err)
 	}
 
-	log.Info("Successfully published execution payload envelope")
+	log.WithField("duration", time.Since(start)).Info("Published execution payload envelope")
 
 	return &emptypb.Empty{}, nil
 }

--- a/changelog/terence_gloas-proposer-logs.md
+++ b/changelog/terence_gloas-proposer-logs.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Cleaned up Gloas proposer flow logs: consistent verbs, `self-build` builder index rendering, single bid selection line with source and gwei value, and publish duration on envelope reveal.

--- a/io/logs/BUILD.bazel
+++ b/io/logs/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//async/event:go_default_library",
         "//cache/lru:go_default_library",
         "//config/params:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "//crypto/rand:go_default_library",
         "//io/file:go_default_library",
         "//runtime/logging/logrus-prefixed-formatter:go_default_library",

--- a/io/logs/logutil.go
+++ b/io/logs/logutil.go
@@ -7,9 +7,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	prefixed "github.com/OffchainLabs/prysm/v7/runtime/logging/logrus-prefixed-formatter"
 	"github.com/pkg/errors"
@@ -162,4 +164,11 @@ func MaskCredentialsLogging(currUrl string) string {
 		MaskedUrl = strings.Replace(MaskedUrl, u.RawFragment, "***", 1)
 	}
 	return MaskedUrl
+}
+
+func BuilderIndexLabel(idx primitives.BuilderIndex) string {
+	if idx == params.BeaconConfig().BuilderIndexSelfBuild {
+		return "self-build"
+	}
+	return strconv.FormatUint(uint64(idx), 10)
 }

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//crypto/hash:go_default_library",
         "//crypto/rand:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//io/logs:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
         "//network/httputil:go_default_library",

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -17,6 +17,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/crypto/rand"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	"github.com/OffchainLabs/prysm/v7/io/logs"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	validatorpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1/validator-client"
@@ -243,7 +244,7 @@ func logProposedBlock(log *logrus.Entry, blk interfaces.SignedBeaconBlock, blkRo
 		if bid != nil && bid.Message != nil {
 			msg := bid.Message
 			log = log.WithFields(logrus.Fields{
-				"builderIndex": msg.BuilderIndex,
+				"builderIndex": logs.BuilderIndexLabel(msg.BuilderIndex),
 				"bidValue":     msg.Value,
 				"blockHash":    fmt.Sprintf("%#x", bytesutil.Trunc(msg.BlockHash)),
 				"parentHash":   fmt.Sprintf("%#x", bytesutil.Trunc(msg.ParentBlockHash)),


### PR DESCRIPTION
This PR improves overall proposer logging experience for gloas.

- verb consistent messages across the proposer flow (`Building block` / `Built block` / `Published execution payload envelope`, envelope import logs `Synced execution payload envelope` to pair with `Synced new block`)
- `builderIndex` renders as `self-build` instead of the `18446744073709551615` (new `logs.BuilderIndexLabel`)
- One bid selection line (`Chose payload bid`) with `source`, `builder`, and gwei-denominated value, the per-bid breakdown with discard reasons moved to DEBUG
- Envelope publish entry demoted to DEBUG; success line carries end-to-end `duration`
- Removed the `Selected payload attestations` debug log (printed the parent root as a raw byte array)

**Before (self-build slot):**
```
 INFO rpc/validator: Begin building block sinceSlotStartTime=130ms slot=75
 INFO rpc/validator: Chose self-build execution payload bid slot=75 value=42000
 INFO rpc/validator: Finished building block sinceSlotStartTime=137ms slot=75 validator=257
 INFO blockchain: Synced new block block=0x128bf3b3... builderIndex=18446744073709551615 ... slot=75
 INFO blockchain: Finished applying state transition builderIndex=18446744073709551615 ... slot=75
 INFO rpc/validator: Publishing signed execution payload envelope beaconBlockRoot=0x128bf3b374f4a7e0 builderIndex=18446744073709551615 slot=75
 INFO blockchain: Processed execution payload envelope blockHash=0x7848ecdc416c blockRoot=0x128bf3b374f4 parentHash=0x55c40ed49fd3 slot=75
 INFO rpc/validator: Successfully published execution payload envelope beaconBlockRoot=0x128bf3b374f4a7e0 builderIndex=18446744073709551615 slot=75
```

**After (self-build slot):**
```
 INFO rpc/validator: Building block sinceSlotStartTime=130ms slot=75
 INFO rpc/validator: Chose payload bid slot=75 source=self-build valueGwei=42000
 INFO rpc/validator: Built block sinceSlotStartTime=137ms slot=75 validator=257
 INFO blockchain: Synced new block block=0x128bf3b3... builderIndex=self-build ... slot=75
 INFO blockchain: Finished applying state transition builderIndex=self-build ... slot=75
 INFO blockchain: Synced execution payload envelope blockHash=0x7848ecdc416c blockRoot=0x128bf3b374f4 parentHash=0x55c40ed49fd3 slot=75
 INFO rpc/validator: Published execution payload envelope beaconBlockRoot=0x128bf3b374f4a7e0 builderIndex=self-build duration=52ms slot=75
```

**Before (builder-api slot, bid selection):**
```
 INFO rpc/validator: Received builder bids: [http://buildoor-1:8080(builder=0 value=268000 payment=0 effective=268000) | http://buildoor-2:8080(builder=1 value=268000 payment=0 effective=268000)] bestBuilder=http://buildoor-1:8080 bestBuilderGwei=268000 slot=156
 INFO rpc/validator: Chose builder-api execution payload bid slot=156 value=268000
```

**After (builder-api slot, bid selection):**
```
 INFO rpc/validator: Chose payload bid builder=0 slot=156 source=builder-api valueGwei=268000
DEBUG rpc/validator: Builder bids: [http://buildoor-1:8080(builder=0 value=268000 payment=0 effective=268000) | http://buildoor-2:8080(builder=1 value=268000 payment=0 effective=268000)]
```