### PR TITLE
Set `PAYLOAD_DUE_BPS` to 5000

### DIFF
--- a/changelog/terence_payload-due-bps-5000.md
+++ b/changelog/terence_payload-due-bps-5000.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Set `PAYLOAD_DUE_BPS` to 5000.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -135,7 +135,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	SyncMessageDueBPSGloas:   primitives.BP(2500),
 	ContributionDueBPSGloas:  primitives.BP(5000),
 	PayloadAttestationDueBPS: primitives.BP(7500),
-	PayloadDueBPS:            primitives.BP(7500),
+	PayloadDueBPS:            primitives.BP(5000),
 	EquivocationEarlyDueBPS:  primitives.BP(7500),
 
 	// Ethereum PoW parameters.

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -41,7 +41,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.SyncMessageDueBPSGloas = 2500
 	minimalConfig.ContributionDueBPSGloas = 5000
 	minimalConfig.PayloadAttestationDueBPS = 7500
-	minimalConfig.PayloadDueBPS = 7500
+	minimalConfig.PayloadDueBPS = 5000
 	minimalConfig.EquivocationEarlyDueBPS = 7500
 	minimalConfig.MinAttestationInclusionDelay = 1
 	minimalConfig.SlotsPerEpoch = 8


### PR DESCRIPTION
- Sets the payload deadline to 50% of the slot per https://github.com/ethereum/consensus-specs/pull/5414