### PR TITLE
Order Gloas before Fulu in gossip block topic mapping

### DIFF
--- a/beacon-chain/p2p/gossip_topic_mappings.go
+++ b/beacon-chain/p2p/gossip_topic_mappings.go
@@ -38,11 +38,11 @@ var gossipTopicMappings = map[string]func() proto.Message{
 func GossipTopicMappings(topic string, epoch primitives.Epoch) proto.Message {
 	switch topic {
 	case BlockSubnetTopicFormat:
-		if epoch >= params.BeaconConfig().FuluForkEpoch {
-			return &ethpb.SignedBeaconBlockFulu{}
-		}
 		if epoch >= params.BeaconConfig().GloasForkEpoch {
 			return &ethpb.SignedBeaconBlockGloas{}
+		}
+		if epoch >= params.BeaconConfig().FuluForkEpoch {
+			return &ethpb.SignedBeaconBlockFulu{}
 		}
 		if epoch >= params.BeaconConfig().ElectraForkEpoch {
 			return &ethpb.SignedBeaconBlockElectra{}

--- a/beacon-chain/p2p/gossip_topic_mappings_test.go
+++ b/beacon-chain/p2p/gossip_topic_mappings_test.go
@@ -31,8 +31,8 @@ func TestGossipTopicMappings_CorrectType(t *testing.T) {
 	capellaForkEpoch := primitives.Epoch(300)
 	denebForkEpoch := primitives.Epoch(400)
 	electraForkEpoch := primitives.Epoch(500)
-	gloasForkEpoch := primitives.Epoch(550)
-	fuluForkEpoch := primitives.Epoch(600)
+	fuluForkEpoch := primitives.Epoch(550)
+	gloasForkEpoch := primitives.Epoch(600)
 
 	bCfg.AltairForkEpoch = altairForkEpoch
 	bCfg.BellatrixForkEpoch = bellatrixForkEpoch
@@ -46,8 +46,8 @@ func TestGossipTopicMappings_CorrectType(t *testing.T) {
 	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(bCfg.CapellaForkVersion)] = primitives.Epoch(300)
 	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(bCfg.DenebForkVersion)] = primitives.Epoch(400)
 	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(bCfg.ElectraForkVersion)] = primitives.Epoch(500)
-	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(bCfg.GloasForkVersion)] = primitives.Epoch(550)
-	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(bCfg.FuluForkVersion)] = primitives.Epoch(600)
+	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(bCfg.FuluForkVersion)] = primitives.Epoch(550)
+	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(bCfg.GloasForkVersion)] = primitives.Epoch(600)
 	params.OverrideBeaconConfig(bCfg)
 
 	// Phase 0
@@ -162,6 +162,11 @@ func TestGossipTopicMappings_CorrectType(t *testing.T) {
 	assert.Equal(t, true, ok)
 	pMessage = GossipTopicMappings(LightClientFinalityUpdateTopicFormat, electraForkEpoch)
 	_, ok = pMessage.(*ethpb.LightClientFinalityUpdateElectra)
+	assert.Equal(t, true, ok)
+
+	// Fulu Fork
+	pMessage = GossipTopicMappings(BlockSubnetTopicFormat, fuluForkEpoch)
+	_, ok = pMessage.(*ethpb.SignedBeaconBlockFulu)
 	assert.Equal(t, true, ok)
 
 	// Gloas Fork

--- a/changelog/terence_gloas-block-gossip-mapping-order.md
+++ b/changelog/terence_gloas-block-gossip-mapping-order.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Order the Gloas branch before Fulu in the gossip block topic mapping so the epoch cascade returns the right block type.


### PR DESCRIPTION
- `GossipTopicMappings` checked `FuluForkEpoch` before `GloasForkEpoch` in the block topic cascade; since any gloas epoch is also past fulu, it returned `SignedBeaconBlockFulu` for gloas epochs and the gloas branch was unreachable
- No impact today: the gossip decode path derives the block type from the fork digest via `types.BlockMap` and only nil-checks this function's result, so nothing consumes the wrong answer, but any future caller trusting the epoch cascade would decode gloas blocks as fulu
- The existing test masked this by configuring gloas before fulu; the test now uses the real fork order and asserts the block type at both epochs, failing against the old branch order