### PR TITLE
Mark full node gas limit

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -439,28 +439,34 @@ func (s *Service) insertFirstPayloadIfNeeded(ctx context.Context, b interfaces.R
 	}
 	parentRoot := b.ParentRoot()
 	if s.builtOnFullParentInForkchoice(b) && !s.cfg.ForkChoiceStore.HasFullNode(parentRoot) {
-		s.cfg.ForkChoiceStore.MarkFullNode(parentRoot, s.parentPayloadGasLimit(ctx, parentRoot))
+		gasLimit, err := s.parentPayloadGasLimit(ctx, parentRoot)
+		if err != nil {
+			log.WithError(err).Debug("Could not read parent payload gas limit, marking full node without it")
+		}
+		s.cfg.ForkChoiceStore.MarkFullNode(parentRoot, gasLimit)
 	}
 }
 
-func (s *Service) parentPayloadGasLimit(ctx context.Context, parentRoot [32]byte) uint64 {
+func (s *Service) parentPayloadGasLimit(ctx context.Context, parentRoot [32]byte) (uint64, error) {
 	parent, err := s.getBlock(ctx, parentRoot)
 	if err != nil {
-		log.WithError(err).Debug("Could not get parent block to set full node gas limit")
-		return 0
+		return 0, err
 	}
 	if parent.Block().Version() >= version.Gloas {
 		bid, err := parent.Block().Body().SignedExecutionPayloadBid()
-		if err != nil || bid == nil || bid.Message == nil {
-			return 0
+		if err != nil {
+			return 0, err
 		}
-		return bid.Message.GasLimit
+		if bid == nil || bid.Message == nil {
+			return 0, errors.New("nil execution payload bid")
+		}
+		return bid.Message.GasLimit, nil
 	}
 	payload, err := parent.Block().Body().Execution()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return payload.GasLimit()
+	return payload.GasLimit(), nil
 }
 
 // inserts finalized deposits into our finalized deposit trie, needs to be

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -420,10 +420,10 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, signed inte
 	// Handle the first payload insertion.
 	if len(pendingNodes) == 0 {
 		// even without pending blocks, the first payload may be pending.
-		s.insertFirstPayloadIfNeeded(signed.Block())
+		s.insertFirstPayloadIfNeeded(ctx, signed.Block())
 		return nil
 	} else {
-		s.insertFirstPayloadIfNeeded(pendingNodes[len(pendingNodes)-1].Block.Block())
+		s.insertFirstPayloadIfNeeded(ctx, pendingNodes[len(pendingNodes)-1].Block.Block())
 	}
 	if root != s.ensureRootNotZeros(finalized.Root) && !s.cfg.ForkChoiceStore.HasNode(root) {
 		return ErrNotDescendantOfFinalized
@@ -433,14 +433,34 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, signed inte
 	return s.cfg.ForkChoiceStore.InsertChain(ctx, pendingNodes)
 }
 
-func (s *Service) insertFirstPayloadIfNeeded(b interfaces.ReadOnlyBeaconBlock) {
+func (s *Service) insertFirstPayloadIfNeeded(ctx context.Context, b interfaces.ReadOnlyBeaconBlock) {
 	if b.Version() < version.Gloas {
 		return
 	}
 	parentRoot := b.ParentRoot()
 	if s.builtOnFullParentInForkchoice(b) && !s.cfg.ForkChoiceStore.HasFullNode(parentRoot) {
-		s.cfg.ForkChoiceStore.MarkFullNode(parentRoot)
+		s.cfg.ForkChoiceStore.MarkFullNode(parentRoot, s.parentPayloadGasLimit(ctx, parentRoot))
 	}
+}
+
+func (s *Service) parentPayloadGasLimit(ctx context.Context, parentRoot [32]byte) uint64 {
+	parent, err := s.getBlock(ctx, parentRoot)
+	if err != nil {
+		log.WithError(err).Debug("Could not get parent block to set full node gas limit")
+		return 0
+	}
+	if parent.Block().Version() >= version.Gloas {
+		bid, err := parent.Block().Body().SignedExecutionPayloadBid()
+		if err != nil || bid == nil || bid.Message == nil {
+			return 0
+		}
+		return bid.Message.GasLimit
+	}
+	payload, err := parent.Block().Body().Execution()
+	if err != nil {
+		return 0
+	}
+	return payload.GasLimit()
 }
 
 // inserts finalized deposits into our finalized deposit trie, needs to be

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -450,12 +450,12 @@ func (s *Service) insertFirstPayloadIfNeeded(ctx context.Context, b interfaces.R
 func (s *Service) parentPayloadGasLimit(ctx context.Context, parentRoot [32]byte) (uint64, error) {
 	parent, err := s.getBlock(ctx, parentRoot)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, "could not get parent block")
 	}
 	if parent.Block().Version() >= version.Gloas {
 		bid, err := parent.Block().Body().SignedExecutionPayloadBid()
 		if err != nil {
-			return 0, err
+			return 0, errors.Wrap(err, "could not get signed execution payload bid")
 		}
 		if bid == nil || bid.Message == nil {
 			return 0, errors.New("nil execution payload bid")
@@ -464,7 +464,7 @@ func (s *Service) parentPayloadGasLimit(ctx context.Context, parentRoot [32]byte
 	}
 	payload, err := parent.Block().Body().Execution()
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, "could not get execution payload")
 	}
 	return payload.GasLimit(), nil
 }

--- a/beacon-chain/blockchain/setup_forkchoice.go
+++ b/beacon-chain/blockchain/setup_forkchoice.go
@@ -201,7 +201,7 @@ func (s *Service) markFinalizedRootFull(chain []*forkchoicetypes.BlockAndCheckpo
 		return nil
 	}
 	// The finalized block's payload was delivered. Create the full node.
-	s.cfg.ForkChoiceStore.MarkFullNode(fRoot)
+	s.cfg.ForkChoiceStore.MarkFullNode(fRoot, fBid.Message.GasLimit)
 	return nil
 }
 

--- a/beacon-chain/blockchain/setup_forkchoice.go
+++ b/beacon-chain/blockchain/setup_forkchoice.go
@@ -200,6 +200,10 @@ func (s *Service) markFinalizedRootFull(chain []*forkchoicetypes.BlockAndCheckpo
 	if err != nil || !builtOn {
 		return nil
 	}
+	fBid, err := fBlock.Block().Body().SignedExecutionPayloadBid()
+	if err != nil || fBid == nil || fBid.Message == nil {
+		return nil
+	}
 	// The finalized block's payload was delivered. Create the full node.
 	s.cfg.ForkChoiceStore.MarkFullNode(fRoot, fBid.Message.GasLimit)
 	return nil

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -581,16 +581,19 @@ func (f *ForkChoice) InsertChain(ctx context.Context, chain []*forkchoicetypes.B
 			root := bcp.Block.Root()
 			en := f.store.emptyNodeByRoot[root]
 			if en != nil && f.store.fullNodeByRoot[root] == nil {
-				var gasLimit uint64
-				if sbid, err := bcp.Block.Block().Body().SignedExecutionPayloadBid(); err == nil && sbid != nil && sbid.Message != nil {
-					gasLimit = sbid.Message.GasLimit
+				sbid, err := bcp.Block.Block().Body().SignedExecutionPayloadBid()
+				if err != nil {
+					return errors.Wrap(err, "could not get signed execution payload bid")
+				}
+				if sbid == nil || sbid.Message == nil {
+					return errors.New("nil execution payload bid for full node")
 				}
 				f.store.fullNodeByRoot[root] = &PayloadNode{
 					node:       en.node,
 					optimistic: true,
 					timestamp:  time.Now(),
 					full:       true,
-					gasLimit:   gasLimit,
+					gasLimit:   sbid.Message.GasLimit,
 					children:   make([]*Node, 0),
 				}
 			}

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -581,11 +581,16 @@ func (f *ForkChoice) InsertChain(ctx context.Context, chain []*forkchoicetypes.B
 			root := bcp.Block.Root()
 			en := f.store.emptyNodeByRoot[root]
 			if en != nil && f.store.fullNodeByRoot[root] == nil {
+				var gasLimit uint64
+				if sbid, err := bcp.Block.Block().Body().SignedExecutionPayloadBid(); err == nil && sbid != nil && sbid.Message != nil {
+					gasLimit = sbid.Message.GasLimit
+				}
 				f.store.fullNodeByRoot[root] = &PayloadNode{
 					node:       en.node,
 					optimistic: true,
 					timestamp:  time.Now(),
 					full:       true,
+					gasLimit:   gasLimit,
 					children:   make([]*Node, 0),
 				}
 			}

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -453,11 +453,9 @@ func (s *Store) nodeTreeDumpV2(ctx context.Context, n *Node, nodes []*forkchoice
 	return nodes, nil
 }
 
-// MarkFullNode creates a full payload node for an existing empty node at the
-// given beacon block root. This is used during forkchoice tree reconstruction on
-// startup to mark blocks whose execution payload was delivered. The caller must
-// hold the forkchoice write lock.
-func (f *ForkChoice) MarkFullNode(root [32]byte) {
+// MarkFullNode creates a full payload node for an existing empty node during
+// tree reconstruction, the caller must hold the forkchoice write lock.
+func (f *ForkChoice) MarkFullNode(root [32]byte, gasLimit uint64) {
 	s := f.store
 	en := s.emptyNodeByRoot[root]
 	if en == nil {
@@ -471,6 +469,7 @@ func (f *ForkChoice) MarkFullNode(root [32]byte) {
 		optimistic: true,
 		timestamp:  time.Now(),
 		full:       true,
+		gasLimit:   gasLimit,
 		children:   make([]*Node, 0),
 	}
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -203,6 +203,27 @@ func TestInsertPayload_DuplicateIsNoop(t *testing.T) {
 	require.Equal(t, 2, len(f.store.fullNodeByRoot))
 }
 
+func TestMarkFullNode_SetsGasLimit(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+
+	root := indexToHash(1)
+	blockHash := indexToHash(100)
+	st, roblock, err := prepareGloasForkchoiceState(ctx, 1, root, params.BeaconConfig().ZeroHash, blockHash, params.BeaconConfig().ZeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	f.MarkFullNode(root, 30_000_000)
+
+	fn := f.store.fullNodeByRoot[root]
+	require.NotNil(t, fn)
+	assert.Equal(t, uint64(30_000_000), fn.gasLimit)
+
+	gl, err := f.GasLimit(root)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(30_000_000), gl)
+}
+
 func TestInsertPayload_WithoutEmptyNode_Errors(t *testing.T) {
 	f := setupGloas(t, 0, 0)
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/go-bitfield"
+	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -222,6 +223,47 @@ func TestMarkFullNode_SetsGasLimit(t *testing.T) {
 	gl, err := f.GasLimit(root)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(30_000_000), gl)
+}
+
+func TestInsertChain_SetsFullNodeGasLimit(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+
+	root := indexToHash(1)
+	blockHash := indexToHash(100)
+	bid := util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			BlockHash:       blockHash[:],
+			ParentBlockHash: params.BeaconConfig().ZeroHash[:],
+			GasLimit:        36_000_000,
+		},
+	})
+	blk := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       1,
+			ParentRoot: params.BeaconConfig().ZeroHash[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{SignedExecutionPayloadBid: bid},
+		},
+	})
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	roblock, err := blocks.NewROBlockWithRoot(signed, root)
+	require.NoError(t, err)
+
+	require.NoError(t, f.InsertChain(ctx, []*forkchoicetypes.BlockAndCheckpoints{{
+		Block:               roblock,
+		JustifiedCheckpoint: &ethpb.Checkpoint{},
+		FinalizedCheckpoint: &ethpb.Checkpoint{},
+		HasPayload:          true,
+	}}))
+
+	fn := f.store.fullNodeByRoot[root]
+	require.NotNil(t, fn)
+	assert.Equal(t, uint64(36_000_000), fn.gasLimit)
+
+	gl, err := f.GasLimit(root)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(36_000_000), gl)
 }
 
 func TestInsertPayload_WithoutEmptyNode_Errors(t *testing.T) {

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -115,5 +115,5 @@ type Setter interface {
 	InsertSlashedIndex(context.Context, primitives.ValidatorIndex)
 	RecordBlockForEquivocation(primitives.Slot, primitives.ValidatorIndex, [32]byte)
 	SetPTCVote(root [32]byte, ptcIdx uint64, payloadPresent, blobDataAvailable bool)
-	MarkFullNode(root [32]byte)
+	MarkFullNode(root [32]byte, gasLimit uint64)
 }

--- a/changelog/terence_mark-full-node-gas-limit.md
+++ b/changelog/terence_mark-full-node-gas-limit.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Set the bid gas limit on full forkchoice nodes restored via `MarkFullNode`, so bid validation no longer sees a zero parent gas limit after a restart.


### PR DESCRIPTION
Full nodes created by `MarkFullNode` and `InsertChain` had no gas limit, so after a restart or batch sync `ForkChoice.GasLimit` returned 0 for the head and bid gossip validation ignored every real bid until the next envelope import. Both paths now take the gas limit from the block's bid, and `insertFirstPayloadIfNeeded` reads it from the parent block