### PR TITLE
Only reset builder withdrawable epoch on top-up when balance is swept

### DIFF
--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -81,6 +81,9 @@ func processBuilderDepositRequest(st state.BeaconState, request *enginev1.Builde
 		if err != nil {
 			return err
 		}
+		if builder == nil {
+			return errors.Errorf("builder at index %d is nil", idx)
+		}
 		// Reset only when exited and fully swept, checked before the top-up is credited.
 		if builder.WithdrawableEpoch != params.BeaconConfig().FarFutureEpoch && builder.Balance == 0 {
 			builder.WithdrawableEpoch = slots.ToEpoch(st.Slot()) + params.BeaconConfig().MinBuilderWithdrawabilityDelay

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -77,18 +77,19 @@ func processBuilderDepositRequest(st state.BeaconState, request *enginev1.Builde
 
 	pubkey := bytesutil.ToBytes48(request.Pubkey)
 	if idx, isBuilder := st.BuilderIndexByPubkey(pubkey); isBuilder {
-		if err := st.IncreaseBuilderBalance(idx, request.Amount); err != nil {
-			return err
-		}
 		builder, err := st.Builder(idx)
 		if err != nil {
 			return err
 		}
-		if builder.WithdrawableEpoch != params.BeaconConfig().FarFutureEpoch {
+		// Reset only when exited and fully swept, checked before the top-up is credited.
+		if builder.WithdrawableEpoch != params.BeaconConfig().FarFutureEpoch && builder.Balance == 0 {
 			builder.WithdrawableEpoch = slots.ToEpoch(st.Slot()) + params.BeaconConfig().MinBuilderWithdrawabilityDelay
 			if err := st.UpdateBuilderAtIndex(idx, builder); err != nil {
 				return err
 			}
+		}
+		if err := st.IncreaseBuilderBalance(idx, request.Amount); err != nil {
+			return err
 		}
 		builderDepositsProcessedTotal.Inc()
 		return nil

--- a/beacon-chain/core/gloas/builder_deposit_request_test.go
+++ b/beacon-chain/core/gloas/builder_deposit_request_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
 func signedBuilderDepositRequest(t *testing.T, sk bls.SecretKey, cred [32]byte, amount uint64) *enginev1.BuilderDepositRequest {
@@ -90,6 +92,68 @@ func TestProcessBuilderDepositRequest_ExistingBuilderTopsUpNoSignatureCheck(t *t
 	builder, err := st.Builder(idx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(205), uint64(builder.Balance))
+}
+
+func TestProcessBuilderDepositRequest_ExitedSweptBuilderTopUpResetsWithdrawableEpoch(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	pubkey := sk.PublicKey().Marshal()
+	builders := []*ethpb.Builder{{
+		Pubkey:            pubkey,
+		Version:           []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           0,
+		WithdrawableEpoch: 0,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	cred := builderWithdrawalCredentials()
+	req := &enginev1.BuilderDepositRequest{
+		Pubkey:                pubkey,
+		WithdrawalCredentials: cred[:],
+		Amount:                200,
+		Signature:             make([]byte, 96),
+	}
+	require.NoError(t, processBuilderDepositRequest(st, req, false))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), uint64(builder.Balance))
+	expected := slots.ToEpoch(st.Slot()) + params.BeaconConfig().MinBuilderWithdrawabilityDelay
+	require.Equal(t, expected, builder.WithdrawableEpoch)
+}
+
+func TestProcessBuilderDepositRequest_ExitedUnsweptBuilderTopUpKeepsWithdrawableEpoch(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	pubkey := sk.PublicKey().Marshal()
+	exitedEpoch := primitives.Epoch(1)
+	builders := []*ethpb.Builder{{
+		Pubkey:            pubkey,
+		Version:           []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           5,
+		WithdrawableEpoch: exitedEpoch,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	cred := builderWithdrawalCredentials()
+	req := &enginev1.BuilderDepositRequest{
+		Pubkey:                pubkey,
+		WithdrawalCredentials: cred[:],
+		Amount:                200,
+		Signature:             make([]byte, 96),
+	}
+	require.NoError(t, processBuilderDepositRequest(st, req, false))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(205), uint64(builder.Balance))
+	require.Equal(t, exitedEpoch, builder.WithdrawableEpoch)
 }
 
 func TestProcessBuilderDepositRequests_BatchMixedValidInvalidAndTopUp(t *testing.T) {

--- a/changelog/terence_builder-topup-swept-reset.md
+++ b/changelog/terence_builder-topup-swept-reset.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reset an exited builder's withdrawable epoch on top-up only when its balance has been swept.


### PR DESCRIPTION
- Resets an exited builder's withdrawable epoch on a deposit top-up only when its balance has already been swept to zero, checked before the top-up is credited, per https://github.com/ethereum/consensus-specs/pull/5384