### PR TITLE
Compute validator mid-slot delay from SLOT_DURATION_MS

### DIFF
--- a/changelog/terence_mid-slot-delay-slot-duration.md
+++ b/changelog/terence_mid-slot-delay-slot-duration.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Compute the validator client's mid-slot submission delay from `SLOT_DURATION_MS` instead of `SECONDS_PER_SLOT`.

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -850,7 +850,7 @@ func (v *validator) PushProposerSettings(ctx context.Context, slot primitives.Sl
 	prefs := v.buildProposerPreferences(ctx, km, slot, false)
 	if len(prefs) > 0 {
 		// Delay to mid-slot so the block for this slot is processed first.
-		delay := time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second
+		delay := params.BeaconConfig().SlotDuration() / 2
 		go func() {
 			time.Sleep(delay)
 			if _, err := v.validatorClient.SubmitSignedProposerPreferences(ctx, &ethpb.SubmitSignedProposerPreferencesRequest{
@@ -862,7 +862,7 @@ func (v *validator) PushProposerSettings(ctx context.Context, slot primitives.Sl
 	}
 
 	if reqs := v.buildBuilderPreferenceRequests(ctx, km, slot); len(reqs) > 0 {
-		delay := time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second
+		delay := params.BeaconConfig().SlotDuration() / 2
 		time.AfterFunc(delay, func() {
 			// Detached from the slot context, which may expire before the delay elapses.
 			subCtx, cancel := context.WithTimeout(context.Background(), delay)
@@ -1393,7 +1393,7 @@ func (v *validator) submitProposerPreferences(ctx context.Context) {
 	if len(prefs) == 0 {
 		return
 	}
-	delay := time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second
+	delay := params.BeaconConfig().SlotDuration() / 2
 	go func() {
 		time.Sleep(delay)
 		if _, err := v.validatorClient.SubmitSignedProposerPreferences(ctx, &ethpb.SubmitSignedProposerPreferencesRequest{


### PR DESCRIPTION
Compute the validator client's mid-slot submission delay (proposer preferences and builder preferences) from `SlotDuration()` instead of `SECONDS_PER_SLOT`, so a config that sets only `SLOT_DURATION_MS` can't turn the half-slot delay into a full slot and push every submission past the slot deadline