### PR TITLE
`saveHead`: Clear the head cache when the head is updated.

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -163,6 +163,10 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 		return errors.Wrap(err, "could not set head")
 	}
 
+	if c := s.cfg.AttestationDataCache; c != nil {
+		c.Clear()
+	}
+
 	// Save the new head root to DB.
 	if err := s.cfg.BeaconDB.SaveHeadBlockRoot(ctx, newHeadRoot); err != nil {
 		return errors.Wrap(err, "could not save head root in DB")

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -164,7 +164,7 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 	}
 
 	if c := s.cfg.AttestationDataCache; c != nil {
-		c.Clear()
+		go c.Clear()
 	}
 
 	// Save the new head root to DB.

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
 	testDB "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
@@ -45,6 +46,10 @@ func TestSaveHead_Different(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 	service := setupBeaconChain(t, beaconDB)
 
+	attDataCache := cache.NewAttestationDataCache()
+	require.NoError(t, attDataCache.Put(&cache.AttestationConsensusData{Slot: 1}))
+	service.cfg.AttestationDataCache = attDataCache
+
 	oldBlock := util.SaveBlock(t, t.Context(), service.cfg.BeaconDB, util.NewBeaconBlock())
 	oldRoot, err := oldBlock.Block().HashTreeRoot()
 	require.NoError(t, err)
@@ -80,6 +85,9 @@ func TestSaveHead_Different(t *testing.T) {
 	require.NoError(t, service.saveHead(t.Context(), newRoot, wsb, headState, false))
 
 	assert.Equal(t, primitives.Slot(1), service.HeadSlot(), "Head did not change")
+
+	// The attestation data cache is cleared in a goroutine once the head changes.
+	require.Eventually(t, func() bool { return attDataCache.Get() == nil }, time.Second, 10*time.Millisecond, "Attestation data cache was not cleared after head update")
 
 	cachedRoot, err := service.HeadRoot(t.Context())
 	require.NoError(t, err)

--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -114,6 +114,14 @@ func WithAttestationCache(c *cache.AttestationCache) Option {
 	}
 }
 
+// WithAttestationDataCache for attestation data cache.
+func WithAttestationDataCache(c *cache.AttestationDataCache) Option {
+	return func(s *Service) error {
+		s.cfg.AttestationDataCache = c
+		return nil
+	}
+}
+
 // WithAttestationPool for attestation lifecycle after chain inclusion.
 func WithAttestationPool(p attestations.Pool) Option {
 	return func(s *Service) error {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -78,6 +78,7 @@ type config struct {
 	ProposerPreferencesCache  *cache.ProposerPreferencesCache
 	SubscribedValidatorsCache *cache.SubscribedValidatorsCache
 	AttestationCache          *cache.AttestationCache
+	AttestationDataCache      *cache.AttestationDataCache
 	AttPool                   attestations.Pool
 	ExitPool                  voluntaryexits.PoolManager
 	SlashingPool              slashings.PoolManager

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -40,3 +40,11 @@ func (c *AttestationDataCache) Put(a *AttestationConsensusData) error {
 	c.a = a
 	return nil
 }
+
+// Clear evicts the cached response.
+func (c *AttestationDataCache) Clear() {
+	c.Lock()
+	defer c.Unlock()
+
+	c.a = nil
+}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -97,6 +97,7 @@ type BeaconNode struct {
 	db                        db.Database
 	slasherDB                 db.SlasherDatabase
 	attestationCache          *cache.AttestationCache
+	attestationDataCache      *cache.AttestationDataCache
 	attestationPool           attestations.Pool
 	payloadAttestationPool    payloadattestation.PoolManager
 	exitPool                  voluntaryexits.PoolManager
@@ -163,6 +164,7 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, optFuncs []func(*cli.Co
 		blockFeed:                 new(event.Feed),
 		opFeed:                    new(event.Feed),
 		attestationCache:          cache.NewAttestationCache(),
+		attestationDataCache:      cache.NewAttestationDataCache(),
 		attestationPool:           attestations.NewPool(),
 		payloadAttestationPool:    payloadattestation.NewPool(),
 		exitPool:                  voluntaryexits.NewPool(),
@@ -761,6 +763,7 @@ func (b *BeaconNode) registerBlockchainService(fc forkchoice.ForkChoicer, gs *st
 		blockchain.WithChainStartFetcher(web3Service),
 		blockchain.WithExecutionEngineCaller(web3Service),
 		blockchain.WithAttestationCache(b.attestationCache),
+		blockchain.WithAttestationDataCache(b.attestationDataCache),
 		blockchain.WithAttestationPool(b.attestationPool),
 		blockchain.WithExitPool(b.exitPool),
 		blockchain.WithSlashingPool(b.slashingsPool),
@@ -1014,6 +1017,7 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		GenesisFetcher:                   chainService,
 		OptimisticModeFetcher:            chainService,
 		AttestationCache:                 b.attestationCache,
+		AttestationDataCache:             b.attestationDataCache,
 		AttestationsPool:                 b.attestationPool,
 		PayloadAttestationPool:           b.payloadAttestationPool,
 		ExitPool:                         b.exitPool,

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -103,6 +103,7 @@ type Config struct {
 	MockEth1Votes                    bool
 	EnableDebugRPCEndpoints          bool
 	AttestationCache                 *cache.AttestationCache
+	AttestationDataCache             *cache.AttestationDataCache
 	AttestationsPool                 attestations.Pool
 	PayloadAttestationPool           payloadattestation.PoolManager
 	ExitPool                         voluntaryexits.PoolManager
@@ -223,7 +224,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		Broadcaster:           s.cfg.Broadcaster,
 		SyncCommitteePool:     s.cfg.SyncCommitteeObjectPool,
 		OperationNotifier:     s.cfg.OperationNotifier,
-		AttestationCache:      cache.NewAttestationDataCache(),
+		AttestationCache:      s.cfg.AttestationDataCache,
 		StateGen:              s.cfg.StateGen,
 		P2P:                   s.cfg.Broadcaster,
 		FinalizedFetcher:      s.cfg.FinalizationFetcher,

--- a/changelog/manu_clear-head-cache-on-head-update.md
+++ b/changelog/manu_clear-head-cache-on-head-update.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Clear the attestation data cache when the head is updated.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
When `GetAttestationData` is called (for example by a validator client via the /[eth/v1/validator/attestation_data](https://ethereum.github.io/beacon-APIs/#/Validator/produceAttestationData) endpoint for the slot `n` while the block at slot `n` is not yet imported, then the attestation data corresponding to the current head (most of the time, corresponding to the block at slot `n-1`) is returned by the beacon node.

However, if, after the block corresponding to the slot `n` is imported, `GetAttestationData` is called again for the slot `n`, this function **still returns the attestation corresponding to the previous head**.

Why? Because, during the first `GetAttestationData` call, the attestation data is cached for slot `n`, and all eventual calls (even if the head actually changed after the first call) will return the cached, stalled attestation data.

While this is a real bug, most of the time this is not really an issue, because the validator clients will call `GetAttestationData` only after they received the corresponding `head` SSE event from the beacon node, showing that the head is effectively updated.

However, in an `active-active` configuration this is an issue:

```
VC-1 --\
        + ----> BN-1
       /
VC-2 -+
       \
        ------> BN-2
```

1. VC-2 is connected in an `active-active` mode to both BN-1 and BN-2. VC-1 is only connected to BN-1.
2. BN-2 imports the block at slot `n` (**not** BN-1), and emits the `head` event.
3. VC-2 calls `GetAttestationData` to both BN-1 and BN-2.
4. BN-2 responds with respond with the block at slot `n`, BN-1 with the block at slot `n-1`. VC-2 keeps the response of BN-2. (VC-1, only connected to BN-1, does not do anything at this time.) 
5. BN-1 finally imports the block at slot `n`, and emits the `head` event.
6. VC-1 calls `GetAttestationData` to BN-1 only.
7. Because of the present cache issue, `BN-1` still responds to with the attestation data corresponding to the slot `n-1`, **even if the block at slot `n` is now imported.**
8. VC-1 votes for the stalled head, missing the head reward (and, potentially, the source and the target reward if this issue happens at the beginning of the epoch).

This PR fixes this issue by clearing the head cache when the head is updated.

**Other notes for review**
> [!NOTE]
> Please read commit by commit with commit messages. 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
