### PR TITLE
Re-verify builder deposit signatures when in-batch index reuse evicts a pubkey

### DIFF
--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -26,13 +26,21 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 	// deposits that would register a new builder.
 	newDeposits := make([]*enginev1.BuilderDepositRequest, 0, len(requests))
 	newIdx := make([]int, 0, len(requests))
+	seen := make(map[[48]byte]bool, len(requests))
 	for i, request := range requests {
 		if request == nil {
 			continue
 		}
-		if _, isBuilder := st.BuilderIndexByPubkey(bytesutil.ToBytes48(request.Pubkey)); !isBuilder {
+		pubkey := bytesutil.ToBytes48(request.Pubkey)
+		// A later duplicate is a top-up if the first registers, otherwise the sigUnverified
+		// fallback covers it, so skip it here to avoid a wasted batch verification.
+		if seen[pubkey] {
+			continue
+		}
+		if _, isBuilder := st.BuilderIndexByPubkey(pubkey); !isBuilder {
 			newDeposits = append(newDeposits, request)
 			newIdx = append(newIdx, i)
+			seen[pubkey] = true
 		}
 	}
 	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(ctx, newDeposits)

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -12,6 +12,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+type sigStatus int
+
+const (
+	sigUnverified sigStatus = iota
+	sigKnownValid
+	sigKnownInvalid
+)
+
 // ProcessBuilderDepositRequests applies each builder deposit request in order.
 func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, requests []*enginev1.BuilderDepositRequest) error {
 	// Topups to an existing builder skip signature verification per spec, so only batch-verify
@@ -31,16 +39,15 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 	if err != nil {
 		return err
 	}
-	badSig := make([]bool, len(requests))
-	preVerified := make([]bool, len(requests))
+	statuses := make([]sigStatus, len(requests))
 	for _, i := range newIdx {
-		preVerified[i] = true
+		statuses[i] = sigKnownValid
 	}
 	for _, j := range invalid {
-		badSig[newIdx[j]] = true
+		statuses[newIdx[j]] = sigKnownInvalid
 	}
 	for i, request := range requests {
-		if err := processBuilderDepositRequest(ctx, st, request, preVerified[i], !badSig[i]); err != nil {
+		if err := processBuilderDepositRequest(ctx, st, request, statuses[i]); err != nil {
 			return errors.Wrap(err, "could not process builder deposit request")
 		}
 	}
@@ -74,7 +81,7 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 //	            epoch = get_current_epoch(state)
 //	            builder.withdrawable_epoch = epoch + MIN_BUILDER_WITHDRAWABILITY_DELAY
 //	</spec>
-func processBuilderDepositRequest(ctx context.Context, st state.BeaconState, request *enginev1.BuilderDepositRequest, preVerified, sigValid bool) error {
+func processBuilderDepositRequest(ctx context.Context, st state.BeaconState, request *enginev1.BuilderDepositRequest, status sigStatus) error {
 	if request == nil {
 		return errors.New("nil builder deposit request")
 	}
@@ -98,15 +105,21 @@ func processBuilderDepositRequest(ctx context.Context, st state.BeaconState, req
 		return nil
 	}
 
-	if !preVerified {
+	// An in-batch index reuse can evict a pubkey that was a top-up at classification time, so
+	// an unverified request reaching the registration path must have its signature checked here.
+	if status == sigUnverified {
 		valid, err := helpers.VerifyBuilderDepositRequestSignature(ctx, request)
 		if err != nil {
 			return err
 		}
-		sigValid = valid
+		if valid {
+			status = sigKnownValid
+		} else {
+			status = sigKnownInvalid
+		}
 	}
 
-	if !sigValid {
+	if status != sigKnownValid {
 		return nil
 	}
 

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -26,21 +26,13 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 	// deposits that would register a new builder.
 	newDeposits := make([]*enginev1.BuilderDepositRequest, 0, len(requests))
 	newIdx := make([]int, 0, len(requests))
-	seen := make(map[[48]byte]bool, len(requests))
 	for i, request := range requests {
 		if request == nil {
 			continue
 		}
-		pubkey := bytesutil.ToBytes48(request.Pubkey)
-		// A later duplicate is a top-up if the first registers, otherwise the sigUnverified
-		// fallback covers it, so skip it here to avoid a wasted batch verification.
-		if seen[pubkey] {
-			continue
-		}
-		if _, isBuilder := st.BuilderIndexByPubkey(pubkey); !isBuilder {
+		if _, isBuilder := st.BuilderIndexByPubkey(bytesutil.ToBytes48(request.Pubkey)); !isBuilder {
 			newDeposits = append(newDeposits, request)
 			newIdx = append(newIdx, i)
-			seen[pubkey] = true
 		}
 	}
 	invalid, err := helpers.BatchVerifyBuilderDepositRequestSignatures(ctx, newDeposits)

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -32,11 +32,15 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 		return err
 	}
 	badSig := make([]bool, len(requests))
+	preVerified := make([]bool, len(requests))
+	for _, i := range newIdx {
+		preVerified[i] = true
+	}
 	for _, j := range invalid {
 		badSig[newIdx[j]] = true
 	}
 	for i, request := range requests {
-		if err := processBuilderDepositRequest(st, request, !badSig[i]); err != nil {
+		if err := processBuilderDepositRequest(ctx, st, request, preVerified[i], !badSig[i]); err != nil {
 			return errors.Wrap(err, "could not process builder deposit request")
 		}
 	}
@@ -70,7 +74,7 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 //	            epoch = get_current_epoch(state)
 //	            builder.withdrawable_epoch = epoch + MIN_BUILDER_WITHDRAWABILITY_DELAY
 //	</spec>
-func processBuilderDepositRequest(st state.BeaconState, request *enginev1.BuilderDepositRequest, sigValid bool) error {
+func processBuilderDepositRequest(ctx context.Context, st state.BeaconState, request *enginev1.BuilderDepositRequest, preVerified, sigValid bool) error {
 	if request == nil {
 		return errors.New("nil builder deposit request")
 	}
@@ -92,6 +96,14 @@ func processBuilderDepositRequest(st state.BeaconState, request *enginev1.Builde
 		}
 		builderDepositsProcessedTotal.Inc()
 		return nil
+	}
+
+	if !preVerified {
+		valid, err := helpers.VerifyBuilderDepositRequestSignature(ctx, request)
+		if err != nil {
+			return err
+		}
+		sigValid = valid
 	}
 
 	if !sigValid {

--- a/beacon-chain/core/gloas/builder_deposit_request_test.go
+++ b/beacon-chain/core/gloas/builder_deposit_request_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -38,7 +39,7 @@ func TestProcessBuilderDepositRequest_NewBuilderValidSignature(t *testing.T) {
 	req := signedBuilderDepositRequest(t, sk, cred, 1234)
 
 	st := newGloasState(t, nil, nil)
-	require.NoError(t, processBuilderDepositRequest(st, req, true))
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, true, true))
 
 	idx, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, true, ok)
@@ -58,7 +59,7 @@ func TestProcessBuilderDepositRequest_NewBuilderInvalidSignatureIgnored(t *testi
 	req := signedBuilderDepositRequest(t, sk, cred, 1234)
 
 	st := newGloasState(t, nil, nil)
-	require.NoError(t, processBuilderDepositRequest(st, req, false))
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, true, false))
 
 	_, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, false, ok)
@@ -83,7 +84,7 @@ func TestProcessBuilderDepositRequest_ExistingBuilderTopsUpNoSignatureCheck(t *t
 		Amount:                200,
 		Signature:             make([]byte, 96), // not checked for top-up
 	}
-	require.NoError(t, processBuilderDepositRequest(st, req, false))
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, false, false))
 
 	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
 	require.Equal(t, true, ok)
@@ -170,6 +171,78 @@ func TestProcessBuilderDepositRequests_DuplicatePubkeyInvalidThenValidRegisters(
 	builder, err := st.Builder(idx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(700), uint64(builder.Balance))
+}
+
+func TestProcessBuilderDepositRequests_EvictedPubkeyReverifiesSignature(t *testing.T) {
+	cred := builderWithdrawalCredentials()
+	skNew, err := bls.RandKey()
+	require.NoError(t, err)
+	skVictim, err := bls.RandKey()
+	require.NoError(t, err)
+	victimPubkey := skVictim.PublicKey().Marshal()
+
+	builders := []*ethpb.Builder{{
+		Pubkey:            victimPubkey,
+		Version:           []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           0,
+		WithdrawableEpoch: 0,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	victimReq := &enginev1.BuilderDepositRequest{
+		Pubkey:                victimPubkey,
+		WithdrawalCredentials: cred[:],
+		Amount:                200,
+		Signature:             make([]byte, 96), // garbage
+	}
+	reqs := []*enginev1.BuilderDepositRequest{
+		signedBuilderDepositRequest(t, skNew, cred, 1000), // reuses index 0, evicts victim
+		victimReq,
+	}
+	require.NoError(t, ProcessBuilderDepositRequests(t.Context(), st, reqs))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(skNew.PublicKey().Marshal()))
+	require.Equal(t, true, ok)
+	require.Equal(t, primitives.BuilderIndex(0), idx)
+
+	_, ok = st.BuilderIndexByPubkey(toBytes48(victimPubkey))
+	require.Equal(t, false, ok)
+}
+
+func TestProcessBuilderDepositRequests_EvictedPubkeyValidSignatureRegisters(t *testing.T) {
+	cred := builderWithdrawalCredentials()
+	skNew, err := bls.RandKey()
+	require.NoError(t, err)
+	skVictim, err := bls.RandKey()
+	require.NoError(t, err)
+	victimPubkey := skVictim.PublicKey().Marshal()
+
+	builders := []*ethpb.Builder{{
+		Pubkey:            victimPubkey,
+		Version:           []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           0,
+		WithdrawableEpoch: 0,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	reqs := []*enginev1.BuilderDepositRequest{
+		signedBuilderDepositRequest(t, skNew, cred, 1000), // reuses index 0, evicts victim
+		signedBuilderDepositRequest(t, skVictim, cred, 200),
+	}
+	require.NoError(t, ProcessBuilderDepositRequests(t.Context(), st, reqs))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(skNew.PublicKey().Marshal()))
+	require.Equal(t, true, ok)
+	require.Equal(t, primitives.BuilderIndex(0), idx)
+
+	idx, ok = st.BuilderIndexByPubkey(toBytes48(victimPubkey))
+	require.Equal(t, true, ok)
+	require.Equal(t, primitives.BuilderIndex(1), idx)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), uint64(builder.Balance))
 }
 
 func builderWithdrawalCredentialsAt(b byte) []byte {

--- a/beacon-chain/core/gloas/builder_deposit_request_test.go
+++ b/beacon-chain/core/gloas/builder_deposit_request_test.go
@@ -39,7 +39,7 @@ func TestProcessBuilderDepositRequest_NewBuilderValidSignature(t *testing.T) {
 	req := signedBuilderDepositRequest(t, sk, cred, 1234)
 
 	st := newGloasState(t, nil, nil)
-	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, true, true))
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, sigKnownValid))
 
 	idx, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, true, ok)
@@ -59,7 +59,7 @@ func TestProcessBuilderDepositRequest_NewBuilderInvalidSignatureIgnored(t *testi
 	req := signedBuilderDepositRequest(t, sk, cred, 1234)
 
 	st := newGloasState(t, nil, nil)
-	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, true, false))
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, sigKnownInvalid))
 
 	_, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, false, ok)
@@ -84,7 +84,7 @@ func TestProcessBuilderDepositRequest_ExistingBuilderTopsUpNoSignatureCheck(t *t
 		Amount:                200,
 		Signature:             make([]byte, 96), // not checked for top-up
 	}
-	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, false, false))
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, sigUnverified))
 
 	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
 	require.Equal(t, true, ok)

--- a/beacon-chain/core/helpers/deposit.go
+++ b/beacon-chain/core/helpers/deposit.go
@@ -156,6 +156,14 @@ func BatchVerifyBuilderDepositRequestSignatures(ctx context.Context, requests []
 	return verifyBuilderDepositRequestsDC(ctx, requests, domain)
 }
 
+func VerifyBuilderDepositRequestSignature(ctx context.Context, request *enginev1.BuilderDepositRequest) (bool, error) {
+	invalid, err := BatchVerifyBuilderDepositRequestSignatures(ctx, []*enginev1.BuilderDepositRequest{request})
+	if err != nil {
+		return false, err
+	}
+	return len(invalid) == 0, nil
+}
+
 func verifyBuilderDepositRequestDataWithDomain(ctx context.Context, reqs []*enginev1.BuilderDepositRequest, domain []byte) error {
 	if len(reqs) == 0 {
 		return nil

--- a/changelog/terence_fix-builder-deposit-sig-toctou.md
+++ b/changelog/terence_fix-builder-deposit-sig-toctou.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Re-verify builder deposit signatures when an in-batch index reuse evicts a pubkey.


### PR DESCRIPTION
- Batch pre-verification classifies deposits as new-builder vs top-up against the pre-batch state, but an in-batch index reuse can evict a pubkey, so a request classified as top-up can actually register a new builder with an unchecked signature
- Re-verify the signature at apply time when the request was not batch pre-verified
- Add tests for both eviction outcomes, invalid signature skipped and valid signature re-registered