### PR TITLE
Fix `execution_optimistic` decision for attestation rewards API: use ancestor so that block root is guaranteed inside DB

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -119,6 +119,7 @@ func (s *Service) rewardsEndpoints(blocker lookup.Blocker, stater lookup.Stater,
 		TimeFetcher:           s.cfg.GenesisTimeFetcher,
 		Stater:                stater,
 		HeadFetcher:           s.cfg.HeadFetcher,
+		ForkchoiceFetcher:     s.cfg.ForkchoiceFetcher,
 		BlockRewardFetcher:    rewardFetcher,
 	}
 

--- a/beacon-chain/rpc/eth/rewards/handlers.go
+++ b/beacon-chain/rpc/eth/rewards/handlers.go
@@ -90,15 +90,29 @@ func (s *Server) AttestationRewards(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blkRoot, err := st.LatestBlockHeader().HashTreeRoot()
+	headRoot, err := s.HeadFetcher.HeadRoot(ctx)
+	if err != nil {
+		httputil.HandleError(w, "Could not get head root: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	blkRoot, err := s.ForkchoiceFetcher.Ancestor(ctx, headRoot, st.Slot())
 	if err != nil {
 		httputil.HandleError(w, "Could not get block root: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	optimistic, err := s.OptimisticModeFetcher.IsOptimisticForRoot(ctx, blkRoot)
+
+	optimistic, err := s.OptimisticModeFetcher.IsOptimistic(ctx)
 	if err != nil {
 		httputil.HandleError(w, "Could not get optimistic mode info: "+err.Error(), http.StatusInternalServerError)
 		return
+	}
+
+	if optimistic {
+		optimistic, err = s.OptimisticModeFetcher.IsOptimisticForRoot(ctx, bytesutil.ToBytes32(blkRoot))
+		if err != nil {
+			httputil.HandleError(w, "Could not get optimistic mode info: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	resp := &structs.AttestationRewardsResponse{
@@ -107,7 +121,7 @@ func (s *Server) AttestationRewards(w http.ResponseWriter, r *http.Request) {
 			TotalRewards: totalRewards,
 		},
 		ExecutionOptimistic: optimistic,
-		Finalized:           s.FinalizationFetcher.IsFinalized(r.Context(), blkRoot),
+		Finalized:           s.FinalizationFetcher.IsFinalized(r.Context(), bytesutil.ToBytes32(blkRoot)),
 	}
 	httputil.WriteJson(w, resp)
 }

--- a/beacon-chain/rpc/eth/rewards/handlers_test.go
+++ b/beacon-chain/rpc/eth/rewards/handlers_test.go
@@ -551,7 +551,14 @@ func TestAttestationRewards(t *testing.T) {
 	blkRoot, err := st.LatestBlockHeader().HashTreeRoot()
 	require.NoError(t, err)
 	currentSlot := params.BeaconConfig().SlotsPerEpoch * 3
-	mockChainService := &mock.ChainService{OptimisticRoots: map[[32]byte]bool{blkRoot: true}, Slot: &currentSlot}
+	headRoot := [32]byte{'h'}
+	mockChainService := &mock.ChainService{
+		Optimistic:      true,
+		OptimisticRoots: map[[32]byte]bool{blkRoot: true},
+		Slot:            &currentSlot,
+		Root:            headRoot[:],
+		Ancestors:       map[[32]byte][32]byte{headRoot: blkRoot},
+	}
 	s := &Server{
 		Stater: &testutil.MockStater{StatesBySlot: map[primitives.Slot]state.BeaconState{
 			params.BeaconConfig().SlotsPerEpoch*3 - 1: st,
@@ -559,6 +566,8 @@ func TestAttestationRewards(t *testing.T) {
 		TimeFetcher:           mockChainService,
 		OptimisticModeFetcher: mockChainService,
 		FinalizationFetcher:   mockChainService,
+		HeadFetcher:           mockChainService,
+		ForkchoiceFetcher:     mockChainService,
 	}
 
 	t.Run("ideal rewards", func(t *testing.T) {
@@ -652,6 +661,8 @@ func TestAttestationRewards(t *testing.T) {
 			TimeFetcher:           mockChainService,
 			OptimisticModeFetcher: mockChainService,
 			FinalizationFetcher:   mockChainService,
+			HeadFetcher:           mockChainService,
+			ForkchoiceFetcher:     mockChainService,
 		}
 
 		url := "http://only.the.epoch.number.at.the.end.is.important/1"
@@ -691,6 +702,8 @@ func TestAttestationRewards(t *testing.T) {
 			TimeFetcher:           mockChainService,
 			OptimisticModeFetcher: mockChainService,
 			FinalizationFetcher:   mockChainService,
+			HeadFetcher:           mockChainService,
+			ForkchoiceFetcher:     mockChainService,
 		}
 
 		url := "http://only.the.epoch.number.at.the.end.is.important/1"
@@ -825,9 +838,88 @@ func TestAttestationRewards(t *testing.T) {
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 	})
+	t.Run("zero state root (state at skipped slot) uses ancestor root", func(t *testing.T) {
+		st := st.Copy()
+		header := st.LatestBlockHeader()
+		header.StateRoot = params.BeaconConfig().ZeroHash[:]
+		require.NoError(t, st.SetLatestBlockHeader(header))
+		headerRoot, err := header.HashTreeRoot()
+		require.NoError(t, err)
+		ancestorRoot := [32]byte{'a'}
+		require.NotEqual(t, ancestorRoot, headerRoot)
+
+		chain := &mock.ChainService{
+			Optimistic:      true,
+			OptimisticRoots: map[[32]byte]bool{ancestorRoot: true},
+			Slot:            &currentSlot,
+			Root:            headRoot[:],
+			Ancestors:       map[[32]byte][32]byte{headRoot: ancestorRoot},
+		}
+		server := &Server{
+			Stater: &testutil.MockStater{StatesBySlot: map[primitives.Slot]state.BeaconState{
+				params.BeaconConfig().SlotsPerEpoch*3 - 1: st,
+			}},
+			TimeFetcher:           chain,
+			OptimisticModeFetcher: chain,
+			FinalizationFetcher:   chain,
+			HeadFetcher:           chain,
+			ForkchoiceFetcher:     chain,
+		}
+
+		url := "http://only.the.epoch.number.at.the.end.is.important/1"
+		request := httptest.NewRequest("POST", url, nil)
+		request.SetPathValue("epoch", "1")
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		server.AttestationRewards(writer, request)
+		assert.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.AttestationRewardsResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		assert.Equal(t, true, resp.ExecutionOptimistic)
+		assert.Equal(t, ancestorRoot, chain.OptimisticCheckRootReceived)
+	})
+	t.Run("node not optimistic skips per-root lookup", func(t *testing.T) {
+		chain := &mock.ChainService{
+			Optimistic:      false,
+			OptimisticRoots: map[[32]byte]bool{blkRoot: true},
+			Slot:            &currentSlot,
+			Root:            headRoot[:],
+			Ancestors:       map[[32]byte][32]byte{headRoot: blkRoot},
+		}
+		server := &Server{
+			Stater: &testutil.MockStater{StatesBySlot: map[primitives.Slot]state.BeaconState{
+				params.BeaconConfig().SlotsPerEpoch*3 - 1: st,
+			}},
+			TimeFetcher:           chain,
+			OptimisticModeFetcher: chain,
+			FinalizationFetcher:   chain,
+			HeadFetcher:           chain,
+			ForkchoiceFetcher:     chain,
+		}
+
+		url := "http://only.the.epoch.number.at.the.end.is.important/1"
+		request := httptest.NewRequest("POST", url, nil)
+		request.SetPathValue("epoch", "1")
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		server.AttestationRewards(writer, request)
+		assert.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.AttestationRewardsResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		assert.Equal(t, false, resp.ExecutionOptimistic)
+		assert.Equal(t, [32]byte{}, chain.OptimisticCheckRootReceived)
+	})
 	t.Run("optimistic checked per block root", func(t *testing.T) {
 		// Block root is NOT in the optimistic set, so ExecutionOptimistic should be false.
-		nonOptMock := &mock.ChainService{OptimisticRoots: map[[32]byte]bool{}, Slot: &currentSlot}
+		nonOptMock := &mock.ChainService{
+			Optimistic:      true,
+			OptimisticRoots: map[[32]byte]bool{},
+			Slot:            &currentSlot,
+			Root:            headRoot[:],
+			Ancestors:       map[[32]byte][32]byte{headRoot: blkRoot},
+		}
 		nonOptServer := &Server{
 			Stater: &testutil.MockStater{StatesBySlot: map[primitives.Slot]state.BeaconState{
 				params.BeaconConfig().SlotsPerEpoch*3 - 1: st,
@@ -835,6 +927,8 @@ func TestAttestationRewards(t *testing.T) {
 			TimeFetcher:           nonOptMock,
 			OptimisticModeFetcher: nonOptMock,
 			FinalizationFetcher:   nonOptMock,
+			HeadFetcher:           nonOptMock,
+			ForkchoiceFetcher:     nonOptMock,
 		}
 
 		url := "http://only.the.epoch.number.at.the.end.is.important/1"
@@ -887,7 +981,14 @@ func TestAttestationRewards_IdealRewardsIncludesCompoundingValidatorEffectiveBal
 	blkRoot, err := st.LatestBlockHeader().HashTreeRoot()
 	require.NoError(t, err)
 	currentSlot := params.BeaconConfig().SlotsPerEpoch * 3
-	mockChainService := &mock.ChainService{OptimisticRoots: map[[32]byte]bool{blkRoot: true}, Slot: &currentSlot}
+	headRoot := [32]byte{'h'}
+	mockChainService := &mock.ChainService{
+		Optimistic:      true,
+		OptimisticRoots: map[[32]byte]bool{blkRoot: true},
+		Slot:            &currentSlot,
+		Root:            headRoot[:],
+		Ancestors:       map[[32]byte][32]byte{headRoot: blkRoot},
+	}
 	s := &Server{
 		Stater: &testutil.MockStater{StatesBySlot: map[primitives.Slot]state.BeaconState{
 			params.BeaconConfig().SlotsPerEpoch*3 - 1: st,
@@ -895,6 +996,8 @@ func TestAttestationRewards_IdealRewardsIncludesCompoundingValidatorEffectiveBal
 		TimeFetcher:           mockChainService,
 		OptimisticModeFetcher: mockChainService,
 		FinalizationFetcher:   mockChainService,
+		HeadFetcher:           mockChainService,
+		ForkchoiceFetcher:     mockChainService,
 	}
 
 	url := "http://only.the.epoch.number.at.the.end.is.important/1"

--- a/beacon-chain/rpc/eth/rewards/server.go
+++ b/beacon-chain/rpc/eth/rewards/server.go
@@ -12,5 +12,6 @@ type Server struct {
 	TimeFetcher           blockchain.TimeFetcher
 	Stater                lookup.Stater
 	HeadFetcher           blockchain.HeadFetcher
+	ForkchoiceFetcher     blockchain.ForkchoiceFetcher
 	BlockRewardFetcher    BlockRewardsFetcher
 }

--- a/changelog/syjn99_fix-optimistic-fetcher.md
+++ b/changelog/syjn99_fix-optimistic-fetcher.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix `execution_optimistic` decision for attestation rewards API: use ancestor so that block root is guaranteed inside DB.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

`POST /eth/v1/beacon/rewards/attestations/{epoch}` returns an error response like:

```
{"message":"Could not get optimistic mode info: could not find block in DB","code":500}
```

This is because it calculates HTR of block root with `latest_block_header`. This PR guarantees that calculting HTR cannot be wrong as it ALWAYS lives in the DB, finding ancestor of the block, so `IsOptimisticForRoot` always receives a valid HTR.


**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
