### PR TITLE
Add `beacon_pending_exits` metric

### DIFF
--- a/beacon-chain/operations/voluntaryexits/BUILD.bazel
+++ b/beacon-chain/operations/voluntaryexits/BUILD.bazel
@@ -19,6 +19,8 @@ go_library(
         "//container/doubly-linked-list:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//time/slots:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/beacon-chain/operations/voluntaryexits/pool.go
+++ b/beacon-chain/operations/voluntaryexits/pool.go
@@ -10,8 +10,15 @@ import (
 	doublylinkedlist "github.com/OffchainLabs/prysm/v7/container/doubly-linked-list"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
 )
+
+var beaconPendingExits = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "beacon_pending_exits",
+	Help: "Number of pending voluntary exits in local operation pool",
+})
 
 // PoolManager maintains pending and seen voluntary exits.
 // This pool is used by proposers to insert voluntary exits into new blocks.
@@ -130,6 +137,8 @@ func (p *Pool) InsertVoluntaryExit(exit *ethpb.SignedVoluntaryExit) {
 
 	p.pending.Append(doublylinkedlist.NewNode(exit))
 	p.m[exit.Exit.ValidatorIndex] = p.pending.Last()
+
+	beaconPendingExits.Set(float64(len(p.m)))
 }
 
 // MarkIncluded is used when an exit has been included in a beacon block. Every block seen by this
@@ -145,4 +154,6 @@ func (p *Pool) MarkIncluded(exit *ethpb.SignedVoluntaryExit) {
 
 	delete(p.m, exit.Exit.ValidatorIndex)
 	p.pending.Remove(node)
+
+	beaconPendingExits.Set(float64(len(p.m)))
 }

--- a/changelog/syjn99_beacon-pending-exits.md
+++ b/changelog/syjn99_beacon-pending-exits.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added `beacon_pending_exits` metric reporting the number of pending voluntary exits in the local operation pool.


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Add `beacon_pending_exits` metrics which is set when there is a write-operation on our voluntary exit pool.

**Which issue(s) does this PR fix?**

Part of
- #17132 

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
