### PR TITLE
Ignore signature failures for queued envelopes and payload attestations

### DIFF
--- a/beacon-chain/sync/pending_payload_attestation.go
+++ b/beacon-chain/sync/pending_payload_attestation.go
@@ -41,7 +41,8 @@ func (s *Service) queuePendingPayloadAttestation(ctx context.Context, v verifica
 	}
 	if err := v.VerifySignature(st); err != nil {
 		s.pendingPayloadAttestationLock.Unlock()
-		return pubsub.ValidationReject, err
+		// The attested block is unknown, so the head state used here may be on a different branch, do not penalize the peer.
+		return pubsub.ValidationIgnore, err
 	}
 	s.pendingPayloadAttestations[root] = append(inner, att)
 	s.pendingPayloadAttestationLock.Unlock()

--- a/beacon-chain/sync/pending_payload_attestation_test.go
+++ b/beacon-chain/sync/pending_payload_attestation_test.go
@@ -98,14 +98,14 @@ func TestQueuePendingPayloadAttestation_RootCap(t *testing.T) {
 	require.Equal(t, false, ok)
 }
 
-func TestQueuePendingPayloadAttestation_RejectsBadSignature(t *testing.T) {
+func TestQueuePendingPayloadAttestation_IgnoresBadSignature(t *testing.T) {
 	s := queueTestService(t)
 	v := &verification.MockPayloadAttestation{ErrInvalidMessageSignature: errors.New("bad signature")}
 
 	att, _ := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
 	res, err := s.queuePendingPayloadAttestation(t.Context(), v, att)
 	require.ErrorContains(t, "bad signature", err)
-	require.Equal(t, pubsub.ValidationReject, res)
+	require.Equal(t, pubsub.ValidationIgnore, res)
 	require.Equal(t, 0, len(s.pendingPayloadAttestations))
 }
 

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -570,7 +570,7 @@ func TestQueuePendingPayloadEnvelope_SelfBuildBypassesPerRootBound(t *testing.T)
 	require.Equal(t, true, ok)
 }
 
-func TestValidateExecutionPayloadEnvelope_RejectBadSignatureBeforeQueue(t *testing.T) {
+func TestValidateExecutionPayloadEnvelope_IgnoreBadSignatureBeforeQueue(t *testing.T) {
 	ctx := context.Background()
 	s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
 	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(
@@ -582,7 +582,7 @@ func TestValidateExecutionPayloadEnvelope_RejectBadSignatureBeforeQueue(t *testi
 
 	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
 	require.NotNil(t, err)
-	require.Equal(t, result, pubsub.ValidationReject)
+	require.Equal(t, result, pubsub.ValidationIgnore)
 	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
 }
 

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -361,7 +361,7 @@ func TestQueuePendingPayloadEnvelope_SelfBuildInLookaheadVerifiesSignature(t *te
 	require.Equal(t, maxSelfBuildSigFailures, s.selfBuildSigFailures)
 }
 
-func TestQueuePendingPayloadEnvelope_RejectBadSignature(t *testing.T) {
+func TestQueuePendingPayloadEnvelope_IgnoreBadSignature(t *testing.T) {
 	ctx := context.Background()
 	s, _, _, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
 
@@ -375,7 +375,7 @@ func TestQueuePendingPayloadEnvelope_RejectBadSignature(t *testing.T) {
 	v := &mockExecutionPayloadEnvelopeVerifier{errSignature: errors.New("bad signature")}
 	result, err := s.queuePendingPayloadEnvelope(ctx, v, env, signedEnv)
 	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationReject, result)
+	require.Equal(t, pubsub.ValidationIgnore, result)
 	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
 }
 

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -209,9 +209,9 @@ func (s *Service) queuePendingPayloadEnvelope(
 				s.selfBuildSigFailures++
 				log.WithError(err).Debug("Ignoring self-built payload with invalid signature")
 				return pubsub.ValidationIgnore, nil
-			} else {
-				return pubsub.ValidationReject, err
 			}
+			// The envelope's block is unknown, so the head state used here may be on a different branch, do not penalize the peer.
+			return pubsub.ValidationIgnore, err
 		}
 	} else {
 		log.Debug("Ignoring payload envelope from self-build outside of the Lookahead window")

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -402,9 +402,9 @@ func TestQueuePendingPayloadEnvelope_SelfBuildInvalidSignature(t *testing.T) {
 			result:     pubsub.ValidationIgnore,
 		},
 		{
-			name:       "non-self-build with invalid signature is rejected",
+			name:       "non-self-build with invalid signature is ignored",
 			builderIdx: 42,
-			result:     pubsub.ValidationReject,
+			result:     pubsub.ValidationIgnore,
 			wantError:  true,
 		},
 	}

--- a/changelog/terence_pending-queue-ignore-sig-failures.md
+++ b/changelog/terence_pending-queue-ignore-sig-failures.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Ignore instead of reject queued payload envelopes and payload attestations whose signatures fail against a possibly divergent head state.


### PR DESCRIPTION
- Queued payload envelopes and payload attestations reference a block we have not seen yet, so their signatures are verified against the head state, which may be on a different branch or behind on builder registrations
- Rejecting on such failures downscores honest peers based on state we cannot know is right, the same failure class as the devnet-6 bid prev_randao incident, so return IGNORE instead
- Queue admission still requires a passing signature check, only the peer penalty is dropped