### PR TITLE
Remove `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` bound in Gloas

### DIFF
--- a/changelog/terence_gloas-remove-deposit-limit.md
+++ b/changelog/terence_gloas-remove-deposit-limit.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Remove the `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` bound on Gloas execution request decoding.

--- a/proto/engine/v1/electra.go
+++ b/proto/engine/v1/electra.go
@@ -2,6 +2,7 @@ package enginev1
 
 import (
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -93,6 +94,8 @@ func decodeExecutionRequestList(raw [][]byte, limits ExecutionRequestLimits) (*E
 // decodeExecutionRequestListGloas decodes the EIP-7685 flat request list into a
 // gloas ExecutionRequests, including builder deposit/exit requests (EIP-8282).
 func decodeExecutionRequestListGloas(raw [][]byte, limits ExecutionRequestLimits) (*ExecutionRequestsGloas, error) {
+	// Gloas removes MAX_DEPOSIT_REQUESTS_PER_PAYLOAD, the EL bounds deposit requests via the gas limit.
+	limits.Deposits = math.MaxUint64 / uint64(drSize)
 	requests := &ExecutionRequestsGloas{}
 	var prevTypeNum *uint8
 	for i := range raw {

--- a/proto/engine/v1/electra_test.go
+++ b/proto/engine/v1/electra_test.go
@@ -276,3 +276,15 @@ func TestEmptyExecutionRequestsHashTreeRoot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
+
+func TestGetDecodedExecutionRequestsGloas_NoDepositLimit(t *testing.T) {
+	cfg := params.BeaconConfig()
+	count := int(cfg.MaxDepositRequestsPerPayload) + 1
+	depositRequestBytes := make([]byte, count*(&enginev1.DepositRequest{}).SizeSSZ())
+	ebg := &enginev1.ExecutionBundleGloas{
+		ExecutionRequests: [][]byte{append([]byte{uint8(enginev1.DepositRequestType)}, depositRequestBytes...)},
+	}
+	requests, err := ebg.GetDecodedExecutionRequests(cfg.ExecutionRequestLimits())
+	require.NoError(t, err)
+	require.Equal(t, count, len(requests.Deposits))
+}


### PR DESCRIPTION
- Stops capping deposit requests when decoding Gloas execution requests from the EL per https://github.com/ethereum/consensus-specs/pull/5436, the gas limit now bounds them
- The SSZ list bound on `ExecutionRequestsGloas` moves to a progressive list with the EIP-7688 migration in #17041