### PR TITLE
Add GET /prysm/v1/node/custody endpoint

### DIFF
--- a/api/server/structs/endpoints_node.go
+++ b/api/server/structs/endpoints_node.go
@@ -92,3 +92,29 @@ type AddrRequest struct {
 type PeersResponse struct {
 	Peers []*Peer `json:"peers"`
 }
+
+type GetCustodyResponse struct {
+	Data *CustodyData `json:"data"`
+}
+
+type CustodyData struct {
+	CustodyGroupCount string   `json:"custody_group_count"`
+	CustodyGroups     []string `json:"custody_groups"`
+	CustodyColumns    []string `json:"custody_columns"`
+	// EarliestAvailableSlot is the earliest slot for which the node can serve the data it custodies.
+	EarliestAvailableSlot string `json:"earliest_available_slot"`
+	// IsSupernode is true when the node custodies all custody groups.
+	IsSupernode bool `json:"is_supernode"`
+	// IsSemiSupernode is true when the node custodies enough custody groups to reconstruct
+	// all data columns, but not all of them.
+	IsSemiSupernode bool `json:"is_semi_supernode"`
+	// Backfill reports historical backfill progress for checkpoint-synced nodes.
+	// It is omitted for nodes synced from genesis.
+	Backfill *BackfillStatus `json:"backfill,omitempty"`
+}
+
+type BackfillStatus struct {
+	OriginSlot string `json:"origin_slot"`
+	// LowSlot is the lowest slot that backfill has filled so far.
+	LowSlot string `json:"low_slot"`
+}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -997,6 +997,7 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		PeersFetcher:                     p2pService,
 		PeerManager:                      p2pService,
 		MetadataProvider:                 p2pService,
+		CustodyManager:                   p2pService,
 		ChainInfoFetcher:                 chainService,
 		HeadFetcher:                      chainService,
 		CanonicalFetcher:                 chainService,

--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -1306,6 +1306,7 @@ func (s *Service) prysmNodeEndpoints() []endpoint {
 		PeersFetcher:              s.cfg.PeersFetcher,
 		PeerManager:               s.cfg.PeerManager,
 		MetadataProvider:          s.cfg.MetadataProvider,
+		CustodyManager:            s.cfg.CustodyManager,
 		HeadFetcher:               s.cfg.HeadFetcher,
 		ExecutionChainInfoFetcher: s.cfg.ExecutionChainInfoFetcher,
 	}
@@ -1373,6 +1374,16 @@ func (s *Service) prysmNodeEndpoints() []endpoint {
 			},
 			handler: server.RemoveTrustedPeer,
 			methods: []string{http.MethodDelete},
+		},
+		{
+			template: "/prysm/v1/node/custody",
+			name:     namespace + ".GetCustody",
+			middleware: []middleware.Middleware{
+				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
+				middleware.AcceptEncodingHeaderHandler(),
+			},
+			handler: server.GetCustody,
+			methods: []string{http.MethodGet},
 		},
 	}
 }

--- a/beacon-chain/rpc/endpoints_test.go
+++ b/beacon-chain/rpc/endpoints_test.go
@@ -136,6 +136,7 @@ func Test_endpoints(t *testing.T) {
 		"/prysm/v1/node/trusted_peers":           {http.MethodGet, http.MethodPost},
 		"/prysm/node/trusted_peers/{peer_id}":    {http.MethodDelete},
 		"/prysm/v1/node/trusted_peers/{peer_id}": {http.MethodDelete},
+		"/prysm/v1/node/custody":                 {http.MethodGet},
 	}
 
 	prysmValidatorRoutes := map[string][]string{

--- a/beacon-chain/rpc/prysm/node/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/node/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "custody.go",
         "handlers.go",
         "server.go",
     ],
@@ -11,12 +12,14 @@ go_library(
     deps = [
         "//api/server/structs:go_default_library",
         "//beacon-chain/blockchain:go_default_library",
+        "//beacon-chain/core/peerdas:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/execution:go_default_library",
         "//beacon-chain/p2p:go_default_library",
         "//beacon-chain/p2p/peers:go_default_library",
         "//beacon-chain/p2p/peers/peerdata:go_default_library",
         "//beacon-chain/sync:go_default_library",
+        "//config/params:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
         "//network/httputil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
@@ -28,14 +31,22 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["handlers_test.go"],
+    srcs = [
+        "custody_test.go",
+        "handlers_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//api/server/structs:go_default_library",
+        "//beacon-chain/core/peerdas:go_default_library",
+        "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/p2p:go_default_library",
         "//beacon-chain/p2p/peers:go_default_library",
         "//beacon-chain/p2p/testing:go_default_library",
+        "//config/params:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "//network/httputil:go_default_library",
+        "//proto/dbval:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/enode:go_default_library",
@@ -44,5 +55,6 @@ go_test(
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/host/peerstore/test:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/prysm/node/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/node/BUILD.bazel
@@ -55,6 +55,5 @@ go_test(
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/host/peerstore/test:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/prysm/node/custody.go
+++ b/beacon-chain/rpc/prysm/node/custody.go
@@ -1,0 +1,109 @@
+package node
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/db"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
+	"github.com/pkg/errors"
+)
+
+// custodyInfoTimeout bounds how long GetCustody waits for the custody info to be
+// initialized at startup before failing the request.
+const custodyInfoTimeout = 3 * time.Second
+
+// GetCustody returns the current data column custody state of the node: the custody
+// group count, the custody groups and columns, the earliest available slot, the
+// supernode/semi-supernode status, and the backfill progress.
+func (s *Server) GetCustody(w http.ResponseWriter, r *http.Request) {
+	ctx, span := trace.StartSpan(r.Context(), "node.GetCustody")
+	defer span.End()
+
+	if !params.FuluEnabled() {
+		httputil.HandleError(w, "Fulu is not scheduled", http.StatusBadRequest)
+		return
+	}
+
+	// Custody info is initialized asynchronously at node startup. Bound the wait so
+	// the request does not hang if it is not available yet.
+	ctx, cancel := context.WithTimeout(ctx, custodyInfoTimeout)
+	defer cancel()
+
+	custodyGroupCount, err := s.CustodyManager.CustodyGroupCount(ctx)
+	if err != nil {
+		httputil.HandleError(w, "Custody info is not available yet: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	earliestAvailableSlot, err := s.CustodyManager.EarliestAvailableSlot(ctx)
+	if err != nil {
+		httputil.HandleError(w, "Custody info is not available yet: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	custodyGroups, err := peerdas.CustodyGroups(s.PeerManager.NodeID(), custodyGroupCount)
+	if err != nil {
+		httputil.HandleError(w, "Could not compute custody groups: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	custodyColumnsMap, err := peerdas.CustodyColumns(custodyGroups)
+	if err != nil {
+		httputil.HandleError(w, "Could not compute custody columns: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	custodyColumns := make([]uint64, 0, len(custodyColumnsMap))
+	for column := range custodyColumnsMap {
+		custodyColumns = append(custodyColumns, column)
+	}
+	slices.Sort(custodyColumns)
+
+	minGroupCountToReconstruct, err := peerdas.MinimumCustodyGroupCountToReconstruct()
+	if err != nil {
+		httputil.HandleError(w, "Could not compute minimum custody group count to reconstruct: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	isSupernode := custodyGroupCount == params.BeaconConfig().NumberOfCustodyGroups
+
+	data := &structs.CustodyData{
+		CustodyGroupCount:     strconv.FormatUint(custodyGroupCount, 10),
+		CustodyGroups:         uint64SliceToStrings(custodyGroups),
+		CustodyColumns:        uint64SliceToStrings(custodyColumns),
+		EarliestAvailableSlot: strconv.FormatUint(uint64(earliestAvailableSlot), 10),
+		IsSupernode:           isSupernode,
+		IsSemiSupernode:       !isSupernode && custodyGroupCount >= minGroupCountToReconstruct,
+	}
+
+	backfillStatus, err := s.BeaconDB.BackfillStatus(ctx)
+	switch {
+	case err == nil:
+		data.Backfill = &structs.BackfillStatus{
+			OriginSlot: strconv.FormatUint(backfillStatus.OriginSlot, 10),
+			LowSlot:    strconv.FormatUint(backfillStatus.LowSlot, 10),
+		}
+	case !errors.Is(err, db.ErrNotFound):
+		httputil.HandleError(w, "Could not get backfill status: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// db.ErrNotFound means the node was synced from genesis and never needed backfill.
+
+	httputil.WriteJson(w, &structs.GetCustodyResponse{Data: data})
+}
+
+func uint64SliceToStrings(values []uint64) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, strconv.FormatUint(value, 10))
+	}
+	return result
+}

--- a/beacon-chain/rpc/prysm/node/custody.go
+++ b/beacon-chain/rpc/prysm/node/custody.go
@@ -17,9 +17,8 @@ import (
 )
 
 // custodyInfoTimeout bounds how long GetCustody waits for the custody info to be
-// initialized at startup before failing the request. It is a variable only so
-// that tests can shorten the wait.
-var custodyInfoTimeout = 3 * time.Second
+// initialized at startup before failing the request.
+const custodyInfoTimeout = 3 * time.Second
 
 // GetCustody returns the current data column custody state of the node: the custody
 // group count, the custody groups and columns, the earliest available slot, the

--- a/beacon-chain/rpc/prysm/node/custody.go
+++ b/beacon-chain/rpc/prysm/node/custody.go
@@ -17,8 +17,9 @@ import (
 )
 
 // custodyInfoTimeout bounds how long GetCustody waits for the custody info to be
-// initialized at startup before failing the request.
-const custodyInfoTimeout = 3 * time.Second
+// initialized at startup before failing the request. It is a variable only so
+// that tests can shorten the wait.
+var custodyInfoTimeout = 3 * time.Second
 
 // GetCustody returns the current data column custody state of the node: the custody
 // group count, the custody groups and columns, the earliest available slot, the

--- a/beacon-chain/rpc/prysm/node/custody_test.go
+++ b/beacon-chain/rpc/prysm/node/custody_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
@@ -32,6 +33,22 @@ func (unavailableCustodyManager) CustodyGroupCount(context.Context) (uint64, err
 
 func (unavailableCustodyManager) EarliestAvailableSlot(context.Context) (primitives.Slot, error) {
 	return 0, errors.New("custody info is not set")
+}
+
+// blockingCustodyManager mimics a node whose custody info is never initialized:
+// like p2p.Service, it blocks until the context is done.
+type blockingCustodyManager struct {
+	p2p.CustodyManager
+}
+
+func (blockingCustodyManager) CustodyGroupCount(ctx context.Context) (uint64, error) {
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func (blockingCustodyManager) EarliestAvailableSlot(ctx context.Context) (primitives.Slot, error) {
+	<-ctx.Done()
+	return 0, ctx.Err()
 }
 
 func getCustody(t *testing.T, s *Server) *httptest.ResponseRecorder {
@@ -68,6 +85,21 @@ func TestGetCustody_CustodyInfoUnavailable(t *testing.T) {
 
 	writer := getCustody(t, &Server{CustodyManager: unavailableCustodyManager{}})
 	assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
+}
+
+func TestGetCustody_CustodyInfoTimeout(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.FuluForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	originalTimeout := custodyInfoTimeout
+	custodyInfoTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { custodyInfoTimeout = originalTimeout })
+
+	writer := getCustody(t, &Server{CustodyManager: blockingCustodyManager{}})
+	assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
+	assert.StringContains(t, context.DeadlineExceeded.Error(), writer.Body.String())
 }
 
 func TestGetCustody(t *testing.T) {

--- a/beacon-chain/rpc/prysm/node/custody_test.go
+++ b/beacon-chain/rpc/prysm/node/custody_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
@@ -20,20 +20,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/proto/dbval"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
-	"github.com/pkg/errors"
 )
-
-type unavailableCustodyManager struct {
-	p2p.CustodyManager
-}
-
-func (unavailableCustodyManager) CustodyGroupCount(context.Context) (uint64, error) {
-	return 0, errors.New("custody info is not set")
-}
-
-func (unavailableCustodyManager) EarliestAvailableSlot(context.Context) (primitives.Slot, error) {
-	return 0, errors.New("custody info is not set")
-}
 
 // blockingCustodyManager mimics a node whose custody info is never initialized:
 // like p2p.Service, it blocks until the context is done.
@@ -83,23 +70,14 @@ func TestGetCustody_CustodyInfoUnavailable(t *testing.T) {
 	cfg.FuluForkEpoch = 0
 	params.OverrideBeaconConfig(cfg)
 
-	writer := getCustody(t, &Server{CustodyManager: unavailableCustodyManager{}})
-	assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-}
-
-func TestGetCustody_CustodyInfoTimeout(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.FuluForkEpoch = 0
-	params.OverrideBeaconConfig(cfg)
-
-	originalTimeout := custodyInfoTimeout
-	custodyInfoTimeout = 20 * time.Millisecond
-	t.Cleanup(func() { custodyInfoTimeout = originalTimeout })
-
-	writer := getCustody(t, &Server{CustodyManager: blockingCustodyManager{}})
-	assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-	assert.StringContains(t, context.DeadlineExceeded.Error(), writer.Body.String())
+	// synctest fakes time within the bubble: the custodyInfoTimeout deadline
+	// fires as soon as the handler blocks on the custody manager, without the
+	// test waiting for it in real time.
+	synctest.Test(t, func(t *testing.T) {
+		writer := getCustody(t, &Server{CustodyManager: blockingCustodyManager{}})
+		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
+		assert.StringContains(t, context.DeadlineExceeded.Error(), writer.Body.String())
+	})
 }
 
 func TestGetCustody(t *testing.T) {

--- a/beacon-chain/rpc/prysm/node/custody_test.go
+++ b/beacon-chain/rpc/prysm/node/custody_test.go
@@ -1,0 +1,171 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
+	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	mockp2p "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/proto/dbval"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/pkg/errors"
+)
+
+type unavailableCustodyManager struct {
+	p2p.CustodyManager
+}
+
+func (unavailableCustodyManager) CustodyGroupCount(context.Context) (uint64, error) {
+	return 0, errors.New("custody info is not set")
+}
+
+func (unavailableCustodyManager) EarliestAvailableSlot(context.Context) (primitives.Slot, error) {
+	return 0, errors.New("custody info is not set")
+}
+
+func getCustody(t *testing.T, s *Server) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/prysm/v1/node/custody", nil)
+	writer := httptest.NewRecorder()
+	writer.Body = &bytes.Buffer{}
+	s.GetCustody(writer, request)
+	return writer
+}
+
+func uint64SliceToStringsForTest(values []uint64) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, strconv.FormatUint(value, 10))
+	}
+	return result
+}
+
+func TestGetCustody_FuluNotScheduled(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.FuluForkEpoch = cfg.FarFutureEpoch
+	params.OverrideBeaconConfig(cfg)
+
+	writer := getCustody(t, &Server{})
+	assert.Equal(t, http.StatusBadRequest, writer.Code)
+}
+
+func TestGetCustody_CustodyInfoUnavailable(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.FuluForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	writer := getCustody(t, &Server{CustodyManager: unavailableCustodyManager{}})
+	assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
+}
+
+func TestGetCustody(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.FuluForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	t.Run("fullnode", func(t *testing.T) {
+		custodyRequirement := params.BeaconConfig().CustodyRequirement
+		p2pService := mockp2p.NewTestP2P(t)
+		_, _, err := p2pService.UpdateCustodyInfo(123, custodyRequirement)
+		require.NoError(t, err)
+		s := &Server{
+			BeaconDB:       dbtest.SetupDB(t),
+			PeerManager:    p2pService,
+			CustodyManager: p2pService,
+		}
+
+		writer := getCustody(t, s)
+		require.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.GetCustodyResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+
+		assert.Equal(t, strconv.FormatUint(custodyRequirement, 10), resp.Data.CustodyGroupCount)
+		assert.Equal(t, "123", resp.Data.EarliestAvailableSlot)
+		assert.Equal(t, false, resp.Data.IsSupernode)
+		assert.Equal(t, false, resp.Data.IsSemiSupernode)
+		// The node is synced from genesis, so no backfill status is expected.
+		assert.Equal(t, true, resp.Data.Backfill == nil)
+
+		expectedGroups, err := peerdas.CustodyGroups(p2pService.NodeID(), custodyRequirement)
+		require.NoError(t, err)
+		assert.DeepEqual(t, uint64SliceToStringsForTest(expectedGroups), resp.Data.CustodyGroups)
+
+		expectedColumnsMap, err := peerdas.CustodyColumns(expectedGroups)
+		require.NoError(t, err)
+		require.Equal(t, len(expectedColumnsMap), len(resp.Data.CustodyColumns))
+		previous := int64(-1)
+		for _, column := range resp.Data.CustodyColumns {
+			c, err := strconv.ParseUint(column, 10, 64)
+			require.NoError(t, err)
+			assert.Equal(t, true, expectedColumnsMap[c])
+			assert.Equal(t, true, int64(c) > previous, "custody columns are not sorted")
+			previous = int64(c)
+		}
+	})
+
+	t.Run("supernode with backfill status", func(t *testing.T) {
+		numberOfGroups := params.BeaconConfig().NumberOfCustodyGroups
+		p2pService := mockp2p.NewTestP2P(t)
+		_, _, err := p2pService.UpdateCustodyInfo(2000, numberOfGroups)
+		require.NoError(t, err)
+		beaconDB := dbtest.SetupDB(t)
+		require.NoError(t, beaconDB.SaveBackfillStatus(context.Background(), &dbval.BackfillStatus{LowSlot: 1000, OriginSlot: 5000}))
+		s := &Server{
+			BeaconDB:       beaconDB,
+			PeerManager:    p2pService,
+			CustodyManager: p2pService,
+		}
+
+		writer := getCustody(t, s)
+		require.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.GetCustodyResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+
+		assert.Equal(t, strconv.FormatUint(numberOfGroups, 10), resp.Data.CustodyGroupCount)
+		assert.Equal(t, true, resp.Data.IsSupernode)
+		assert.Equal(t, false, resp.Data.IsSemiSupernode)
+		require.Equal(t, int(numberOfGroups), len(resp.Data.CustodyGroups))
+		assert.Equal(t, "0", resp.Data.CustodyGroups[0])
+		assert.Equal(t, strconv.FormatUint(numberOfGroups-1, 10), resp.Data.CustodyGroups[numberOfGroups-1])
+
+		require.Equal(t, true, resp.Data.Backfill != nil)
+		assert.Equal(t, "5000", resp.Data.Backfill.OriginSlot)
+		assert.Equal(t, "1000", resp.Data.Backfill.LowSlot)
+	})
+
+	t.Run("semi-supernode", func(t *testing.T) {
+		semiSupernodeTarget, err := peerdas.MinimumCustodyGroupCountToReconstruct()
+		require.NoError(t, err)
+		p2pService := mockp2p.NewTestP2P(t)
+		_, _, err = p2pService.UpdateCustodyInfo(456, semiSupernodeTarget)
+		require.NoError(t, err)
+		s := &Server{
+			BeaconDB:       dbtest.SetupDB(t),
+			PeerManager:    p2pService,
+			CustodyManager: p2pService,
+		}
+
+		writer := getCustody(t, s)
+		require.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.GetCustodyResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+
+		assert.Equal(t, strconv.FormatUint(semiSupernodeTarget, 10), resp.Data.CustodyGroupCount)
+		assert.Equal(t, "456", resp.Data.EarliestAvailableSlot)
+		assert.Equal(t, false, resp.Data.IsSupernode)
+		assert.Equal(t, true, resp.Data.IsSemiSupernode)
+	})
+}

--- a/beacon-chain/rpc/prysm/node/server.go
+++ b/beacon-chain/rpc/prysm/node/server.go
@@ -15,6 +15,7 @@ type Server struct {
 	PeersFetcher              p2p.PeersProvider
 	PeerManager               p2p.PeerManager
 	MetadataProvider          p2p.MetadataProvider
+	CustodyManager            p2p.CustodyManager
 	GenesisTimeFetcher        blockchain.TimeFetcher
 	HeadFetcher               blockchain.HeadFetcher
 	ExecutionChainInfoFetcher execution.ChainInfoFetcher

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -114,6 +114,7 @@ type Config struct {
 	PeersFetcher                     p2p.PeersProvider
 	PeerManager                      p2p.PeerManager
 	MetadataProvider                 p2p.MetadataProvider
+	CustodyManager                   p2p.CustodyManager
 	DepositFetcher                   cache.DepositFetcher
 	PendingDepositFetcher            depositsnapshot.PendingDepositsFetcher
 	StateNotifier                    statefeed.Notifier

--- a/changelog/satushh_node-custody-endpoint.md
+++ b/changelog/satushh_node-custody-endpoint.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add `GET /prysm/v1/node/custody` endpoint exposing the node's data column custody state: custody group count, custody groups and columns, earliest available slot, supernode/semi-supernode status, and backfill progress.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

- Adds a Prysm-namespace operator endpoint that answers the node's PeerDAS custody state in one call: custody group count, custody groups/columns, earliest available slot, supernode/semi-supernode status, and backfill progress (omitted for genesis-synced nodes).
- Supernode/semi-supernode are derived from the live CGC rather than CLI flags, so sticky supernodes and validator-custody escalation report correctly. 
- Returns 400 when Fulu is not scheduled and 503 while custody info is still initializing. 
- Covered by unit tests and verified on a 4-node kurtosis devnet exercising fullnode, supernode, semi-supernode, and validator-custody-driven modes.

**Other notes for review**

<img width="1001" height="222" alt="Screenshot 2026-07-09 at 20 41 09" src="https://github.com/user-attachments/assets/ab603d1e-89b1-4c81-8207-e987e8f866e3" />


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
