### PR TITLE
Run `isAggregator` check concurrently in `validator.subscribeToSubnets` method body

### DIFF
--- a/changelog/syjn99_feat-concurrent-is-aggregator-call.md
+++ b/changelog/syjn99_feat-concurrent-is-aggregator-call.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Run `isAggregator` check concurrently in `validator.subscribeToSubnets` method body.

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -99,6 +99,7 @@ go_library(
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
         "@org_golang_x_sync//singleflight:go_default_library",
     ],
 )

--- a/validator/client/subnets.go
+++ b/validator/client/subnets.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// The length of total subscribeDuties can be large,
+// so need to limit the number of workers to avoid too many goroutines being created.
 const subnetSubscriptionAggregatorWorkers = 16
 
 // subscribeToSubnets iterates through each validator duty, signs each slot, and asks beacon node

--- a/validator/client/subnets.go
+++ b/validator/client/subnets.go
@@ -51,7 +51,6 @@ func (v *validator) subscribeToSubnets(ctx context.Context, duties *ethpb.Valida
 	g.SetLimit(subnetSubscriptionAggregatorWorkers)
 	req.IsAggregator = make([]bool, len(subscribeDuties))
 	for i, duty := range subscribeDuties {
-		i, duty := i, duty
 		g.Go(func() error {
 			agg, err := v.isAggregator(gctx, duty.CommitteeLength, duty.AttesterSlot, bytesutil.ToBytes48(duty.PublicKey))
 			if err != nil {

--- a/validator/client/subnets.go
+++ b/validator/client/subnets.go
@@ -2,12 +2,12 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -29,7 +29,7 @@ func (v *validator) subscribeToSubnets(ctx context.Context, duties *ethpb.Valida
 	}
 
 	if err := v.aggSelector.RefreshSelectionProofs(ctx); err != nil {
-		return errors.Wrap(err, "could not prepare aggregated selection proofs")
+		return fmt.Errorf("could not prepare aggregated selection proofs: %w", err)
 	}
 
 	for _, set := range [][]*ethpb.ValidatorDuty{duties.CurrentEpochDuties, duties.NextEpochDuties} {
@@ -54,19 +54,20 @@ func (v *validator) subscribeToSubnets(ctx context.Context, duties *ethpb.Valida
 		g.Go(func() error {
 			agg, err := v.isAggregator(gctx, duty.CommitteeLength, duty.AttesterSlot, bytesutil.ToBytes48(duty.PublicKey))
 			if err != nil {
-				return err
+				return fmt.Errorf("could not check if validator is an aggregator: %w", err)
 			}
 			req.IsAggregator[i] = agg
 			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {
-		return errors.Wrap(err, "could not check if a validator is an aggregator")
+		return fmt.Errorf("could not check if a validator is an aggregator: %w", err)
 	}
 
-	_, err := v.validatorClient.SubscribeCommitteeSubnets(ctx, req)
-
-	return err
+	if _, err := v.validatorClient.SubscribeCommitteeSubnets(ctx, req); err != nil {
+		return fmt.Errorf("could not subscribe to committee subnets: %w", err)
+	}
+	return nil
 }
 
 func validatorSubnetSubscriptionKey(slot primitives.Slot, committeeIndex primitives.CommitteeIndex) [64]byte {

--- a/validator/client/subnets.go
+++ b/validator/client/subnets.go
@@ -8,7 +8,10 @@ import (
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
+
+const subnetSubscriptionAggregatorWorkers = 16
 
 // subscribeToSubnets iterates through each validator duty, signs each slot, and asks beacon node
 // to eagerly subscribe to subnets so that the aggregator has attestations to aggregate.
@@ -17,11 +20,13 @@ func (v *validator) subscribeToSubnets(ctx context.Context, duties *ethpb.Valida
 	defer span.End()
 
 	total := len(duties.CurrentEpochDuties) + len(duties.NextEpochDuties)
-	subscribeSlots := make([]primitives.Slot, 0, total)
-	subscribeCommitteeIndices := make([]primitives.CommitteeIndex, 0, total)
-	subscribeIsAggregator := make([]bool, 0, total)
-	subscribeValidatorIndices := make([]primitives.ValidatorIndex, 0, total)
-	subscribeCommitteesAtSlot := make([]uint64, 0, total)
+	subscribeDuties := make([]*ethpb.ValidatorDuty, 0, total)
+	req := &ethpb.CommitteeSubnetsSubscribeRequest{
+		Slots:            make([]primitives.Slot, 0, total),
+		CommitteeIds:     make([]primitives.CommitteeIndex, 0, total),
+		ValidatorIndices: make([]primitives.ValidatorIndex, 0, total),
+		CommitteesAtSlot: make([]uint64, 0, total),
+	}
 
 	if err := v.aggSelector.RefreshSelectionProofs(ctx); err != nil {
 		return errors.Wrap(err, "could not prepare aggregated selection proofs")
@@ -32,28 +37,35 @@ func (v *validator) subscribeToSubnets(ctx context.Context, duties *ethpb.Valida
 			if duty.Status != ethpb.ValidatorStatus_ACTIVE && duty.Status != ethpb.ValidatorStatus_EXITING {
 				continue
 			}
-			// TODO: parallelize — serial sign here is O(N) signer round-trips at scale.
-			isAgg, err := v.isAggregator(ctx, duty.CommitteeLength, duty.AttesterSlot, bytesutil.ToBytes48(duty.PublicKey))
-			if err != nil {
-				return errors.Wrap(err, "could not check if a validator is an aggregator")
-			}
-			subscribeSlots = append(subscribeSlots, duty.AttesterSlot)
-			subscribeCommitteeIndices = append(subscribeCommitteeIndices, duty.CommitteeIndex)
-			subscribeIsAggregator = append(subscribeIsAggregator, isAgg)
-			subscribeValidatorIndices = append(subscribeValidatorIndices, duty.ValidatorIndex)
-			subscribeCommitteesAtSlot = append(subscribeCommitteesAtSlot, duty.CommitteesAtSlot)
+			subscribeDuties = append(subscribeDuties, duty)
+			req.Slots = append(req.Slots, duty.AttesterSlot)
+			req.CommitteeIds = append(req.CommitteeIds, duty.CommitteeIndex)
+			req.ValidatorIndices = append(req.ValidatorIndices, duty.ValidatorIndex)
+			req.CommitteesAtSlot = append(req.CommitteesAtSlot, duty.CommitteesAtSlot)
 		}
 	}
 
-	_, err := v.validatorClient.SubscribeCommitteeSubnets(ctx,
-		&ethpb.CommitteeSubnetsSubscribeRequest{
-			Slots:            subscribeSlots,
-			CommitteeIds:     subscribeCommitteeIndices,
-			IsAggregator:     subscribeIsAggregator,
-			ValidatorIndices: subscribeValidatorIndices,
-			CommitteesAtSlot: subscribeCommitteesAtSlot,
-		},
-	)
+	// Run concurrently to check if each validator is an aggregator.
+	// Maximum goroutine: subnetSubscriptionAggregatorWorkers (16)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(subnetSubscriptionAggregatorWorkers)
+	req.IsAggregator = make([]bool, len(subscribeDuties))
+	for i, duty := range subscribeDuties {
+		i, duty := i, duty
+		g.Go(func() error {
+			agg, err := v.isAggregator(gctx, duty.CommitteeLength, duty.AttesterSlot, bytesutil.ToBytes48(duty.PublicKey))
+			if err != nil {
+				return err
+			}
+			req.IsAggregator[i] = agg
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.Wrap(err, "could not check if a validator is an aggregator")
+	}
+
+	_, err := v.validatorClient.SubscribeCommitteeSubnets(ctx, req)
 
 	return err
 }

--- a/validator/client/subnets_test.go
+++ b/validator/client/subnets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"testing"
+	"testing/synctest"
 
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -113,6 +114,104 @@ func TestSubscribeToSubnets_AggregatorEvaluatedPerValidator(t *testing.T) {
 	assert.Equal(t, false, captured.IsAggregator[0], "pkB still not aggregator when evaluated first")
 	assert.Equal(t, true, captured.IsAggregator[1], "pkA still aggregator when evaluated second")
 	require.DeepEqual(t, []primitives.ValidatorIndex{2, 1}, captured.ValidatorIndices)
+}
+
+type blockingAggregatorSelector struct {
+	stubAggregatorSelector
+	blockPubKey [fieldparams.BLSPubkeyLength]byte
+	blocked     bool
+	otherDone   bool
+	release     chan struct{}
+}
+
+func (s *blockingAggregatorSelector) AttestationSelectionProof(ctx context.Context, slot primitives.Slot, pk [fieldparams.BLSPubkeyLength]byte) ([]byte, error) {
+	if pk == s.blockPubKey {
+		s.blocked = true
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	} else {
+		s.otherDone = true
+	}
+	return s.stubAggregatorSelector.AttestationSelectionProof(ctx, slot, pk)
+}
+
+// TestSubscribeToSubnets_AggregatorChecksRunConcurrentlyAndKeepOrder ensures that aggregator checks run concurrently
+// and the order of duties is preserved in the request.
+//
+// Scenario:
+// 1. Two validators with different pubkeys are subscribed to the same slot and committee.
+// 2. The first validator's aggregator check is blocked until the test releases it. (close(selector.release))
+// 3. The second validator's aggregator check runs concurrently and sets a flag to indicate it has completed. (s.otherDone = true)
+// 4. The test verifies that the order of duties is preserved in the request, even though the aggregator checks ran concurrently.
+func TestSubscribeToSubnets_AggregatorChecksRunConcurrentlyAndKeepOrder(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		committeeLength := uint64(64)
+		modulo := committeeLength / params.BeaconConfig().TargetAggregatorsPerCommittee
+		sigAgg, sigNotAgg := pickDistinguishingProofs(t, modulo)
+
+		pkA := [fieldparams.BLSPubkeyLength]byte{0xaa}
+		pkB := [fieldparams.BLSPubkeyLength]byte{0xbb}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := validatormock.NewMockValidatorClient(ctrl)
+		v := &validator{
+			validatorClient: client,
+			aggSelector: &blockingAggregatorSelector{
+				stubAggregatorSelector: stubAggregatorSelector{
+					proofs: map[[fieldparams.BLSPubkeyLength]byte][]byte{
+						pkA: sigAgg,
+						pkB: sigNotAgg,
+					},
+				},
+				blockPubKey: pkA,
+				release:     make(chan struct{}),
+			},
+		}
+
+		duties := &ethpb.ValidatorDutiesContainer{
+			CurrentEpochDuties: []*ethpb.ValidatorDuty{
+				{AttesterSlot: 10, CommitteeIndex: 3, CommitteeLength: committeeLength, PublicKey: pkA[:], Status: ethpb.ValidatorStatus_ACTIVE, ValidatorIndex: 1},
+				{AttesterSlot: 11, CommitteeIndex: 4, CommitteeLength: committeeLength, PublicKey: pkB[:], Status: ethpb.ValidatorStatus_ACTIVE, ValidatorIndex: 2},
+			},
+		}
+
+		var captured *ethpb.CommitteeSubnetsSubscribeRequest
+		client.EXPECT().SubscribeCommitteeSubnets(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *ethpb.CommitteeSubnetsSubscribeRequest) (*emptypb.Empty, error) {
+				captured = req
+				return &emptypb.Empty{}, nil
+			})
+
+		var err error
+		done := false
+		go func() {
+			err = v.subscribeToSubnets(t.Context(), duties)
+			done = true
+		}()
+		synctest.Wait()
+
+		selector := v.aggSelector.(*blockingAggregatorSelector)
+		require.Equal(t, true, selector.blocked, "first aggregator check did not start")
+		require.Equal(t, true, selector.otherDone, "second aggregator check did not run while first was blocked")
+		require.Equal(t, false, done, "subscribeToSubnets finished before the blocked signer was released")
+
+		close(selector.release)
+		synctest.Wait()
+
+		require.Equal(t, true, done, "subscribeToSubnets did not finish")
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+
+		// Order of the duties are preserved in the request, even though the aggregator checks ran concurrently.
+		require.DeepEqual(t, []primitives.ValidatorIndex{1, 2}, captured.ValidatorIndices)
+		require.DeepEqual(t, []primitives.Slot{10, 11}, captured.Slots)
+		assert.Equal(t, true, captured.IsAggregator[0])
+		assert.Equal(t, false, captured.IsAggregator[1])
+	})
 }
 
 // pickDistinguishingProofs returns two stub selection proofs that map to opposite isAggregator outcomes.


### PR DESCRIPTION
**What type of PR is this?**

> Other: Optimization

**What does this PR do? Why is it needed?**

https://github.com/OffchainLabs/prysm/blob/fbfc449591c422b39c8f0adcc4b3cd9bb0c9a01a/validator/client/subnets.go#L35-L39

Resolve this TODO. FYI `isAggregator` check requires hash computation.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
