### PR TITLE
Ignore instead of reject on bid fee recipient mismatch

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -96,9 +96,10 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyExecutionPaymentZero(); err != nil {
 		return pubsub.ValidationReject, err
 	}
-	// [REJECT] bid.fee_recipient matches the fee_recipient from the proposer's SignedProposerPreferences associated with bid.slot.
+	// [IGNORE] bid.fee_recipient matches the fee_recipient from the proposer's SignedProposerPreferences associated with bid.slot.
+	// Preferences are not checked for equivocations, so a mismatch is not provably the builder's fault.
 	if err := v.VerifyFeeRecipientMatches(pref.FeeRecipient[:]); err != nil {
-		return pubsub.ValidationReject, err
+		return pubsub.ValidationIgnore, err
 	}
 	// [REJECT] len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block.
 	if err := v.VerifyBlobKzgCommitmentsLimit(); err != nil {

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -124,7 +124,7 @@ func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
 		{
 			name:      "fee recipient mismatch",
 			verifier:  mockExecutionPayloadBidVerifier{errFeeRecipientMismatch: errors.New("wrong fee recipient")},
-			result:    pubsub.ValidationReject,
+			result:    pubsub.ValidationIgnore,
 			wantError: true,
 		},
 		{
@@ -302,7 +302,7 @@ func TestValidateExecutionPayloadBidGossip_FeeRecipientMismatch(t *testing.T) {
 
 	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
 	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationReject, result)
+	require.Equal(t, pubsub.ValidationIgnore, result)
 	require.ErrorIs(t, err, verification.ErrBidFeeRecipientMismatch)
 }
 

--- a/changelog/terence_bid-fee-recipient-ignore.md
+++ b/changelog/terence_bid-fee-recipient-ignore.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Ignore instead of reject execution payload bids whose fee recipient does not match proposer preferences.


### PR DESCRIPTION
- Downgrades the bid gossip `fee_recipient` check from REJECT to IGNORE per https://github.com/ethereum/consensus-specs/pull/5429, proposer preferences are not checked for equivocations so a mismatch is not provably malicious