### PR TITLE
Wrap payload_attestation_message SSE event in version/data envelope

### DIFF
--- a/api/server/structs/endpoints_events.go
+++ b/api/server/structs/endpoints_events.go
@@ -140,6 +140,11 @@ type ExecutionPayloadBidEvent struct {
 	Data    *SignedExecutionPayloadBid `json:"data"`
 }
 
+type PayloadAttestationMessageEvent struct {
+	Version string                     `json:"version"`
+	Data    *PayloadAttestationMessage `json:"data"`
+}
+
 type ExecutionPayloadAvailableEvent struct {
 	Slot      string `json:"slot"`
 	BlockRoot string `json:"block_root"`

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -689,7 +689,11 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 		}, nil
 	case *operation.PayloadAttestationMessageReceivedData:
 		return func() io.Reader {
-			return jsonMarshalReader(eventName, structs.PayloadAttestationMessageFromConsensus(v.Message))
+			epoch := slots.ToEpoch(v.Message.Data.Slot)
+			return jsonMarshalReader(eventName, &structs.PayloadAttestationMessageEvent{
+				Version: version.String(params.GetNetworkScheduleEntry(epoch).VersionEnum),
+				Data:    structs.PayloadAttestationMessageFromConsensus(v.Message),
+			})
 		}, nil
 	case *operation.ProposerPreferencesReceivedData:
 		return func() io.Reader {

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -438,6 +438,45 @@ func TestStreamEvents_ProposerPreferencesWrappedWithVersion(t *testing.T) {
 	require.Equal(t, "7", got.Data.Message.ValidatorIndex)
 }
 
+func TestStreamEvents_PayloadAttestationMessageWrappedWithVersion(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	s := &Server{}
+	topics, err := newTopicRequest([]string{PayloadAttestationMessageTopic})
+	require.NoError(t, err)
+	ev := &feed.Event{
+		Type: operation.PayloadAttestationMessageReceived,
+		Data: &operation.PayloadAttestationMessageReceivedData{
+			Message: &eth.PayloadAttestationMessage{
+				ValidatorIndex: 3,
+				Data: &eth.PayloadAttestationData{
+					BeaconBlockRoot:   make([]byte, fieldparams.RootLength),
+					Slot:              0,
+					PayloadPresent:    true,
+					BlobDataAvailable: true,
+				},
+				Signature: make([]byte, fieldparams.BLSSignatureLength),
+			},
+		},
+	}
+	lr, err := s.lazyReaderForEvent(t.Context(), ev, topics)
+	require.NoError(t, err)
+	out, err := io.ReadAll(lr())
+	require.NoError(t, err)
+
+	_, payload, found := strings.Cut(string(out), "data: ")
+	require.Equal(t, true, found)
+	var got structs.PayloadAttestationMessageEvent
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(payload)), &got))
+	require.Equal(t, "gloas", got.Version)
+	require.NotNil(t, got.Data)
+	require.Equal(t, "3", got.Data.ValidatorIndex)
+	require.Equal(t, true, got.Data.Data.PayloadPresent)
+}
+
 func TestStreamEvents_OperationsEvents(t *testing.T) {
 	t.Run("operations", func(t *testing.T) {
 		testSync := newStreamTestSync(t)

--- a/changelog/terence_fix-payload-attestation-sse-version.md
+++ b/changelog/terence_fix-payload-attestation-sse-version.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Wrapped the `payload_attestation_message` SSE event in the `version`/`data` envelope to match the beacon-APIs spec.


### PR DESCRIPTION
The `payload_attestation_message` SSE event was emitted as a flat object, but the beacon-APIs spec requires the `{version, data}` wrapper used by the other Gloas events (`execution_payload_bid`, `proposer_preferences`). Spec-following consumers such as Xatu could not parse it correctly.