### PR TITLE
Add `beacon_pending_deposits`, `beacon_pending_partial_withdrawals`, and `beacon_pending_consolidations` metrics

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -67,6 +67,18 @@ var (
 		Name: "beacon_current_active_validators",
 		Help: "Current total active validators",
 	})
+	beaconPendingDeposits = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_pending_deposits",
+		Help: "Number of pending deposits in the current state",
+	})
+	beaconPendingPartialWithdrawals = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_pending_partial_withdrawals",
+		Help: "Number of pending partial withdrawals in the current state",
+	})
+	beaconPendingConsolidations = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_pending_consolidations",
+		Help: "Number of pending consolidations in the current state",
+	})
 	validatorsCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "validator_count",
 		Help: "The total number of validators",
@@ -397,6 +409,19 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 	prevEpochSourceBalances.Set(float64(b.PrevEpochAttested))
 	prevEpochTargetBalances.Set(float64(b.PrevEpochTargetAttested))
 	prevEpochHeadBalances.Set(float64(b.PrevEpochHeadAttested))
+
+	// Post-Electra state queue lengths.
+	if postState.Version() >= version.Electra {
+		if n, err := postState.NumPendingDeposits(); err == nil {
+			beaconPendingDeposits.Set(float64(n))
+		}
+		if n, err := postState.NumPendingPartialWithdrawals(); err == nil {
+			beaconPendingPartialWithdrawals.Set(float64(n))
+		}
+		if n, err := postState.NumPendingConsolidations(); err == nil {
+			beaconPendingConsolidations.Set(float64(n))
+		}
+	}
 
 	refMap := postState.FieldReferencesCount()
 	for name, val := range refMap {

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -241,6 +241,7 @@ type ReadOnlyDeposits interface {
 	DepositRequestsStartIndex() (uint64, error)
 	PendingDeposits() ([]*ethpb.PendingDeposit, error)
 	IsPendingValidator(pubkey []byte) (bool, error)
+	NumPendingDeposits() (uint64, error)
 }
 
 type ReadOnlyConsolidations interface {

--- a/beacon-chain/state/state-native/getters_deposits.go
+++ b/beacon-chain/state/state-native/getters_deposits.go
@@ -42,6 +42,16 @@ func (b *BeaconState) IsPendingValidator(pubkey []byte) (bool, error) {
 	return helpers.IsPendingValidator(b.pendingDeposits, pubkey)
 }
 
+// NumPendingDeposits returns the number of pending deposits in the state's pending_deposits queue under RLock.
+func (b *BeaconState) NumPendingDeposits() (uint64, error) {
+	if b.version < version.Electra {
+		return 0, errNotSupported("NumPendingDeposits", b.version)
+	}
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+	return uint64(len(b.pendingDeposits)), nil
+}
+
 func (b *BeaconState) pendingDepositsVal() []*ethpb.PendingDeposit {
 	if b.pendingDeposits == nil {
 		return nil

--- a/changelog/syjn99_beacon-pending-queues.md
+++ b/changelog/syjn99_beacon-pending-queues.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added `beacon_pending_deposits`, `beacon_pending_partial_withdrawals`, and `beacon_pending_consolidations` metrics for post-Electra state queue lengths.


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Adds these metrics:
- `beacon_pending_deposits`
- `beacon_pending_partial_withdrawals`
- `beacon_pending_consolidations`

in `reportEpochMetrics`.

Note that these metrics are emitted every epoch, not every block (which [beacon-metrics](https://github.com/ethereum/beacon-metrics/blob/master/metrics.md) states). I think it's fine to keep this tho.

**Which issue(s) does this PR fix?**

Part of
- #17132 

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
