### PR TITLE
Copy payload attestations out of the pool to prevent in-place aggregation races

### DIFF
--- a/beacon-chain/operations/payloadattestation/pool.go
+++ b/beacon-chain/operations/payloadattestation/pool.go
@@ -59,10 +59,26 @@ func (p *Pool) PendingPayloadAttestations(slot primitives.Slot) []*ethpb.Payload
 	result := make([]*ethpb.PayloadAttestation, 0, len(p.pending))
 	for _, att := range p.pending {
 		if att.Data.Slot == slot {
-			result = append(result, att)
+			result = append(result, copyPayloadAttestation(att))
 		}
 	}
 	return result
+}
+
+// Copies protect readers from later in-place aggregation of pool entries, a torn signature and bits pair would invalidate the block including it.
+func copyPayloadAttestation(att *ethpb.PayloadAttestation) *ethpb.PayloadAttestation {
+	bits := ethpb.NewPayloadAttestationAggregationBits()
+	copy(bits, att.AggregationBits)
+	return &ethpb.PayloadAttestation{
+		AggregationBits: bits,
+		Data: &ethpb.PayloadAttestationData{
+			BeaconBlockRoot:   bytesutil.SafeCopyBytes(att.Data.BeaconBlockRoot),
+			Slot:              att.Data.Slot,
+			PayloadPresent:    att.Data.PayloadPresent,
+			BlobDataAvailable: att.Data.BlobDataAvailable,
+		},
+		Signature: bytesutil.SafeCopyBytes(att.Signature),
+	}
 }
 
 // InsertPayloadAttestation inserts a payload attestation message into the pool.

--- a/changelog/terence_copy-pending-payload-attestations.md
+++ b/changelog/terence_copy-pending-payload-attestations.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Return deep copies from the payload attestation pool so later aggregation cannot mutate attestations already handed to block building.


### PR DESCRIPTION
- `PendingPayloadAttestations` returned live pool pointers while `InsertPayloadAttestation` mutates the same entries' `Signature` and `AggregationBits` in place under the pool lock, so a proposer serializing the aggregate at slot start could observe a torn signature/bits pair from a late PTC message and build an invalid block
- Return deep copies under the lock instead