### PR TITLE
Propagate client stats Prometheus scrape errors

### DIFF
--- a/changelog/weifanglab_clientstats_scrape_prom_error.md
+++ b/changelog/weifanglab_clientstats_scrape_prom_error.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Propagate client-stats Prometheus scrape errors when metric collection fails.

--- a/monitoring/clientstats/scrapers.go
+++ b/monitoring/clientstats/scrapers.go
@@ -80,10 +80,7 @@ func scrapeProm(url string, tripper http.RoundTripper) (map[string]*dto.MetricFa
 	go func() {
 		// FetchMetricFamilies handles grpc flavored prometheus ez
 		// but at the cost of the awkward channel select loop below
-		err := prom2json.FetchMetricFamilies(url, mfChan, tripper)
-		if err != nil {
-			errChan <- err
-		}
+		errChan <- prom2json.FetchMetricFamilies(url, mfChan, tripper)
 	}()
 	result := make(map[string]*dto.MetricFamily)
 	// channel select accumulates results from FetchMetricFamilies
@@ -94,15 +91,12 @@ func scrapeProm(url string, tripper http.RoundTripper) (map[string]*dto.MetricFa
 			// FetchMetricFamilies will close the channel when done
 			// at which point we want to stop the goroutine
 			if fam == nil && !chanOpen {
-				return result, nil
+				return result, <-errChan
 			}
 			ptr := fam
 			result[fam.GetName()] = ptr
 		case err := <-errChan:
 			return result, err
-		}
-		if errChan == nil && mfChan == nil {
-			return result, nil
 		}
 	}
 }

--- a/monitoring/clientstats/scrapers_test.go
+++ b/monitoring/clientstats/scrapers_test.go
@@ -25,9 +25,17 @@ type mockRT struct {
 }
 
 func (rt *mockRT) RoundTrip(_ *http.Request) (*http.Response, error) {
+	statusCode := rt.statusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	status := rt.status
+	if status == "" {
+		status = http.StatusText(statusCode)
+	}
 	return &http.Response{
-		Status:     http.StatusText(http.StatusOK),
-		StatusCode: http.StatusOK,
+		Status:     status,
+		StatusCode: statusCode,
 		Body:       io.NopCloser(strings.NewReader(rt.body)),
 	}, nil
 }
@@ -203,6 +211,16 @@ func TestBadInput(t *testing.T) {
 	_, err := bnScraper.Scrape()
 	require.NoError(t, err)
 	require.LogsContain(t, hook, "Failed to get prysm_version")
+}
+
+func TestScrapePromReturnsFetchMetricFamiliesError(t *testing.T) {
+	_, err := scrapeProm("http://localhost/metrics", &mockRT{
+		body:       "upstream failure",
+		status:     "500 Internal Server Error",
+		statusCode: http.StatusInternalServerError,
+	})
+
+	require.ErrorContains(t, "returned HTTP status 500 Internal Server Error", err)
 }
 
 var prometheusTestBody = `


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix


**What does this PR do? Why is it needed?**

This PR updates `scrapeProm` to propagate the final error returned by `prom2json.FetchMetricFamilies`.

`FetchMetricFamilies` closes the metric-family channel before returning some scrape errors, such as non-200 HTTP responses. The previous select loop could observe the closed channel first and return a successful result with a nil error, hiding the actual scrape failure.

The fix always forwards the final fetch result on `errChan` and waits for it when the metric-family channel closes. A regression test covers the non-200 response case.



**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

I have tested by executed the following cmd:

```shell
- `go test ./monitoring/clientstats -run TestScrapePromReturnsFetchMetricFamiliesError -count=1`
- `go test ./monitoring/clientstats -count=1`
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
