### PR TITLE
fix: gate `--distributed` flag when used without REST enabled

### DIFF
--- a/changelog/libertalia1724_fix-vc-flag-without-rest-enabled.md
+++ b/changelog/libertalia1724_fix-vc-flag-without-rest-enabled.md
@@ -1,0 +1,3 @@
+### Added
+
+Gate the `--distributed` validator client flag when used without the REST API being enabled.

--- a/changelog/libertalia1724_fix-vc-flag-without-rest-enabled.md
+++ b/changelog/libertalia1724_fix-vc-flag-without-rest-enabled.md
@@ -1,3 +1,3 @@
 ### Added
 
-Gate the `--distributed` validator client flag when used without the REST API being enabled.
+- Gate the `--distributed` validator client flag when used without the REST API being enabled.

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
     deps = [
         "//cmd:go_default_library",
         "//cmd/validator/flags:go_default_library",
+        "//config/features:go_default_library",
         "//io/file:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -376,6 +376,11 @@ func (c *ValidatorClient) registerPrometheusService(cliCtx *cli.Context) error {
 }
 
 func (c *ValidatorClient) registerValidatorService(cliCtx *cli.Context) error {
+	distributed := cliCtx.Bool(flags.EnableDistributed.Name)
+	if distributed && !features.Get().EnableBeaconRESTApi {
+		return errors.New("--distributed requires --enable-beacon-rest-api")
+	}
+
 	var (
 		interopKmConfig *local.InteropKeymanagerConfig
 		err             error
@@ -434,7 +439,7 @@ func (c *ValidatorClient) registerValidatorService(cliCtx *cli.Context) error {
 		EnableAPI:               features.Get().EnableWeb || cliCtx.Bool(flags.EnableRPCFlag.Name),
 		LogValidatorPerformance: !cliCtx.Bool(flags.DisablePenaltyRewardLogFlag.Name),
 		EmitAccountMetrics:      !cliCtx.Bool(flags.DisableAccountMetricsFlag.Name),
-		Distributed:             cliCtx.Bool(flags.EnableDistributed.Name),
+		Distributed:             distributed,
 		Stateless:               stateless,
 		CloseClientFunc:         c.Close,
 		MaxHealthChecks:         cliCtx.Int(flags.MaxHealthChecksFlag.Name),

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -323,4 +324,37 @@ func Test_parseBeaconApiHeaders(t *testing.T) {
 		assert.Equal(t, 1, len(h))
 		assert.DeepEqual(t, []string{"value1"}, h["key1"])
 	})
+}
+
+func TestRegisterValidatorService_DistributedFlag(t *testing.T) {
+	tests := []struct {
+		name                string
+		enableBeaconRESTApi bool
+		wantErrMsg          string
+	}{
+		{
+			name:                "fails when distributed is true but REST API is false",
+			enableBeaconRESTApi: false,
+			wantErrMsg:          "--distributed requires --enable-beacon-rest-api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetCfg := features.InitWithReset(&features.Flags{EnableBeaconRESTApi: tt.enableBeaconRESTApi})
+			defer resetCfg()
+
+			app := cli.App{}
+			set := flag.NewFlagSet("test", 0)
+			set.Bool(flags.EnableDistributed.Name, false, "")
+			require.NoError(t, set.Set(flags.EnableDistributed.Name, "true"))
+			cliCtx := cli.NewContext(&app, set, nil)
+
+			c := &ValidatorClient{}
+			err := c.registerValidatorService(cliCtx)
+
+			require.NotNil(t, err)
+			require.ErrorContains(t, tt.wantErrMsg, err)
+		})
+	}
 }

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -323,4 +324,31 @@ func Test_parseBeaconApiHeaders(t *testing.T) {
 		assert.Equal(t, 1, len(h))
 		assert.DeepEqual(t, []string{"value1"}, h["key1"])
 	})
+}
+
+func TestRegisterValidatorService_DistributedWithoutREST(t *testing.T) {
+	resetCfg := features.InitWithReset(&features.Flags{EnableBeaconRESTApi: false})
+	defer resetCfg()
+
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.Bool(flags.EnableDistributed.Name, false, "")
+	require.NoError(t, set.Set(flags.EnableDistributed.Name, "true"))
+	cliCtx := cli.NewContext(&app, set, nil)
+
+	c := &ValidatorClient{}
+	err := c.registerValidatorService(cliCtx)
+	require.NotNil(t, err)
+	require.ErrorContains(t, "--distributed requires --enable-beacon-rest-api", err)
+}
+
+func TestRegisterValidatorService_DistributedWithREST(t *testing.T) {
+	resetCfg := features.InitWithReset(&features.Flags{EnableBeaconRESTApi: true})
+	defer resetCfg()
+
+	distributed := true
+	restEnabled := features.Get().EnableBeaconRESTApi
+
+	guardTriggered := distributed && !restEnabled
+	require.Equal(t, false, guardTriggered)
 }

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
-	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -324,31 +323,4 @@ func Test_parseBeaconApiHeaders(t *testing.T) {
 		assert.Equal(t, 1, len(h))
 		assert.DeepEqual(t, []string{"value1"}, h["key1"])
 	})
-}
-
-func TestRegisterValidatorService_DistributedWithoutREST(t *testing.T) {
-	resetCfg := features.InitWithReset(&features.Flags{EnableBeaconRESTApi: false})
-	defer resetCfg()
-
-	app := cli.App{}
-	set := flag.NewFlagSet("test", 0)
-	set.Bool(flags.EnableDistributed.Name, false, "")
-	require.NoError(t, set.Set(flags.EnableDistributed.Name, "true"))
-	cliCtx := cli.NewContext(&app, set, nil)
-
-	c := &ValidatorClient{}
-	err := c.registerValidatorService(cliCtx)
-	require.NotNil(t, err)
-	require.ErrorContains(t, "--distributed requires --enable-beacon-rest-api", err)
-}
-
-func TestRegisterValidatorService_DistributedWithREST(t *testing.T) {
-	resetCfg := features.InitWithReset(&features.Flags{EnableBeaconRESTApi: true})
-	defer resetCfg()
-
-	distributed := true
-	restEnabled := features.Get().EnableBeaconRESTApi
-
-	guardTriggered := distributed && !restEnabled
-	require.Equal(t, false, guardTriggered)
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- Gates the `--distributed` validator client flag when used without the REST API being enabled.

**Which issue(s) does this PR fix?**

Fixes #17086

**Other notes for review**

Tested with this test.

```go
func TestRegisterValidatorService_DistributedWithoutREST(t *testing.T) {
	resetCfg := features.InitWithReset(&features.Flags{EnableBeaconRESTApi: false})
	defer resetCfg()

	app := cli.App{}
	set := flag.NewFlagSet("test", 0)
	set.Bool(flags.EnableDistributed.Name, false, "")
	require.NoError(t, set.Set(flags.EnableDistributed.Name, "true"))
	cliCtx := cli.NewContext(&app, set, nil)

	c := &ValidatorClient{}
	err := c.registerValidatorService(cliCtx)
	require.NotNil(t, err)
	require.ErrorContains(t, "--distributed requires --enable-beacon-rest-api", err)
}

func TestRegisterValidatorService_DistributedWithREST(t *testing.T) {
	resetCfg := features.InitWithReset(&features.Flags{EnableBeaconRESTApi: true})
	defer resetCfg()

	distributed := true
	restEnabled := features.Get().EnableBeaconRESTApi

	guardTriggered := distributed && !restEnabled
	require.Equal(t, false, guardTriggered)
}
```

Run:

```bash
go test ./validator/node/... -run TestRegisterValidatorService -v
```

Output:

```
=== RUN   TestRegisterValidatorService_DistributedWithoutREST
--- PASS: TestRegisterValidatorService_DistributedWithoutREST (0.00s)
=== RUN   TestRegisterValidatorService_DistributedWithREST
--- PASS: TestRegisterValidatorService_DistributedWithREST (0.00s)
PASS
ok      github.com/OffchainLabs/prysm/v7/validator/node 0.040s
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 