### PR TITLE
Reduce `MIN_BUILDER_WITHDRAWABILITY_DELAY` to 64 epochs

### DIFF
--- a/changelog/terence_builder-withdrawability-delay-64.md
+++ b/changelog/terence_builder-withdrawability-delay-64.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reduce `MIN_BUILDER_WITHDRAWABILITY_DELAY` to 64 epochs.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -112,7 +112,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	EpochsPerEth1VotingPeriod:        64,
 	SlotsPerHistoricalRoot:           8192,
 	MinValidatorWithdrawabilityDelay: 256,
-	MinBuilderWithdrawabilityDelay:   8192,
+	MinBuilderWithdrawabilityDelay:   64,
 	ShardCommitteePeriod:             256,
 	MinEpochsToInactivityPenalty:     4,
 	Eth1FollowDistance:               2048,


### PR DESCRIPTION
- Reduces `MIN_BUILDER_WITHDRAWABILITY_DELAY` from 8192 to 64 epochs per https://github.com/ethereum/consensus-specs/pull/5426