### PR TITLE
Skip nil builder entries in builderInsertionIndex

### DIFF
--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -410,7 +410,8 @@ func (b *BeaconState) addBuilderFromDepositAtEpoch(pubkey [fieldparams.BLSPubkey
 
 func (b *BeaconState) builderInsertionIndex(currentEpoch primitives.Epoch) primitives.BuilderIndex {
 	for i, builder := range b.builders {
-		if builder.WithdrawableEpoch <= currentEpoch && builder.Balance == 0 {
+		// A nil entry behaves like a zero-value builder, which is reusable.
+		if builder == nil || (builder.WithdrawableEpoch <= currentEpoch && builder.Balance == 0) {
 			return primitives.BuilderIndex(i)
 		}
 	}

--- a/changelog/terence_builder-insertion-index-nil.md
+++ b/changelog/terence_builder-insertion-index-nil.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Treat nil builder registry entries as reusable slots in `builderInsertionIndex` instead of panicking.


### PR DESCRIPTION
`builderInsertionIndex` dereferenced builder registry entries unconditionally, but the slice can hold nil via gap-filling and hdiff. A nil entry is now treated as a reusable slot, matching how the spec loop handles a zero-value builder