### PR TITLE
Recover from nil headblock in db at startup

### DIFF
--- a/beacon-chain/blockchain/setup_forkchoice.go
+++ b/beacon-chain/blockchain/setup_forkchoice.go
@@ -69,7 +69,12 @@ func (s *Service) setupForkchoiceTree(st state.BeaconState) error {
 		log.WithError(err).Error("Could not get head block, starting with finalized block as head")
 		return nil
 	}
-	if slots.ToEpoch(blk.Block().Slot()) < cp.Epoch {
+	b := blk.Block()
+	if b == nil {
+		log.WithField("headRoot", fmt.Sprintf("%#x", headRoot)).Error("Head block is nil, starting with finalized block as head")
+		return nil
+	}
+	if slots.ToEpoch(b.Slot()) < cp.Epoch {
 		log.WithField("headRoot", fmt.Sprintf("%#x", headRoot)).Error("Head block is older than finalized block, starting with finalized block as head")
 		return nil
 	}

--- a/changelog/potuz_nil_headblock.md
+++ b/changelog/potuz_nil_headblock.md
@@ -1,0 +1,2 @@
+### Fixed
+- Recover from nil headblock in db at startup.


### PR DESCRIPTION
When setting up forkchoice, the devnet instance segfaulted with the db returning a nil headblock without any error from the call to DB. This PR recovers this by attempting to sync from finalized checkpoint, it avoids the segfault but I believe such a node will anyway be in a broken status.

