### PR TITLE
VC logging: Consolidate validator status log at startup (grouping them by status)

### DIFF
--- a/changelog/syjn99_consolidate-validator-status-logs.md
+++ b/changelog/syjn99_consolidate-validator-status-logs.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Consolidated validator client status logs into one info line each with range-compressed validator indices instead of one line per validator.

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/config/proposer"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/container/slice"
 	"github.com/OffchainLabs/prysm/v7/crypto/hash"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -390,23 +391,87 @@ func (v *validator) WaitForSync(ctx context.Context) error {
 	}
 }
 
+// checkAndLogValidatorStatus aggregates validator information by status and logs it.
+// Returns true if any validator is active, false otherwise.
 func (v *validator) checkAndLogValidatorStatus() bool {
-	nonexistentIndex := primitives.ValidatorIndex(^uint64(0))
-	var someAreActive bool
+	type logData struct {
+		pubkeys []string
+		indices []primitives.ValidatorIndex
+	}
+
+	var (
+		nonexistentIndex = primitives.ValidatorIndex(^uint64(0))
+		statusToLogData  = make(map[ethpb.ValidatorStatus]logData)
+	)
+
+	// Loop through all validators and group them by status.
 	for _, s := range v.pubkeyToStatus {
-		fields := logrus.Fields{
-			"pubkey": fmt.Sprintf("%#x", bytesutil.Trunc(s.publicKey)),
-			"status": s.status.Status.String(),
-		}
-		if s.index != nonexistentIndex {
-			fields["validatorIndex"] = s.index
-		}
-		log := log.WithFields(fields)
 		if v.emitAccountMetrics {
 			fmtKey, fmtIndex := fmt.Sprintf("%#x", s.publicKey), fmt.Sprintf("%#x", s.index)
 			ValidatorStatusesGaugeVec.WithLabelValues(fmtKey, fmtIndex).Set(float64(s.status.Status))
 		}
-		switch s.status.Status {
+
+		truncatedPubkey := fmt.Sprintf("%#x", bytesutil.Trunc(s.publicKey))
+
+		data, exists := statusToLogData[s.status.Status]
+		if !exists {
+			statusToLogData[s.status.Status] = logData{
+				pubkeys: []string{truncatedPubkey},
+				indices: []primitives.ValidatorIndex{s.index},
+			}
+			continue
+		}
+
+		data.pubkeys = append(data.pubkeys, truncatedPubkey)
+		data.indices = append(data.indices, s.index)
+		statusToLogData[s.status.Status] = data
+	}
+
+	// Consolidate active and exiting entries, as they are both considered "active" for the purposes of logging.
+	exitingData, exitingExists := statusToLogData[ethpb.ValidatorStatus_EXITING]
+	if exitingExists {
+		activeData, activeExists := statusToLogData[ethpb.ValidatorStatus_ACTIVE]
+		if activeExists {
+			activeData.pubkeys = append(activeData.pubkeys, exitingData.pubkeys...)
+			activeData.indices = append(activeData.indices, exitingData.indices...)
+			statusToLogData[ethpb.ValidatorStatus_ACTIVE] = activeData
+		} else {
+			statusToLogData[ethpb.ValidatorStatus_ACTIVE] = exitingData
+		}
+
+		delete(statusToLogData, ethpb.ValidatorStatus_EXITING)
+	}
+
+	for status, data := range statusToLogData {
+		count := len(data.pubkeys)
+		if count == 0 {
+			continue
+		}
+
+		fields := logrus.Fields{
+			"pubkeys": data.pubkeys,
+			"status":  status.String(),
+			"count":   count,
+		}
+
+		// Filter out non-existent indices.
+		indices := make([]uint64, 0, count)
+		for _, index := range data.indices {
+			if index != nonexistentIndex {
+				indices = append(indices, uint64(index))
+			}
+		}
+
+		// If there exists any valid indices, sort and prettify them for logging.
+		if len(indices) > 0 {
+			slices.Sort(indices)
+			fields["indices"] = slice.PrettySlice(indices)
+		}
+
+		log := log.WithFields(fields)
+
+		// Log a message based on the validator status.
+		switch status {
 		case ethpb.ValidatorStatus_UNKNOWN_STATUS:
 			log.Info("Waiting for deposit to be observed by beacon node")
 		case ethpb.ValidatorStatus_DEPOSITED:
@@ -414,21 +479,22 @@ func (v *validator) checkAndLogValidatorStatus() bool {
 		case ethpb.ValidatorStatus_PENDING:
 			log.Info("Waiting for activation... Check validator queue status in a block explorer")
 		case ethpb.ValidatorStatus_ACTIVE, ethpb.ValidatorStatus_EXITING:
-			someAreActive = true
-			log.WithFields(logrus.Fields{
-				"index": s.index,
-			}).Info("Validator activated")
+			log.Info("Validator activated")
 		case ethpb.ValidatorStatus_EXITED:
 			log.Info("Validator exited")
 		case ethpb.ValidatorStatus_INVALID:
 			log.Warn("Invalid Eth1 deposit")
 		default:
-			log.WithFields(logrus.Fields{
-				"status": s.status.Status.String(),
-			}).Info("Validator status")
+			log.Info("Validator status")
 		}
 	}
-	return someAreActive
+
+	// Return true if any validator is active, false otherwise.
+	if data, exists := statusToLogData[ethpb.ValidatorStatus_ACTIVE]; exists && len(data.pubkeys) > 0 {
+		return true
+	}
+
+	return false
 }
 
 // NextSlot emits the next slot number at the start time of that slot.

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -460,84 +460,178 @@ func TestRolesAt_DoesNotAssignProposer_Slot0(t *testing.T) {
 func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 	nonexistentIndex := primitives.ValidatorIndex(^uint64(0))
 	type statusTest struct {
-		name   string
-		status *validatorStatus
-		log    string
-		active bool
+		name     string
+		statuses []*validatorStatus
+		log      string
+		active   bool
 	}
-	pubKeys := [][]byte{bytesutil.Uint64ToBytesLittleEndian(0)}
+	pubKeys := [][]byte{
+		bytesutil.Uint64ToBytesLittleEndian(0),
+		bytesutil.Uint64ToBytesLittleEndian(1),
+		bytesutil.Uint64ToBytesLittleEndian(2),
+	}
 	tests := []statusTest{
 		{
 			name: "UNKNOWN_STATUS, no deposit found yet",
-			status: &validatorStatus{
-				publicKey: pubKeys[0],
-				index:     nonexistentIndex,
-				status: &ethpb.ValidatorStatusResponse{
-					Status: ethpb.ValidatorStatus_UNKNOWN_STATUS,
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     nonexistentIndex,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_UNKNOWN_STATUS,
+					},
 				},
 			},
-			log:    "Waiting for deposit to be observed by beacon node",
+			// non existent validator index is filtered out.
+			log:    "Waiting for deposit to be observed by beacon node\" count=1 package=validator/client pubkeys=\"[0x000000000000]\" status=UNKNOWN_STATUS",
 			active: false,
 		},
 		{
 			name: "DEPOSITED into state",
-			status: &validatorStatus{
-				publicKey: pubKeys[0],
-				index:     30,
-				status: &ethpb.ValidatorStatusResponse{
-					Status: ethpb.ValidatorStatus_DEPOSITED,
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     30,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_DEPOSITED,
+					},
 				},
 			},
-			log:    "Validator deposited, entering activation queue after finalization\" package=validator/client pubkey=0x000000000000 status=DEPOSITED validatorIndex=30",
+			log:    "Validator deposited, entering activation queue after finalization\" count=1 indices=30 package=validator/client pubkeys=\"[0x000000000000]\" status=DEPOSITED",
 			active: false,
 		},
 		{
 			name: "PENDING",
-			status: &validatorStatus{
-				publicKey: pubKeys[0],
-				index:     50,
-				status: &ethpb.ValidatorStatusResponse{
-					Status:          ethpb.ValidatorStatus_PENDING,
-					ActivationEpoch: params.BeaconConfig().FarFutureEpoch,
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     50,
+					status: &ethpb.ValidatorStatusResponse{
+						Status:          ethpb.ValidatorStatus_PENDING,
+						ActivationEpoch: params.BeaconConfig().FarFutureEpoch,
+					},
 				},
 			},
-			log:    "Waiting for activation... Check validator queue status in a block explorer\" package=validator/client pubkey=0x000000000000 status=PENDING validatorIndex=50",
+			log:    "Waiting for activation... Check validator queue status in a block explorer\" count=1 indices=50 package=validator/client pubkeys=\"[0x000000000000]\" status=PENDING",
 			active: false,
 		},
 		{
 			name: "ACTIVE",
-			status: &validatorStatus{
-				publicKey: pubKeys[0],
-				index:     89,
-				status: &ethpb.ValidatorStatusResponse{
-					Status: ethpb.ValidatorStatus_ACTIVE,
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     89,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_ACTIVE,
+					},
 				},
 			},
 			active: true,
 		},
 		{
 			name: "EXITING",
-			status: &validatorStatus{
-				publicKey: pubKeys[0],
-				index:     89,
-				status: &ethpb.ValidatorStatusResponse{
-					Status: ethpb.ValidatorStatus_EXITING,
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     89,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_EXITING,
+					},
 				},
 			},
 			active: true,
 		},
 		{
 			name: "EXITED",
-			status: &validatorStatus{
-				publicKey: pubKeys[0],
-				status: &ethpb.ValidatorStatusResponse{
-					Status: ethpb.ValidatorStatus_EXITED,
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     89,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_EXITED,
+					},
 				},
 			},
-			log:    "Validator exited",
 			active: false,
 		},
+		{
+			name: "multiple activated validators",
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     89,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_ACTIVE,
+					},
+				},
+				{
+					publicKey: pubKeys[1],
+					index:     90,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_ACTIVE,
+					},
+				},
+				{
+					publicKey: pubKeys[2],
+					index:     100,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_ACTIVE,
+					},
+				},
+			},
+			// Check whether the log message correctly shows the range of activated validator indices.
+			log:    "indices=\"89-90,100\"",
+			active: true,
+		},
+		{
+			name: "multiple activated validators including exiting validator",
+			statuses: []*validatorStatus{
+				{
+					publicKey: pubKeys[0],
+					index:     89,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_ACTIVE,
+					},
+				},
+				{
+					publicKey: pubKeys[1],
+					index:     90,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_ACTIVE,
+					},
+				},
+				{
+					publicKey: pubKeys[2],
+					index:     100,
+					status: &ethpb.ValidatorStatusResponse{
+						Status: ethpb.ValidatorStatus_EXITING,
+					},
+				},
+			},
+			log:    "\"Validator activated\" count=3 indices=\"89-90,100\"",
+			active: true,
+		},
+		{
+			name: "thousands of activated validators",
+			statuses: func() []*validatorStatus {
+				statuses := make([]*validatorStatus, 1000)
+				for i := range 1000 {
+					statuses[i] = &validatorStatus{
+						publicKey: bytesutil.Uint64ToBytesLittleEndian(uint64(i)),
+						index:     primitives.ValidatorIndex(i),
+						status: &ethpb.ValidatorStatusResponse{
+							Status: ethpb.ValidatorStatus_ACTIVE,
+						},
+					}
+				}
+
+				return statuses
+			}(),
+			log:    "\"Validator activated\" count=1000 indices=0-999",
+			active: true,
+		},
 	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			hook := logTest.NewGlobal()
@@ -551,7 +645,9 @@ func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 				}),
 				pubkeyToStatus: make(map[[48]byte]*validatorStatus),
 			}
-			v.pubkeyToStatus[bytesutil.ToBytes48(test.status.publicKey)] = test.status
+			for _, status := range test.statuses {
+				v.pubkeyToStatus[bytesutil.ToBytes48(status.publicKey)] = status
+			}
 			active := v.checkAndLogValidatorStatus()
 			require.Equal(t, test.active, active)
 			if test.log != "" {


### PR DESCRIPTION
**What type of PR is this?**

> Other: Better UX

**What does this PR do? Why is it needed?**

Follow up for #17083. Currently we have N logs for validator status where N is the count of the validators registered in this VC process:

```
[2026-07-06 11:53:12.31]  INFO client: Validator activated index=0 pubkey=0x851cb7093041 status=ACTIVE
...
[2026-07-06 11:53:12.40]  INFO client: Validator activated index=127 pubkey=0x8457b3220923 status=ACTIVE
```

Now this will be consolidated by few lines of logs. If VC starts with all validators active, it only requires one-line:
```
[2026-07-06 12:06:12.62]  INFO client: Validator activated count=128 indices=0-127 pubkeys=[0x851cb7093041 ... (abbreviated for convienience) ... 0x8457b3220923] status=ACTIVE
```


**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
