### PR TITLE
Add `beacon_engine_getBlobsV2_*` metrics

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -614,9 +614,13 @@ func (s *Service) GetBlobsV2(ctx context.Context, versionedHashes []common.Hash)
 		return []*pb.BlobAndProofV2{}, nil
 	}
 
+	getBlobsV2RequestsTotal.Inc()
 	result := make([]*pb.BlobAndProofV2, len(versionedHashes))
 	err := s.rpcClient.CallContext(ctx, &result, GetBlobsV2, versionedHashes)
 
+	if err == nil {
+		getBlobsV2ResponsesTotal.Inc()
+	}
 	if len(result) != 0 {
 		getBlobsV2Latency.Observe(float64(time.Since(start).Milliseconds()))
 	}

--- a/beacon-chain/execution/metrics.go
+++ b/beacon-chain/execution/metrics.go
@@ -27,6 +27,16 @@ var (
 			Buckets: []float64{25, 50, 100, 200, 500, 1000, 2000, 4000},
 		},
 	)
+	getBlobsV2RequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_engine_getBlobsV2_requests_total",
+		Help: "Total number of engine_getBlobsV2 requests sent",
+	})
+	getBlobsV2ResponsesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_engine_getBlobsV2_responses_total",
+		Help: "Total number of engine_getBlobsV2 responses received",
+	})
+	// Note: This metric is equivalent to beacon_engine_getBlobsV2_request_duration_seconds,
+	// with the difference that this metric is in milliseconds.
 	getBlobsV2Latency = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "get_blobs_v2_latency_milliseconds",

--- a/changelog/syjn99_beacon-engine-getblobsv2.md
+++ b/changelog/syjn99_beacon-engine-getblobsv2.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added `beacon_engine_getBlobsV2_requests_total` and `beacon_engine_getBlobsV2_responses_total` metrics.


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Adds missing metrics:
- `beacon_engine_getBlobsV2_requests_total`
- `beacon_engine_getBlobsV2_responses_total`
which are listed in [beacon-metrics](https://github.com/ethereum/beacon-metrics/blob/master/metrics.md).

**Which issue(s) does this PR fix?**

Part of
- #17132 

**Other notes for review**

`get_blobs_v2_latency_milliseconds` is equivalent to `beacon_engine_getBlobsV2_request_duration_seconds`, so I'd left a comment rather than renaming it.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
