### PR TITLE
Drop loopclosure static analyzer: can report false positives after Go 1.22

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -238,7 +238,10 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/httpresponse:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/ifaceassert:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/inspect:go_default_library",
-        "@org_golang_x_tools//go/analysis/passes/loopclosure:go_default_library",
+        # loopclosure disabled: can generate false positives after Go 1.22.
+        # Note: Loop variables declared using := are now unique per iteration.
+        # See https://github.com/golang/go/issues/60078 for more details.
+        # "@org_golang_x_tools//go/analysis/passes/loopclosure:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/nilfunc:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/nilness:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/pkgfact:go_default_library",

--- a/changelog/syjn99_drop-loopclosure.md
+++ b/changelog/syjn99_drop-loopclosure.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Drop loopclosure static analyzer.

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -210,12 +210,6 @@
       "rules_go_work-.*": "Third party code"
     }
   },
-  "loopclosure": {
-    "exclude_files": {
-      "external/com_github_ethereum_go_ethereum/.*": "Unsafe third party code",
-      "rules_go_work-.*": "Third party code"
-    }
-  },
   "buildtag": {
     "exclude_files": {
       "external/.*": "Third party code"


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Drops loopclosure analyzer. As the [package description](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/loopclosure) says, this analyzer can report this code snippet as incorrect:

```go
for _, v := range list {
    defer func() {
        use(v) // incorrect
    }()
}
```

But since Go 1.22, this issue is resolved, which means if we declare a variable via `:=`, its lifetime is independent of other loop iteration.

Originally included in #16999 when upgrading `x/tools` version, but I think it's better to separate this PR.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
