### PR TITLE
Call FCU once per batch on init-sync

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -208,6 +208,19 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b interfaces.ReadOnlySignedB
 	if err := s.setHeadInitialSync(r, bCp, hs, optimistic); err != nil {
 		return errors.Wrap(err, "could not set head")
 	}
+	if b.Version() >= version.Gloas {
+		sbid, err := b.Block().Body().SignedExecutionPayloadBid()
+		if err != nil || sbid == nil || sbid.Message == nil || len(sbid.Message.ParentBlockHash) != 32 {
+			log.WithError(err).Error("Could not get bid parent block hash for forkchoice update")
+			return nil
+		}
+		parentHash := bytesutil.ToBytes32(sbid.Message.ParentBlockHash)
+		go func() {
+			if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, parentHash, nil); err != nil {
+				log.WithError(err).Error("Could not notify forkchoice update after batch import")
+			}
+		}()
+	}
 	return nil
 }
 

--- a/changelog/potuz_fcu-per-batch-gloas.md
+++ b/changelog/potuz_fcu-per-batch-gloas.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Notify the execution engine of the head per imported batch during Gloas initial sync.


### PR DESCRIPTION
This PR adds a call to FCU in the background once per batch during init-sync, it ignores any errors from the engine. Only affects post-Gloas syncing. 