### PR TITLE
Fail block data column availability check during initial sync instead of blocking

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -918,6 +918,17 @@ func (s *Service) isDataAvailable(
 		if len(kzgCommitments) == 0 {
 			return nil
 		}
+		// Initial sync fetches columns via range requests, so check availability synchronously rather than blocking on gossip; fail if missing.
+		if !s.inRegularSync() {
+			available, err := s.dataColumnsAvailableNow(ctx, root, block.Slot())
+			if err != nil {
+				return errors.Wrap(err, "data columns available now")
+			}
+			if !available {
+				return errors.Errorf("data columns unavailable for block slot %d root %#x", block.Slot(), root)
+			}
+			return nil
+		}
 		return s.areDataColumnsAvailable(ctx, root, block.Slot())
 	}
 

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -3006,6 +3006,55 @@ func TestIsDataAvailable(t *testing.T) {
 	})
 }
 
+// Reproduces the checkpoint sync stall, during initial sync a block with missing columns must fail fast instead of waiting for gossip that never comes.
+func TestIsDataAvailable_InitSync(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.AltairForkEpoch, cfg.BellatrixForkEpoch, cfg.CapellaForkEpoch, cfg.DenebForkEpoch, cfg.ElectraForkEpoch, cfg.FuluForkEpoch = 0, 0, 0, 0, 0, 0
+	params.OverrideBeaconConfig(cfg)
+
+	t.Run("missing columns fail instead of blocking", func(t *testing.T) {
+		testParams := testIsAvailableParams{
+			options:                 []Option{WithSyncChecker(&mock.MockSyncChecker{})},
+			blobKzgCommitmentsCount: 3,
+		}
+
+		ctx, cancel, service, root, signed := testIsAvailableSetup(t, testParams)
+		defer cancel()
+
+		roBlock, err := consensusblocks.NewROBlockWithRoot(signed, root)
+		require.NoError(t, err)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- service.isDataAvailable(ctx, roBlock)
+		}()
+
+		bound := time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + 2*time.Second
+		select {
+		case err := <-done:
+			require.NotNil(t, err)
+		case <-time.After(bound):
+			t.Fatal("isDataAvailable did not return for a block with missing data columns, the init-sync consumer stalls forever on this path")
+		}
+	})
+
+	t.Run("stored columns pass", func(t *testing.T) {
+		testParams := testIsAvailableParams{
+			options:                 []Option{WithSyncChecker(&mock.MockSyncChecker{})},
+			columnsToSave:           []uint64{1, 17, 19, 42, 75, 87, 102, 117},
+			blobKzgCommitmentsCount: 3,
+		}
+
+		ctx, cancel, service, root, signed := testIsAvailableSetup(t, testParams)
+		defer cancel()
+
+		roBlock, err := consensusblocks.NewROBlockWithRoot(signed, root)
+		require.NoError(t, err)
+		require.NoError(t, service.isDataAvailable(ctx, roBlock))
+	})
+}
+
 func TestDataColumnsAvailableNow(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig()

--- a/changelog/terence_fail-fast-initsync-column-da.md
+++ b/changelog/terence_fail-fast-initsync-column-da.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fail the block data column availability check during initial sync instead of waiting indefinitely, so checkpoint sync no longer stalls when a block's custody columns are missing.


### PR DESCRIPTION
- During initial sync, `isDataAvailable` waits on `areDataColumnsAvailable` with no bound. For a block whose slot has already passed, the slot-end timer is never armed, so if the block's custody columns are missing the init-sync consumer blocks forever and sync silently dead-ends. #16978 bounded the batch path and #16994 fixed the payload envelope path, but checkpoint sync routes every block through this per-block path (`syncToNonFinalizedEpoch` -> `ReceiveBlock` with nil `avs`).
- Example from a stuck mainnet checkpoint sync (https://gist.github.com/nalepae/345a926d7ac0d3335de07d612d99a0d3), the node imports a few blocks then stops with no error and never recovers:

```
[13:21:32.39]  INFO blockchain: Synced new block block=0x614562f4... slot=14738725
[13:21:32.41]  INFO blockchain: Called new payload with optimistic block ... slot=14738726
(nothing after this, block processing never resumes)
```

- Fix mirrors #16994: during initial sync, check column availability synchronously with `dataColumnsAvailableNow` and return an error if columns are missing, so round robin retries the batch and refetches the columns instead of hanging.
- Added a regression test that stalls forever without this change.