### PR TITLE
Apply fork choice PTC votes for REST-submitted payload attestations

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -590,6 +590,7 @@ func (s *Service) beaconEndpoints(
 		ExecutionReconstructor:        s.cfg.ExecutionReconstructor,
 		BLSChangesPool:                s.cfg.BLSChangesPool,
 		PayloadAttestationPool:        s.cfg.PayloadAttestationPool,
+		PayloadAttestationReceiver:    s.cfg.PayloadAttestationReceiver,
 		FinalizationFetcher:           s.cfg.FinalizationFetcher,
 		ForkchoiceFetcher:             s.cfg.ForkchoiceFetcher,
 		CoreService:                   coreService,

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -982,24 +982,35 @@ func (s *Server) SubmitPayloadAttestations(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	st, err := s.HeadFetcher.HeadStateReadOnly(ctx)
-	if err != nil {
-		httputil.HandleError(w, "Could not get head state: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
+	currentSlot := s.TimeFetcher.CurrentSlot()
 	for i, consensusMsg := range consensusMsgs {
 		if consensusMsg == nil {
 			continue
 		}
-		if _, err = bls.SignatureFromBytes(consensusMsg.Signature); err != nil {
+		if _, err := bls.SignatureFromBytes(consensusMsg.Signature); err != nil {
 			failures = append(failures, &server.IndexedError{
 				Index:   i,
 				Message: "Incorrect payload attestation signature: " + err.Error(),
 			})
 			continue
 		}
+		if consensusMsg.Data.Slot != currentSlot {
+			failures = append(failures, &server.IndexedError{
+				Index:   i,
+				Message: fmt.Sprintf("Payload attestation slot %d does not match current slot %d", consensusMsg.Data.Slot, currentSlot),
+			})
+			continue
+		}
 
+		st, err := s.PayloadAttestationReceiver.PtcLookupState(ctx, bytesutil.ToBytes32(consensusMsg.Data.BeaconBlockRoot), consensusMsg.Data.Slot)
+		if err != nil || st == nil {
+			msg := "Could not find state for payload attestation"
+			if err != nil {
+				msg += ": " + err.Error()
+			}
+			failures = append(failures, &server.IndexedError{Index: i, Message: msg})
+			continue
+		}
 		idx, err := gloas.PayloadCommitteeIndex(ctx, st, consensusMsg.Data.Slot, consensusMsg.ValidatorIndex)
 		if err != nil {
 			failures = append(failures, &server.IndexedError{
@@ -1013,6 +1024,15 @@ func (s *Server) SubmitPayloadAttestations(w http.ResponseWriter, r *http.Reques
 			failures = append(failures, &server.IndexedError{
 				Index:   i,
 				Message: server.NewBroadcastFailedError("PayloadAttestation", err).Error(),
+			})
+			continue
+		}
+
+		// Self-published gossip is not looped back, so apply the PTC vote to fork choice here.
+		if err := s.PayloadAttestationReceiver.ReceivePayloadAttestationMessage(ctx, consensusMsg); err != nil {
+			failures = append(failures, &server.IndexedError{
+				Index:   i,
+				Message: "Could not process payload attestation: " + err.Error(),
 			})
 			continue
 		}

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -2726,13 +2726,14 @@ func TestSubmitPayloadAttestations(t *testing.T) {
 		broadcaster := &p2pMock.MockBroadcaster{}
 		pool := &payloadattestationmock.PoolMock{}
 		s := &Server{
-			SyncChecker:            &mockSync.Sync{IsSyncing: false},
-			HeadFetcher:            chainService,
-			TimeFetcher:            chainService,
-			OptimisticModeFetcher:  chainService,
-			Broadcaster:            broadcaster,
-			PayloadAttestationPool: pool,
-			OperationNotifier:      &blockchainmock.MockOperationNotifier{},
+			SyncChecker:                &mockSync.Sync{IsSyncing: false},
+			HeadFetcher:                chainService,
+			TimeFetcher:                chainService,
+			OptimisticModeFetcher:      chainService,
+			Broadcaster:                broadcaster,
+			PayloadAttestationPool:     pool,
+			PayloadAttestationReceiver: chainService,
+			OperationNotifier:          &blockchainmock.MockOperationNotifier{},
 		}
 
 		body := fmt.Sprintf(`[{
@@ -2798,13 +2799,14 @@ func TestSubmitPayloadAttestations(t *testing.T) {
 		broadcaster := &p2pMock.MockBroadcaster{}
 		pool := &payloadattestationmock.PoolMock{}
 		s := &Server{
-			SyncChecker:            &mockSync.Sync{IsSyncing: false},
-			HeadFetcher:            chainService,
-			TimeFetcher:            chainService,
-			OptimisticModeFetcher:  chainService,
-			Broadcaster:            broadcaster,
-			PayloadAttestationPool: pool,
-			OperationNotifier:      &blockchainmock.MockOperationNotifier{},
+			SyncChecker:                &mockSync.Sync{IsSyncing: false},
+			HeadFetcher:                chainService,
+			TimeFetcher:                chainService,
+			OptimisticModeFetcher:      chainService,
+			Broadcaster:                broadcaster,
+			PayloadAttestationPool:     pool,
+			PayloadAttestationReceiver: chainService,
+			OperationNotifier:          &blockchainmock.MockOperationNotifier{},
 		}
 
 		msg := &ethpbv1alpha1.PayloadAttestationMessage{

--- a/beacon-chain/rpc/eth/beacon/server.go
+++ b/beacon-chain/rpc/eth/beacon/server.go
@@ -27,34 +27,35 @@ import (
 // Server defines a server implementation of the gRPC Beacon Chain service,
 // providing RPC endpoints to access data relevant to the Ethereum Beacon Chain.
 type Server struct {
-	BeaconDB                db.ReadOnlyDatabase
-	ChainInfoFetcher        blockchain.ChainInfoFetcher
-	GenesisTimeFetcher      blockchain.TimeFetcher
-	BlockReceiver           blockchain.BlockReceiver
-	BlockNotifier           blockfeed.Notifier
-	OperationNotifier       operation.Notifier
-	Broadcaster             p2p.Broadcaster
-	DataColumnReceiver      blockchain.DataColumnReceiver
-	AttestationCache        *cache.AttestationCache
-	AttestationsPool        attestations.Pool
-	SlashingsPool           slashings.PoolManager
-	VoluntaryExitsPool      voluntaryexits.PoolManager
-	StateGenService         stategen.StateManager
-	Stater                  lookup.Stater
-	Blocker                 lookup.Blocker
-	HeadFetcher             blockchain.HeadFetcher
-	TimeFetcher             blockchain.TimeFetcher
-	OptimisticModeFetcher   blockchain.OptimisticModeFetcher
-	V1Alpha1ValidatorServer eth.BeaconNodeValidatorServer
-	SyncChecker             sync.Checker
-	CanonicalHistory        *stategen.CanonicalHistory
-	ExecutionReconstructor  execution.Reconstructor
-	FinalizationFetcher     blockchain.FinalizationFetcher
-	BLSChangesPool          blstoexec.PoolManager
-	PayloadAttestationPool  payloadattestation.PoolManager
-	ForkchoiceFetcher       blockchain.ForkchoiceFetcher
-	CoreService             *core.Service
-	AttestationStateFetcher blockchain.AttestationStateFetcher
+	BeaconDB                   db.ReadOnlyDatabase
+	ChainInfoFetcher           blockchain.ChainInfoFetcher
+	GenesisTimeFetcher         blockchain.TimeFetcher
+	BlockReceiver              blockchain.BlockReceiver
+	BlockNotifier              blockfeed.Notifier
+	OperationNotifier          operation.Notifier
+	Broadcaster                p2p.Broadcaster
+	DataColumnReceiver         blockchain.DataColumnReceiver
+	AttestationCache           *cache.AttestationCache
+	AttestationsPool           attestations.Pool
+	SlashingsPool              slashings.PoolManager
+	VoluntaryExitsPool         voluntaryexits.PoolManager
+	StateGenService            stategen.StateManager
+	Stater                     lookup.Stater
+	Blocker                    lookup.Blocker
+	HeadFetcher                blockchain.HeadFetcher
+	TimeFetcher                blockchain.TimeFetcher
+	OptimisticModeFetcher      blockchain.OptimisticModeFetcher
+	V1Alpha1ValidatorServer    eth.BeaconNodeValidatorServer
+	SyncChecker                sync.Checker
+	CanonicalHistory           *stategen.CanonicalHistory
+	ExecutionReconstructor     execution.Reconstructor
+	FinalizationFetcher        blockchain.FinalizationFetcher
+	BLSChangesPool             blstoexec.PoolManager
+	PayloadAttestationPool     payloadattestation.PoolManager
+	PayloadAttestationReceiver blockchain.PayloadAttestationReceiver
+	ForkchoiceFetcher          blockchain.ForkchoiceFetcher
+	CoreService                *core.Service
+	AttestationStateFetcher    blockchain.AttestationStateFetcher
 	// PayloadEnvelopeVerifier runs gossip-level checks on published envelopes.
 	PayloadEnvelopeVerifier verification.NewExecutionPayloadEnvelopeVerifier
 	// ExecutionPayloadEnvelopeCache reconstructs the full envelope in the blinded publish flow.

--- a/changelog/terence_rest-payload-attestation-forkchoice.md
+++ b/changelog/terence_rest-payload-attestation-forkchoice.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Apply fork choice PTC votes and enforce the current-slot check for payload attestations submitted via the REST pool endpoint.


### PR DESCRIPTION
- The REST `POST /eth/v1/beacon/pool/payload_attestations` handler only inserted into the pool and broadcast; unlike the gRPC path it never called `ReceivePayloadAttestationMessage`, and self-published gossip is not looped back, so a REST-connected VC's own PTC votes never reached this node's fork choice
- Wire `PayloadAttestationReceiver` into the beacon REST server, apply the fork choice vote after broadcast, and use `PtcLookupState` for the committee index instead of the head state
- Enforce the same current-slot check the gRPC path has