### PR TITLE
Surface undefined engine errors from gloas forkchoice updates

### DIFF
--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -2,6 +2,7 @@ package blockchain
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -376,6 +377,17 @@ func TestNotifyForkchoiceUpdateGloas_NilAttributes(t *testing.T) {
 	blockHash := bytesutil.ToBytes32([]byte("hash1"))
 	_, err := s.notifyForkchoiceUpdateGloas(ctx, blockHash, nil)
 	require.NoError(t, err)
+}
+
+func TestNotifyForkchoiceUpdateGloas_UndefinedError(t *testing.T) {
+	s, _ := setupGloasService(t, &mockExecution.EngineClient{
+		ErrForkchoiceUpdated: errors.New("engine timeout"),
+	})
+	ctx := t.Context()
+
+	blockHash := bytesutil.ToBytes32([]byte("hash1"))
+	_, err := s.notifyForkchoiceUpdateGloas(ctx, blockHash, nil)
+	require.ErrorIs(t, err, ErrUndefinedExecutionEngineError)
 }
 
 func TestFcuFromReorgData_CachesPayloadID(t *testing.T) {

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -430,7 +430,6 @@ func (s *Service) notifyForkchoiceUpdateGloas(ctx context.Context, blockHash [32
 			lastValidHash: bytesutil.ToBytes32(lastValidHash),
 		}
 	default:
-		log.WithError(err).Error(ErrUndefinedExecutionEngineError)
-		return nil, nil
+		return nil, errors.WithMessage(ErrUndefinedExecutionEngineError, err.Error())
 	}
 }

--- a/changelog/terence_surface-gloas-fcu-engine-errors.md
+++ b/changelog/terence_surface-gloas-fcu-engine-errors.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Surface undefined execution engine errors from gloas forkchoice updates instead of returning a nil payload ID that callers read as not proposing.


### PR DESCRIPTION
Code health change, no real bug here. `notifyForkchoiceUpdateGloas` logged undefined execution engine errors and returned a nil payload ID, which callers treated the same as not proposing. It now returns error, while callers keep their log-and-continue behavior.