### PR TITLE
Add unit tests for FOCIL inclusion list helpers

### DIFF
--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "attestation_test.go",
         "beacon_committee_test.go",
         "block_test.go",
+        "inclusion_list_test.go",
         "legacy_test.go",
         "private_access_fuzz_noop_test.go",  # keep
         "private_access_test.go",
@@ -71,6 +72,7 @@ go_test(
     tags = ["CI_race_detection"],
     deps = [
         "//beacon-chain/cache:go_default_library",
+        "//beacon-chain/core/signing:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",

--- a/beacon-chain/core/helpers/inclusion_list_test.go
+++ b/beacon-chain/core/helpers/inclusion_list_test.go
@@ -1,0 +1,164 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
+	"github.com/OffchainLabs/prysm/v6/config/params"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
+	eth "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v6/testing/require"
+	"github.com/OffchainLabs/prysm/v6/testing/util"
+	"github.com/OffchainLabs/prysm/v6/time/slots"
+)
+
+func TestValidateNilInclusionList(t *testing.T) {
+	tests := []struct {
+		name        string
+		il          *eth.InclusionList
+		errContains string
+	}{
+		{
+			name:        "nil inclusion list",
+			il:          nil,
+			errContains: "nil inclusion list",
+		},
+		{
+			name:        "nil committee root",
+			il:          &eth.InclusionList{},
+			errContains: "nil inclusion list committee root",
+		},
+		{
+			name: "valid",
+			il:   &eth.InclusionList{InclusionListCommitteeRoot: make([]byte, 32)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := helpers.ValidateNilInclusionList(tt.il)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, tt.errContains, err)
+		})
+	}
+}
+
+func TestValidateNilSignedInclusionList(t *testing.T) {
+	tests := []struct {
+		name        string
+		il          *eth.SignedInclusionList
+		errContains string
+	}{
+		{
+			name:        "nil signed inclusion list",
+			il:          nil,
+			errContains: "nil inclusion list",
+		},
+		{
+			name:        "nil signature",
+			il:          &eth.SignedInclusionList{Message: &eth.InclusionList{InclusionListCommitteeRoot: make([]byte, 32)}},
+			errContains: "nil signature",
+		},
+		{
+			name:        "nil message",
+			il:          &eth.SignedInclusionList{Signature: make([]byte, 96)},
+			errContains: "nil inclusion list",
+		},
+		{
+			name:        "nil committee root",
+			il:          &eth.SignedInclusionList{Signature: make([]byte, 96), Message: &eth.InclusionList{}},
+			errContains: "nil inclusion list committee root",
+		},
+		{
+			name: "valid",
+			il: &eth.SignedInclusionList{
+				Signature: make([]byte, 96),
+				Message:   &eth.InclusionList{InclusionListCommitteeRoot: make([]byte, 32)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := helpers.ValidateNilSignedInclusionList(tt.il)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, tt.errContains, err)
+		})
+	}
+}
+
+func TestGetInclusionListCommittee_OK(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.Eip7805ForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	st, _ := util.DeterministicGenesisStateElectra(t, 256)
+
+	committee, err := helpers.GetInclusionListCommittee(t.Context(), st, 0)
+	require.NoError(t, err)
+	require.Equal(t, int(params.BeaconConfig().InclusionListCommitteeSize), len(committee))
+
+	numValidators := st.NumValidators()
+	for _, idx := range committee {
+		require.Equal(t, true, uint64(idx) < uint64(numValidators))
+	}
+
+	committee2, err := helpers.GetInclusionListCommittee(t.Context(), st, 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, committee, committee2)
+}
+
+func TestGetInclusionListCommittee_BeforeFork(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.Eip7805ForkEpoch = 5
+	params.OverrideBeaconConfig(cfg)
+
+	st, _ := util.DeterministicGenesisStateElectra(t, 256)
+
+	_, err := helpers.GetInclusionListCommittee(t.Context(), st, 0)
+	require.ErrorContains(t, "incorrect state version", err)
+}
+
+func TestValidateInclusionListSignature(t *testing.T) {
+	st, privKeys := util.DeterministicGenesisStateElectra(t, 64)
+
+	valIdx := primitives.ValidatorIndex(3)
+	msg := &eth.InclusionList{
+		Slot:                       0,
+		ValidatorIndex:             valIdx,
+		InclusionListCommitteeRoot: make([]byte, 32),
+		Transactions:               [][]byte{[]byte("tx1")},
+	}
+
+	epoch := slots.ToEpoch(st.Slot())
+	domain, err := signing.Domain(st.Fork(), epoch, params.BeaconConfig().DomainInclusionListCommittee, st.GenesisValidatorsRoot())
+	require.NoError(t, err)
+	root, err := signing.ComputeSigningRoot(msg, domain)
+	require.NoError(t, err)
+
+	t.Run("valid signature", func(t *testing.T) {
+		sig := privKeys[valIdx].Sign(root[:])
+		signed := &eth.SignedInclusionList{Message: msg, Signature: sig.Marshal()}
+		require.NoError(t, helpers.ValidateInclusionListSignature(t.Context(), st, signed))
+	})
+
+	t.Run("wrong signer fails verification", func(t *testing.T) {
+		// Signed by a different validator than msg.ValidatorIndex, so verification must fail.
+		sig := privKeys[valIdx+1].Sign(root[:])
+		signed := &eth.SignedInclusionList{Message: msg, Signature: sig.Marshal()}
+		err := helpers.ValidateInclusionListSignature(t.Context(), st, signed)
+		require.NotNil(t, err)
+	})
+
+	t.Run("nil signed inclusion list", func(t *testing.T) {
+		err := helpers.ValidateInclusionListSignature(t.Context(), st, nil)
+		require.ErrorContains(t, "nil inclusion list", err)
+	})
+}

--- a/changelog/rahulbarmann_test-focil-inclusion-list-helpers.md
+++ b/changelog/rahulbarmann_test-focil-inclusion-list-helpers.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Add unit tests for FOCIL inclusion list helpers.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines

You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.

2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have an associated issue with a design discussed and decided upon. Small bug fixes and documentation improvements don't need issues.

3. New features and bug fixes must have tests. Documentation may need to be updated. If you're unsure what to update, send the PR, and we'll discuss in review.

4. Note that PRs updating dependencies and new Go versions are not accepted.
Please file an issue instead.

5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Other (test coverage)

**What does this PR do? Why is it needed?**

Adds unit tests for `beacon-chain/core/helpers/inclusion_list.go`, which was previously untested. The file has the FOCIL (EIP-7805) helpers used by the gossip and validator paths, so coverage here guards the inclusion-list committee selection, signature verification, and the nil-input validation against regressions.

Covers all four exported helpers:

- `ValidateNilInclusionList` / `ValidateNilSignedInclusionList`: branch coverage of the nil and missing-field paths (nil list, nil signature, nil message, nil committee root, valid).
- `GetInclusionListCommittee`: committee length equals `INCLUSION_LIST_COMMITTEE_SIZE`, every returned index is a valid validator, the result is deterministic for the same state and slot, and querying before the EIP-7805 fork epoch returns an error.
- `ValidateInclusionListSignature`: a correctly signed inclusion list verifies, a signature from a different validator fails verification, and nil input errors.

**Which issue(s) does this PR fix?**

N/A. Test-only change, no associated tracking issue.

**Other notes for review**

These tests assert the current behavior of the helpers, they intentionally do not assert spec-conformance of the committee selection algorithm.

While writing them I noticed one possible drift worth flagging: this branch's `GetInclusionListCommittee` selects the committee by slicing an unshuffled list of all active validators, whereas the current Heze `get_inclusion_list_committee` concatenates the slot's beacon committees and cycles (`indices[i % len(indices)]`). Since this branch predates recent spec revisions, this may already be known or intentional. Happy to open a separate issue with the details rather than expand the scope of this PR.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).
