### PR TITLE
Align FOCIL inclusion list committee and signature domain with the Heze spec

### DIFF
--- a/beacon-chain/core/helpers/inclusion_list.go
+++ b/beacon-chain/core/helpers/inclusion_list.go
@@ -18,6 +18,7 @@ var (
 	errNilCommitteeRoot = errors.New("nil inclusion list committee root")
 	errNilSignature     = errors.New("nil signature")
 	errIncorrectState   = errors.New("incorrect state version")
+	errNoCommittee      = errors.New("no beacon committee members for inclusion list committee")
 )
 
 // ValidateNilSignedInclusionList validates that a SignedInclusionList is not nil and contains a signature.
@@ -42,31 +43,39 @@ func ValidateNilInclusionList(il *eth.InclusionList) error {
 	return nil
 }
 
-// GetInclusionListCommittee retrieves the validator indices assigned to the inclusion list committee
-// for a given slot. Returns an error if the state or slot does not meet the required constraints.
+// GetInclusionListCommittee returns the inclusion list committee for the given slot,
+// formed by concatenating the slot's beacon committees in order and cycling over
+// them to fill INCLUSION_LIST_COMMITTEE_SIZE entries.
 func GetInclusionListCommittee(ctx context.Context, state state.ReadOnlyBeaconState, slot primitives.Slot) ([]primitives.ValidatorIndex, error) {
-	if slots.ToEpoch(slot) < params.BeaconConfig().Eip7805ForkEpoch {
+	epoch := slots.ToEpoch(slot)
+	if epoch < params.BeaconConfig().Eip7805ForkEpoch {
 		return nil, errIncorrectState
 	}
-	epoch := slots.ToEpoch(slot)
-	seed, err := Seed(state, epoch, params.BeaconConfig().DomainInclusionListCommittee)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get seed")
-	}
-	indices, err := ActiveValidatorIndices(ctx, state, epoch)
-	if err != nil {
-		return nil, err
-	}
-	start := uint64(slot%params.BeaconConfig().SlotsPerEpoch) * params.BeaconConfig().InclusionListCommitteeSize
-	end := start + params.BeaconConfig().InclusionListCommitteeSize
 
-	shuffledIndices := make([]primitives.ValidatorIndex, len(indices))
-	copy(shuffledIndices, indices)
-	shuffledList, err := UnshuffleList(shuffledIndices, seed)
+	activeCount, err := ActiveValidatorCount(ctx, state, epoch)
 	if err != nil {
 		return nil, err
 	}
-	return shuffledList[start:end], nil
+	committeesPerSlot := SlotCommitteeCount(activeCount)
+
+	var indices []primitives.ValidatorIndex
+	for i := uint64(0); i < committeesPerSlot; i++ {
+		committee, err := BeaconCommitteeFromState(ctx, state, slot, primitives.CommitteeIndex(i))
+		if err != nil {
+			return nil, err
+		}
+		indices = append(indices, committee...)
+	}
+	if len(indices) == 0 {
+		return nil, errNoCommittee
+	}
+
+	size := params.BeaconConfig().InclusionListCommitteeSize
+	committee := make([]primitives.ValidatorIndex, size)
+	for i := uint64(0); i < size; i++ {
+		committee[i] = indices[i%uint64(len(indices))]
+	}
+	return committee, nil
 }
 
 // ValidateInclusionListSignature verifies the signature on a SignedInclusionList against the public key
@@ -89,8 +98,8 @@ func ValidateInclusionListSignature(ctx context.Context, st state.ReadOnlyBeacon
 		return err
 	}
 
-	currentEpoch := slots.ToEpoch(st.Slot())
-	domain, err := signing.Domain(st.Fork(), currentEpoch, params.BeaconConfig().DomainInclusionListCommittee, st.GenesisValidatorsRoot())
+	epoch := slots.ToEpoch(il.Message.Slot)
+	domain, err := signing.Domain(st.Fork(), epoch, params.BeaconConfig().DomainInclusionListCommittee, st.GenesisValidatorsRoot())
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/core/helpers/inclusion_list_test.go
+++ b/beacon-chain/core/helpers/inclusion_list_test.go
@@ -93,6 +93,7 @@ func TestValidateNilSignedInclusionList(t *testing.T) {
 }
 
 func TestGetInclusionListCommittee_OK(t *testing.T) {
+	helpers.ClearCache()
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig().Copy()
 	cfg.Eip7805ForkEpoch = 0
@@ -114,7 +115,38 @@ func TestGetInclusionListCommittee_OK(t *testing.T) {
 	require.DeepEqual(t, committee, committee2)
 }
 
+func TestGetInclusionListCommittee_MatchesConcatenatedBeaconCommittees(t *testing.T) {
+	helpers.ClearCache()
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.Eip7805ForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	st, _ := util.DeterministicGenesisStateElectra(t, 256)
+	slot := primitives.Slot(0)
+
+	activeCount, err := helpers.ActiveValidatorCount(t.Context(), st, slots.ToEpoch(slot))
+	require.NoError(t, err)
+	var concatenated []primitives.ValidatorIndex
+	for i := uint64(0); i < helpers.SlotCommitteeCount(activeCount); i++ {
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), st, slot, primitives.CommitteeIndex(i))
+		require.NoError(t, err)
+		concatenated = append(concatenated, committee...)
+	}
+	require.Equal(t, true, len(concatenated) > 0)
+
+	got, err := helpers.GetInclusionListCommittee(t.Context(), st, slot)
+	require.NoError(t, err)
+
+	size := int(params.BeaconConfig().InclusionListCommitteeSize)
+	require.Equal(t, size, len(got))
+	for i := 0; i < size; i++ {
+		require.Equal(t, concatenated[i%len(concatenated)], got[i])
+	}
+}
+
 func TestGetInclusionListCommittee_BeforeFork(t *testing.T) {
+	helpers.ClearCache()
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig().Copy()
 	cfg.Eip7805ForkEpoch = 5

--- a/changelog/rahulbarmann_fix-focil-committee-and-signature.md
+++ b/changelog/rahulbarmann_fix-focil-committee-and-signature.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Align FOCIL `get_inclusion_list_committee` with the current Heze spec (concatenate the slot's beacon committees and cycle to fill the committee) and derive the inclusion-list signature domain from the inclusion list's own slot.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes two spec-conformance drifts in the FOCIL helpers on the `focil` branch, found while comparing against the current Heze spec (#17102).

1. `GetInclusionListCommittee` previously unshuffled all active validators and sliced a per-slot window. The current spec instead concatenates the slot's beacon committees in order and cycles over them to fill `INCLUSION_LIST_COMMITTEE_SIZE`:

    ```python
    indices = []
    for i in range(get_committee_count_per_slot(state, epoch)):
        indices.extend(get_beacon_committee(state, slot, CommitteeIndex(i)))
    return [indices[i % len(indices)] for i in range(INCLUSION_LIST_COMMITTEE_SIZE)]
    ```

    The old path produced a different validator set, so `inclusion_list_committee_root` would not match other clients. This is the change with interop impact. Now implemented via `SlotCommitteeCount` and `BeaconCommitteeFromState`, with a guard against an empty committee set.

2. `ValidateInclusionListSignature` derived the signature domain from the head-state slot (`slots.ToEpoch(st.Slot())`). The spec's `is_valid_inclusion_list_signature` uses the inclusion list's own slot (`compute_epoch_at_slot(message.slot)`). These agree within an epoch but diverge at epoch boundaries. Now uses `il.Message.Slot`.

**Which issue(s) does this PR fix?**

Fixes #17102

**Other notes for review**

Scope is limited to the two accessor/predicate drifts. The remaining items noted in #17102 (gossip `IGNORE`/`REJECT` severities and slot variant in `beacon-chain/sync/inclusion_list.go`, and seconds-based timing vs `INCLUSION_LIST_DUE_BPS`) are separate and not addressed here.

Testing: adds a conformance test asserting `GetInclusionListCommittee` equals the concatenated-and-cycled beacon committees for the slot.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
