### PR TITLE
Respond with 410 Gone and a replacement hint on spec-removed Beacon API routes

### DIFF
--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "endpoints.go",
+        "endpoints_removed.go",
         "log.go",
         "metrics.go",
         "service.go",
@@ -58,6 +59,7 @@ go_library(
         "//consensus-types/interfaces:go_default_library",
         "//io/logs:go_default_library",
         "//monitoring/tracing:go_default_library",
+        "//network/httputil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//recovery:go_default_library",
@@ -80,6 +82,7 @@ go_test(
     name = "go_default_test",
     size = "medium",
     srcs = [
+        "endpoints_removed_test.go",
         "endpoints_test.go",
         "service_test.go",
     ],
@@ -90,6 +93,7 @@ go_test(
         "//beacon-chain/startup:go_default_library",
         "//beacon-chain/sync/initial-sync/testing:go_default_library",
         "//config/features:go_default_library",
+        "//network/httputil:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -99,6 +99,7 @@ func (s *Service) endpoints(
 	endpoints = append(endpoints, s.prysmBeaconEndpoints(ch, stater, blocker, coreService)...)
 	endpoints = append(endpoints, s.prysmNodeEndpoints()...)
 	endpoints = append(endpoints, s.prysmValidatorEndpoints(stater, coreService)...)
+	endpoints = append(endpoints, s.removedEndpoints()...)
 
 	if features.Get().EnableLightClient {
 		endpoints = append(endpoints, s.lightClientEndpoints()...)
@@ -106,6 +107,7 @@ func (s *Service) endpoints(
 
 	if enableDebug {
 		endpoints = append(endpoints, s.debugEndpoints(stater, blocker)...)
+		endpoints = append(endpoints, s.removedDebugEndpoints()...)
 	}
 
 	return endpoints

--- a/beacon-chain/rpc/endpoints_removed.go
+++ b/beacon-chain/rpc/endpoints_removed.go
@@ -1,0 +1,58 @@
+package rpc
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
+)
+
+// removedEndpoint returns an endpoint responding with 410 Gone for a route that Prysm used to
+// serve but which has since been removed from the Beacon API specification. Naming the
+// replacement route turns breakage of outdated tooling into an actionable migration hint
+// instead of a silent 404. An empty replacement means the route was retired without a successor.
+func removedEndpoint(name, template string, methods []string, replacement string) endpoint {
+	msg := "This endpoint was removed from the Beacon API specification and is no longer supported."
+	if replacement == "" {
+		msg += " It has no replacement."
+	} else {
+		msg = fmt.Sprintf("%s Use %s instead.", msg, replacement)
+	}
+	return endpoint{
+		template: template,
+		name:     "removed." + name,
+		handler: func(w http.ResponseWriter, _ *http.Request) {
+			httputil.HandleError(w, msg, http.StatusGone)
+		},
+		methods: methods,
+	}
+}
+
+func (*Service) removedEndpoints() []endpoint {
+	return []endpoint{
+		removedEndpoint("GetBlock", "/eth/v1/beacon/blocks/{block_id}", []string{http.MethodGet}, "/eth/v2/beacon/blocks/{block_id}"),
+		removedEndpoint("GetBlockAttestations", "/eth/v1/beacon/blocks/{block_id}/attestations", []string{http.MethodGet}, "/eth/v2/beacon/blocks/{block_id}/attestations"),
+		removedEndpoint("PublishBlock", "/eth/v1/beacon/blocks", []string{http.MethodPost}, "/eth/v2/beacon/blocks"),
+		removedEndpoint("PublishBlindedBlock", "/eth/v1/beacon/blinded_blocks", []string{http.MethodPost}, "/eth/v2/beacon/blinded_blocks"),
+		removedEndpoint("ListAttestations", "/eth/v1/beacon/pool/attestations", []string{http.MethodGet}, "/eth/v2/beacon/pool/attestations"),
+		removedEndpoint("SubmitAttestations", "/eth/v1/beacon/pool/attestations", []string{http.MethodPost}, "/eth/v2/beacon/pool/attestations"),
+		removedEndpoint("GetAttesterSlashings", "/eth/v1/beacon/pool/attester_slashings", []string{http.MethodGet}, "/eth/v2/beacon/pool/attester_slashings"),
+		removedEndpoint("SubmitAttesterSlashings", "/eth/v1/beacon/pool/attester_slashings", []string{http.MethodPost}, "/eth/v2/beacon/pool/attester_slashings"),
+		removedEndpoint("GetDepositSnapshot", "/eth/v1/beacon/deposit_snapshot", []string{http.MethodGet}, ""),
+		removedEndpoint("ExpectedWithdrawals", "/eth/v1/builder/states/{state_id}/expected_withdrawals", []string{http.MethodGet}, ""),
+		removedEndpoint("GetAggregateAttestation", "/eth/v1/validator/aggregate_attestation", []string{http.MethodGet}, "/eth/v2/validator/aggregate_attestation"),
+		removedEndpoint("SubmitAggregateAndProofs", "/eth/v1/validator/aggregate_and_proofs", []string{http.MethodPost}, "/eth/v2/validator/aggregate_and_proofs"),
+		removedEndpoint("ProduceBlock", "/eth/v1/validator/blocks/{slot}", []string{http.MethodGet}, "/eth/v3/validator/blocks/{slot}"),
+		removedEndpoint("ProduceBlockV2", "/eth/v2/validator/blocks/{slot}", []string{http.MethodGet}, "/eth/v3/validator/blocks/{slot}"),
+		removedEndpoint("ProduceBlindedBlock", "/eth/v1/validator/blinded_blocks/{slot}", []string{http.MethodGet}, "/eth/v3/validator/blocks/{slot}"),
+	}
+}
+
+// removedDebugEndpoints is registered only alongside the live debug endpoints so that the whole
+// debug namespace stays dark when debug endpoints are disabled.
+func (*Service) removedDebugEndpoints() []endpoint {
+	return []endpoint{
+		removedEndpoint("GetBeaconState", "/eth/v1/debug/beacon/states/{state_id}", []string{http.MethodGet}, "/eth/v2/debug/beacon/states/{state_id}"),
+		removedEndpoint("GetForkChoiceHeads", "/eth/v1/debug/beacon/heads", []string{http.MethodGet}, "/eth/v2/debug/beacon/heads"),
+	}
+}

--- a/beacon-chain/rpc/endpoints_removed_test.go
+++ b/beacon-chain/rpc/endpoints_removed_test.go
@@ -1,0 +1,79 @@
+package rpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func TestRemovedEndpoints(t *testing.T) {
+	s := &Service{cfg: &Config{}}
+
+	// Registering every endpoint also guards against pattern conflicts between removed and live
+	// routes, since http.ServeMux panics on conflicting patterns.
+	mux := http.NewServeMux()
+	for _, e := range s.endpoints(true, nil, nil, nil, nil, nil, nil) {
+		for _, m := range e.methods {
+			mux.HandleFunc(fmt.Sprintf("%s %s", m, e.template), e.handlerWithMiddleware())
+		}
+	}
+
+	wildcards := strings.NewReplacer("{block_id}", "head", "{state_id}", "head", "{slot}", "1")
+	removed := append(s.removedEndpoints(), s.removedDebugEndpoints()...)
+	assert.NotEqual(t, 0, len(removed))
+	for _, e := range removed {
+		for _, m := range e.methods {
+			t.Run(m+" "+e.template, func(t *testing.T) {
+				request := httptest.NewRequest(m, wildcards.Replace(e.template), nil)
+				writer := httptest.NewRecorder()
+				mux.ServeHTTP(writer, request)
+
+				require.Equal(t, http.StatusGone, writer.Code)
+				errJson := &httputil.DefaultJsonError{}
+				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), errJson))
+				assert.Equal(t, http.StatusGone, errJson.Code)
+				assert.StringContains(t, "removed from the Beacon API specification", errJson.Message)
+			})
+		}
+	}
+}
+
+func TestRemovedEndpoint_Message(t *testing.T) {
+	testCases := []struct {
+		name        string
+		replacement string
+		wantMessage string
+	}{
+		{
+			name:        "with replacement",
+			replacement: "/eth/v2/beacon/blocks/{block_id}",
+			wantMessage: "Use /eth/v2/beacon/blocks/{block_id} instead.",
+		},
+		{
+			name:        "without replacement",
+			replacement: "",
+			wantMessage: "It has no replacement.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := removedEndpoint("GetBlock", "/eth/v1/beacon/blocks/{block_id}", []string{http.MethodGet}, tc.replacement)
+			request := httptest.NewRequest(http.MethodGet, "/eth/v1/beacon/blocks/head", nil)
+			writer := httptest.NewRecorder()
+			e.handler(writer, request)
+
+			require.Equal(t, http.StatusGone, writer.Code)
+			errJson := &httputil.DefaultJsonError{}
+			require.NoError(t, json.Unmarshal(writer.Body.Bytes(), errJson))
+			assert.StringContains(t, tc.wantMessage, errJson.Message)
+		})
+	}
+}

--- a/beacon-chain/rpc/endpoints_test.go
+++ b/beacon-chain/rpc/endpoints_test.go
@@ -145,6 +145,28 @@ func Test_endpoints(t *testing.T) {
 		"/prysm/v1/validators/{state_id}/active_set_changes": {http.MethodGet},
 	}
 
+	// Routes removed from the Beacon API specification, registered to respond with 410 Gone.
+	removedRoutes := map[string][]string{
+		"/eth/v1/beacon/blocks/{block_id}":                       {http.MethodGet},
+		"/eth/v1/beacon/blocks/{block_id}/attestations":          {http.MethodGet},
+		"/eth/v1/beacon/blocks":                                  {http.MethodPost},
+		"/eth/v1/beacon/blinded_blocks":                          {http.MethodPost},
+		"/eth/v1/beacon/pool/attestations":                       {http.MethodGet, http.MethodPost},
+		"/eth/v1/beacon/pool/attester_slashings":                 {http.MethodGet, http.MethodPost},
+		"/eth/v1/beacon/deposit_snapshot":                        {http.MethodGet},
+		"/eth/v1/builder/states/{state_id}/expected_withdrawals": {http.MethodGet},
+		"/eth/v1/validator/aggregate_attestation":                {http.MethodGet},
+		"/eth/v1/validator/aggregate_and_proofs":                 {http.MethodPost},
+		"/eth/v1/validator/blocks/{slot}":                        {http.MethodGet},
+		"/eth/v2/validator/blocks/{slot}":                        {http.MethodGet},
+		"/eth/v1/validator/blinded_blocks/{slot}":                {http.MethodGet},
+	}
+
+	removedDebugRoutes := map[string][]string{
+		"/eth/v1/debug/beacon/states/{state_id}": {http.MethodGet},
+		"/eth/v1/debug/beacon/heads":             {http.MethodGet},
+	}
+
 	testCases := []struct {
 		name                     string
 		flag                     *features.Flags
@@ -185,6 +207,7 @@ func Test_endpoints(t *testing.T) {
 				beaconRoutes, configRoutes, debugRoutes, eventsRoutes,
 				nodeRoutes, validatorRoutes, rewardsRoutes, blobRoutes,
 				prysmValidatorRoutes, prysmNodeRoutes, prysmBeaconRoutes,
+				removedRoutes, removedDebugRoutes,
 			} {
 				maps.Copy(expectedRoutes, m)
 			}

--- a/changelog/satushh_410-gone-removed-routes.md
+++ b/changelog/satushh_410-gone-removed-routes.md
@@ -1,0 +1,3 @@
+### Added
+
+- Respond with `410 Gone` and a message naming the replacement route when a Beacon API route that was removed from the spec (e.g. `GET /eth/v1/beacon/blocks/{block_id}`, `POST /eth/v1/beacon/pool/attestations`, `GET /eth/v2/validator/blocks/{slot}`) is requested, instead of a bare `404 Not Found`.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

- Beacon API routes that Prysm once served but were later removed from the spec (e.g. GET /eth/v1/beacon/pool/attestations, removed in beacon-APIs v4.0.0 and dropped in #15962) currently fail with a bare text 404, indistinguishable from a typo'd URL. 
- This PR registers explicit handlers for all 17 such routes that return 410 Gone with the standard error JSON naming the replacement path (e.g. "Use /eth/v2/beacon/pool/attestations instead."), so legacy tooling breaks with an actionable migration hint. 
- Hits are visible in HTTP metrics under endpoint="removed.*"; debug-namespace routes stay 404 when --enable-debug-rpc-endpoints is off.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

Was tested with kurtosis locally. 
Couple of examples: 


<img width="1190" height="163" alt="Screenshot 2026-07-08 at 13 04 27" src="https://github.com/user-attachments/assets/f0d0d74a-39e3-45e0-8a1a-9163617cbe34" />



<img width="1004" height="176" alt="Screenshot 2026-07-08 at 13 04 11" src="https://github.com/user-attachments/assets/575b85b5-fd17-480a-88e6-6deb5f366330" />

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
