### PR TITLE
Set `BUILDER_WITHDRAWAL_PREFIX` to `0xB0` as per spec

### DIFF
--- a/changelog/syjn99_fix-builder-withdrawal-prefix.md
+++ b/changelog/syjn99_fix-builder-withdrawal-prefix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Set `BUILDER_WITHDRAWAL_PREFIX` to `0xB0`.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -96,7 +96,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	BLSWithdrawalPrefixByte:         byte(0),
 	ETH1AddressWithdrawalPrefixByte: byte(1),
 	CompoundingWithdrawalPrefixByte: byte(2),
-	BuilderWithdrawalPrefixByte:     byte(3),
+	BuilderWithdrawalPrefixByte:     byte(0xB0),
 	PayloadBuilderVersion:           byte(0),
 	BuilderIndexSelfBuild:           primitives.BuilderIndex(math.MaxUint64),
 	ZeroHash:                        [32]byte{},

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -31,7 +31,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	// Initial values
 	minimalConfig.BLSWithdrawalPrefixByte = byte(0)
 	minimalConfig.ETH1AddressWithdrawalPrefixByte = byte(1)
-	minimalConfig.BuilderWithdrawalPrefixByte = byte(3)
+	minimalConfig.BuilderWithdrawalPrefixByte = byte(0xB0)
 
 	// Time parameters
 	minimalConfig.SecondsPerSlot = 6


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

As per https://github.com/ethereum/consensus-specs/pull/5416, this PR changes `BUILDER_WITHDRAWAL_PREFIX` from `0x03` to `0xB0`. This was found while running spectest (`TestMinimal_UpgradeToGloas`).

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
