### PR TITLE
Restrict builder deposits to payload builders

### DIFF
--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -19,7 +19,7 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 	newDeposits := make([]*enginev1.BuilderDepositRequest, 0, len(requests))
 	newIdx := make([]int, 0, len(requests))
 	for i, request := range requests {
-		if request == nil {
+		if request == nil || !helpers.IsBuilderWithdrawalCredential(request.WithdrawalCredentials) {
 			continue
 		}
 		if _, isBuilder := st.BuilderIndexByPubkey(bytesutil.ToBytes48(request.Pubkey)); !isBuilder {
@@ -73,6 +73,11 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 func processBuilderDepositRequest(st state.BeaconState, request *enginev1.BuilderDepositRequest, sigValid bool) error {
 	if request == nil {
 		return errors.New("nil builder deposit request")
+	}
+
+	// Deposits without BUILDER_WITHDRAWAL_PREFIX are dropped and the funds are lost.
+	if !helpers.IsBuilderWithdrawalCredential(request.WithdrawalCredentials) {
+		return nil
 	}
 
 	pubkey := bytesutil.ToBytes48(request.Pubkey)

--- a/beacon-chain/core/gloas/builder_deposit_request_test.go
+++ b/beacon-chain/core/gloas/builder_deposit_request_test.go
@@ -45,7 +45,7 @@ func TestProcessBuilderDepositRequest_NewBuilderValidSignature(t *testing.T) {
 	builder, err := st.Builder(idx)
 	require.NoError(t, err)
 	require.DeepEqual(t, req.Pubkey, builder.Pubkey)
-	require.DeepEqual(t, []byte{cred[0]}, builder.Version)
+	require.DeepEqual(t, []byte{params.BeaconConfig().PayloadBuilderVersion}, builder.Version)
 	require.DeepEqual(t, cred[12:], builder.ExecutionAddress)
 	require.Equal(t, uint64(1234), uint64(builder.Balance))
 	require.Equal(t, params.BeaconConfig().FarFutureEpoch, builder.WithdrawableEpoch)
@@ -62,6 +62,50 @@ func TestProcessBuilderDepositRequest_NewBuilderInvalidSignatureIgnored(t *testi
 
 	_, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, false, ok)
+}
+
+func TestProcessBuilderDepositRequest_NewBuilderNonBuilderPrefixIgnored(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	cred := builderWithdrawalCredentials()
+	cred[0] = 0x01
+	req := signedBuilderDepositRequest(t, sk, cred, 1234)
+
+	st := newGloasState(t, nil, nil)
+	require.NoError(t, processBuilderDepositRequest(st, req, true))
+
+	_, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
+	require.Equal(t, false, ok)
+}
+
+func TestProcessBuilderDepositRequest_TopUpNonBuilderPrefixIgnored(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	pubkey := sk.PublicKey().Marshal()
+	builders := []*ethpb.Builder{{
+		Pubkey:            pubkey,
+		Version:           []byte{params.BeaconConfig().PayloadBuilderVersion},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           5,
+		WithdrawableEpoch: params.BeaconConfig().FarFutureEpoch,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	cred := builderWithdrawalCredentials()
+	cred[0] = 0x01
+	req := &enginev1.BuilderDepositRequest{
+		Pubkey:                pubkey,
+		WithdrawalCredentials: cred[:],
+		Amount:                200,
+		Signature:             make([]byte, 96),
+	}
+	require.NoError(t, processBuilderDepositRequest(st, req, true))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), uint64(builder.Balance))
 }
 
 func TestProcessBuilderDepositRequest_ExistingBuilderTopsUpNoSignatureCheck(t *testing.T) {

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -368,8 +368,7 @@ func (b *BeaconState) AddBuilderFromDeposit(pubkey [fieldparams.BLSPubkeyLength]
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	// process_builder_deposit_request sets version to withdrawal_credentials[0].
-	return b.addBuilderFromDepositAtEpoch(pubkey, withdrawalCredentials[0], withdrawalCredentials, amount, slots.ToEpoch(b.slot))
+	return b.addBuilderFromDepositAtEpoch(pubkey, params.BeaconConfig().PayloadBuilderVersion, withdrawalCredentials, amount, slots.ToEpoch(b.slot))
 }
 
 func (b *BeaconState) addBuilderFromDepositAtEpoch(pubkey [fieldparams.BLSPubkeyLength]byte, builderVersion byte, withdrawalCredentials [fieldparams.RootLength]byte, amount uint64, depositEpoch primitives.Epoch) error {

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -882,7 +882,7 @@ func TestAddBuilderFromDeposit(t *testing.T) {
 		copy(pubkey[:], bytes.Repeat([]byte{0xAA}, 48))
 		var wc [32]byte
 		copy(wc[:], bytes.Repeat([]byte{0xBB}, 32))
-		wc[0] = 0x42 // version byte
+		wc[0] = 0x42 // registered version must ignore the credential prefix
 
 		st := &BeaconState{
 			version:     version.Gloas,
@@ -905,7 +905,7 @@ func TestAddBuilderFromDeposit(t *testing.T) {
 		got := st.builders[0]
 		require.NotNil(t, got)
 		require.DeepEqual(t, pubkey[:], got.Pubkey)
-		require.DeepEqual(t, []byte{0x42}, got.Version)
+		require.DeepEqual(t, []byte{params.BeaconConfig().PayloadBuilderVersion}, got.Version)
 		require.DeepEqual(t, wc[12:], got.ExecutionAddress)
 		require.Equal(t, primitives.Gwei(123), got.Balance)
 		require.Equal(t, primitives.Epoch(0), got.DepositEpoch)

--- a/changelog/terence_builder-deposit-prefix.md
+++ b/changelog/terence_builder-deposit-prefix.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Ignore builder deposit requests without `BUILDER_WITHDRAWAL_PREFIX` and register new builders with `PAYLOAD_BUILDER_VERSION`.


### PR DESCRIPTION
- Ignores builder deposit requests whose withdrawal credentials do not start with `BUILDER_WITHDRAWAL_PREFIX` and registers new builders with `PAYLOAD_BUILDER_VERSION` instead of the credential's first byte, per https://github.com/ethereum/consensus-specs/pull/5439
- Non-builder-prefix requests are also excluded from batch signature verification