### PR TITLE
Add tests for FOCIL fork-choice inclusion list enforcement

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/BUILD.bazel
+++ b/beacon-chain/forkchoice/doubly-linked-tree/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "attester_head_test.go",
         "ffg_update_test.go",
         "forkchoice_test.go",
         "last_root_test.go",

--- a/beacon-chain/forkchoice/doubly-linked-tree/attester_head_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/attester_head_test.go
@@ -1,0 +1,63 @@
+package doublylinkedtree
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v6/config/params"
+	"github.com/OffchainLabs/prysm/v6/testing/require"
+)
+
+func TestForkChoice_GetAttesterHead(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("nil head returns zero root", func(t *testing.T) {
+		f := setup(0, 0)
+		f.store.headNode = nil
+		require.Equal(t, [32]byte{}, f.GetAttesterHead())
+	})
+
+	t.Run("head without parent returns head root", func(t *testing.T) {
+		f := setup(0, 0)
+		f.store.headNode = f.store.treeRootNode
+		require.Equal(t, params.BeaconConfig().ZeroHash, f.GetAttesterHead())
+	})
+
+	t.Run("head satisfying inclusion list returns head root", func(t *testing.T) {
+		f := setup(0, 0)
+		st, blk, err := prepareForkchoiceState(ctx, 1, indexToHash(1), params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 0, 0)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertNode(ctx, st, blk))
+
+		head := f.store.nodeByRoot[indexToHash(1)]
+		require.Equal(t, false, head.notSatisfyingInclusionList)
+		f.store.headNode = head
+		require.Equal(t, indexToHash(1), f.GetAttesterHead())
+	})
+
+	t.Run("head not satisfying inclusion list returns parent root", func(t *testing.T) {
+		f := setup(0, 0)
+		st, blk, err := prepareForkchoiceState(ctx, 1, indexToHash(1), params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 0, 0)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertNode(ctx, st, blk))
+
+		head := f.store.nodeByRoot[indexToHash(1)]
+		head.notSatisfyingInclusionList = true
+		f.store.headNode = head
+		require.Equal(t, params.BeaconConfig().ZeroHash, f.GetAttesterHead())
+	})
+
+	// Covers the wiring in store.insert: a block marked as not satisfying the
+	// inclusion list must propagate the flag onto its forkchoice node.
+	t.Run("insert propagates not-satisfying flag from block", func(t *testing.T) {
+		f := setup(0, 0)
+		st, blk, err := prepareForkchoiceState(ctx, 1, indexToHash(1), params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 0, 0)
+		require.NoError(t, err)
+		blk.Block().MarkInclusionListNotSatisfied()
+		require.NoError(t, f.InsertNode(ctx, st, blk))
+
+		head := f.store.nodeByRoot[indexToHash(1)]
+		require.Equal(t, true, head.notSatisfyingInclusionList)
+		f.store.headNode = head
+		require.Equal(t, params.BeaconConfig().ZeroHash, f.GetAttesterHead())
+	})
+}

--- a/changelog/rahulbarmann_test-focil-forkchoice-il-enforcement.md
+++ b/changelog/rahulbarmann_test-focil-forkchoice-il-enforcement.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Add unit tests for FOCIL fork-choice inclusion list enforcement in `GetAttesterHead`, covering the satisfying and not-satisfying head branches and the propagation of the block's not-satisfying flag through `store.insert`.


### PR DESCRIPTION
**What type of PR is this?**

Other (tests)

**What does this PR do? Why is it needed?**

Adds unit tests for the FOCIL fork-choice inclusion list enforcement path, which currently has no coverage. `GetAttesterHead` is the point where an unsatisfied inclusion list is enforced: if the head block does not satisfy the inclusion list, the attester head falls back to the parent.

The test covers every branch of `GetAttesterHead`:

- nil head returns the zero root
- head with no parent returns its own root
- head that satisfies the inclusion list returns the head root
- head that does not satisfy the inclusion list returns the parent root

It also covers the wiring in `store.insert`: a block marked via `MarkInclusionListNotSatisfied()` must propagate the flag onto its forkchoice node so `GetAttesterHead` reorgs to the parent end to end.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

The `GetProposerHead` inclusion-list branch in `reorg_late_blocks.go` is also untested and is a natural follow-up, but it needs the full weighted and timed reorg setup, so it is left out of this PR to keep the scope tight.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
