### PR TITLE
Adopt `testing/synctest` in `beacon-chain/{p2p,sync}` test packages

### DIFF
--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -44,11 +44,43 @@ var (
 
 // CommitteeCache is a struct with 1 queue for looking up shuffled indices list by seed.
 type CommitteeCache struct {
-	Wg             sync.WaitGroup
 	Sf             singleflight.Group
 	CommitteeCache *lru.Cache
 	lock           sync.RWMutex
 	size           int
+
+	// Synchronization for in-flight fill tracking, using mutex and condition variable.
+	// Note: Not a sync.WaitGroup: one used inside a testing/synctest
+	// bubble crashes a later Wait from outside it.
+	fillsMu   sync.Mutex
+	fills     int
+	fillsDone sync.Cond
+}
+
+// GoFill runs f in a new goroutine and tracks it so Clear can wait for
+// in-flight cache fills.
+func (c *CommitteeCache) GoFill(f func()) {
+	c.fillsMu.Lock()
+	c.fills++
+	c.fillsMu.Unlock()
+	go func() {
+		defer func() {
+			c.fillsMu.Lock()
+			c.fills--
+			c.fillsDone.Broadcast()
+			c.fillsMu.Unlock()
+		}()
+		f()
+	}()
+}
+
+// waitFills blocks until no cache fill goroutines are in flight.
+func (c *CommitteeCache) waitFills() {
+	c.fillsMu.Lock()
+	for c.fills > 0 {
+		c.fillsDone.Wait()
+	}
+	c.fillsMu.Unlock()
 }
 
 // committeeKeyFn takes the seed as the key to retrieve shuffled indices of a committee in a given epoch.
@@ -63,13 +95,14 @@ func committeeKeyFn(obj any) (string, error) {
 // NewCommitteesCache creates a new committee cache for storing/accessing shuffled indices of a committee.
 func NewCommitteesCache() *CommitteeCache {
 	cc := &CommitteeCache{}
+	cc.fillsDone.L = &cc.fillsMu
 	cc.Clear()
 	return cc
 }
 
 // Clear resets the CommitteeCache to its initial state
 func (c *CommitteeCache) Clear() {
-	c.Wg.Wait()
+	c.waitFills()
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.CommitteeCache = lruwrpr.New(maxCommitteesCacheSize)

--- a/beacon-chain/cache/committee_disabled.go
+++ b/beacon-chain/cache/committee_disabled.go
@@ -76,3 +76,7 @@ func (c *FakeCommitteeCache) ExpandCommitteeCache() {
 func (c *FakeCommitteeCache) CompressCommitteeCache() {
 	return
 }
+
+func (c *FakeCommitteeCache) GoFill(func()) {
+	return
+}

--- a/beacon-chain/cache/committee_test.go
+++ b/beacon-chain/cache/committee_test.go
@@ -7,7 +7,10 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -149,4 +152,84 @@ func TestCommitteeCache_DoesNothingWhenCancelledContext(t *testing.T) {
 	count, err = cache.ActiveIndicesCount(item.Seed)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+func TestCommitteeCache_GoFill(t *testing.T) {
+	t.Run("clear waits for in-flight fills", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			cache := NewCommitteesCache()
+
+			release := make(chan struct{})
+			cache.GoFill(func() { <-release })
+
+			cleared := make(chan struct{})
+			go func() {
+				cache.Clear()
+				close(cleared)
+			}()
+
+			synctest.Wait()
+
+			select {
+			case <-cleared:
+				t.Fatal("Clear returned while a fill was still in flight")
+			default:
+			}
+
+			close(release)
+			<-cleared
+		})
+	})
+
+	// Regression test for the sync.WaitGroup when used with synctest.
+	t.Run("fill inside bubble then clear outside", func(t *testing.T) {
+		cache := NewCommitteesCache()
+		synctest.Test(t, func(t *testing.T) {
+			done := make(chan struct{})
+			cache.GoFill(func() { close(done) })
+			<-done
+		})
+		cache.Clear()
+	})
+
+	t.Run("concurrent fills and clears", func(t *testing.T) {
+		cache := NewCommitteesCache()
+
+		var inFlight atomic.Int64
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				for range 1000 {
+					cache.GoFill(func() {
+						inFlight.Add(1)
+						defer inFlight.Add(-1)
+					})
+				}
+			})
+
+			wg.Go(func() {
+				for range 200 {
+					cache.Clear()
+				}
+			})
+		}
+		wg.Wait()
+
+		cache.Clear()
+		assert.Equal(t, int64(0), inFlight.Load(), "Fills still in flight after final Clear")
+	})
+
+	t.Run("panicking fill still decrements", func(t *testing.T) {
+		cache := NewCommitteesCache()
+
+		panicked := make(chan any, 1)
+		cache.GoFill(func() {
+			defer func() { panicked <- recover() }()
+			panic("fill failed")
+		})
+
+		require.NotNil(t, <-panicked)
+		// Must not deadlock: the deferred decrement ran despite the panic.
+		cache.Clear()
+	})
 }

--- a/beacon-chain/cache/proposer_preferences.go
+++ b/beacon-chain/cache/proposer_preferences.go
@@ -12,10 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const (
-	defaultExpiration = 1 * time.Hour
-	cleanupInterval   = 15 * time.Minute
-)
+const defaultExpiration = 1 * time.Hour
 
 var (
 	proposerPreferencesCacheHit = promauto.NewCounter(prometheus.CounterOpts{
@@ -81,7 +78,13 @@ type ProposerPreferencesCache struct {
 func NewProposerPreferencesCache() *ProposerPreferencesCache {
 	return &ProposerPreferencesCache{
 		preferences: make(map[primitives.Slot][]ProposerPreference),
-		defaults:    gocache.New(defaultExpiration, cleanupInterval),
+
+		// Disable janitor because
+		// 1. If janitor is enabled, it stops ONLY when the cache is GC'd,
+		// which makes it impossible to stop goroutines.
+		// 2. It's still correct to access expired entries, which are treated as absent by Get.
+		// Janitor is manually invoked by PruneBefore as go-cache exposes a DeleteExpired method.
+		defaults: gocache.New(defaultExpiration, 0 /* disable janitor */),
 	}
 }
 
@@ -143,7 +146,8 @@ func (c *ProposerPreferencesCache) Has(dependentRoot [32]byte, slot primitives.S
 	return false
 }
 
-// PruneBefore removes all signed preferences for slots before the provided slot.
+// PruneBefore removes all signed preferences for slots before the provided
+// slot, and deletes expired per-validator defaults.
 func (c *ProposerPreferencesCache) PruneBefore(slot primitives.Slot) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -153,6 +157,8 @@ func (c *ProposerPreferencesCache) PruneBefore(slot primitives.Slot) {
 			delete(c.preferences, cachedSlot)
 		}
 	}
+
+	c.defaults.DeleteExpired()
 }
 
 // Clear removes all cached signed preferences. Does not touch defaults.

--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -606,7 +606,7 @@ func fillCommitteeCacheAsync(seed [32]byte, indices []primitives.ValidatorIndex)
 	count := SlotCommitteeCount(uint64(len(indices)))
 	committeeCount := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(count))
 
-	committeeCache.Wg.Go(func() {
+	committeeCache.GoFill(func() {
 		if committeeCache.HasEntry(seedKey) {
 			return
 		}

--- a/beacon-chain/db/filesystem/mock.go
+++ b/beacon-chain/db/filesystem/mock.go
@@ -130,7 +130,10 @@ func NewEphemeralDataColumnStorageUsingFs(t testing.TB, fs afero.Fs, opts ...Dat
 		WithDataColumnFs(fs),
 	)
 
-	bs, err := NewDataColumnStorage(context.Background(), opts...)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	bs, err := NewDataColumnStorage(ctx, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/operations/attestations/kv/kv.go
+++ b/beacon-chain/operations/attestations/kv/kv.go
@@ -33,7 +33,9 @@ type AttCaches struct {
 // various kind of attestations.
 func NewAttCaches() *AttCaches {
 	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
-	c := cache.New(2*epochDuration, 2*epochDuration)
+	// Disable janitor because janitor only stops when the cache is GC'd, which makes it impossible to stop goroutines.
+	// Expired entries are still reclaimed each slot via DeleteExpiredSeenBits.
+	c := cache.New(2*epochDuration, 0 /* disable janitor */)
 	pool := &AttCaches{
 		unAggregatedAtt:   make(map[attestation.Id]ethpb.Att),
 		aggregatedAtt:     make(map[attestation.Id][]ethpb.Att),

--- a/beacon-chain/operations/attestations/kv/kv.go
+++ b/beacon-chain/operations/attestations/kv/kv.go
@@ -34,7 +34,9 @@ type AttCaches struct {
 // various kind of attestations.
 func NewAttCaches() *AttCaches {
 	secsInEpoch := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	c := cache.New(2*secsInEpoch*time.Second, 2*secsInEpoch*time.Second)
+	// Disable janitor because janitor only stops when the cache is GC'd, which makes it impossible to stop goroutines.
+	// Expired entries are still reclaimed each slot via DeleteExpiredSeenBits.
+	c := cache.New(2*secsInEpoch*time.Second, 0 /* disable janitor */)
 	pool := &AttCaches{
 		unAggregatedAtt:   make(map[attestation.Id]ethpb.Att),
 		aggregatedAtt:     make(map[attestation.Id][]ethpb.Att),

--- a/beacon-chain/operations/attestations/kv/seen_bits.go
+++ b/beacon-chain/operations/attestations/kv/seen_bits.go
@@ -40,6 +40,11 @@ func (c *AttCaches) insertSeenBit(att ethpb.Att) error {
 	return nil
 }
 
+// DeleteExpiredSeenBits reclaims expired seen-bits entries.
+func (c *AttCaches) DeleteExpiredSeenBits() {
+	c.seenAtt.DeleteExpired()
+}
+
 func (c *AttCaches) hasSeenBit(att ethpb.Att) (bool, error) {
 	id, err := attestation.NewId(att, attestation.Data)
 	if err != nil {

--- a/beacon-chain/operations/attestations/mock/mock.go
+++ b/beacon-chain/operations/attestations/mock/mock.go
@@ -78,6 +78,11 @@ func (*PoolMock) SeenAggregatedAttestationCount() int {
 	panic("implement me")
 }
 
+// DeleteExpiredSeenBits --
+func (*PoolMock) DeleteExpiredSeenBits() {
+	panic("implement me")
+}
+
 // SaveUnaggregatedAttestation --
 func (*PoolMock) SaveUnaggregatedAttestation(_ ethpb.Att) error {
 	panic("implement me")

--- a/beacon-chain/operations/attestations/pool.go
+++ b/beacon-chain/operations/attestations/pool.go
@@ -26,6 +26,7 @@ type Pool interface {
 	// Seen aggregated attestations.
 	DeleteSeenAggregatedAttestationsBefore(expirySlot primitives.Slot)
 	SeenAggregatedAttestationCount() int
+	DeleteExpiredSeenBits()
 	// For unaggregated attestations.
 	SaveUnaggregatedAttestation(att ethpb.Att) error
 	SaveUnaggregatedAttestations(atts []ethpb.Att) error

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -89,6 +89,7 @@ func (s *Service) pruneExpiredAtts() {
 	}
 
 	s.cfg.Pool.DeleteSeenAggregatedAttestationsBefore(expirySlot)
+	s.cfg.Pool.DeleteExpiredSeenBits()
 }
 
 // Return true if the input slot has been expired.

--- a/beacon-chain/p2p/broadcaster_test.go
+++ b/beacon-chain/p2p/broadcaster_test.go
@@ -41,66 +41,68 @@ import (
 )
 
 func TestService_Broadcast(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	if len(p1.BHost.Network().Peers()) == 0 {
-		t.Fatal("No peers")
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		if len(p1.BHost.Network().Peers()) == 0 {
+			t.Fatal("No peers")
+		}
 
-	p := &Service{
-		host:                  p1.BHost,
-		pubsub:                p1.PubSub(),
-		joinedTopics:          map[string]*pubsub.Topic{},
-		cfg:                   &Config{},
-		genesisTime:           time.Now(),
-		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
-	}
+		p := &Service{
+			host:                  p1.BHost,
+			pubsub:                p1.PubSub(),
+			joinedTopics:          map[string]*pubsub.Topic{},
+			cfg:                   &Config{},
+			genesisTime:           time.Now(),
+			genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+		}
 
-	msg := &ethpb.Fork{
-		Epoch:           55,
-		CurrentVersion:  []byte("fooo"),
-		PreviousVersion: []byte("barr"),
-	}
+		msg := &ethpb.Fork{
+			Epoch:           55,
+			CurrentVersion:  []byte("fooo"),
+			PreviousVersion: []byte("barr"),
+		}
 
-	topic := "/eth2/%x/testing"
-	// Set a test gossip mapping for testpb.TestSimpleMessage.
-	GossipTypeMapping[reflect.TypeFor[*ethpb.Fork]()] = topic
-	digest, err := p.currentForkDigest()
-	require.NoError(t, err)
-	topic = fmt.Sprintf(topic, digest)
+		topic := "/eth2/%x/testing"
+		// Set a test gossip mapping for testpb.TestSimpleMessage.
+		GossipTypeMapping[reflect.TypeFor[*ethpb.Fork]()] = topic
+		digest, err := p.currentForkDigest()
+		require.NoError(t, err)
+		topic = fmt.Sprintf(topic, digest)
 
-	// External peer subscribes to the topic.
-	topic += p.Encoding().ProtocolSuffix()
-	sub, err := p2.SubscribeToTopic(topic)
-	require.NoError(t, err)
-
-	// Wait for libp2p mesh to establish
-	require.Eventually(t, func() bool {
-		return len(p.pubsub.ListPeers(topic)) > 0
-	}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
-
-	// Async listen for the pubsub, must be before the broadcast.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
-		defer cancel()
-
-		incomingMessage, err := sub.Next(ctx)
+		// External peer subscribes to the topic.
+		topic += p.Encoding().ProtocolSuffix()
+		sub, err := p2.SubscribeToTopic(topic)
 		require.NoError(t, err)
 
-		result := &ethpb.Fork{}
-		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
-		if !proto.Equal(result, msg) {
-			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+		// Wait for libp2p mesh to establish
+		require.Eventually(t, func() bool {
+			return len(p.pubsub.ListPeers(topic)) > 0
+		}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
+
+		// Async listen for the pubsub, must be before the broadcast.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+			defer cancel()
+
+			incomingMessage, err := sub.Next(ctx)
+			require.NoError(t, err)
+
+			result := &ethpb.Fork{}
+			require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
+			if !proto.Equal(result, msg) {
+				t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			}
+		})
+
+		// Broadcast to peers and wait.
+		require.NoError(t, p.Broadcast(t.Context(), msg))
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Error("Failed to receive pubsub within 1s")
 		}
 	})
-
-	// Broadcast to peers and wait.
-	require.NoError(t, p.Broadcast(t.Context(), msg))
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Error("Failed to receive pubsub within 1s")
-	}
 }
 
 func TestService_Broadcast_ReturnsErr_TopicNotMapped(t *testing.T) {
@@ -155,71 +157,73 @@ func TestService_Attestation_Subnet(t *testing.T) {
 }
 
 func TestService_BroadcastAttestation(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	if len(p1.BHost.Network().Peers()) == 0 {
-		t.Fatal("No peers")
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		if len(p1.BHost.Network().Peers()) == 0 {
+			t.Fatal("No peers")
+		}
 
-	p := &Service{
-		host:                  p1.BHost,
-		pubsub:                p1.PubSub(),
-		joinedTopics:          map[string]*pubsub.Topic{},
-		cfg:                   &Config{},
-		genesisTime:           time.Now(),
-		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:           make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:       sync.Mutex{},
-		peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
-			ScorerParams: &scorers.Config{},
-		}),
-	}
+		p := &Service{
+			host:                  p1.BHost,
+			pubsub:                p1.PubSub(),
+			joinedTopics:          map[string]*pubsub.Topic{},
+			cfg:                   &Config{},
+			genesisTime:           time.Now(),
+			genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+			subnetsLock:           make(map[uint64]*sync.RWMutex),
+			subnetsLockLock:       sync.Mutex{},
+			peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
+				ScorerParams: &scorers.Config{},
+			}),
+		}
 
-	msg := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.NewBitlist(7)})
-	subnet := uint64(5)
+		msg := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.NewBitlist(7)})
+		subnet := uint64(5)
 
-	topic := AttestationSubnetTopicFormat
-	GossipTypeMapping[reflect.TypeFor[*ethpb.Attestation]()] = topic
-	digest, err := p.currentForkDigest()
-	require.NoError(t, err)
-	topic = fmt.Sprintf(topic, digest, subnet)
+		topic := AttestationSubnetTopicFormat
+		GossipTypeMapping[reflect.TypeFor[*ethpb.Attestation]()] = topic
+		digest, err := p.currentForkDigest()
+		require.NoError(t, err)
+		topic = fmt.Sprintf(topic, digest, subnet)
 
-	// External peer subscribes to the topic.
-	topic += p.Encoding().ProtocolSuffix()
-	sub, err := p2.SubscribeToTopic(topic)
-	require.NoError(t, err)
-
-	// Wait for libp2p mesh to establish
-	require.Eventually(t, func() bool {
-		return len(p.pubsub.ListPeers(topic)) > 0
-	}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
-
-	// Async listen for the pubsub, must be before the broadcast.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
-		defer cancel()
-
-		incomingMessage, err := sub.Next(ctx)
+		// External peer subscribes to the topic.
+		topic += p.Encoding().ProtocolSuffix()
+		sub, err := p2.SubscribeToTopic(topic)
 		require.NoError(t, err)
 
-		result := &ethpb.Attestation{}
-		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
-		if !proto.Equal(result, msg) {
-			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+		// Wait for libp2p mesh to establish
+		require.Eventually(t, func() bool {
+			return len(p.pubsub.ListPeers(topic)) > 0
+		}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
+
+		// Async listen for the pubsub, must be before the broadcast.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+			defer cancel()
+
+			incomingMessage, err := sub.Next(ctx)
+			require.NoError(t, err)
+
+			result := &ethpb.Attestation{}
+			require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
+			if !proto.Equal(result, msg) {
+				t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			}
+		})
+
+		// Attempt to broadcast nil object should fail.
+		ctx := t.Context()
+		require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastAttestation(ctx, subnet, nil))
+
+		// Broadcast to peers and wait.
+		require.NoError(t, p.BroadcastAttestation(ctx, subnet, msg))
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Error("Failed to receive pubsub within 1s")
 		}
 	})
-
-	// Attempt to broadcast nil object should fail.
-	ctx := t.Context()
-	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastAttestation(ctx, subnet, nil))
-
-	// Broadcast to peers and wait.
-	require.NoError(t, p.BroadcastAttestation(ctx, subnet, msg))
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Error("Failed to receive pubsub within 1s")
-	}
 }
 
 func TestService_BroadcastAttestationWithDiscoveryAttempts(t *testing.T) {
@@ -409,299 +413,307 @@ func TestService_BroadcastAttestationWithDiscoveryAttempts(t *testing.T) {
 }
 
 func TestService_BroadcastSyncCommittee(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	if len(p1.BHost.Network().Peers()) == 0 {
-		t.Fatal("No peers")
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		if len(p1.BHost.Network().Peers()) == 0 {
+			t.Fatal("No peers")
+		}
 
-	p := &Service{
-		host:                  p1.BHost,
-		pubsub:                p1.PubSub(),
-		joinedTopics:          map[string]*pubsub.Topic{},
-		cfg:                   &Config{},
-		genesisTime:           time.Now(),
-		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:           make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:       sync.Mutex{},
-		peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
-			ScorerParams: &scorers.Config{},
-		}),
-	}
+		p := &Service{
+			host:                  p1.BHost,
+			pubsub:                p1.PubSub(),
+			joinedTopics:          map[string]*pubsub.Topic{},
+			cfg:                   &Config{},
+			genesisTime:           time.Now(),
+			genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+			subnetsLock:           make(map[uint64]*sync.RWMutex),
+			subnetsLockLock:       sync.Mutex{},
+			peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
+				ScorerParams: &scorers.Config{},
+			}),
+		}
 
-	msg := util.HydrateSyncCommittee(&ethpb.SyncCommitteeMessage{})
-	subnet := uint64(5)
+		msg := util.HydrateSyncCommittee(&ethpb.SyncCommitteeMessage{})
+		subnet := uint64(5)
 
-	topic := SyncCommitteeSubnetTopicFormat
-	GossipTypeMapping[reflect.TypeFor[*ethpb.SyncCommitteeMessage]()] = topic
-	digest, err := p.currentForkDigest()
-	require.NoError(t, err)
-	topic = fmt.Sprintf(topic, digest, subnet)
+		topic := SyncCommitteeSubnetTopicFormat
+		GossipTypeMapping[reflect.TypeFor[*ethpb.SyncCommitteeMessage]()] = topic
+		digest, err := p.currentForkDigest()
+		require.NoError(t, err)
+		topic = fmt.Sprintf(topic, digest, subnet)
 
-	// External peer subscribes to the topic.
-	topic += p.Encoding().ProtocolSuffix()
-	sub, err := p2.SubscribeToTopic(topic)
-	require.NoError(t, err)
-
-	// Wait for libp2p mesh to establish
-	require.Eventually(t, func() bool {
-		return len(p.pubsub.ListPeers(topic)) > 0
-	}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
-
-	// Async listen for the pubsub, must be before the broadcast.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
-		defer cancel()
-
-		incomingMessage, err := sub.Next(ctx)
+		// External peer subscribes to the topic.
+		topic += p.Encoding().ProtocolSuffix()
+		sub, err := p2.SubscribeToTopic(topic)
 		require.NoError(t, err)
 
-		result := &ethpb.SyncCommitteeMessage{}
-		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
-		if !proto.Equal(result, msg) {
-			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+		// Wait for libp2p mesh to establish
+		require.Eventually(t, func() bool {
+			return len(p.pubsub.ListPeers(topic)) > 0
+		}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
+
+		// Async listen for the pubsub, must be before the broadcast.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+			defer cancel()
+
+			incomingMessage, err := sub.Next(ctx)
+			require.NoError(t, err)
+
+			result := &ethpb.SyncCommitteeMessage{}
+			require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
+			if !proto.Equal(result, msg) {
+				t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			}
+		})
+
+		// Broadcasting nil should fail.
+		ctx := t.Context()
+		require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastSyncCommitteeMessage(ctx, subnet, nil))
+
+		// Broadcast to peers and wait.
+		require.NoError(t, p.BroadcastSyncCommitteeMessage(ctx, subnet, msg))
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Error("Failed to receive pubsub within 1s")
 		}
 	})
-
-	// Broadcasting nil should fail.
-	ctx := t.Context()
-	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastSyncCommitteeMessage(ctx, subnet, nil))
-
-	// Broadcast to peers and wait.
-	require.NoError(t, p.BroadcastSyncCommitteeMessage(ctx, subnet, msg))
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Error("Failed to receive pubsub within 1s")
-	}
 }
 
 func TestService_BroadcastBlob(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	require.NotEqual(t, 0, len(p1.BHost.Network().Peers()), "No peers")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		require.NotEqual(t, 0, len(p1.BHost.Network().Peers()), "No peers")
 
-	p := &Service{
-		host:                  p1.BHost,
-		pubsub:                p1.PubSub(),
-		joinedTopics:          map[string]*pubsub.Topic{},
-		cfg:                   &Config{},
-		genesisTime:           time.Now(),
-		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:           make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:       sync.Mutex{},
-		peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
-			ScorerParams: &scorers.Config{},
-		}),
-	}
+		p := &Service{
+			host:                  p1.BHost,
+			pubsub:                p1.PubSub(),
+			joinedTopics:          map[string]*pubsub.Topic{},
+			cfg:                   &Config{},
+			genesisTime:           time.Now(),
+			genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+			subnetsLock:           make(map[uint64]*sync.RWMutex),
+			subnetsLockLock:       sync.Mutex{},
+			peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
+				ScorerParams: &scorers.Config{},
+			}),
+		}
 
-	header := util.HydrateSignedBeaconHeader(&ethpb.SignedBeaconBlockHeader{})
-	commitmentInclusionProof := make([][]byte, 17)
-	for i := range commitmentInclusionProof {
-		commitmentInclusionProof[i] = bytesutil.PadTo([]byte{}, 32)
-	}
-	blobSidecar := &ethpb.BlobSidecar{
-		Index:                    1,
-		Blob:                     bytesutil.PadTo([]byte{'C'}, fieldparams.BlobLength),
-		KzgCommitment:            bytesutil.PadTo([]byte{'D'}, fieldparams.BLSPubkeyLength),
-		KzgProof:                 bytesutil.PadTo([]byte{'E'}, fieldparams.BLSPubkeyLength),
-		SignedBlockHeader:        header,
-		CommitmentInclusionProof: commitmentInclusionProof,
-	}
-	subnet := uint64(0)
+		header := util.HydrateSignedBeaconHeader(&ethpb.SignedBeaconBlockHeader{})
+		commitmentInclusionProof := make([][]byte, 17)
+		for i := range commitmentInclusionProof {
+			commitmentInclusionProof[i] = bytesutil.PadTo([]byte{}, 32)
+		}
+		blobSidecar := &ethpb.BlobSidecar{
+			Index:                    1,
+			Blob:                     bytesutil.PadTo([]byte{'C'}, fieldparams.BlobLength),
+			KzgCommitment:            bytesutil.PadTo([]byte{'D'}, fieldparams.BLSPubkeyLength),
+			KzgProof:                 bytesutil.PadTo([]byte{'E'}, fieldparams.BLSPubkeyLength),
+			SignedBlockHeader:        header,
+			CommitmentInclusionProof: commitmentInclusionProof,
+		}
+		subnet := uint64(0)
 
-	topic := BlobSubnetTopicFormat
-	GossipTypeMapping[reflect.TypeFor[*ethpb.BlobSidecar]()] = topic
-	digest, err := p.currentForkDigest()
-	require.NoError(t, err)
-	topic = fmt.Sprintf(topic, digest, subnet)
+		topic := BlobSubnetTopicFormat
+		GossipTypeMapping[reflect.TypeFor[*ethpb.BlobSidecar]()] = topic
+		digest, err := p.currentForkDigest()
+		require.NoError(t, err)
+		topic = fmt.Sprintf(topic, digest, subnet)
 
-	// External peer subscribes to the topic.
-	topic += p.Encoding().ProtocolSuffix()
-	sub, err := p2.SubscribeToTopic(topic)
-	require.NoError(t, err)
-
-	// Wait for libp2p mesh to establish
-	require.Eventually(t, func() bool {
-		return len(p.pubsub.ListPeers(topic)) > 0
-	}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
-
-	// Async listen for the pubsub, must be before the broadcast.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
-		defer cancel()
-
-		incomingMessage, err := sub.Next(ctx)
+		// External peer subscribes to the topic.
+		topic += p.Encoding().ProtocolSuffix()
+		sub, err := p2.SubscribeToTopic(topic)
 		require.NoError(t, err)
 
-		result := &ethpb.BlobSidecar{}
-		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
-		require.DeepEqual(t, result, blobSidecar)
+		// Wait for libp2p mesh to establish
+		require.Eventually(t, func() bool {
+			return len(p.pubsub.ListPeers(topic)) > 0
+		}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
+
+		// Async listen for the pubsub, must be before the broadcast.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+			defer cancel()
+
+			incomingMessage, err := sub.Next(ctx)
+			require.NoError(t, err)
+
+			result := &ethpb.BlobSidecar{}
+			require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
+			require.DeepEqual(t, result, blobSidecar)
+		})
+
+		// Attempt to broadcast nil object should fail.
+		ctx := t.Context()
+		require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastBlob(ctx, subnet, nil))
+
+		// Broadcast to peers and wait.
+		require.NoError(t, p.BroadcastBlob(ctx, subnet, blobSidecar))
+		require.Equal(t, false, util.WaitTimeout(&wg, 1*time.Second), "Failed to receive pubsub within 1s")
 	})
-
-	// Attempt to broadcast nil object should fail.
-	ctx := t.Context()
-	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastBlob(ctx, subnet, nil))
-
-	// Broadcast to peers and wait.
-	require.NoError(t, p.BroadcastBlob(ctx, subnet, blobSidecar))
-	require.Equal(t, false, util.WaitTimeout(&wg, 1*time.Second), "Failed to receive pubsub within 1s")
 }
 
 func TestService_BroadcastLightClientOptimisticUpdate(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	config := params.BeaconConfig().Copy()
-	config.SyncMessageDueBPS = 60 // ~72 millisecond
-	params.OverrideBeaconConfig(config)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		config := params.BeaconConfig().Copy()
+		config.SyncMessageDueBPS = 60 // ~72 millisecond
+		params.OverrideBeaconConfig(config)
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	require.NotEqual(t, 0, len(p1.BHost.Network().Peers()))
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		require.NotEqual(t, 0, len(p1.BHost.Network().Peers()))
 
-	p := &Service{
-		host:                  p1.BHost,
-		pubsub:                p1.PubSub(),
-		joinedTopics:          map[string]*pubsub.Topic{},
-		cfg:                   &Config{},
-		genesisTime:           time.Now().Add(-33 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), // the signature slot of the mock update is 33
-		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:           make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:       sync.Mutex{},
-		peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
-			ScorerParams: &scorers.Config{},
-		}),
-	}
-
-	msg, err := util.MockOptimisticUpdate()
-	require.NoError(t, err)
-
-	GossipTypeMapping[reflect.TypeOf(msg)] = LightClientOptimisticUpdateTopicFormat
-	topic := fmt.Sprintf(LightClientOptimisticUpdateTopicFormat, params.ForkDigest(slots.ToEpoch(msg.AttestedHeader().Beacon().Slot)))
-
-	// External peer subscribes to the topic.
-	topic += p.Encoding().ProtocolSuffix()
-	sub, err := p2.SubscribeToTopic(topic)
-	require.NoError(t, err)
-
-	// Wait for libp2p mesh to establish
-	require.Eventually(t, func() bool {
-		return len(p.pubsub.ListPeers(topic)) > 0
-	}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
-
-	// Async listen for the pubsub, must be before the broadcast.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
-		defer cancel()
-
-		incomingMessage, err := sub.Next(ctx)
-		require.NoError(t, err)
-
-		slotStartTime, err := slots.StartTime(p.genesisTime, msg.SignatureSlot())
-		require.NoError(t, err)
-		expectedDelay := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().SyncMessageDueBPS)
-		if time.Now().Before(slotStartTime.Add(expectedDelay)) {
-			t.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
+		p := &Service{
+			host:                  p1.BHost,
+			pubsub:                p1.PubSub(),
+			joinedTopics:          map[string]*pubsub.Topic{},
+			cfg:                   &Config{},
+			genesisTime:           time.Now().Add(-33 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), // the signature slot of the mock update is 33
+			genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+			subnetsLock:           make(map[uint64]*sync.RWMutex),
+			subnetsLockLock:       sync.Mutex{},
+			peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
+				ScorerParams: &scorers.Config{},
+			}),
 		}
 
-		result := &ethpb.LightClientOptimisticUpdateAltair{}
-		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
-		if !proto.Equal(result, msg.Proto()) {
-			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+		msg, err := util.MockOptimisticUpdate()
+		require.NoError(t, err)
+
+		GossipTypeMapping[reflect.TypeOf(msg)] = LightClientOptimisticUpdateTopicFormat
+		topic := fmt.Sprintf(LightClientOptimisticUpdateTopicFormat, params.ForkDigest(slots.ToEpoch(msg.AttestedHeader().Beacon().Slot)))
+
+		// External peer subscribes to the topic.
+		topic += p.Encoding().ProtocolSuffix()
+		sub, err := p2.SubscribeToTopic(topic)
+		require.NoError(t, err)
+
+		// Wait for libp2p mesh to establish
+		require.Eventually(t, func() bool {
+			return len(p.pubsub.ListPeers(topic)) > 0
+		}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
+
+		// Async listen for the pubsub, must be before the broadcast.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+			defer cancel()
+
+			incomingMessage, err := sub.Next(ctx)
+			require.NoError(t, err)
+
+			slotStartTime, err := slots.StartTime(p.genesisTime, msg.SignatureSlot())
+			require.NoError(t, err)
+			expectedDelay := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().SyncMessageDueBPS)
+			if time.Now().Before(slotStartTime.Add(expectedDelay)) {
+				t.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
+			}
+
+			result := &ethpb.LightClientOptimisticUpdateAltair{}
+			require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
+			if !proto.Equal(result, msg.Proto()) {
+				t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			}
+		})
+
+		// Broadcasting nil should fail.
+		ctx := t.Context()
+		require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientOptimisticUpdate(ctx, nil))
+		var nilUpdate interfaces.LightClientOptimisticUpdate
+		require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientOptimisticUpdate(ctx, nilUpdate))
+
+		// Broadcast to peers and wait.
+		require.NoError(t, p.BroadcastLightClientOptimisticUpdate(ctx, msg))
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Error("Failed to receive pubsub within 1s")
 		}
 	})
-
-	// Broadcasting nil should fail.
-	ctx := t.Context()
-	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientOptimisticUpdate(ctx, nil))
-	var nilUpdate interfaces.LightClientOptimisticUpdate
-	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientOptimisticUpdate(ctx, nilUpdate))
-
-	// Broadcast to peers and wait.
-	require.NoError(t, p.BroadcastLightClientOptimisticUpdate(ctx, msg))
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Error("Failed to receive pubsub within 1s")
-	}
 }
 
 func TestService_BroadcastLightClientFinalityUpdate(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	config := params.BeaconConfig().Copy()
-	config.SyncMessageDueBPS = 60 // ~72 millisecond
-	params.OverrideBeaconConfig(config)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		config := params.BeaconConfig().Copy()
+		config.SyncMessageDueBPS = 60 // ~72 millisecond
+		params.OverrideBeaconConfig(config)
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	require.NotEqual(t, 0, len(p1.BHost.Network().Peers()))
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		require.NotEqual(t, 0, len(p1.BHost.Network().Peers()))
 
-	p := &Service{
-		host:                  p1.BHost,
-		pubsub:                p1.PubSub(),
-		joinedTopics:          map[string]*pubsub.Topic{},
-		cfg:                   &Config{},
-		genesisTime:           time.Now().Add(-33 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), // the signature slot of the mock update is 33
-		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:           make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:       sync.Mutex{},
-		peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
-			ScorerParams: &scorers.Config{},
-		}),
-	}
-
-	msg, err := util.MockFinalityUpdate()
-	require.NoError(t, err)
-
-	GossipTypeMapping[reflect.TypeOf(msg)] = LightClientFinalityUpdateTopicFormat
-	topic := fmt.Sprintf(LightClientFinalityUpdateTopicFormat, params.ForkDigest(slots.ToEpoch(msg.AttestedHeader().Beacon().Slot)))
-
-	// External peer subscribes to the topic.
-	topic += p.Encoding().ProtocolSuffix()
-	sub, err := p2.SubscribeToTopic(topic)
-	require.NoError(t, err)
-
-	// Wait for libp2p mesh to establish
-	require.Eventually(t, func() bool {
-		return len(p.pubsub.ListPeers(topic)) > 0
-	}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
-
-	// Async listen for the pubsub, must be before the broadcast.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
-		defer cancel()
-
-		incomingMessage, err := sub.Next(ctx)
-		require.NoError(t, err)
-
-		slotStartTime, err := slots.StartTime(p.genesisTime, msg.SignatureSlot())
-		require.NoError(t, err)
-		expectedDelay := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().SyncMessageDueBPS)
-		if time.Now().Before(slotStartTime.Add(expectedDelay)) {
-			t.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
+		p := &Service{
+			host:                  p1.BHost,
+			pubsub:                p1.PubSub(),
+			joinedTopics:          map[string]*pubsub.Topic{},
+			cfg:                   &Config{},
+			genesisTime:           time.Now().Add(-33 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), // the signature slot of the mock update is 33
+			genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+			subnetsLock:           make(map[uint64]*sync.RWMutex),
+			subnetsLockLock:       sync.Mutex{},
+			peers: peers.NewStatus(t.Context(), &peers.StatusConfig{
+				ScorerParams: &scorers.Config{},
+			}),
 		}
 
-		result := &ethpb.LightClientFinalityUpdateAltair{}
-		require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
-		if !proto.Equal(result, msg.Proto()) {
-			t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+		msg, err := util.MockFinalityUpdate()
+		require.NoError(t, err)
+
+		GossipTypeMapping[reflect.TypeOf(msg)] = LightClientFinalityUpdateTopicFormat
+		topic := fmt.Sprintf(LightClientFinalityUpdateTopicFormat, params.ForkDigest(slots.ToEpoch(msg.AttestedHeader().Beacon().Slot)))
+
+		// External peer subscribes to the topic.
+		topic += p.Encoding().ProtocolSuffix()
+		sub, err := p2.SubscribeToTopic(topic)
+		require.NoError(t, err)
+
+		// Wait for libp2p mesh to establish
+		require.Eventually(t, func() bool {
+			return len(p.pubsub.ListPeers(topic)) > 0
+		}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
+
+		// Async listen for the pubsub, must be before the broadcast.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+			defer cancel()
+
+			incomingMessage, err := sub.Next(ctx)
+			require.NoError(t, err)
+
+			slotStartTime, err := slots.StartTime(p.genesisTime, msg.SignatureSlot())
+			require.NoError(t, err)
+			expectedDelay := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().SyncMessageDueBPS)
+			if time.Now().Before(slotStartTime.Add(expectedDelay)) {
+				t.Errorf("Message received too early, now %v, expected at least %v", time.Now(), slotStartTime.Add(expectedDelay))
+			}
+
+			result := &ethpb.LightClientFinalityUpdateAltair{}
+			require.NoError(t, p.Encoding().DecodeGossip(incomingMessage.Data, result))
+			if !proto.Equal(result, msg.Proto()) {
+				t.Errorf("Did not receive expected message, got %+v, wanted %+v", result, msg)
+			}
+		})
+
+		// Broadcasting nil should fail.
+		ctx := t.Context()
+		require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientFinalityUpdate(ctx, nil))
+		var nilUpdate interfaces.LightClientFinalityUpdate
+		require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientFinalityUpdate(ctx, nilUpdate))
+
+		// Broadcast to peers and wait.
+		require.NoError(t, p.BroadcastLightClientFinalityUpdate(ctx, msg))
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Error("Failed to receive pubsub within 1s")
 		}
 	})
-
-	// Broadcasting nil should fail.
-	ctx := t.Context()
-	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientFinalityUpdate(ctx, nil))
-	var nilUpdate interfaces.LightClientFinalityUpdate
-	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastLightClientFinalityUpdate(ctx, nilUpdate))
-
-	// Broadcast to peers and wait.
-	require.NoError(t, p.BroadcastLightClientFinalityUpdate(ctx, msg))
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Error("Failed to receive pubsub within 1s")
-	}
 }
 
 func TestService_BroadcastDataColumn(t *testing.T) {
@@ -848,108 +860,112 @@ func buildTestPartialColumn(t *testing.T, index uint64) blocks.PartialDataColumn
 // when a peer is already subscribed to the column's subnet, the partial column is published directly
 // via the broadcaster (no peer discovery).
 func TestService_BroadcastDataColumnPartialWithPeers(t *testing.T) {
-	const columnIndex = 12
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		const columnIndex = 12
 
-	// Require at least one peer per subnet so hasPeerWithSubnet is meaningful.
-	gFlags := new(flags.GlobalFlags)
-	gFlags.MinimumPeersPerSubnet = 1
-	flags.Init(gFlags)
-	defer flags.Init(new(flags.GlobalFlags))
+		// Require at least one peer per subnet so hasPeerWithSubnet is meaningful.
+		gFlags := new(flags.GlobalFlags)
+		gFlags.MinimumPeersPerSubnet = 1
+		flags.Init(gFlags)
+		defer flags.Init(new(flags.GlobalFlags))
 
-	ctx := t.Context()
-	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	require.NotEqual(t, 0, len(p1.BHost.Network().Peers()), "No peers")
+		ctx := t.Context()
+		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		require.NotEqual(t, 0, len(p1.BHost.Network().Peers()), "No peers")
 
-	fake := &fakePartialColumnBroadcaster{}
-	service := &Service{
-		ctx:                      ctx,
-		host:                     p1.BHost,
-		pubsub:                   p1.PubSub(),
-		joinedTopics:             map[string]*pubsub.Topic{},
-		cfg:                      &Config{},
-		genesisTime:              time.Now(),
-		genesisValidatorsRoot:    bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:              make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:          sync.Mutex{},
-		peers:                    peers.NewStatus(ctx, &peers.StatusConfig{ScorerParams: &scorers.Config{}}),
-		partialColumnBroadcaster: fake,
-	}
+		fake := &fakePartialColumnBroadcaster{}
+		service := &Service{
+			ctx:                      ctx,
+			host:                     p1.BHost,
+			pubsub:                   p1.PubSub(),
+			joinedTopics:             map[string]*pubsub.Topic{},
+			cfg:                      &Config{},
+			genesisTime:              time.Now(),
+			genesisValidatorsRoot:    bytesutil.PadTo([]byte{'A'}, 32),
+			subnetsLock:              make(map[uint64]*sync.RWMutex),
+			subnetsLockLock:          sync.Mutex{},
+			peers:                    peers.NewStatus(ctx, &peers.StatusConfig{ScorerParams: &scorers.Config{}}),
+			partialColumnBroadcaster: fake,
+		}
 
-	digest, err := service.currentForkDigest()
-	require.NoError(t, err)
+		digest, err := service.currentForkDigest()
+		require.NoError(t, err)
 
-	subnet := peerdas.ComputeSubnetForDataColumnSidecar(columnIndex)
-	topic := fmt.Sprintf(DataColumnSubnetTopicFormat, digest, subnet) + service.Encoding().ProtocolSuffix()
+		subnet := peerdas.ComputeSubnetForDataColumnSidecar(columnIndex)
+		topic := fmt.Sprintf(DataColumnSubnetTopicFormat, digest, subnet) + service.Encoding().ProtocolSuffix()
 
-	// p2 subscribes to the subnet topic so service sees a peer for it.
-	_, err = p2.SubscribeToTopic(topic)
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		return len(service.pubsub.ListPeers(topic)) > 0
-	}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
+		// p2 subscribes to the subnet topic so service sees a peer for it.
+		_, err = p2.SubscribeToTopic(topic)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			return len(service.pubsub.ListPeers(topic)) > 0
+		}, 5*time.Second, 10*time.Millisecond, "libp2p mesh did not establish")
 
-	pc := buildTestPartialColumn(t, columnIndex)
-	require.NoError(t, service.BroadcastDataColumnSidecars(ctx, nil, []blocks.PartialDataColumn{pc}))
+		pc := buildTestPartialColumn(t, columnIndex)
+		require.NoError(t, service.BroadcastDataColumnSidecars(ctx, nil, []blocks.PartialDataColumn{pc}))
 
-	require.Eventually(t, func() bool {
-		return len(fake.publishedColumns()) == 1
-	}, 5*time.Second, 10*time.Millisecond, "partial column was not published")
+		require.Eventually(t, func() bool {
+			return len(fake.publishedColumns()) == 1
+		}, 5*time.Second, 10*time.Millisecond, "partial column was not published")
 
-	published := fake.publishedColumns()
-	require.Equal(t, 1, len(published))
-	require.Equal(t, topic, published[0].topic)
-	require.Equal(t, uint64(columnIndex), published[0].index)
+		published := fake.publishedColumns()
+		require.Equal(t, 1, len(published))
+		require.Equal(t, topic, published[0].topic)
+		require.Equal(t, uint64(columnIndex), published[0].index)
+	})
 }
 
 func TestService_BroadcastDataColumnPartialWithoutPeers(t *testing.T) {
-	const columnIndex = 12
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		const columnIndex = 12
 
-	// Require at least one peer per subnet so the column is categorized as "without peers".
-	gFlags := new(flags.GlobalFlags)
-	gFlags.MinimumPeersPerSubnet = 1
-	flags.Init(gFlags)
-	defer flags.Init(new(flags.GlobalFlags))
+		// Require at least one peer per subnet so the column is categorized as "without peers".
+		gFlags := new(flags.GlobalFlags)
+		gFlags.MinimumPeersPerSubnet = 1
+		flags.Init(gFlags)
+		defer flags.Init(new(flags.GlobalFlags))
 
-	ctx := t.Context()
-	p1 := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		p1 := p2ptest.NewTestP2P(t)
 
-	fake := &fakePartialColumnBroadcaster{}
-	service := &Service{
-		ctx:                      ctx,
-		host:                     p1.BHost,
-		pubsub:                   p1.PubSub(),
-		joinedTopics:             map[string]*pubsub.Topic{},
-		cfg:                      &Config{},
-		genesisTime:              time.Now(),
-		genesisValidatorsRoot:    bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:              make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:          sync.Mutex{},
-		peers:                    peers.NewStatus(ctx, &peers.StatusConfig{ScorerParams: &scorers.Config{}}),
-		partialColumnBroadcaster: fake,
-		// dv5Listener is nil, so FindAndDialPeersWithSubnets returns immediately without discovery.
-	}
+		fake := &fakePartialColumnBroadcaster{}
+		service := &Service{
+			ctx:                      ctx,
+			host:                     p1.BHost,
+			pubsub:                   p1.PubSub(),
+			joinedTopics:             map[string]*pubsub.Topic{},
+			cfg:                      &Config{},
+			genesisTime:              time.Now(),
+			genesisValidatorsRoot:    bytesutil.PadTo([]byte{'A'}, 32),
+			subnetsLock:              make(map[uint64]*sync.RWMutex),
+			subnetsLockLock:          sync.Mutex{},
+			peers:                    peers.NewStatus(ctx, &peers.StatusConfig{ScorerParams: &scorers.Config{}}),
+			partialColumnBroadcaster: fake,
+			// dv5Listener is nil, so FindAndDialPeersWithSubnets returns immediately without discovery.
+		}
 
-	digest, err := service.currentForkDigest()
-	require.NoError(t, err)
+		digest, err := service.currentForkDigest()
+		require.NoError(t, err)
 
-	subnet := peerdas.ComputeSubnetForDataColumnSidecar(columnIndex)
-	expectedTopic := fmt.Sprintf(DataColumnSubnetTopicFormat, digest, subnet) + service.Encoding().ProtocolSuffix()
+		subnet := peerdas.ComputeSubnetForDataColumnSidecar(columnIndex)
+		expectedTopic := fmt.Sprintf(DataColumnSubnetTopicFormat, digest, subnet) + service.Encoding().ProtocolSuffix()
 
-	// No peer is subscribed to the subnet, so hasPeerWithSubnet is false.
-	require.Equal(t, 0, len(service.pubsub.ListPeers(expectedTopic)))
+		// No peer is subscribed to the subnet, so hasPeerWithSubnet is false.
+		require.Equal(t, 0, len(service.pubsub.ListPeers(expectedTopic)))
 
-	pc := buildTestPartialColumn(t, columnIndex)
-	require.NoError(t, service.BroadcastDataColumnSidecars(ctx, nil, []blocks.PartialDataColumn{pc}))
+		pc := buildTestPartialColumn(t, columnIndex)
+		require.NoError(t, service.BroadcastDataColumnSidecars(ctx, nil, []blocks.PartialDataColumn{pc}))
 
-	require.Eventually(t, func() bool {
-		return len(fake.publishedColumns()) == 1
-	}, 5*time.Second, 10*time.Millisecond, "partial column was not published")
+		require.Eventually(t, func() bool {
+			return len(fake.publishedColumns()) == 1
+		}, 5*time.Second, 10*time.Millisecond, "partial column was not published")
 
-	published := fake.publishedColumns()
-	require.Equal(t, 1, len(published))
-	require.Equal(t, expectedTopic, published[0].topic)
-	require.Equal(t, uint64(columnIndex), published[0].index)
+		published := fake.publishedColumns()
+		require.Equal(t, 1, len(published))
+		require.Equal(t, expectedTopic, published[0].topic)
+		require.Equal(t, uint64(columnIndex), published[0].index)
+	})
 }
 
 type topicInvoked struct {

--- a/beacon-chain/p2p/sender_test.go
+++ b/beacon-chain/p2p/sender_test.go
@@ -16,47 +16,49 @@ import (
 )
 
 func TestService_Send(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	p1 := testp2p.NewTestP2P(t)
-	p2 := testp2p.NewTestP2P(t)
-	p1.Connect(p2)
+	testp2p.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		p1 := testp2p.NewTestP2P(t)
+		p2 := testp2p.NewTestP2P(t)
+		p1.Connect(p2)
 
-	svc := &Service{
-		host: p1.BHost,
-		cfg:  &Config{},
-	}
+		svc := &Service{
+			host: p1.BHost,
+			cfg:  &Config{},
+		}
 
-	msg := &ethpb.Fork{
-		CurrentVersion:  []byte("fooo"),
-		PreviousVersion: []byte("barr"),
-		Epoch:           55,
-	}
+		msg := &ethpb.Fork{
+			CurrentVersion:  []byte("fooo"),
+			PreviousVersion: []byte("barr"),
+			Epoch:           55,
+		}
 
-	// Register external listener which will repeat the message back.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	topic := "/testing/1"
-	RPCTopicMappings[topic] = new(ethpb.Fork)
-	defer func() {
-		delete(RPCTopicMappings, topic)
-	}()
-	p2.SetStreamHandler(topic+"/ssz_snappy", func(stream network.Stream) {
+		// Register external listener which will repeat the message back.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		topic := "/testing/1"
+		RPCTopicMappings[topic] = new(ethpb.Fork)
+		defer func() {
+			delete(RPCTopicMappings, topic)
+		}()
+		p2.SetStreamHandler(topic+"/ssz_snappy", func(stream network.Stream) {
+			rcvd := &ethpb.Fork{}
+			require.NoError(t, svc.Encoding().DecodeWithMaxLength(stream, rcvd))
+			_, err := svc.Encoding().EncodeWithMaxLength(stream, rcvd)
+			require.NoError(t, err)
+			assert.NoError(t, stream.Close())
+			wg.Done()
+		})
+
+		stream, err := svc.Send(t.Context(), msg, "/testing/1", p2.BHost.ID())
+		require.NoError(t, err)
+
+		util.WaitTimeout(&wg, 1*time.Second)
+
 		rcvd := &ethpb.Fork{}
 		require.NoError(t, svc.Encoding().DecodeWithMaxLength(stream, rcvd))
-		_, err := svc.Encoding().EncodeWithMaxLength(stream, rcvd)
-		require.NoError(t, err)
-		assert.NoError(t, stream.Close())
-		wg.Done()
+		if !proto.Equal(rcvd, msg) {
+			t.Errorf("Expected identical message to be received. got %v want %v", rcvd, msg)
+		}
 	})
-
-	stream, err := svc.Send(t.Context(), msg, "/testing/1", p2.BHost.ID())
-	require.NoError(t, err)
-
-	util.WaitTimeout(&wg, 1*time.Second)
-
-	rcvd := &ethpb.Fork{}
-	require.NoError(t, svc.Encoding().DecodeWithMaxLength(stream, rcvd))
-	if !proto.Equal(rcvd, msg) {
-		t.Errorf("Expected identical message to be received. got %v want %v", rcvd, msg)
-	}
 }

--- a/beacon-chain/p2p/testing/BUILD.bazel
+++ b/beacon-chain/p2p/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,7 +13,10 @@ go_library(
         "mock_metadataprovider.go",
         "mock_peermanager.go",
         "mock_peersprovider.go",
+        "norace.go",
         "p2p.go",
+        "race.go",
+        "simnet.go",
     ],
     importpath = "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing",
     visibility = [
@@ -48,11 +51,21 @@ go_library(
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peerstore:go_default_library",
         "@com_github_libp2p_go_libp2p//core/protocol:go_default_library",
-        "@com_github_libp2p_go_libp2p//p2p/transport/tcp:go_default_library",
+        "@com_github_libp2p_go_libp2p//x/simlibp2p:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
+        "@com_github_marcopolo_simnet//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
         "@com_github_prysmaticlabs_fastssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["simnet_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//testing/require:go_default_library",
     ],
 )

--- a/beacon-chain/p2p/testing/norace.go
+++ b/beacon-chain/p2p/testing/norace.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package testing
+
+const raceEnabled = false

--- a/beacon-chain/p2p/testing/p2p.go
+++ b/beacon-chain/p2p/testing/p2p.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"runtime"
+	"strings"
+	"testing/synctest"
+
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/encoder"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/partialdatacolumnbroadcaster"
@@ -23,10 +27,8 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1/metadata"
-	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
-	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/config"
 	core "github.com/libp2p/go-libp2p/core"
@@ -35,7 +37,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/multiformats/go-multiaddr"
 	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/sirupsen/logrus"
@@ -50,10 +51,26 @@ const (
 	metadataV3Topic = "/eth2/beacon_chain/req/metadata/3"
 )
 
+// SynctestTest runs f inside a testing/synctest bubble with fake time, making
+// sleeps instant and deterministic.
+//
+// Rules: construct all fixtures inside f (channels/timers are bubble-affine), no
+// real sockets, and every goroutine must stop before f returns.
+func SynctestTest(t *testing.T, f func(t *testing.T)) {
+	if raceEnabled {
+		// Work around a Go runtime bug.
+		// https://github.com/golang/go/issues/78156
+		prev := runtime.GOMAXPROCS(1)
+		t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+	}
+	synctest.Test(t, f)
+}
+
 // TestP2P represents a p2p implementation that can be used for testing.
 type TestP2P struct {
 	mu                    sync.Mutex
 	t                     *testing.T
+	sim                   *SimNet // non-nil when the host runs on a simulated network
 	BHost                 host.Host
 	EnodeID               enode.ID
 	pubsub                *pubsub.PubSub
@@ -78,20 +95,36 @@ func NewTestP2P(t *testing.T, userOptions ...config.Option) *TestP2P {
 
 // NewTestP2PWithPubsubOptions initializes a new p2p test service with custom pubsub options.
 func NewTestP2PWithPubsubOptions(t *testing.T, pubsubOpts []pubsub.Option, userOptions ...config.Option) *TestP2P {
-	ctx := context.Background()
-	options := []config.Option{
-		libp2p.ResourceManager(&network.NullResourceManager{}),
-		libp2p.Transport(tcp.NewTCPTransport),
-		libp2p.DefaultListenAddrs,
+	var simnet *SimNet
+	best := -1
+
+	// Find the longest-prefix matching test name in the map of testSims.
+	testSims.Range(func(k, v any) bool {
+		name := k.(string)
+		if (t.Name() == name || strings.HasPrefix(t.Name(), name+"/")) && len(name) > best {
+			best = len(name)
+			simnet = v.(*SimNet)
+		}
+		return true
+	})
+	// If no matching test name was found, create a new one.
+	if simnet == nil {
+		simnet = NewSimNet(t)
+
+		// Store this new SimNet in the map of testSims so that subtests can use it.
+		name := t.Name()
+		testSims.Store(name, simnet)
+		t.Cleanup(func() { testSims.Delete(name) })
 	}
 
-	// Favour user options if provided.
-	if len(userOptions) > 0 {
-		options = append(userOptions, options...)
-	}
+	host := simnet.newHost(t, userOptions...)
+	return newTestP2P(t, host, simnet, pubsubOpts)
+}
 
-	h, err := libp2p.New(options...)
-	require.NoError(t, err)
+// newTestP2P wires pubsub and peer status around an existing host.
+func newTestP2P(t *testing.T, h host.Host, sim *SimNet, pubsubOpts []pubsub.Option) *TestP2P {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	defaultPubsubOpts := []pubsub.Option{
 		pubsub.WithMessageSigning(false),
@@ -104,7 +137,7 @@ func NewTestP2PWithPubsubOptions(t *testing.T, pubsubOpts []pubsub.Option, userO
 		t.Fatal(err)
 	}
 
-	peerStatuses := peers.NewStatus(context.Background(), &peers.StatusConfig{
+	peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
 		PeerLimit: 30,
 		ScorerParams: &scorers.Config{
 			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
@@ -114,12 +147,18 @@ func NewTestP2PWithPubsubOptions(t *testing.T, pubsubOpts []pubsub.Option, userO
 	})
 	return &TestP2P{
 		t:            t,
+		sim:          sim,
 		BHost:        h,
 		pubsub:       ps,
 		joinedTopics: map[string]*pubsub.Topic{},
 		peers:        peerStatuses,
 		enr:          new(enr.Record),
 	}
+}
+
+// ephemeralHost creates an extra host, on the same simulated network.
+func (p *TestP2P) ephemeralHost() host.Host {
+	return p.sim.newHost(p.t)
 }
 
 // Connect two test peers together.
@@ -139,11 +178,7 @@ func connect(a, b host.Host) error {
 
 // ReceiveRPC simulates an incoming RPC.
 func (p *TestP2P) ReceiveRPC(topic string, msg proto.Message) {
-	h, err := libp2p.New(libp2p.ResourceManager(&network.NullResourceManager{}))
-	require.NoError(p.t, err)
-	p.t.Cleanup(func() {
-		require.NoError(p.t, h.Close())
-	})
+	h := p.ephemeralHost()
 	if err := connect(h, p.BHost); err != nil {
 		p.t.Fatalf("Failed to connect two peers for RPC: %v", err)
 	}
@@ -173,12 +208,10 @@ func (p *TestP2P) ReceiveRPC(topic string, msg proto.Message) {
 
 // ReceivePubSub simulates an incoming message over pubsub on a given topic.
 func (p *TestP2P) ReceivePubSub(topic string, msg proto.Message) {
-	h, err := libp2p.New(libp2p.ResourceManager(&network.NullResourceManager{}))
-	require.NoError(p.t, err)
-	p.t.Cleanup(func() {
-		require.NoError(p.t, h.Close())
-	})
-	ps, err := pubsub.NewFloodSub(context.Background(), h,
+	h := p.ephemeralHost()
+	ctx, cancel := context.WithCancel(context.Background())
+	p.t.Cleanup(cancel)
+	ps, err := pubsub.NewFloodSub(ctx, h,
 		pubsub.WithMessageSigning(false),
 		pubsub.WithStrictSignatureVerification(false),
 	)

--- a/beacon-chain/p2p/testing/race.go
+++ b/beacon-chain/p2p/testing/race.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package testing
+
+const raceEnabled = true

--- a/beacon-chain/p2p/testing/simnet.go
+++ b/beacon-chain/p2p/testing/simnet.go
@@ -1,0 +1,66 @@
+package testing
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/config"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/x/simlibp2p"
+	"github.com/marcopolo/simnet"
+)
+
+const (
+	// simnetLatency is the default latency for the simulated network.
+	simnetLatency = time.Millisecond
+
+	// bandwidthLimit is the default bandwidth limit for the simulated network,
+	// both for downlink and uplink.
+	// Note: 10 Gbps is intended to be fast enough to not throttle the tests.
+	bandwidthLimit = 10_000 * simlibp2p.OneMbps
+)
+
+// testSims maps test names to their SimNet so all TestP2P instances of a test, including its subtests.
+// e.g., TestFoo and TestFoo/Bar share the same SimNet, so they can talk to each other.
+var testSims sync.Map
+
+// SimNet is a wrapper of simnet.Simnet which is an in-memory libp2p network for tests.
+// Note that this is not a mock of libp2p, but a real libp2p stack (QUIC, TLS, muxing, gossipsub) over a simulated wire.
+type SimNet struct {
+	net   *simnet.Simnet
+	count int
+}
+
+// NewSimNet starts a simulated network.
+func NewSimNet(t *testing.T) *SimNet {
+	nw := &simnet.Simnet{LatencyFunc: simnet.StaticLatency(simnetLatency)}
+	nw.Start()
+	t.Cleanup(nw.Close)
+	return &SimNet{net: nw}
+}
+
+// newHost creates a libp2p host on the simulated network.
+func (s *SimNet) newHost(t *testing.T, userOptions ...config.Option) host.Host {
+	s.count++
+
+	ip := simnet.IntToPublicIPv4(s.count)
+	opts := []config.Option{
+		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/udp/8000/quic-v1", ip)),
+		simlibp2p.QUICSimnet(s.net, simnet.NodeBiDiLinkSettings{
+			Downlink: simnet.LinkSettings{BitsPerSecond: bandwidthLimit},
+			Uplink:   simnet.LinkSettings{BitsPerSecond: bandwidthLimit},
+		}),
+		// Identify address discovery stalls synctest.
+		libp2p.DisableIdentifyAddressDiscovery(),
+		libp2p.ResourceManager(&network.NullResourceManager{}),
+	}
+	h, err := libp2p.New(append(opts, userOptions...)...)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, h.Close()) })
+	return h
+}

--- a/beacon-chain/p2p/testing/simnet_test.go
+++ b/beacon-chain/p2p/testing/simnet_test.go
@@ -1,0 +1,53 @@
+package testing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+// TestSimNetGossip verifies that two TestP2P instances on a simulated network can
+// deliver a gossipsub message inside a synctest bubble.
+func TestSimNetGossip(t *testing.T) {
+	SynctestTest(t, func(t *testing.T) {
+		p1 := NewTestP2P(t)
+		p2 := NewTestP2P(t)
+		require.NotNil(t, p1.sim, "expected simulated host inside bubble")
+		p1.Connect(p2)
+
+		const topic = "/test/synctest"
+		sub, err := p2.SubscribeToTopic(topic)
+		require.NoError(t, err)
+		_, err = p1.JoinTopic(topic)
+		require.NoError(t, err)
+
+		start := time.Now()
+		// Note: This sleep is on the fake clock so it should not delay the test.
+		time.Sleep(2 * time.Second)
+
+		require.NoError(t, p1.PublishToTopic(context.Background(), topic, []byte("hello")))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		msg, err := sub.Next(ctx)
+		require.NoError(t, err)
+		require.DeepEqual(t, []byte("hello"), msg.Data)
+
+		require.Equal(t, true, time.Since(start) >= 2*time.Second)
+
+		sub.Cancel()
+	})
+}
+
+// TestSimNet_Connect verifies the ephemeral-host path works on the simulated network.
+func TestSimNet_Connect(t *testing.T) {
+	SynctestTest(t, func(t *testing.T) {
+		p := NewTestP2P(t)
+
+		h := p.ephemeralHost()
+		require.NoError(t, connect(h, p.BHost))
+		require.Equal(t, 1, len(p.BHost.Network().Peers()))
+	})
+}

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -330,7 +330,6 @@ go_test(
         "@com_github_libp2p_go_libp2p//core/network:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_libp2p_go_libp2p//core/protocol:go_default_library",
-        "@com_github_libp2p_go_libp2p//p2p/transport/quic:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -329,7 +329,6 @@ go_test(
         "@com_github_libp2p_go_libp2p//core/network:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_libp2p_go_libp2p//core/protocol:go_default_library",
-        "@com_github_libp2p_go_libp2p//p2p/transport/quic:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",

--- a/beacon-chain/sync/blobs_test.go
+++ b/beacon-chain/sync/blobs_test.go
@@ -279,28 +279,30 @@ func defaultMockChain(t *testing.T, current primitives.Epoch) *mock.ChainService
 }
 
 func TestTestcaseSetup_BlocksAndBlobs(t *testing.T) {
-	ds := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)
-	ctx := t.Context()
-	nblocks := 10
-	c := &blobsTestCase{nblocks: nblocks, clock: startup.NewClock(genesis.Time(), genesis.ValidatorsRoot(), startup.WithSlotAsNow(ds))}
-	c.oldestSlot = c.defaultOldestSlotByRoot
-	s, sidecars := c.setup(t)
-	req := blobRootRequestFromSidecars(sidecars)
-	expect := c.filterExpectedByRoot(t, sidecars, req)
-	maxed := nblocks * params.BeaconConfig().MaxBlobsPerBlockAtEpoch(params.BeaconConfig().DenebForkEpoch)
-	require.Equal(t, maxed, len(sidecars))
-	require.Equal(t, maxed, len(expect))
-	for _, sc := range sidecars {
-		blk, err := s.cfg.beaconDB.Block(ctx, sc.BlockRoot())
-		require.NoError(t, err)
-		var found *int
-		comms, err := blk.Block().Body().BlobKzgCommitments()
-		require.NoError(t, err)
-		for i, cm := range comms {
-			if bytesutil.ToBytes48(sc.KzgCommitment) == bytesutil.ToBytes48(cm) {
-				found = &i
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ds := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)
+		ctx := t.Context()
+		nblocks := 10
+		c := &blobsTestCase{nblocks: nblocks, clock: startup.NewClock(genesis.Time(), genesis.ValidatorsRoot(), startup.WithSlotAsNow(ds))}
+		c.oldestSlot = c.defaultOldestSlotByRoot
+		s, sidecars := c.setup(t)
+		req := blobRootRequestFromSidecars(sidecars)
+		expect := c.filterExpectedByRoot(t, sidecars, req)
+		maxed := nblocks * params.BeaconConfig().MaxBlobsPerBlockAtEpoch(params.BeaconConfig().DenebForkEpoch)
+		require.Equal(t, maxed, len(sidecars))
+		require.Equal(t, maxed, len(expect))
+		for _, sc := range sidecars {
+			blk, err := s.cfg.beaconDB.Block(ctx, sc.BlockRoot())
+			require.NoError(t, err)
+			var found *int
+			comms, err := blk.Block().Body().BlobKzgCommitments()
+			require.NoError(t, err)
+			for i, cm := range comms {
+				if bytesutil.ToBytes48(sc.KzgCommitment) == bytesutil.ToBytes48(cm) {
+					found = &i
+				}
 			}
+			require.Equal(t, true, found != nil)
 		}
-		require.Equal(t, true, found != nil)
-	}
+	})
 }

--- a/beacon-chain/sync/context_test.go
+++ b/beacon-chain/sync/context_test.go
@@ -15,60 +15,64 @@ import (
 )
 
 func TestContextWrite_NoWrites(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	nPeer := p2ptest.NewTestP2P(t)
-	p1.Connect(nPeer)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		nPeer := p2ptest.NewTestP2P(t)
+		p1.Connect(nPeer)
 
-	wg := new(sync.WaitGroup)
-	prID := p2p.RPCPingTopicV1
-	wg.Add(1)
-	nPeer.BHost.SetStreamHandler(core.ProtocolID(prID), func(stream network.Stream) {
-		wg.Done()
-		// no-op
+		wg := new(sync.WaitGroup)
+		prID := p2p.RPCPingTopicV1
+		wg.Add(1)
+		nPeer.BHost.SetStreamHandler(core.ProtocolID(prID), func(stream network.Stream) {
+			wg.Done()
+			// no-op
+		})
+		strm, err := p1.BHost.NewStream(t.Context(), nPeer.PeerID(), p2p.RPCPingTopicV1)
+		assert.NoError(t, err)
+
+		// Nothing will be written to the stream
+		assert.NoError(t, writeContextToStream([]byte{}, strm))
+		if util.WaitTimeout(wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
 	})
-	strm, err := p1.BHost.NewStream(t.Context(), nPeer.PeerID(), p2p.RPCPingTopicV1)
-	assert.NoError(t, err)
-
-	// Nothing will be written to the stream
-	assert.NoError(t, writeContextToStream([]byte{}, strm))
-	if util.WaitTimeout(wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestContextRead_NoReads(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	nPeer := p2ptest.NewTestP2P(t)
-	p1.Connect(nPeer)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		nPeer := p2ptest.NewTestP2P(t)
+		p1.Connect(nPeer)
 
-	wg := new(sync.WaitGroup)
-	prID := p2p.RPCPingTopicV1
-	wg.Add(1)
-	wantedData := []byte{'A', 'B', 'C', 'D'}
-	nPeer.BHost.SetStreamHandler(core.ProtocolID(prID), func(stream network.Stream) {
-		// No Context will be read from it
-		dt, err := readContextFromStream(stream)
+		wg := new(sync.WaitGroup)
+		prID := p2p.RPCPingTopicV1
+		wg.Add(1)
+		wantedData := []byte{'A', 'B', 'C', 'D'}
+		nPeer.BHost.SetStreamHandler(core.ProtocolID(prID), func(stream network.Stream) {
+			// No Context will be read from it
+			dt, err := readContextFromStream(stream)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(dt))
+
+			// Ensure sent over data hasn't been modified.
+			buf := make([]byte, len(wantedData))
+			n, err := stream.Read(buf)
+			assert.NoError(t, err)
+			assert.Equal(t, len(wantedData), n)
+			assert.DeepEqual(t, wantedData, buf)
+
+			wg.Done()
+		})
+		strm, err := p1.BHost.NewStream(t.Context(), nPeer.PeerID(), p2p.RPCPingTopicV1)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(dt))
 
-		// Ensure sent over data hasn't been modified.
-		buf := make([]byte, len(wantedData))
-		n, err := stream.Read(buf)
+		n, err := strm.Write(wantedData)
 		assert.NoError(t, err)
 		assert.Equal(t, len(wantedData), n)
-		assert.DeepEqual(t, wantedData, buf)
-
-		wg.Done()
+		if util.WaitTimeout(wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
 	})
-	strm, err := p1.BHost.NewStream(t.Context(), nPeer.PeerID(), p2p.RPCPingTopicV1)
-	assert.NoError(t, err)
-
-	n, err := strm.Write(wantedData)
-	assert.NoError(t, err)
-	assert.Equal(t, len(wantedData), n)
-	if util.WaitTimeout(wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 var _ = withProtocol(&fakeStream{})

--- a/beacon-chain/sync/custody_test.go
+++ b/beacon-chain/sync/custody_test.go
@@ -131,43 +131,49 @@ func TestUpdateCustodyInfoIfNeeded(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("Skip update when actual custody count >= target", func(t *testing.T) {
-		setup := setupCustodyTest(t, false)
-
-		err := setup.service.updateCustodyInfoIfNeeded()
-		require.NoError(t, err)
-
-		setup.assertCustodyInfo(t, setup.initialSlot, setup.initialCount)
-	})
-
-	t.Run("not enough peers in some subnets", func(t *testing.T) {
-		const randomTopic = "aTotalRandomTopicName"
-		require.Equal(t, false, strings.Contains(randomTopic, p2p.GossipDataColumnSidecarMessage))
-
-		withSubscribeAllDataSubnets(t, func() {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
 			setup := setupCustodyTest(t, false)
 
-			_, err := setup.service.cfg.p2p.SubscribeToTopic(p2p.GossipDataColumnSidecarMessage)
-			require.NoError(t, err)
-
-			_, err = setup.service.cfg.p2p.SubscribeToTopic(randomTopic)
-			require.NoError(t, err)
-
-			err = setup.service.updateCustodyInfoIfNeeded()
+			err := setup.service.updateCustodyInfoIfNeeded()
 			require.NoError(t, err)
 
 			setup.assertCustodyInfo(t, setup.initialSlot, setup.initialCount)
 		})
 	})
 
+	t.Run("not enough peers in some subnets", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			const randomTopic = "aTotalRandomTopicName"
+			require.Equal(t, false, strings.Contains(randomTopic, p2p.GossipDataColumnSidecarMessage))
+
+			withSubscribeAllDataSubnets(t, func() {
+				setup := setupCustodyTest(t, false)
+
+				_, err := setup.service.cfg.p2p.SubscribeToTopic(p2p.GossipDataColumnSidecarMessage)
+				require.NoError(t, err)
+
+				_, err = setup.service.cfg.p2p.SubscribeToTopic(randomTopic)
+				require.NoError(t, err)
+
+				err = setup.service.updateCustodyInfoIfNeeded()
+				require.NoError(t, err)
+
+				setup.assertCustodyInfo(t, setup.initialSlot, setup.initialCount)
+			})
+		})
+	})
+
 	t.Run("should update", func(t *testing.T) {
-		withSubscribeAllDataSubnets(t, func() {
-			setup := setupCustodyTest(t, true)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			withSubscribeAllDataSubnets(t, func() {
+				setup := setupCustodyTest(t, true)
 
-			err := setup.service.updateCustodyInfoIfNeeded()
-			require.NoError(t, err)
+				err := setup.service.updateCustodyInfoIfNeeded()
+				require.NoError(t, err)
 
-			const expectedSlot = primitives.Slot(100)
-			setup.assertCustodyInfo(t, expectedSlot, cfg.NumberOfCustodyGroups)
+				const expectedSlot = primitives.Slot(100)
+				setup.assertCustodyInfo(t, expectedSlot, cfg.NumberOfCustodyGroups)
+			})
 		})
 	})
 }

--- a/beacon-chain/sync/data_column_assignment_test.go
+++ b/beacon-chain/sync/data_column_assignment_test.go
@@ -105,35 +105,41 @@ func TestNewPicker(t *testing.T) {
 	custodyReq := params.BeaconConfig().CustodyRequirement
 
 	t.Run("valid peers with columns", func(t *testing.T) {
-		setup := setupDASTest(t, 3, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
-		require.NotEqual(t, 0, toCustody.Count(), "test peers should custody some columns")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 3, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
+			require.NotEqual(t, 0, toCustody.Count(), "test peers should custody some columns")
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
-		require.NotNil(t, picker)
-		require.Equal(t, 3, len(picker.scores))
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
+			require.NotNil(t, picker)
+			require.Equal(t, 3, len(picker.scores))
+		})
 	})
 
 	t.Run("empty peer list", func(t *testing.T) {
-		setup := setupDASTest(t, 0, custodyReq)
-		toCustody := peerdas.NewColumnIndicesFromSlice([]uint64{0, 1})
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 0, custodyReq)
+			toCustody := peerdas.NewColumnIndicesFromSlice([]uint64{0, 1})
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
-		require.NotNil(t, picker)
-		require.Equal(t, 0, len(picker.scores))
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
+			require.NotNil(t, picker)
+			require.Equal(t, 0, len(picker.scores))
+		})
 	})
 
 	t.Run("empty custody columns", func(t *testing.T) {
-		setup := setupDASTest(t, 2, custodyReq)
-		toCustody := peerdas.NewColumnIndices()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 2, custodyReq)
+			toCustody := peerdas.NewColumnIndices()
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
-		require.NotNil(t, picker)
-		// With empty toCustody, peers are still added to scores but have no custodied columns
-		require.Equal(t, 2, len(picker.scores))
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
+			require.NotNil(t, picker)
+			// With empty toCustody, peers are still added to scores but have no custodied columns
+			require.Equal(t, 2, len(picker.scores))
+		})
 	})
 }
 
@@ -141,92 +147,102 @@ func TestForColumns(t *testing.T) {
 	custodyReq := params.BeaconConfig().CustodyRequirement
 
 	t.Run("basic selection returns covering peer", func(t *testing.T) {
-		setup := setupDASTest(t, 3, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
-		require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 3, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
+			require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		// Request columns that we know peers custody
-		needed := toCustody
+			// Request columns that we know peers custody
+			needed := toCustody
 
-		pid, cols, err := picker.ForColumns(needed, nil)
-		require.NoError(t, err)
-		require.NotEmpty(t, pid)
-		require.NotEmpty(t, cols)
+			pid, cols, err := picker.ForColumns(needed, nil)
+			require.NoError(t, err)
+			require.NotEmpty(t, pid)
+			require.NotEmpty(t, cols)
 
-		// Verify the returned columns are a subset of what was needed
-		for _, col := range cols {
-			require.Equal(t, true, needed.Has(col), "returned column should be in needed set")
-		}
+			// Verify the returned columns are a subset of what was needed
+			for _, col := range cols {
+				require.Equal(t, true, needed.Has(col), "returned column should be in needed set")
+			}
+		})
 	})
 
 	t.Run("skip busy peers", func(t *testing.T) {
-		setup := setupDASTest(t, 2, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
-		require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 2, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
+			require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		// Mark first peer as busy
-		busy := map[peer.ID]bool{setup.peerIDs[0]: true}
+			// Mark first peer as busy
+			busy := map[peer.ID]bool{setup.peerIDs[0]: true}
 
-		pid, _, err := picker.ForColumns(toCustody, busy)
-		require.NoError(t, err)
-		// Should not return the busy peer
-		require.NotEqual(t, setup.peerIDs[0], pid)
+			pid, _, err := picker.ForColumns(toCustody, busy)
+			require.NoError(t, err)
+			// Should not return the busy peer
+			require.NotEqual(t, setup.peerIDs[0], pid)
+		})
 	})
 
 	t.Run("rate limiting respects reqInterval", func(t *testing.T) {
-		setup := setupDASTest(t, 1, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
-		require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 1, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
+			require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
 
-		// Use a long interval so the peer can't be picked twice
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Hour)
-		require.NoError(t, err)
+			// Use a long interval so the peer can't be picked twice
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Hour)
+			require.NoError(t, err)
 
-		// First call should succeed
-		pid, _, err := picker.ForColumns(toCustody, nil)
-		require.NoError(t, err)
-		require.NotEmpty(t, pid)
+			// First call should succeed
+			pid, _, err := picker.ForColumns(toCustody, nil)
+			require.NoError(t, err)
+			require.NotEmpty(t, pid)
 
-		// Second call should fail due to rate limiting
-		_, _, err = picker.ForColumns(toCustody, nil)
-		require.ErrorIs(t, err, ErrNoPeersCoverNeeded)
+			// Second call should fail due to rate limiting
+			_, _, err = picker.ForColumns(toCustody, nil)
+			require.ErrorIs(t, err, ErrNoPeersCoverNeeded)
+		})
 	})
 
 	t.Run("no peers available returns error", func(t *testing.T) {
-		setup := setupDASTest(t, 2, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
-		require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 2, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
+			require.NotEqual(t, 0, toCustody.Count(), "test peers must custody some columns")
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		// Mark all peers as busy
-		busy := map[peer.ID]bool{
-			setup.peerIDs[0]: true,
-			setup.peerIDs[1]: true,
-		}
+			// Mark all peers as busy
+			busy := map[peer.ID]bool{
+				setup.peerIDs[0]: true,
+				setup.peerIDs[1]: true,
+			}
 
-		_, _, err = picker.ForColumns(toCustody, busy)
-		require.ErrorIs(t, err, ErrNoPeersCoverNeeded)
+			_, _, err = picker.ForColumns(toCustody, busy)
+			require.ErrorIs(t, err, ErrNoPeersCoverNeeded)
+		})
 	})
 
 	t.Run("empty needed columns returns error", func(t *testing.T) {
-		setup := setupDASTest(t, 2, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 2, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		// Request empty set of columns
-		needed := peerdas.NewColumnIndices()
-		_, _, err = picker.ForColumns(needed, nil)
-		require.ErrorIs(t, err, ErrNoPeersCoverNeeded)
+			// Request empty set of columns
+			needed := peerdas.NewColumnIndices()
+			_, _, err = picker.ForColumns(needed, nil)
+			require.ErrorIs(t, err, ErrNoPeersCoverNeeded)
+		})
 	})
 }
 
@@ -234,62 +250,70 @@ func TestForBlocks(t *testing.T) {
 	custodyReq := params.BeaconConfig().CustodyRequirement
 
 	t.Run("returns available peer", func(t *testing.T) {
-		setup := setupDASTest(t, 3, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 3, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		pid, err := picker.ForBlocks(nil)
-		require.NoError(t, err)
-		require.NotEmpty(t, pid)
+			pid, err := picker.ForBlocks(nil)
+			require.NoError(t, err)
+			require.NotEmpty(t, pid)
+		})
 	})
 
 	t.Run("skips busy peers", func(t *testing.T) {
-		setup := setupDASTest(t, 3, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 3, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		// Mark first two peers as busy
-		busy := map[peer.ID]bool{
-			setup.peerIDs[0]: true,
-			setup.peerIDs[1]: true,
-		}
+			// Mark first two peers as busy
+			busy := map[peer.ID]bool{
+				setup.peerIDs[0]: true,
+				setup.peerIDs[1]: true,
+			}
 
-		pid, err := picker.ForBlocks(busy)
-		require.NoError(t, err)
-		require.NotEmpty(t, pid)
-		// Verify returned peer is not busy
-		require.Equal(t, false, busy[pid], "returned peer should not be busy")
+			pid, err := picker.ForBlocks(busy)
+			require.NoError(t, err)
+			require.NotEmpty(t, pid)
+			// Verify returned peer is not busy
+			require.Equal(t, false, busy[pid], "returned peer should not be busy")
+		})
 	})
 
 	t.Run("all peers busy returns error", func(t *testing.T) {
-		setup := setupDASTest(t, 2, custodyReq)
-		toCustody := setup.getActualCustodyColumns()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 2, custodyReq)
+			toCustody := setup.getActualCustodyColumns()
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		// Mark all peers as busy
-		busy := map[peer.ID]bool{
-			setup.peerIDs[0]: true,
-			setup.peerIDs[1]: true,
-		}
+			// Mark all peers as busy
+			busy := map[peer.ID]bool{
+				setup.peerIDs[0]: true,
+				setup.peerIDs[1]: true,
+			}
 
-		_, err = picker.ForBlocks(busy)
-		require.ErrorIs(t, err, ErrNoPeersAvailable)
+			_, err = picker.ForBlocks(busy)
+			require.ErrorIs(t, err, ErrNoPeersAvailable)
+		})
 	})
 
 	t.Run("no peers returns error", func(t *testing.T) {
-		setup := setupDASTest(t, 0, custodyReq)
-		toCustody := peerdas.NewColumnIndicesFromSlice([]uint64{0, 1, 2, 3})
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			setup := setupDASTest(t, 0, custodyReq)
+			toCustody := peerdas.NewColumnIndicesFromSlice([]uint64{0, 1, 2, 3})
 
-		picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
-		require.NoError(t, err)
+			picker, err := setup.cache.NewPicker(setup.peerIDs, toCustody, time.Millisecond)
+			require.NoError(t, err)
 
-		_, err = picker.ForBlocks(nil)
-		require.ErrorIs(t, err, ErrNoPeersAvailable)
+			_, err = picker.ForBlocks(nil)
+			require.ErrorIs(t, err, ErrNoPeersAvailable)
+		})
 	})
 }

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -33,257 +33,259 @@ import (
 )
 
 func TestFetchDataColumnSidecars(t *testing.T) {
-	const numberOfColumns = uint64(fieldparams.NumberOfColumns)
-	// Slot 1: All needed sidecars are available in storage ==> Retrieval from storage only.
-	// Slot 2: No commitment ==> Nothing to do.
-	// Slot 3: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers.
-	// Slot 4: Some sidecars are in the storage, other have to be retrieved from peers but peers do not deliver all requested sidecars ==> Retrieval from storage and peers then reconstruction.
-	// Slot 5: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond needed sidecars on second attempt ==> Retrieval from storage and peers.
-	// Slot 6: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond not needed sidecars on second attempt ==> Retrieval from storage and peers then reconstruction.
-	// Slot 7: Some sidecars are in the storage, other have to be retrieved from peers but peers do not send anything ==> Still missing.
+	testp2p.SynctestTest(t, func(t *testing.T) {
+		const numberOfColumns = uint64(fieldparams.NumberOfColumns)
+		// Slot 1: All needed sidecars are available in storage ==> Retrieval from storage only.
+		// Slot 2: No commitment ==> Nothing to do.
+		// Slot 3: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers.
+		// Slot 4: Some sidecars are in the storage, other have to be retrieved from peers but peers do not deliver all requested sidecars ==> Retrieval from storage and peers then reconstruction.
+		// Slot 5: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond needed sidecars on second attempt ==> Retrieval from storage and peers.
+		// Slot 6: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond not needed sidecars on second attempt ==> Retrieval from storage and peers then reconstruction.
+		// Slot 7: Some sidecars are in the storage, other have to be retrieved from peers but peers do not send anything ==> Still missing.
 
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.FuluForkEpoch = 0
-	cfg.BlobSchedule = []params.BlobScheduleEntry{{Epoch: 0, MaxBlobsPerBlock: 10}}
-	params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.FuluForkEpoch = 0
+		cfg.BlobSchedule = []params.BlobScheduleEntry{{Epoch: 0, MaxBlobsPerBlock: 10}}
+		params.OverrideBeaconConfig(cfg)
 
-	// Start the trusted setup.
-	err := kzg.Start()
-	require.NoError(t, err)
+		// Start the trusted setup.
+		err := kzg.Start()
+		require.NoError(t, err)
 
-	storage := filesystem.NewEphemeralDataColumnStorage(t)
+		storage := filesystem.NewEphemeralDataColumnStorage(t)
 
-	ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
-	require.NoError(t, err)
+		ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
+		require.NoError(t, err)
 
-	const blobCount = 3
-	indices := map[uint64]bool{31: true, 81: true, 106: true}
+		const blobCount = 3
+		indices := map[uint64]bool{31: true, 81: true, 106: true}
 
-	// Block 1
-	block1, _, verifiedSidecars1 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(1))
-	root1 := block1.Root()
+		// Block 1
+		block1, _, verifiedSidecars1 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(1))
+		root1 := block1.Root()
 
-	toStore1 := make([]blocks.VerifiedRODataColumn, 0, len(indices))
-	for index := range indices {
-		sidecar := verifiedSidecars1[index]
-		toStore1 = append(toStore1, sidecar)
-	}
-
-	err = storage.Save(toStore1)
-	require.NoError(t, err)
-
-	// Block 2
-	block2, _, _ := util.GenerateTestFuluBlockWithSidecars(t, 0, util.WithSlot(2))
-
-	// Block 3
-	block3, _, verifiedSidecars3 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(3))
-	root3 := block3.Root()
-	toStore3 := []blocks.VerifiedRODataColumn{verifiedSidecars3[106]}
-
-	err = storage.Save(toStore3)
-	require.NoError(t, err)
-
-	// Block 4
-	minimumColumnsCountToReconstruct := peerdas.MinimumColumnCountToReconstruct()
-	block4, _, verifiedSidecars4 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(4))
-	root4 := block4.Root()
-
-	toStoreCount := minimumColumnsCountToReconstruct - 1
-	toStore4 := make([]blocks.VerifiedRODataColumn, 0, toStoreCount)
-
-	for i := uint64(0); uint64(len(toStore4)) < toStoreCount; i++ {
-		sidecar := verifiedSidecars4[minimumColumnsCountToReconstruct+i]
-		if sidecar.Index() == 81 {
-			continue
+		toStore1 := make([]blocks.VerifiedRODataColumn, 0, len(indices))
+		for index := range indices {
+			sidecar := verifiedSidecars1[index]
+			toStore1 = append(toStore1, sidecar)
 		}
 
-		toStore4 = append(toStore4, sidecar)
-	}
+		err = storage.Save(toStore1)
+		require.NoError(t, err)
 
-	err = storage.Save(toStore4)
-	require.NoError(t, err)
+		// Block 2
+		block2, _, _ := util.GenerateTestFuluBlockWithSidecars(t, 0, util.WithSlot(2))
 
-	// Block 5
-	block5, _, verifiedSidecars5 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(5))
-	root5 := block5.Root()
-	toStore5 := []blocks.VerifiedRODataColumn{verifiedSidecars5[106]}
+		// Block 3
+		block3, _, verifiedSidecars3 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(3))
+		root3 := block3.Root()
+		toStore3 := []blocks.VerifiedRODataColumn{verifiedSidecars3[106]}
 
-	err = storage.Save(toStore5)
-	require.NoError(t, err)
+		err = storage.Save(toStore3)
+		require.NoError(t, err)
 
-	// Block 6
-	block6, _, verifiedSidecars6 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(6))
-	root6 := block6.Root()
-	toStore6 := []blocks.VerifiedRODataColumn{verifiedSidecars6[106]}
+		// Block 4
+		minimumColumnsCountToReconstruct := peerdas.MinimumColumnCountToReconstruct()
+		block4, _, verifiedSidecars4 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(4))
+		root4 := block4.Root()
 
-	err = storage.Save(toStore6)
-	require.NoError(t, err)
+		toStoreCount := minimumColumnsCountToReconstruct - 1
+		toStore4 := make([]blocks.VerifiedRODataColumn, 0, toStoreCount)
 
-	// Block 7
-	block7, _, verifiedSidecars7 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(7))
-	root7 := block7.Root()
-	toStore7 := []blocks.VerifiedRODataColumn{verifiedSidecars7[106]}
-
-	err = storage.Save(toStore7)
-	require.NoError(t, err)
-
-	// Peers
-	byRangeProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
-	byRootProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
-
-	privateKeyBytes := [32]byte{1}
-	privateKey, err := crypto.UnmarshalSecp256k1PrivateKey(privateKeyBytes[:])
-	require.NoError(t, err)
-
-	p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t, libp2p.Identity(privateKey))
-	p2p.Peers().SetConnectionState(other.PeerID(), peers.Connected)
-	p2p.Connect(other)
-
-	p2p.Peers().SetChainState(other.PeerID(), &ethpb.StatusV2{
-		HeadSlot: 8,
-	})
-
-	p2p.Peers().SetMetadata(other.PeerID(), wrapper.WrappedMetadataV2(&ethpb.MetaDataV2{
-		CustodyGroupCount: 128,
-	}))
-
-	clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
-
-	gs := startup.NewClockSynchronizer()
-	err = gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-	require.NoError(t, err)
-
-	waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-	initializer, err := waiter.WaitForInitializer(t.Context())
-	require.NoError(t, err)
-
-	newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-
-	other.SetStreamHandler(byRangeProtocol, func(stream network.Stream) {
-		expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
-			StartSlot: 3,
-			Count:     5,
-			Columns:   []uint64{31, 81},
-		}
-
-		actualRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
-		err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
-		assert.NoError(t, err)
-		assert.DeepEqual(t, expectedRequest, actualRequest)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[31].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[81].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars4[81].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[31].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[31].RODataColumn)
-		assert.NoError(t, err)
-
-		err = stream.CloseWrite()
-		assert.NoError(t, err)
-	})
-
-	other.SetStreamHandler(byRootProtocol, func(stream network.Stream) {
-		allBut31And81And106 := make([]uint64, 0, numberOfColumns-3)
-		allBut31And106 := make([]uint64, 0, numberOfColumns-2)
-		allBut106 := make([]uint64, 0, numberOfColumns-1)
-		for i := range numberOfColumns {
-			if !map[uint64]bool{31: true, 81: true, 106: true}[i] {
-				allBut31And81And106 = append(allBut31And81And106, i)
-			}
-			if !map[uint64]bool{31: true, 106: true}[i] {
-				allBut31And106 = append(allBut31And106, i)
+		for i := uint64(0); uint64(len(toStore4)) < toStoreCount; i++ {
+			sidecar := verifiedSidecars4[minimumColumnsCountToReconstruct+i]
+			if sidecar.Index() == 81 {
+				continue
 			}
 
-			if i != 106 {
-				allBut106 = append(allBut106, i)
+			toStore4 = append(toStore4, sidecar)
+		}
+
+		err = storage.Save(toStore4)
+		require.NoError(t, err)
+
+		// Block 5
+		block5, _, verifiedSidecars5 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(5))
+		root5 := block5.Root()
+		toStore5 := []blocks.VerifiedRODataColumn{verifiedSidecars5[106]}
+
+		err = storage.Save(toStore5)
+		require.NoError(t, err)
+
+		// Block 6
+		block6, _, verifiedSidecars6 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(6))
+		root6 := block6.Root()
+		toStore6 := []blocks.VerifiedRODataColumn{verifiedSidecars6[106]}
+
+		err = storage.Save(toStore6)
+		require.NoError(t, err)
+
+		// Block 7
+		block7, _, verifiedSidecars7 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(7))
+		root7 := block7.Root()
+		toStore7 := []blocks.VerifiedRODataColumn{verifiedSidecars7[106]}
+
+		err = storage.Save(toStore7)
+		require.NoError(t, err)
+
+		// Peers
+		byRangeProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+		byRootProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
+
+		privateKeyBytes := [32]byte{1}
+		privateKey, err := crypto.UnmarshalSecp256k1PrivateKey(privateKeyBytes[:])
+		require.NoError(t, err)
+
+		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t, libp2p.Identity(privateKey))
+		p2p.Peers().SetConnectionState(other.PeerID(), peers.Connected)
+		p2p.Connect(other)
+
+		p2p.Peers().SetChainState(other.PeerID(), &ethpb.StatusV2{
+			HeadSlot: 8,
+		})
+
+		p2p.Peers().SetMetadata(other.PeerID(), wrapper.WrappedMetadataV2(&ethpb.MetaDataV2{
+			CustodyGroupCount: 128,
+		}))
+
+		clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
+
+		gs := startup.NewClockSynchronizer()
+		err = gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+		require.NoError(t, err)
+
+		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+		initializer, err := waiter.WaitForInitializer(t.Context())
+		require.NoError(t, err)
+
+		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+
+		other.SetStreamHandler(byRangeProtocol, func(stream network.Stream) {
+			expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
+				StartSlot: 3,
+				Count:     5,
+				Columns:   []uint64{31, 81},
 			}
-		}
 
-		expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
-			{
-				BlockRoot: root7[:],
-				Columns:   allBut106,
-			},
-			{
-				BlockRoot: root5[:],
-				Columns:   allBut31And106,
-			},
-			{
-				BlockRoot: root6[:],
-				Columns:   allBut31And106,
-			},
-		}
-
-		actualRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
-		err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
-		assert.NoError(t, err)
-		assert.DeepEqual(t, expectedRequest, actualRequest)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[81].RODataColumn)
-		assert.NoError(t, err)
-
-		for _, index := range allBut31And81And106 {
-			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[index].RODataColumn)
+			actualRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
+			err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
 			assert.NoError(t, err)
+			assert.DeepEqual(t, expectedRequest, actualRequest)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[31].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[81].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars4[81].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[31].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[31].RODataColumn)
+			assert.NoError(t, err)
+
+			err = stream.CloseWrite()
+			assert.NoError(t, err)
+		})
+
+		other.SetStreamHandler(byRootProtocol, func(stream network.Stream) {
+			allBut31And81And106 := make([]uint64, 0, numberOfColumns-3)
+			allBut31And106 := make([]uint64, 0, numberOfColumns-2)
+			allBut106 := make([]uint64, 0, numberOfColumns-1)
+			for i := range numberOfColumns {
+				if !map[uint64]bool{31: true, 81: true, 106: true}[i] {
+					allBut31And81And106 = append(allBut31And81And106, i)
+				}
+				if !map[uint64]bool{31: true, 106: true}[i] {
+					allBut31And106 = append(allBut31And106, i)
+				}
+
+				if i != 106 {
+					allBut106 = append(allBut106, i)
+				}
+			}
+
+			expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
+				{
+					BlockRoot: root7[:],
+					Columns:   allBut106,
+				},
+				{
+					BlockRoot: root5[:],
+					Columns:   allBut31And106,
+				},
+				{
+					BlockRoot: root6[:],
+					Columns:   allBut31And106,
+				},
+			}
+
+			actualRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
+			err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
+			assert.NoError(t, err)
+			assert.DeepEqual(t, expectedRequest, actualRequest)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[81].RODataColumn)
+			assert.NoError(t, err)
+
+			for _, index := range allBut31And81And106 {
+				err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[index].RODataColumn)
+				assert.NoError(t, err)
+			}
+
+			err = stream.CloseWrite()
+			assert.NoError(t, err)
+		})
+
+		params := DataColumnSidecarsParams{
+			Ctx:         t.Context(),
+			Tor:         clock,
+			P2P:         p2p,
+			RateLimiter: leakybucket.NewCollector(1., 10, time.Second, false /* deleteEmptyBuckets */),
+			CtxMap:      ctxMap,
+			Storage:     storage,
+			NewVerifier: newDataColumnsVerifier,
 		}
 
-		err = stream.CloseWrite()
-		assert.NoError(t, err)
+		expectedResult := map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn{
+			root1: {verifiedSidecars1[31], verifiedSidecars1[81], verifiedSidecars1[106]},
+			// no root2 (no commitments in this block)
+			root3: {verifiedSidecars3[106], verifiedSidecars3[31], verifiedSidecars3[81]},
+			root4: {verifiedSidecars4[31], verifiedSidecars4[81], verifiedSidecars4[106]},
+			root5: {verifiedSidecars5[106], verifiedSidecars5[31], verifiedSidecars5[81]},
+			root6: {verifiedSidecars6[31], verifiedSidecars6[81], verifiedSidecars6[106]},
+			root7: {verifiedSidecars7[106]},
+		}
+
+		expectedMissingIndicesBYRoots := map[[fieldparams.RootLength]byte]map[uint64]bool{
+			root7: {31: true, 81: true},
+		}
+
+		blocks := []blocks.ROBlock{block1, block2, block3, block4, block5, block6, block7}
+		actualResult, actualMissingRoots, err := FetchDataColumnSidecars(params, blocks, indices)
+		require.NoError(t, err)
+
+		require.Equal(t, len(expectedResult), len(actualResult))
+		for root := range expectedResult {
+			require.Equal(t, len(expectedResult[root]), len(actualResult[root]))
+			for i := range expectedResult[root] {
+				require.DeepSSZEqual(t, expectedResult[root][i].DataColumnSidecar(), actualResult[root][i].DataColumnSidecar())
+			}
+		}
+
+		require.Equal(t, len(expectedMissingIndicesBYRoots), len(actualMissingRoots))
+		for root, expectedMissingIndices := range expectedMissingIndicesBYRoots {
+			actualMissingIndices := actualMissingRoots[root]
+			require.Equal(t, len(expectedMissingIndices), len(actualMissingIndices))
+			for index := range expectedMissingIndices {
+				require.Equal(t, true, actualMissingIndices[index])
+			}
+		}
 	})
-
-	params := DataColumnSidecarsParams{
-		Ctx:         t.Context(),
-		Tor:         clock,
-		P2P:         p2p,
-		RateLimiter: leakybucket.NewCollector(1., 10, time.Second, false /* deleteEmptyBuckets */),
-		CtxMap:      ctxMap,
-		Storage:     storage,
-		NewVerifier: newDataColumnsVerifier,
-	}
-
-	expectedResult := map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn{
-		root1: {verifiedSidecars1[31], verifiedSidecars1[81], verifiedSidecars1[106]},
-		// no root2 (no commitments in this block)
-		root3: {verifiedSidecars3[106], verifiedSidecars3[31], verifiedSidecars3[81]},
-		root4: {verifiedSidecars4[31], verifiedSidecars4[81], verifiedSidecars4[106]},
-		root5: {verifiedSidecars5[106], verifiedSidecars5[31], verifiedSidecars5[81]},
-		root6: {verifiedSidecars6[31], verifiedSidecars6[81], verifiedSidecars6[106]},
-		root7: {verifiedSidecars7[106]},
-	}
-
-	expectedMissingIndicesBYRoots := map[[fieldparams.RootLength]byte]map[uint64]bool{
-		root7: {31: true, 81: true},
-	}
-
-	blocks := []blocks.ROBlock{block1, block2, block3, block4, block5, block6, block7}
-	actualResult, actualMissingRoots, err := FetchDataColumnSidecars(params, blocks, indices)
-	require.NoError(t, err)
-
-	require.Equal(t, len(expectedResult), len(actualResult))
-	for root := range expectedResult {
-		require.Equal(t, len(expectedResult[root]), len(actualResult[root]))
-		for i := range expectedResult[root] {
-			require.DeepSSZEqual(t, expectedResult[root][i].DataColumnSidecar(), actualResult[root][i].DataColumnSidecar())
-		}
-	}
-
-	require.Equal(t, len(expectedMissingIndicesBYRoots), len(actualMissingRoots))
-	for root, expectedMissingIndices := range expectedMissingIndicesBYRoots {
-		actualMissingIndices := actualMissingRoots[root]
-		require.Equal(t, len(expectedMissingIndices), len(actualMissingIndices))
-		for index := range expectedMissingIndices {
-			require.Equal(t, true, actualMissingIndices[index])
-		}
-	}
 }
 
 func TestSelectPeers(t *testing.T) {
@@ -373,106 +375,108 @@ func TestUpdateResults(t *testing.T) {
 }
 
 func TestFetchDataColumnSidecarsFromPeers(t *testing.T) {
-	const count = 4
+	testp2p.SynctestTest(t, func(t *testing.T) {
+		const count = 4
 
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.FuluForkEpoch = 0
-	params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.FuluForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
 
-	clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
-	ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
-	require.NoError(t, err)
+		clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
+		ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
+		require.NoError(t, err)
 
-	kzgCommitmentsInclusionProof := make([][]byte, 0, count)
-	for range count {
-		kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
-	}
-
-	expectedResponseSidecarPb := &ethpb.DataColumnSidecar{
-		Index: 2,
-		SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
-			Header: &ethpb.BeaconBlockHeader{
-				Slot:       1,
-				ParentRoot: make([]byte, fieldparams.RootLength),
-				StateRoot:  make([]byte, fieldparams.RootLength),
-				BodyRoot:   make([]byte, fieldparams.RootLength),
-			},
-			Signature: make([]byte, fieldparams.BLSSignatureLength),
-		},
-		KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
-	}
-
-	expectedResponseSidecar, err := blocks.NewRODataColumn(expectedResponseSidecarPb)
-	require.NoError(t, err)
-
-	slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-		{1}: 1,
-		{3}: 3,
-		{4}: 4,
-		{7}: 7,
-	}
-
-	slotsWithCommitments := map[primitives.Slot]bool{
-		1: true,
-		3: true,
-		4: true,
-		7: true,
-	}
-
-	expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
-		StartSlot: 1,
-		Count:     7,
-		Columns:   []uint64{1, 2},
-	}
-
-	protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
-	p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
-	p2p.Connect(other)
-
-	other.SetStreamHandler(protocol, func(stream network.Stream) {
-		receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
-		err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
-		assert.NoError(t, err)
-		assert.DeepEqual(t, expectedRequest, receivedRequest)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponseSidecar)
-		assert.NoError(t, err)
-
-		err = stream.CloseWrite()
-		assert.NoError(t, err)
-	})
-
-	indicesByRootByPeer := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
-		other.PeerID(): {
-			{1}: {1: true, 2: true},
-			{3}: {1: true, 2: true},
-			{4}: {1: true, 2: true},
-			{7}: {1: true, 2: true},
-		},
-	}
-
-	params := DataColumnSidecarsParams{
-		Ctx:         t.Context(),
-		Tor:         clock,
-		P2P:         p2p,
-		CtxMap:      ctxMap,
-		RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
-	}
-
-	expectedResponse := map[peer.ID][]blocks.RODataColumn{
-		other.PeerID(): {expectedResponseSidecar},
-	}
-
-	actualResponse := fetchDataColumnSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, indicesByRootByPeer)
-	require.Equal(t, len(expectedResponse), len(actualResponse))
-
-	for peerID := range expectedResponse {
-		require.Equal(t, len(expectedResponse[peerID]), len(actualResponse[peerID]))
-		for i := range expectedResponse[peerID] {
-			require.DeepSSZEqual(t, expectedResponse[peerID][i].DataColumnSidecar(), actualResponse[peerID][i].DataColumnSidecar())
+		kzgCommitmentsInclusionProof := make([][]byte, 0, count)
+		for range count {
+			kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
 		}
-	}
+
+		expectedResponseSidecarPb := &ethpb.DataColumnSidecar{
+			Index: 2,
+			SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
+				Header: &ethpb.BeaconBlockHeader{
+					Slot:       1,
+					ParentRoot: make([]byte, fieldparams.RootLength),
+					StateRoot:  make([]byte, fieldparams.RootLength),
+					BodyRoot:   make([]byte, fieldparams.RootLength),
+				},
+				Signature: make([]byte, fieldparams.BLSSignatureLength),
+			},
+			KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
+		}
+
+		expectedResponseSidecar, err := blocks.NewRODataColumn(expectedResponseSidecarPb)
+		require.NoError(t, err)
+
+		slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+			{1}: 1,
+			{3}: 3,
+			{4}: 4,
+			{7}: 7,
+		}
+
+		slotsWithCommitments := map[primitives.Slot]bool{
+			1: true,
+			3: true,
+			4: true,
+			7: true,
+		}
+
+		expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
+			StartSlot: 1,
+			Count:     7,
+			Columns:   []uint64{1, 2},
+		}
+
+		protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
+		p2p.Connect(other)
+
+		other.SetStreamHandler(protocol, func(stream network.Stream) {
+			receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
+			err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
+			assert.NoError(t, err)
+			assert.DeepEqual(t, expectedRequest, receivedRequest)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponseSidecar)
+			assert.NoError(t, err)
+
+			err = stream.CloseWrite()
+			assert.NoError(t, err)
+		})
+
+		indicesByRootByPeer := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
+			other.PeerID(): {
+				{1}: {1: true, 2: true},
+				{3}: {1: true, 2: true},
+				{4}: {1: true, 2: true},
+				{7}: {1: true, 2: true},
+			},
+		}
+
+		params := DataColumnSidecarsParams{
+			Ctx:         t.Context(),
+			Tor:         clock,
+			P2P:         p2p,
+			CtxMap:      ctxMap,
+			RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
+		}
+
+		expectedResponse := map[peer.ID][]blocks.RODataColumn{
+			other.PeerID(): {expectedResponseSidecar},
+		}
+
+		actualResponse := fetchDataColumnSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, indicesByRootByPeer)
+		require.Equal(t, len(expectedResponse), len(actualResponse))
+
+		for peerID := range expectedResponse {
+			require.Equal(t, len(expectedResponse[peerID]), len(actualResponse[peerID]))
+			for i := range expectedResponse[peerID] {
+				require.DeepSSZEqual(t, expectedResponse[peerID][i].DataColumnSidecar(), actualResponse[peerID][i].DataColumnSidecar())
+			}
+		}
+	})
 }
 
 func TestSendDataColumnSidecarsRequest(t *testing.T) {
@@ -510,128 +514,132 @@ func TestSendDataColumnSidecarsRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("contiguous", func(t *testing.T) {
-		indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
-			{1}: {1: true, 2: true},
-			{3}: {1: true, 2: true},
-			{4}: {1: true, 2: true},
-			{7}: {1: true, 2: true},
-		}
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
+				{1}: {1: true, 2: true},
+				{3}: {1: true, 2: true},
+				{4}: {1: true, 2: true},
+				{7}: {1: true, 2: true},
+			}
 
-		slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-			{1}: 1,
-			{3}: 3,
-			{4}: 4,
-			{7}: 7,
-		}
+			slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+				{1}: 1,
+				{3}: 3,
+				{4}: 4,
+				{7}: 7,
+			}
 
-		slotsWithCommitments := map[primitives.Slot]bool{
-			1: true,
-			3: true,
-			4: true,
-			7: true,
-		}
+			slotsWithCommitments := map[primitives.Slot]bool{
+				1: true,
+				3: true,
+				4: true,
+				7: true,
+			}
 
-		expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
-			StartSlot: 1,
-			Count:     7,
-			Columns:   []uint64{1, 2},
-		}
+			expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
+				StartSlot: 1,
+				Count:     7,
+				Columns:   []uint64{1, 2},
+			}
 
-		protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
-		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
-		p2p.Connect(other)
+			protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+			p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
+			p2p.Connect(other)
 
-		other.SetStreamHandler(protocol, func(stream network.Stream) {
-			receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
-			err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
-			assert.NoError(t, err)
-			assert.DeepEqual(t, expectedRequest, receivedRequest)
+			other.SetStreamHandler(protocol, func(stream network.Stream) {
+				receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
+				err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
+				assert.NoError(t, err)
+				assert.DeepEqual(t, expectedRequest, receivedRequest)
 
-			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
-			assert.NoError(t, err)
+				err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
+				assert.NoError(t, err)
 
-			err = stream.CloseWrite()
-			assert.NoError(t, err)
+				err = stream.CloseWrite()
+				assert.NoError(t, err)
+			})
+
+			params := DataColumnSidecarsParams{
+				Ctx:         t.Context(),
+				Tor:         clock,
+				P2P:         p2p,
+				CtxMap:      ctxMap,
+				RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
+			}
+
+			actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
+			require.NoError(t, err)
+			require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 		})
-
-		params := DataColumnSidecarsParams{
-			Ctx:         t.Context(),
-			Tor:         clock,
-			P2P:         p2p,
-			CtxMap:      ctxMap,
-			RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
-		}
-
-		actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
-		require.NoError(t, err)
-		require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 	})
 
 	t.Run("non contiguous", func(t *testing.T) {
-		indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
-			expectedResponse.BlockRoot(): {1: true, 2: true},
-			{4}:                          {1: true, 2: true},
-			{7}:                          {1: true, 2: true},
-		}
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
+				expectedResponse.BlockRoot(): {1: true, 2: true},
+				{4}:                          {1: true, 2: true},
+				{7}:                          {1: true, 2: true},
+			}
 
-		slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-			expectedResponse.BlockRoot(): 1,
-			{4}:                          4,
-			{7}:                          7,
-		}
+			slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+				expectedResponse.BlockRoot(): 1,
+				{4}:                          4,
+				{7}:                          7,
+			}
 
-		slotsWithCommitments := map[primitives.Slot]bool{
-			1: true,
-			3: true,
-			4: true,
-			7: true,
-		}
+			slotsWithCommitments := map[primitives.Slot]bool{
+				1: true,
+				3: true,
+				4: true,
+				7: true,
+			}
 
-		roots := [...][fieldparams.RootLength]byte{expectedResponse.BlockRoot(), {4}, {7}}
+			roots := [...][fieldparams.RootLength]byte{expectedResponse.BlockRoot(), {4}, {7}}
 
-		expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
-			{
-				BlockRoot: roots[1][:],
-				Columns:   []uint64{1, 2},
-			},
-			{
-				BlockRoot: roots[2][:],
-				Columns:   []uint64{1, 2},
-			},
-			{
-				BlockRoot: roots[0][:],
-				Columns:   []uint64{1, 2},
-			},
-		}
+			expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
+				{
+					BlockRoot: roots[1][:],
+					Columns:   []uint64{1, 2},
+				},
+				{
+					BlockRoot: roots[2][:],
+					Columns:   []uint64{1, 2},
+				},
+				{
+					BlockRoot: roots[0][:],
+					Columns:   []uint64{1, 2},
+				},
+			}
 
-		protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
-		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
-		p2p.Connect(other)
+			protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
+			p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
+			p2p.Connect(other)
 
-		other.SetStreamHandler(protocol, func(stream network.Stream) {
-			receivedRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
-			err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
-			assert.NoError(t, err)
-			assert.DeepSSZEqual(t, *expectedRequest, *receivedRequest)
+			other.SetStreamHandler(protocol, func(stream network.Stream) {
+				receivedRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
+				err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
+				assert.NoError(t, err)
+				assert.DeepSSZEqual(t, *expectedRequest, *receivedRequest)
 
-			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
-			assert.NoError(t, err)
+				err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
+				assert.NoError(t, err)
 
-			err = stream.CloseWrite()
-			assert.NoError(t, err)
+				err = stream.CloseWrite()
+				assert.NoError(t, err)
+			})
+
+			params := DataColumnSidecarsParams{
+				Ctx:         t.Context(),
+				Tor:         clock,
+				P2P:         p2p,
+				CtxMap:      ctxMap,
+				RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
+			}
+
+			actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
+			require.NoError(t, err)
+			require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 		})
-
-		params := DataColumnSidecarsParams{
-			Ctx:         t.Context(),
-			Tor:         clock,
-			P2P:         p2p,
-			CtxMap:      ctxMap,
-			RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
-		}
-
-		actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
-		require.NoError(t, err)
-		require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 	})
 
 	t.Run("recovery forces by root", func(t *testing.T) {
@@ -835,178 +843,186 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("nominal", func(t *testing.T) {
-		const (
-			start, stop = 0, 15
-			blobCount   = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, stop = 0, 15
+				blobCount   = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		// Setup test data and expectations
-		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			// Setup test data and expectations
+			roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:5],
-			"peer2": roDataColumnSidecars[5:9],
-			"peer3": roDataColumnSidecars[9:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:5],
+				"peer2": roDataColumnSidecars[5:9],
+				"peer3": roDataColumnSidecars[9:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
-			roBlock.Root(): roBlock,
-		}
+			blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+				roBlock.Root(): roBlock,
+			}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
 
-		require.Equal(t, stop-start, len(actual))
+			require.Equal(t, stop-start, len(actual))
 
-		for i := range actual {
-			actualSidecar := actual[i]
-			index := actualSidecar.Index()
-			expectedSidecar := expected[index]
-			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
-		}
+			for i := range actual {
+				actualSidecar := actual[i]
+				index := actualSidecar.Index()
+				expectedSidecar := expected[index]
+				require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
+			}
+		})
 	})
 
 	t.Run("one rogue peer", func(t *testing.T) {
-		const (
-			start, middle, stop = 0, 5, 15
-			blobCount           = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, middle, stop = 0, 5, 15
+				blobCount           = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		// Setup test data and expectations
-		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			// Setup test data and expectations
+			roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		// Modify one sidecar to ensure proof verification fails.
-		if roDataColumnSidecars[middle].KzgProofs()[0][0] == 0 {
-			roDataColumnSidecars[middle].KzgProofs()[0][0]++
-		} else {
-			roDataColumnSidecars[middle].KzgProofs()[0][0]--
-		}
+			// Modify one sidecar to ensure proof verification fails.
+			if roDataColumnSidecars[middle].KzgProofs()[0][0] == 0 {
+				roDataColumnSidecars[middle].KzgProofs()[0][0]++
+			} else {
+				roDataColumnSidecars[middle].KzgProofs()[0][0]--
+			}
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:middle],
-			"peer2": roDataColumnSidecars[5:middle],
-			"peer3": roDataColumnSidecars[middle:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:middle],
+				"peer2": roDataColumnSidecars[5:middle],
+				"peer3": roDataColumnSidecars[middle:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
-			roBlock.Root(): roBlock,
-		}
+			blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+				roBlock.Root(): roBlock,
+			}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
 
-		require.Equal(t, middle-start, len(actual))
+			require.Equal(t, middle-start, len(actual))
 
-		for i := range actual {
-			actualSidecar := actual[i]
-			index := actualSidecar.Index()
-			expectedSidecar := expected[index]
-			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
-		}
+			for i := range actual {
+				actualSidecar := actual[i]
+				index := actualSidecar.Index()
+				expectedSidecar := expected[index]
+				require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
+			}
 
-		scorer := p2p.Peers().Scorers().BadResponsesScorer()
-		require.Equal(t, true, scorer.Score("peer3") < 0)   // genuine KZG-proof fault is downscored
-		require.Equal(t, float64(0), scorer.Score("peer1")) // honest peer is not penalized
+			scorer := p2p.Peers().Scorers().BadResponsesScorer()
+			require.Equal(t, true, scorer.Score("peer3") < 0)   // genuine KZG-proof fault is downscored
+			require.Equal(t, float64(0), scorer.Score("peer1")) // honest peer is not penalized
+		})
 	})
 
 	t.Run("rogue peer with junk header signature", func(t *testing.T) {
-		const (
-			start, middle, stop = 0, 5, 15
-			blobCount           = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, middle, stop = 0, 5, 15
+				blobCount           = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		origHeader, headerErr := roDataColumnSidecars[middle].SignedBlockHeader()
-		require.NoError(t, headerErr)
-		junkSig := make([]byte, fieldparams.BLSSignatureLength)
-		junkSig[0] = 0xff
-		roDataColumnSidecars[middle].DataColumnSidecar().SignedBlockHeader = &ethpb.SignedBeaconBlockHeader{
-			Header:    origHeader.Header,
-			Signature: junkSig,
-		}
+			origHeader, headerErr := roDataColumnSidecars[middle].SignedBlockHeader()
+			require.NoError(t, headerErr)
+			junkSig := make([]byte, fieldparams.BLSSignatureLength)
+			junkSig[0] = 0xff
+			roDataColumnSidecars[middle].DataColumnSidecar().SignedBlockHeader = &ethpb.SignedBeaconBlockHeader{
+				Header:    origHeader.Header,
+				Signature: junkSig,
+			}
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:middle],
-			"peer2": roDataColumnSidecars[middle:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:middle],
+				"peer2": roDataColumnSidecars[middle:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blocksByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
-			roBlock.Root(): roBlock,
-		}
+			blocksByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+				roBlock.Root(): roBlock,
+			}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blocksByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blocksByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
 
-		// Only the honest peer's sidecars should be returned.
-		require.Equal(t, middle-start, len(actual))
-		for i := range actual {
-			actualSidecar := actual[i]
-			index := actualSidecar.Index()
-			expectedSidecar := expected[index]
-			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
-		}
+			// Only the honest peer's sidecars should be returned.
+			require.Equal(t, middle-start, len(actual))
+			for i := range actual {
+				actualSidecar := actual[i]
+				index := actualSidecar.Index()
+				expectedSidecar := expected[index]
+				require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
+			}
+		})
 	})
 
 	t.Run("unknown block root", func(t *testing.T) {
-		const (
-			start, stop = 0, 15
-			blobCount   = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, stop = 0, 15
+				blobCount   = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		_, roDataColumnSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			_, roDataColumnSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{}
+			blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
-		require.Equal(t, 0, len(actual))
-		// The peer is NOT downscored for returning sidecars whose block we don't hold locally.
-		require.Equal(t, float64(0), p2p.Peers().Scorers().BadResponsesScorer().Score("peer1"))
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(actual))
+			// The peer is NOT downscored for returning sidecars whose block we don't hold locally.
+			require.Equal(t, float64(0), p2p.Peers().Scorers().BadResponsesScorer().Score("peer1"))
+		})
 	})
 
 	t.Run("foreign roots dropped without downscore", func(t *testing.T) {
@@ -1048,84 +1064,86 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 }
 
 func TestComputeIndicesByRootByPeer(t *testing.T) {
-	peerIdStrs := []string{
-		"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq", // Custodies 89, 94, 97 & 122
-		"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf", // Custodies 1, 11, 37 & 86
-		"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8", // Custodies 2, 37, 38 & 68
-		"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx", // Custodies 10, 29, 36 & 108
-	}
+	testp2p.SynctestTest(t, func(t *testing.T) {
+		peerIdStrs := []string{
+			"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq", // Custodies 89, 94, 97 & 122
+			"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf", // Custodies 1, 11, 37 & 86
+			"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8", // Custodies 2, 37, 38 & 68
+			"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx", // Custodies 10, 29, 36 & 108
+		}
 
-	headSlotByPeer := map[string]primitives.Slot{
-		"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq": 89,
-		"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf": 10,
-		"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8": 12,
-		"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx": 9,
-	}
+		headSlotByPeer := map[string]primitives.Slot{
+			"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq": 89,
+			"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf": 10,
+			"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8": 12,
+			"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx": 9,
+		}
 
-	p2p := testp2p.NewTestP2P(t)
-	peers := p2p.Peers()
+		p2p := testp2p.NewTestP2P(t)
+		peers := p2p.Peers()
 
-	peerIDs := make([]peer.ID, 0, len(peerIdStrs))
-	for _, peerIdStr := range peerIdStrs {
-		peerID, err := peer.Decode(peerIdStr)
+		peerIDs := make([]peer.ID, 0, len(peerIdStrs))
+		for _, peerIdStr := range peerIdStrs {
+			peerID, err := peer.Decode(peerIdStr)
+			require.NoError(t, err)
+
+			peers.SetChainState(peerID, &ethpb.StatusV2{
+				HeadSlot: headSlotByPeer[peerIdStr],
+			})
+
+			peerIDs = append(peerIDs, peerID)
+		}
+
+		slotByBlockRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+			[fieldparams.RootLength]byte{1}: 8,
+			[fieldparams.RootLength]byte{2}: 10,
+			[fieldparams.RootLength]byte{3}: 9,
+			[fieldparams.RootLength]byte{4}: 50,
+		}
+
+		indicesByBlockRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
+			[fieldparams.RootLength]byte{1}: {3: true, 4: true, 5: true},
+			[fieldparams.RootLength]byte{2}: {1: true, 10: true, 37: true, 80: true},
+			[fieldparams.RootLength]byte{3}: {10: true, 38: true, 39: true, 40: true},
+			[fieldparams.RootLength]byte{4}: {89: true, 108: true, 122: true},
+		}
+
+		expected := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
+			peerIDs[0]: {
+				[fieldparams.RootLength]byte{4}: {89: true, 122: true},
+			},
+			peerIDs[1]: {
+				[fieldparams.RootLength]byte{2}: {1: true, 37: true},
+			},
+			peerIDs[2]: {
+				[fieldparams.RootLength]byte{2}: {37: true},
+				[fieldparams.RootLength]byte{3}: {38: true},
+			},
+			peerIDs[3]: {
+				[fieldparams.RootLength]byte{2}: {10: true},
+				[fieldparams.RootLength]byte{3}: {10: true},
+			},
+		}
+
+		peerIDsMap := make(map[peer.ID]bool, len(peerIDs))
+		for _, id := range peerIDs {
+			peerIDsMap[id] = true
+		}
+
+		actual, err := computeIndicesByRootByPeer(p2p, slotByBlockRoot, indicesByBlockRoot, peerIDsMap)
 		require.NoError(t, err)
+		require.Equal(t, len(expected), len(actual))
 
-		peers.SetChainState(peerID, &ethpb.StatusV2{
-			HeadSlot: headSlotByPeer[peerIdStr],
-		})
-
-		peerIDs = append(peerIDs, peerID)
-	}
-
-	slotByBlockRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-		[fieldparams.RootLength]byte{1}: 8,
-		[fieldparams.RootLength]byte{2}: 10,
-		[fieldparams.RootLength]byte{3}: 9,
-		[fieldparams.RootLength]byte{4}: 50,
-	}
-
-	indicesByBlockRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
-		[fieldparams.RootLength]byte{1}: {3: true, 4: true, 5: true},
-		[fieldparams.RootLength]byte{2}: {1: true, 10: true, 37: true, 80: true},
-		[fieldparams.RootLength]byte{3}: {10: true, 38: true, 39: true, 40: true},
-		[fieldparams.RootLength]byte{4}: {89: true, 108: true, 122: true},
-	}
-
-	expected := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
-		peerIDs[0]: {
-			[fieldparams.RootLength]byte{4}: {89: true, 122: true},
-		},
-		peerIDs[1]: {
-			[fieldparams.RootLength]byte{2}: {1: true, 37: true},
-		},
-		peerIDs[2]: {
-			[fieldparams.RootLength]byte{2}: {37: true},
-			[fieldparams.RootLength]byte{3}: {38: true},
-		},
-		peerIDs[3]: {
-			[fieldparams.RootLength]byte{2}: {10: true},
-			[fieldparams.RootLength]byte{3}: {10: true},
-		},
-	}
-
-	peerIDsMap := make(map[peer.ID]bool, len(peerIDs))
-	for _, id := range peerIDs {
-		peerIDsMap[id] = true
-	}
-
-	actual, err := computeIndicesByRootByPeer(p2p, slotByBlockRoot, indicesByBlockRoot, peerIDsMap)
-	require.NoError(t, err)
-	require.Equal(t, len(expected), len(actual))
-
-	for peer, indicesByRoot := range expected {
-		require.Equal(t, len(indicesByRoot), len(actual[peer]))
-		for root, indices := range indicesByRoot {
-			require.Equal(t, len(indices), len(actual[peer][root]))
-			for index := range indices {
-				require.Equal(t, actual[peer][root][index], true)
+		for peer, indicesByRoot := range expected {
+			require.Equal(t, len(indicesByRoot), len(actual[peer]))
+			for root, indices := range indicesByRoot {
+				require.Equal(t, len(indices), len(actual[peer][root]))
+				for index := range indices {
+					require.Equal(t, actual[peer][root][index], true)
+				}
 			}
 		}
-	}
+	})
 }
 
 func TestRandomPeer(t *testing.T) {

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -33,257 +33,259 @@ import (
 )
 
 func TestFetchDataColumnSidecars(t *testing.T) {
-	const numberOfColumns = uint64(fieldparams.NumberOfColumns)
-	// Slot 1: All needed sidecars are available in storage ==> Retrieval from storage only.
-	// Slot 2: No commitment ==> Nothing to do.
-	// Slot 3: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers.
-	// Slot 4: Some sidecars are in the storage, other have to be retrieved from peers but peers do not deliver all requested sidecars ==> Retrieval from storage and peers then reconstruction.
-	// Slot 5: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond needed sidecars on second attempt ==> Retrieval from storage and peers.
-	// Slot 6: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond not needed sidecars on second attempt ==> Retrieval from storage and peers then reconstruction.
-	// Slot 7: Some sidecars are in the storage, other have to be retrieved from peers but peers do not send anything ==> Still missing.
+	testp2p.SynctestTest(t, func(t *testing.T) {
+		const numberOfColumns = uint64(fieldparams.NumberOfColumns)
+		// Slot 1: All needed sidecars are available in storage ==> Retrieval from storage only.
+		// Slot 2: No commitment ==> Nothing to do.
+		// Slot 3: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers.
+		// Slot 4: Some sidecars are in the storage, other have to be retrieved from peers but peers do not deliver all requested sidecars ==> Retrieval from storage and peers then reconstruction.
+		// Slot 5: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond needed sidecars on second attempt ==> Retrieval from storage and peers.
+		// Slot 6: Some sidecars are in the storage, other have to be retrieved from peers ==> Retrieval from storage and peers but peers do not respond all needed on first attempt and respond not needed sidecars on second attempt ==> Retrieval from storage and peers then reconstruction.
+		// Slot 7: Some sidecars are in the storage, other have to be retrieved from peers but peers do not send anything ==> Still missing.
 
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.FuluForkEpoch = 0
-	cfg.BlobSchedule = []params.BlobScheduleEntry{{Epoch: 0, MaxBlobsPerBlock: 10}}
-	params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.FuluForkEpoch = 0
+		cfg.BlobSchedule = []params.BlobScheduleEntry{{Epoch: 0, MaxBlobsPerBlock: 10}}
+		params.OverrideBeaconConfig(cfg)
 
-	// Start the trusted setup.
-	err := kzg.Start()
-	require.NoError(t, err)
+		// Start the trusted setup.
+		err := kzg.Start()
+		require.NoError(t, err)
 
-	storage := filesystem.NewEphemeralDataColumnStorage(t)
+		storage := filesystem.NewEphemeralDataColumnStorage(t)
 
-	ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
-	require.NoError(t, err)
+		ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
+		require.NoError(t, err)
 
-	const blobCount = 3
-	indices := map[uint64]bool{31: true, 81: true, 106: true}
+		const blobCount = 3
+		indices := map[uint64]bool{31: true, 81: true, 106: true}
 
-	// Block 1
-	block1, _, verifiedSidecars1 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(1))
-	root1 := block1.Root()
+		// Block 1
+		block1, _, verifiedSidecars1 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(1))
+		root1 := block1.Root()
 
-	toStore1 := make([]blocks.VerifiedRODataColumn, 0, len(indices))
-	for index := range indices {
-		sidecar := verifiedSidecars1[index]
-		toStore1 = append(toStore1, sidecar)
-	}
-
-	err = storage.Save(toStore1)
-	require.NoError(t, err)
-
-	// Block 2
-	block2, _, _ := util.GenerateTestFuluBlockWithSidecars(t, 0, util.WithSlot(2))
-
-	// Block 3
-	block3, _, verifiedSidecars3 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(3))
-	root3 := block3.Root()
-	toStore3 := []blocks.VerifiedRODataColumn{verifiedSidecars3[106]}
-
-	err = storage.Save(toStore3)
-	require.NoError(t, err)
-
-	// Block 4
-	minimumColumnsCountToReconstruct := peerdas.MinimumColumnCountToReconstruct()
-	block4, _, verifiedSidecars4 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(4))
-	root4 := block4.Root()
-
-	toStoreCount := minimumColumnsCountToReconstruct - 1
-	toStore4 := make([]blocks.VerifiedRODataColumn, 0, toStoreCount)
-
-	for i := uint64(0); uint64(len(toStore4)) < toStoreCount; i++ {
-		sidecar := verifiedSidecars4[minimumColumnsCountToReconstruct+i]
-		if sidecar.Index() == 81 {
-			continue
+		toStore1 := make([]blocks.VerifiedRODataColumn, 0, len(indices))
+		for index := range indices {
+			sidecar := verifiedSidecars1[index]
+			toStore1 = append(toStore1, sidecar)
 		}
 
-		toStore4 = append(toStore4, sidecar)
-	}
+		err = storage.Save(toStore1)
+		require.NoError(t, err)
 
-	err = storage.Save(toStore4)
-	require.NoError(t, err)
+		// Block 2
+		block2, _, _ := util.GenerateTestFuluBlockWithSidecars(t, 0, util.WithSlot(2))
 
-	// Block 5
-	block5, _, verifiedSidecars5 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(5))
-	root5 := block5.Root()
-	toStore5 := []blocks.VerifiedRODataColumn{verifiedSidecars5[106]}
+		// Block 3
+		block3, _, verifiedSidecars3 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(3))
+		root3 := block3.Root()
+		toStore3 := []blocks.VerifiedRODataColumn{verifiedSidecars3[106]}
 
-	err = storage.Save(toStore5)
-	require.NoError(t, err)
+		err = storage.Save(toStore3)
+		require.NoError(t, err)
 
-	// Block 6
-	block6, _, verifiedSidecars6 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(6))
-	root6 := block6.Root()
-	toStore6 := []blocks.VerifiedRODataColumn{verifiedSidecars6[106]}
+		// Block 4
+		minimumColumnsCountToReconstruct := peerdas.MinimumColumnCountToReconstruct()
+		block4, _, verifiedSidecars4 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(4))
+		root4 := block4.Root()
 
-	err = storage.Save(toStore6)
-	require.NoError(t, err)
+		toStoreCount := minimumColumnsCountToReconstruct - 1
+		toStore4 := make([]blocks.VerifiedRODataColumn, 0, toStoreCount)
 
-	// Block 7
-	block7, _, verifiedSidecars7 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(7))
-	root7 := block7.Root()
-	toStore7 := []blocks.VerifiedRODataColumn{verifiedSidecars7[106]}
-
-	err = storage.Save(toStore7)
-	require.NoError(t, err)
-
-	// Peers
-	byRangeProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
-	byRootProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
-
-	privateKeyBytes := [32]byte{1}
-	privateKey, err := crypto.UnmarshalSecp256k1PrivateKey(privateKeyBytes[:])
-	require.NoError(t, err)
-
-	p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t, libp2p.Identity(privateKey))
-	p2p.Peers().SetConnectionState(other.PeerID(), peers.Connected)
-	p2p.Connect(other)
-
-	p2p.Peers().SetChainState(other.PeerID(), &ethpb.StatusV2{
-		HeadSlot: 8,
-	})
-
-	p2p.Peers().SetMetadata(other.PeerID(), wrapper.WrappedMetadataV2(&ethpb.MetaDataV2{
-		CustodyGroupCount: 128,
-	}))
-
-	clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
-
-	gs := startup.NewClockSynchronizer()
-	err = gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-	require.NoError(t, err)
-
-	waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-	initializer, err := waiter.WaitForInitializer(t.Context())
-	require.NoError(t, err)
-
-	newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-
-	other.SetStreamHandler(byRangeProtocol, func(stream network.Stream) {
-		expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
-			StartSlot: 3,
-			Count:     5,
-			Columns:   []uint64{31, 81},
-		}
-
-		actualRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
-		err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
-		assert.NoError(t, err)
-		assert.DeepEqual(t, expectedRequest, actualRequest)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[31].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[81].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars4[81].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[31].RODataColumn)
-		assert.NoError(t, err)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[31].RODataColumn)
-		assert.NoError(t, err)
-
-		err = stream.CloseWrite()
-		assert.NoError(t, err)
-	})
-
-	other.SetStreamHandler(byRootProtocol, func(stream network.Stream) {
-		allBut31And81And106 := make([]uint64, 0, numberOfColumns-3)
-		allBut31And106 := make([]uint64, 0, numberOfColumns-2)
-		allBut106 := make([]uint64, 0, numberOfColumns-1)
-		for i := range numberOfColumns {
-			if !map[uint64]bool{31: true, 81: true, 106: true}[i] {
-				allBut31And81And106 = append(allBut31And81And106, i)
-			}
-			if !map[uint64]bool{31: true, 106: true}[i] {
-				allBut31And106 = append(allBut31And106, i)
+		for i := uint64(0); uint64(len(toStore4)) < toStoreCount; i++ {
+			sidecar := verifiedSidecars4[minimumColumnsCountToReconstruct+i]
+			if sidecar.Index() == 81 {
+				continue
 			}
 
-			if i != 106 {
-				allBut106 = append(allBut106, i)
+			toStore4 = append(toStore4, sidecar)
+		}
+
+		err = storage.Save(toStore4)
+		require.NoError(t, err)
+
+		// Block 5
+		block5, _, verifiedSidecars5 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(5))
+		root5 := block5.Root()
+		toStore5 := []blocks.VerifiedRODataColumn{verifiedSidecars5[106]}
+
+		err = storage.Save(toStore5)
+		require.NoError(t, err)
+
+		// Block 6
+		block6, _, verifiedSidecars6 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(6))
+		root6 := block6.Root()
+		toStore6 := []blocks.VerifiedRODataColumn{verifiedSidecars6[106]}
+
+		err = storage.Save(toStore6)
+		require.NoError(t, err)
+
+		// Block 7
+		block7, _, verifiedSidecars7 := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(7))
+		root7 := block7.Root()
+		toStore7 := []blocks.VerifiedRODataColumn{verifiedSidecars7[106]}
+
+		err = storage.Save(toStore7)
+		require.NoError(t, err)
+
+		// Peers
+		byRangeProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+		byRootProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
+
+		privateKeyBytes := [32]byte{1}
+		privateKey, err := crypto.UnmarshalSecp256k1PrivateKey(privateKeyBytes[:])
+		require.NoError(t, err)
+
+		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t, libp2p.Identity(privateKey))
+		p2p.Peers().SetConnectionState(other.PeerID(), peers.Connected)
+		p2p.Connect(other)
+
+		p2p.Peers().SetChainState(other.PeerID(), &ethpb.StatusV2{
+			HeadSlot: 8,
+		})
+
+		p2p.Peers().SetMetadata(other.PeerID(), wrapper.WrappedMetadataV2(&ethpb.MetaDataV2{
+			CustodyGroupCount: 128,
+		}))
+
+		clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
+
+		gs := startup.NewClockSynchronizer()
+		err = gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+		require.NoError(t, err)
+
+		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+		initializer, err := waiter.WaitForInitializer(t.Context())
+		require.NoError(t, err)
+
+		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+
+		other.SetStreamHandler(byRangeProtocol, func(stream network.Stream) {
+			expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
+				StartSlot: 3,
+				Count:     5,
+				Columns:   []uint64{31, 81},
 			}
-		}
 
-		expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
-			{
-				BlockRoot: root7[:],
-				Columns:   allBut106,
-			},
-			{
-				BlockRoot: root5[:],
-				Columns:   allBut31And106,
-			},
-			{
-				BlockRoot: root6[:],
-				Columns:   allBut31And106,
-			},
-		}
-
-		actualRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
-		err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
-		assert.NoError(t, err)
-		assert.DeepEqual(t, expectedRequest, actualRequest)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[81].RODataColumn)
-		assert.NoError(t, err)
-
-		for _, index := range allBut31And81And106 {
-			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[index].RODataColumn)
+			actualRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
+			err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
 			assert.NoError(t, err)
+			assert.DeepEqual(t, expectedRequest, actualRequest)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[31].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars3[81].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars4[81].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[31].RODataColumn)
+			assert.NoError(t, err)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[31].RODataColumn)
+			assert.NoError(t, err)
+
+			err = stream.CloseWrite()
+			assert.NoError(t, err)
+		})
+
+		other.SetStreamHandler(byRootProtocol, func(stream network.Stream) {
+			allBut31And81And106 := make([]uint64, 0, numberOfColumns-3)
+			allBut31And106 := make([]uint64, 0, numberOfColumns-2)
+			allBut106 := make([]uint64, 0, numberOfColumns-1)
+			for i := range numberOfColumns {
+				if !map[uint64]bool{31: true, 81: true, 106: true}[i] {
+					allBut31And81And106 = append(allBut31And81And106, i)
+				}
+				if !map[uint64]bool{31: true, 106: true}[i] {
+					allBut31And106 = append(allBut31And106, i)
+				}
+
+				if i != 106 {
+					allBut106 = append(allBut106, i)
+				}
+			}
+
+			expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
+				{
+					BlockRoot: root7[:],
+					Columns:   allBut106,
+				},
+				{
+					BlockRoot: root5[:],
+					Columns:   allBut31And106,
+				},
+				{
+					BlockRoot: root6[:],
+					Columns:   allBut31And106,
+				},
+			}
+
+			actualRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
+			err := other.Encoding().DecodeWithMaxLength(stream, actualRequest)
+			assert.NoError(t, err)
+			assert.DeepEqual(t, expectedRequest, actualRequest)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars5[81].RODataColumn)
+			assert.NoError(t, err)
+
+			for _, index := range allBut31And81And106 {
+				err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), verifiedSidecars6[index].RODataColumn)
+				assert.NoError(t, err)
+			}
+
+			err = stream.CloseWrite()
+			assert.NoError(t, err)
+		})
+
+		params := DataColumnSidecarsParams{
+			Ctx:         t.Context(),
+			Tor:         clock,
+			P2P:         p2p,
+			RateLimiter: leakybucket.NewCollector(1., 10, time.Second, false /* deleteEmptyBuckets */),
+			CtxMap:      ctxMap,
+			Storage:     storage,
+			NewVerifier: newDataColumnsVerifier,
 		}
 
-		err = stream.CloseWrite()
-		assert.NoError(t, err)
+		expectedResult := map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn{
+			root1: {verifiedSidecars1[31], verifiedSidecars1[81], verifiedSidecars1[106]},
+			// no root2 (no commitments in this block)
+			root3: {verifiedSidecars3[106], verifiedSidecars3[31], verifiedSidecars3[81]},
+			root4: {verifiedSidecars4[31], verifiedSidecars4[81], verifiedSidecars4[106]},
+			root5: {verifiedSidecars5[106], verifiedSidecars5[31], verifiedSidecars5[81]},
+			root6: {verifiedSidecars6[31], verifiedSidecars6[81], verifiedSidecars6[106]},
+			root7: {verifiedSidecars7[106]},
+		}
+
+		expectedMissingIndicesBYRoots := map[[fieldparams.RootLength]byte]map[uint64]bool{
+			root7: {31: true, 81: true},
+		}
+
+		blocks := []blocks.ROBlock{block1, block2, block3, block4, block5, block6, block7}
+		actualResult, actualMissingRoots, err := FetchDataColumnSidecars(params, blocks, indices)
+		require.NoError(t, err)
+
+		require.Equal(t, len(expectedResult), len(actualResult))
+		for root := range expectedResult {
+			require.Equal(t, len(expectedResult[root]), len(actualResult[root]))
+			for i := range expectedResult[root] {
+				require.DeepSSZEqual(t, expectedResult[root][i].DataColumnSidecar(), actualResult[root][i].DataColumnSidecar())
+			}
+		}
+
+		require.Equal(t, len(expectedMissingIndicesBYRoots), len(actualMissingRoots))
+		for root, expectedMissingIndices := range expectedMissingIndicesBYRoots {
+			actualMissingIndices := actualMissingRoots[root]
+			require.Equal(t, len(expectedMissingIndices), len(actualMissingIndices))
+			for index := range expectedMissingIndices {
+				require.Equal(t, true, actualMissingIndices[index])
+			}
+		}
 	})
-
-	params := DataColumnSidecarsParams{
-		Ctx:         t.Context(),
-		Tor:         clock,
-		P2P:         p2p,
-		RateLimiter: leakybucket.NewCollector(1., 10, time.Second, false /* deleteEmptyBuckets */),
-		CtxMap:      ctxMap,
-		Storage:     storage,
-		NewVerifier: newDataColumnsVerifier,
-	}
-
-	expectedResult := map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn{
-		root1: {verifiedSidecars1[31], verifiedSidecars1[81], verifiedSidecars1[106]},
-		// no root2 (no commitments in this block)
-		root3: {verifiedSidecars3[106], verifiedSidecars3[31], verifiedSidecars3[81]},
-		root4: {verifiedSidecars4[31], verifiedSidecars4[81], verifiedSidecars4[106]},
-		root5: {verifiedSidecars5[106], verifiedSidecars5[31], verifiedSidecars5[81]},
-		root6: {verifiedSidecars6[31], verifiedSidecars6[81], verifiedSidecars6[106]},
-		root7: {verifiedSidecars7[106]},
-	}
-
-	expectedMissingIndicesBYRoots := map[[fieldparams.RootLength]byte]map[uint64]bool{
-		root7: {31: true, 81: true},
-	}
-
-	blocks := []blocks.ROBlock{block1, block2, block3, block4, block5, block6, block7}
-	actualResult, actualMissingRoots, err := FetchDataColumnSidecars(params, blocks, indices)
-	require.NoError(t, err)
-
-	require.Equal(t, len(expectedResult), len(actualResult))
-	for root := range expectedResult {
-		require.Equal(t, len(expectedResult[root]), len(actualResult[root]))
-		for i := range expectedResult[root] {
-			require.DeepSSZEqual(t, expectedResult[root][i].DataColumnSidecar(), actualResult[root][i].DataColumnSidecar())
-		}
-	}
-
-	require.Equal(t, len(expectedMissingIndicesBYRoots), len(actualMissingRoots))
-	for root, expectedMissingIndices := range expectedMissingIndicesBYRoots {
-		actualMissingIndices := actualMissingRoots[root]
-		require.Equal(t, len(expectedMissingIndices), len(actualMissingIndices))
-		for index := range expectedMissingIndices {
-			require.Equal(t, true, actualMissingIndices[index])
-		}
-	}
 }
 
 func TestSelectPeers(t *testing.T) {
@@ -373,106 +375,108 @@ func TestUpdateResults(t *testing.T) {
 }
 
 func TestFetchDataColumnSidecarsFromPeers(t *testing.T) {
-	const count = 4
+	testp2p.SynctestTest(t, func(t *testing.T) {
+		const count = 4
 
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.FuluForkEpoch = 0
-	params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.FuluForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
 
-	clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
-	ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
-	require.NoError(t, err)
+		clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
+		ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
+		require.NoError(t, err)
 
-	kzgCommitmentsInclusionProof := make([][]byte, 0, count)
-	for range count {
-		kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
-	}
-
-	expectedResponseSidecarPb := &ethpb.DataColumnSidecar{
-		Index: 2,
-		SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
-			Header: &ethpb.BeaconBlockHeader{
-				Slot:       1,
-				ParentRoot: make([]byte, fieldparams.RootLength),
-				StateRoot:  make([]byte, fieldparams.RootLength),
-				BodyRoot:   make([]byte, fieldparams.RootLength),
-			},
-			Signature: make([]byte, fieldparams.BLSSignatureLength),
-		},
-		KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
-	}
-
-	expectedResponseSidecar, err := blocks.NewRODataColumn(expectedResponseSidecarPb)
-	require.NoError(t, err)
-
-	slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-		{1}: 1,
-		{3}: 3,
-		{4}: 4,
-		{7}: 7,
-	}
-
-	slotsWithCommitments := map[primitives.Slot]bool{
-		1: true,
-		3: true,
-		4: true,
-		7: true,
-	}
-
-	expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
-		StartSlot: 1,
-		Count:     7,
-		Columns:   []uint64{1, 2},
-	}
-
-	protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
-	p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
-	p2p.Connect(other)
-
-	other.SetStreamHandler(protocol, func(stream network.Stream) {
-		receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
-		err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
-		assert.NoError(t, err)
-		assert.DeepEqual(t, expectedRequest, receivedRequest)
-
-		err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponseSidecar)
-		assert.NoError(t, err)
-
-		err = stream.CloseWrite()
-		assert.NoError(t, err)
-	})
-
-	indicesByRootByPeer := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
-		other.PeerID(): {
-			{1}: {1: true, 2: true},
-			{3}: {1: true, 2: true},
-			{4}: {1: true, 2: true},
-			{7}: {1: true, 2: true},
-		},
-	}
-
-	params := DataColumnSidecarsParams{
-		Ctx:         t.Context(),
-		Tor:         clock,
-		P2P:         p2p,
-		CtxMap:      ctxMap,
-		RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
-	}
-
-	expectedResponse := map[peer.ID][]blocks.RODataColumn{
-		other.PeerID(): {expectedResponseSidecar},
-	}
-
-	actualResponse := fetchDataColumnSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, indicesByRootByPeer)
-	require.Equal(t, len(expectedResponse), len(actualResponse))
-
-	for peerID := range expectedResponse {
-		require.Equal(t, len(expectedResponse[peerID]), len(actualResponse[peerID]))
-		for i := range expectedResponse[peerID] {
-			require.DeepSSZEqual(t, expectedResponse[peerID][i].DataColumnSidecar(), actualResponse[peerID][i].DataColumnSidecar())
+		kzgCommitmentsInclusionProof := make([][]byte, 0, count)
+		for range count {
+			kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
 		}
-	}
+
+		expectedResponseSidecarPb := &ethpb.DataColumnSidecar{
+			Index: 2,
+			SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
+				Header: &ethpb.BeaconBlockHeader{
+					Slot:       1,
+					ParentRoot: make([]byte, fieldparams.RootLength),
+					StateRoot:  make([]byte, fieldparams.RootLength),
+					BodyRoot:   make([]byte, fieldparams.RootLength),
+				},
+				Signature: make([]byte, fieldparams.BLSSignatureLength),
+			},
+			KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
+		}
+
+		expectedResponseSidecar, err := blocks.NewRODataColumn(expectedResponseSidecarPb)
+		require.NoError(t, err)
+
+		slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+			{1}: 1,
+			{3}: 3,
+			{4}: 4,
+			{7}: 7,
+		}
+
+		slotsWithCommitments := map[primitives.Slot]bool{
+			1: true,
+			3: true,
+			4: true,
+			7: true,
+		}
+
+		expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
+			StartSlot: 1,
+			Count:     7,
+			Columns:   []uint64{1, 2},
+		}
+
+		protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
+		p2p.Connect(other)
+
+		other.SetStreamHandler(protocol, func(stream network.Stream) {
+			receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
+			err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
+			assert.NoError(t, err)
+			assert.DeepEqual(t, expectedRequest, receivedRequest)
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponseSidecar)
+			assert.NoError(t, err)
+
+			err = stream.CloseWrite()
+			assert.NoError(t, err)
+		})
+
+		indicesByRootByPeer := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
+			other.PeerID(): {
+				{1}: {1: true, 2: true},
+				{3}: {1: true, 2: true},
+				{4}: {1: true, 2: true},
+				{7}: {1: true, 2: true},
+			},
+		}
+
+		params := DataColumnSidecarsParams{
+			Ctx:         t.Context(),
+			Tor:         clock,
+			P2P:         p2p,
+			CtxMap:      ctxMap,
+			RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
+		}
+
+		expectedResponse := map[peer.ID][]blocks.RODataColumn{
+			other.PeerID(): {expectedResponseSidecar},
+		}
+
+		actualResponse := fetchDataColumnSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, indicesByRootByPeer)
+		require.Equal(t, len(expectedResponse), len(actualResponse))
+
+		for peerID := range expectedResponse {
+			require.Equal(t, len(expectedResponse[peerID]), len(actualResponse[peerID]))
+			for i := range expectedResponse[peerID] {
+				require.DeepSSZEqual(t, expectedResponse[peerID][i].DataColumnSidecar(), actualResponse[peerID][i].DataColumnSidecar())
+			}
+		}
+	})
 }
 
 func TestSendDataColumnSidecarsRequest(t *testing.T) {
@@ -510,128 +514,132 @@ func TestSendDataColumnSidecarsRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("contiguous", func(t *testing.T) {
-		indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
-			{1}: {1: true, 2: true},
-			{3}: {1: true, 2: true},
-			{4}: {1: true, 2: true},
-			{7}: {1: true, 2: true},
-		}
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
+				{1}: {1: true, 2: true},
+				{3}: {1: true, 2: true},
+				{4}: {1: true, 2: true},
+				{7}: {1: true, 2: true},
+			}
 
-		slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-			{1}: 1,
-			{3}: 3,
-			{4}: 4,
-			{7}: 7,
-		}
+			slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+				{1}: 1,
+				{3}: 3,
+				{4}: 4,
+				{7}: 7,
+			}
 
-		slotsWithCommitments := map[primitives.Slot]bool{
-			1: true,
-			3: true,
-			4: true,
-			7: true,
-		}
+			slotsWithCommitments := map[primitives.Slot]bool{
+				1: true,
+				3: true,
+				4: true,
+				7: true,
+			}
 
-		expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
-			StartSlot: 1,
-			Count:     7,
-			Columns:   []uint64{1, 2},
-		}
+			expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
+				StartSlot: 1,
+				Count:     7,
+				Columns:   []uint64{1, 2},
+			}
 
-		protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
-		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
-		p2p.Connect(other)
+			protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+			p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
+			p2p.Connect(other)
 
-		other.SetStreamHandler(protocol, func(stream network.Stream) {
-			receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
-			err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
-			assert.NoError(t, err)
-			assert.DeepEqual(t, expectedRequest, receivedRequest)
+			other.SetStreamHandler(protocol, func(stream network.Stream) {
+				receivedRequest := new(ethpb.DataColumnSidecarsByRangeRequest)
+				err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
+				assert.NoError(t, err)
+				assert.DeepEqual(t, expectedRequest, receivedRequest)
 
-			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
-			assert.NoError(t, err)
+				err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
+				assert.NoError(t, err)
 
-			err = stream.CloseWrite()
-			assert.NoError(t, err)
+				err = stream.CloseWrite()
+				assert.NoError(t, err)
+			})
+
+			params := DataColumnSidecarsParams{
+				Ctx:         t.Context(),
+				Tor:         clock,
+				P2P:         p2p,
+				CtxMap:      ctxMap,
+				RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
+			}
+
+			actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
+			require.NoError(t, err)
+			require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 		})
-
-		params := DataColumnSidecarsParams{
-			Ctx:         t.Context(),
-			Tor:         clock,
-			P2P:         p2p,
-			CtxMap:      ctxMap,
-			RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
-		}
-
-		actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
-		require.NoError(t, err)
-		require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 	})
 
 	t.Run("non contiguous", func(t *testing.T) {
-		indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
-			expectedResponse.BlockRoot(): {1: true, 2: true},
-			{4}:                          {1: true, 2: true},
-			{7}:                          {1: true, 2: true},
-		}
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
+				expectedResponse.BlockRoot(): {1: true, 2: true},
+				{4}:                          {1: true, 2: true},
+				{7}:                          {1: true, 2: true},
+			}
 
-		slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-			expectedResponse.BlockRoot(): 1,
-			{4}:                          4,
-			{7}:                          7,
-		}
+			slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+				expectedResponse.BlockRoot(): 1,
+				{4}:                          4,
+				{7}:                          7,
+			}
 
-		slotsWithCommitments := map[primitives.Slot]bool{
-			1: true,
-			3: true,
-			4: true,
-			7: true,
-		}
+			slotsWithCommitments := map[primitives.Slot]bool{
+				1: true,
+				3: true,
+				4: true,
+				7: true,
+			}
 
-		roots := [...][fieldparams.RootLength]byte{expectedResponse.BlockRoot(), {4}, {7}}
+			roots := [...][fieldparams.RootLength]byte{expectedResponse.BlockRoot(), {4}, {7}}
 
-		expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
-			{
-				BlockRoot: roots[1][:],
-				Columns:   []uint64{1, 2},
-			},
-			{
-				BlockRoot: roots[2][:],
-				Columns:   []uint64{1, 2},
-			},
-			{
-				BlockRoot: roots[0][:],
-				Columns:   []uint64{1, 2},
-			},
-		}
+			expectedRequest := &p2ptypes.DataColumnsByRootIdentifiers{
+				{
+					BlockRoot: roots[1][:],
+					Columns:   []uint64{1, 2},
+				},
+				{
+					BlockRoot: roots[2][:],
+					Columns:   []uint64{1, 2},
+				},
+				{
+					BlockRoot: roots[0][:],
+					Columns:   []uint64{1, 2},
+				},
+			}
 
-		protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
-		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
-		p2p.Connect(other)
+			protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
+			p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
+			p2p.Connect(other)
 
-		other.SetStreamHandler(protocol, func(stream network.Stream) {
-			receivedRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
-			err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
-			assert.NoError(t, err)
-			assert.DeepSSZEqual(t, *expectedRequest, *receivedRequest)
+			other.SetStreamHandler(protocol, func(stream network.Stream) {
+				receivedRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
+				err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
+				assert.NoError(t, err)
+				assert.DeepSSZEqual(t, *expectedRequest, *receivedRequest)
 
-			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
-			assert.NoError(t, err)
+				err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
+				assert.NoError(t, err)
 
-			err = stream.CloseWrite()
-			assert.NoError(t, err)
+				err = stream.CloseWrite()
+				assert.NoError(t, err)
+			})
+
+			params := DataColumnSidecarsParams{
+				Ctx:         t.Context(),
+				Tor:         clock,
+				P2P:         p2p,
+				CtxMap:      ctxMap,
+				RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
+			}
+
+			actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
+			require.NoError(t, err)
+			require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 		})
-
-		params := DataColumnSidecarsParams{
-			Ctx:         t.Context(),
-			Tor:         clock,
-			P2P:         p2p,
-			CtxMap:      ctxMap,
-			RateLimiter: leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
-		}
-
-		actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
-		require.NoError(t, err)
-		require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 	})
 }
 
@@ -777,254 +785,264 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("nominal", func(t *testing.T) {
-		const (
-			start, stop = 0, 15
-			blobCount   = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, stop = 0, 15
+				blobCount   = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		// Setup test data and expectations
-		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			// Setup test data and expectations
+			roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:5],
-			"peer2": roDataColumnSidecars[5:9],
-			"peer3": roDataColumnSidecars[9:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:5],
+				"peer2": roDataColumnSidecars[5:9],
+				"peer3": roDataColumnSidecars[9:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
-			roBlock.Root(): roBlock,
-		}
+			blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+				roBlock.Root(): roBlock,
+			}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
 
-		require.Equal(t, stop-start, len(actual))
+			require.Equal(t, stop-start, len(actual))
 
-		for i := range actual {
-			actualSidecar := actual[i]
-			index := actualSidecar.Index()
-			expectedSidecar := expected[index]
-			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
-		}
+			for i := range actual {
+				actualSidecar := actual[i]
+				index := actualSidecar.Index()
+				expectedSidecar := expected[index]
+				require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
+			}
+		})
 	})
 
 	t.Run("one rogue peer", func(t *testing.T) {
-		const (
-			start, middle, stop = 0, 5, 15
-			blobCount           = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, middle, stop = 0, 5, 15
+				blobCount           = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		// Setup test data and expectations
-		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			// Setup test data and expectations
+			roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		// Modify one sidecar to ensure proof verification fails.
-		if roDataColumnSidecars[middle].KzgProofs()[0][0] == 0 {
-			roDataColumnSidecars[middle].KzgProofs()[0][0]++
-		} else {
-			roDataColumnSidecars[middle].KzgProofs()[0][0]--
-		}
+			// Modify one sidecar to ensure proof verification fails.
+			if roDataColumnSidecars[middle].KzgProofs()[0][0] == 0 {
+				roDataColumnSidecars[middle].KzgProofs()[0][0]++
+			} else {
+				roDataColumnSidecars[middle].KzgProofs()[0][0]--
+			}
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:middle],
-			"peer2": roDataColumnSidecars[5:middle],
-			"peer3": roDataColumnSidecars[middle:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:middle],
+				"peer2": roDataColumnSidecars[5:middle],
+				"peer3": roDataColumnSidecars[middle:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
-			roBlock.Root(): roBlock,
-		}
+			blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+				roBlock.Root(): roBlock,
+			}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
 
-		require.Equal(t, middle-start, len(actual))
+			require.Equal(t, middle-start, len(actual))
 
-		for i := range actual {
-			actualSidecar := actual[i]
-			index := actualSidecar.Index()
-			expectedSidecar := expected[index]
-			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
-		}
+			for i := range actual {
+				actualSidecar := actual[i]
+				index := actualSidecar.Index()
+				expectedSidecar := expected[index]
+				require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
+			}
+		})
 	})
 
 	t.Run("rogue peer with junk header signature", func(t *testing.T) {
-		const (
-			start, middle, stop = 0, 5, 15
-			blobCount           = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, middle, stop = 0, 5, 15
+				blobCount           = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			roBlock, roDataColumnSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		origHeader, headerErr := roDataColumnSidecars[middle].SignedBlockHeader()
-		require.NoError(t, headerErr)
-		junkSig := make([]byte, fieldparams.BLSSignatureLength)
-		junkSig[0] = 0xff
-		roDataColumnSidecars[middle].DataColumnSidecar().SignedBlockHeader = &ethpb.SignedBeaconBlockHeader{
-			Header:    origHeader.Header,
-			Signature: junkSig,
-		}
+			origHeader, headerErr := roDataColumnSidecars[middle].SignedBlockHeader()
+			require.NoError(t, headerErr)
+			junkSig := make([]byte, fieldparams.BLSSignatureLength)
+			junkSig[0] = 0xff
+			roDataColumnSidecars[middle].DataColumnSidecar().SignedBlockHeader = &ethpb.SignedBeaconBlockHeader{
+				Header:    origHeader.Header,
+				Signature: junkSig,
+			}
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:middle],
-			"peer2": roDataColumnSidecars[middle:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:middle],
+				"peer2": roDataColumnSidecars[middle:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blocksByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
-			roBlock.Root(): roBlock,
-		}
+			blocksByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{
+				roBlock.Root(): roBlock,
+			}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blocksByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blocksByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
 
-		// Only the honest peer's sidecars should be returned.
-		require.Equal(t, middle-start, len(actual))
-		for i := range actual {
-			actualSidecar := actual[i]
-			index := actualSidecar.Index()
-			expectedSidecar := expected[index]
-			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
-		}
+			// Only the honest peer's sidecars should be returned.
+			require.Equal(t, middle-start, len(actual))
+			for i := range actual {
+				actualSidecar := actual[i]
+				index := actualSidecar.Index()
+				expectedSidecar := expected[index]
+				require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
+			}
+		})
 	})
 
 	t.Run("unknown block root", func(t *testing.T) {
-		const (
-			start, stop = 0, 15
-			blobCount   = 1
-		)
+		testp2p.SynctestTest(t, func(t *testing.T) {
+			const (
+				start, stop = 0, 15
+				blobCount   = 1
+			)
 
-		p2p := testp2p.NewTestP2P(t)
+			p2p := testp2p.NewTestP2P(t)
 
-		_, roDataColumnSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+			_, roDataColumnSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
 
-		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
-			"peer1": roDataColumnSidecars[start:stop],
-		}
-		gs := startup.NewClockSynchronizer()
-		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
-		require.NoError(t, err)
+			roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{
+				"peer1": roDataColumnSidecars[start:stop],
+			}
+			gs := startup.NewClockSynchronizer()
+			err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+			require.NoError(t, err)
 
-		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
-		initializer, err := waiter.WaitForInitializer(t.Context())
-		require.NoError(t, err)
+			waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+			initializer, err := waiter.WaitForInitializer(t.Context())
+			require.NoError(t, err)
 
-		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{}
+			blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{}
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
-		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
-		require.NoError(t, err)
-		require.Equal(t, 0, len(actual))
+			newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+			actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(actual))
+		})
 	})
 }
 
 func TestComputeIndicesByRootByPeer(t *testing.T) {
-	peerIdStrs := []string{
-		"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq", // Custodies 89, 94, 97 & 122
-		"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf", // Custodies 1, 11, 37 & 86
-		"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8", // Custodies 2, 37, 38 & 68
-		"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx", // Custodies 10, 29, 36 & 108
-	}
+	testp2p.SynctestTest(t, func(t *testing.T) {
+		peerIdStrs := []string{
+			"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq", // Custodies 89, 94, 97 & 122
+			"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf", // Custodies 1, 11, 37 & 86
+			"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8", // Custodies 2, 37, 38 & 68
+			"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx", // Custodies 10, 29, 36 & 108
+		}
 
-	headSlotByPeer := map[string]primitives.Slot{
-		"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq": 89,
-		"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf": 10,
-		"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8": 12,
-		"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx": 9,
-	}
+		headSlotByPeer := map[string]primitives.Slot{
+			"16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq": 89,
+			"16Uiu2HAmTwQPAwzTr6hTgBmKNecCfH6kP3Kbzxj36ZRyyQ46L6gf": 10,
+			"16Uiu2HAmMDB5uUePTpN7737m78ehePfWPtBL9qMGdH8kCygjzNA8": 12,
+			"16Uiu2HAmTAE5Vxf7Pgfk7eWpmCvVJdSba4C9xg4xkYuuvnVbgfFx": 9,
+		}
 
-	p2p := testp2p.NewTestP2P(t)
-	peers := p2p.Peers()
+		p2p := testp2p.NewTestP2P(t)
+		peers := p2p.Peers()
 
-	peerIDs := make([]peer.ID, 0, len(peerIdStrs))
-	for _, peerIdStr := range peerIdStrs {
-		peerID, err := peer.Decode(peerIdStr)
+		peerIDs := make([]peer.ID, 0, len(peerIdStrs))
+		for _, peerIdStr := range peerIdStrs {
+			peerID, err := peer.Decode(peerIdStr)
+			require.NoError(t, err)
+
+			peers.SetChainState(peerID, &ethpb.StatusV2{
+				HeadSlot: headSlotByPeer[peerIdStr],
+			})
+
+			peerIDs = append(peerIDs, peerID)
+		}
+
+		slotByBlockRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+			[fieldparams.RootLength]byte{1}: 8,
+			[fieldparams.RootLength]byte{2}: 10,
+			[fieldparams.RootLength]byte{3}: 9,
+			[fieldparams.RootLength]byte{4}: 50,
+		}
+
+		indicesByBlockRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
+			[fieldparams.RootLength]byte{1}: {3: true, 4: true, 5: true},
+			[fieldparams.RootLength]byte{2}: {1: true, 10: true, 37: true, 80: true},
+			[fieldparams.RootLength]byte{3}: {10: true, 38: true, 39: true, 40: true},
+			[fieldparams.RootLength]byte{4}: {89: true, 108: true, 122: true},
+		}
+
+		expected := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
+			peerIDs[0]: {
+				[fieldparams.RootLength]byte{4}: {89: true, 122: true},
+			},
+			peerIDs[1]: {
+				[fieldparams.RootLength]byte{2}: {1: true, 37: true},
+			},
+			peerIDs[2]: {
+				[fieldparams.RootLength]byte{2}: {37: true},
+				[fieldparams.RootLength]byte{3}: {38: true},
+			},
+			peerIDs[3]: {
+				[fieldparams.RootLength]byte{2}: {10: true},
+				[fieldparams.RootLength]byte{3}: {10: true},
+			},
+		}
+
+		peerIDsMap := make(map[peer.ID]bool, len(peerIDs))
+		for _, id := range peerIDs {
+			peerIDsMap[id] = true
+		}
+
+		actual, err := computeIndicesByRootByPeer(p2p, slotByBlockRoot, indicesByBlockRoot, peerIDsMap)
 		require.NoError(t, err)
+		require.Equal(t, len(expected), len(actual))
 
-		peers.SetChainState(peerID, &ethpb.StatusV2{
-			HeadSlot: headSlotByPeer[peerIdStr],
-		})
-
-		peerIDs = append(peerIDs, peerID)
-	}
-
-	slotByBlockRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
-		[fieldparams.RootLength]byte{1}: 8,
-		[fieldparams.RootLength]byte{2}: 10,
-		[fieldparams.RootLength]byte{3}: 9,
-		[fieldparams.RootLength]byte{4}: 50,
-	}
-
-	indicesByBlockRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
-		[fieldparams.RootLength]byte{1}: {3: true, 4: true, 5: true},
-		[fieldparams.RootLength]byte{2}: {1: true, 10: true, 37: true, 80: true},
-		[fieldparams.RootLength]byte{3}: {10: true, 38: true, 39: true, 40: true},
-		[fieldparams.RootLength]byte{4}: {89: true, 108: true, 122: true},
-	}
-
-	expected := map[peer.ID]map[[fieldparams.RootLength]byte]map[uint64]bool{
-		peerIDs[0]: {
-			[fieldparams.RootLength]byte{4}: {89: true, 122: true},
-		},
-		peerIDs[1]: {
-			[fieldparams.RootLength]byte{2}: {1: true, 37: true},
-		},
-		peerIDs[2]: {
-			[fieldparams.RootLength]byte{2}: {37: true},
-			[fieldparams.RootLength]byte{3}: {38: true},
-		},
-		peerIDs[3]: {
-			[fieldparams.RootLength]byte{2}: {10: true},
-			[fieldparams.RootLength]byte{3}: {10: true},
-		},
-	}
-
-	peerIDsMap := make(map[peer.ID]bool, len(peerIDs))
-	for _, id := range peerIDs {
-		peerIDsMap[id] = true
-	}
-
-	actual, err := computeIndicesByRootByPeer(p2p, slotByBlockRoot, indicesByBlockRoot, peerIDsMap)
-	require.NoError(t, err)
-	require.Equal(t, len(expected), len(actual))
-
-	for peer, indicesByRoot := range expected {
-		require.Equal(t, len(indicesByRoot), len(actual[peer]))
-		for root, indices := range indicesByRoot {
-			require.Equal(t, len(indices), len(actual[peer][root]))
-			for index := range indices {
-				require.Equal(t, actual[peer][root][index], true)
+		for peer, indicesByRoot := range expected {
+			require.Equal(t, len(indicesByRoot), len(actual[peer]))
+			for root, indices := range indicesByRoot {
+				require.Equal(t, len(indices), len(actual[peer][root]))
+				for index := range indices {
+					require.Equal(t, actual[peer][root][index], true)
+				}
 			}
 		}
-	}
+	})
 }
 
 func TestRandomPeer(t *testing.T) {

--- a/beacon-chain/sync/data_columns_reconstruct_test.go
+++ b/beacon-chain/sync/data_columns_reconstruct_test.go
@@ -128,21 +128,23 @@ func TestProcessDataColumnSidecarsFromReconstruction(t *testing.T) {
 }
 
 func TestComputeRandomDelay(t *testing.T) {
-	const (
-		seed     = 42
-		expected = 746056722 * time.Nanosecond // = 0.746056722 seconds
-	)
-	slotStartTime := time.Date(2020, 12, 30, 0, 0, 0, 0, time.UTC)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		const (
+			seed     = 42
+			expected = 746056722 * time.Nanosecond // = 0.746056722 seconds
+		)
+		slotStartTime := time.Date(2020, 12, 30, 0, 0, 0, 0, time.UTC)
 
-	service := NewService(
-		t.Context(),
-		WithP2P(p2ptest.NewTestP2P(t)),
-		WithReconstructionRandGen(rand.New(rand.NewSource(seed))),
-	)
+		service := NewService(
+			t.Context(),
+			WithP2P(p2ptest.NewTestP2P(t)),
+			WithReconstructionRandGen(rand.New(rand.NewSource(seed))),
+		)
 
-	waitingTime := service.computeRandomDelay(slotStartTime)
-	fmt.Print(waitingTime)
-	require.Equal(t, expected, waitingTime)
+		waitingTime := service.computeRandomDelay(slotStartTime)
+		fmt.Print(waitingTime)
+		require.Equal(t, expected, waitingTime)
+	})
 }
 
 func TestSemiSupernodeReconstruction(t *testing.T) {

--- a/beacon-chain/sync/data_columns_reconstruct_test.go
+++ b/beacon-chain/sync/data_columns_reconstruct_test.go
@@ -20,8 +20,6 @@ import (
 func TestProcessDataColumnSidecarsFromReconstruction(t *testing.T) {
 	const blobCount = 4
 
-	ctx := t.Context()
-
 	// Start the trusted setup.
 	err := kzg.Start()
 	require.NoError(t, err)
@@ -32,98 +30,107 @@ func TestProcessDataColumnSidecarsFromReconstruction(t *testing.T) {
 	minimumCount := peerdas.MinimumColumnCountToReconstruct()
 
 	t.Run("not enough stored sidecars", func(t *testing.T) {
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
-		err := storage.Save(verifiedRoDataColumns[:minimumCount-1])
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			storage := filesystem.NewEphemeralDataColumnStorage(t)
+			err := storage.Save(verifiedRoDataColumns[:minimumCount-1])
+			require.NoError(t, err)
 
-		service := NewService(ctx, WithP2P(p2ptest.NewTestP2P(t)), WithDataColumnStorage(storage))
-		err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
-		require.NoError(t, err)
+			service := NewService(ctx, WithP2P(p2ptest.NewTestP2P(t)), WithDataColumnStorage(storage))
+			err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("all stored sidecars", func(t *testing.T) {
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
-		err := storage.Save(verifiedRoDataColumns)
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			storage := filesystem.NewEphemeralDataColumnStorage(t)
+			err := storage.Save(verifiedRoDataColumns)
+			require.NoError(t, err)
 
-		service := NewService(ctx, WithP2P(p2ptest.NewTestP2P(t)), WithDataColumnStorage(storage))
-		err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
-		require.NoError(t, err)
+			service := NewService(ctx, WithP2P(p2ptest.NewTestP2P(t)), WithDataColumnStorage(storage))
+			err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("should reconstruct", func(t *testing.T) {
-		// Here we setup a cgc of 8, which is not realistic, since there is no
-		// real reason for a node to both:
-		// - store enough data column sidecars to enable reconstruction, and
-		// - custody not enough columns to enable reconstruction.
-		// However, for the needs of this test, this is perfectly fine.
-		const cgc = 8
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			// Here we setup a cgc of 8, which is not realistic, since there is no
+			// real reason for a node to both:
+			// - store enough data column sidecars to enable reconstruction, and
+			// - custody not enough columns to enable reconstruction.
+			// However, for the needs of this test, this is perfectly fine.
+			const cgc = 8
 
-		require.NoError(t, err)
+			require.NoError(t, err)
 
-		chainService := &mockChain.ChainService{}
-		p2p := p2ptest.NewTestP2P(t)
-		// Enable the partial column broadcaster.
-		p2p.EnablePartialColumnBroadcaster()
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
+			chainService := &mockChain.ChainService{}
+			p2p := p2ptest.NewTestP2P(t)
+			// Enable the partial column broadcaster.
+			p2p.EnablePartialColumnBroadcaster()
+			storage := filesystem.NewEphemeralDataColumnStorage(t)
 
-		service := NewService(
-			ctx,
-			WithP2P(p2p),
-			WithDataColumnStorage(storage),
-			WithChainService(chainService),
-			WithOperationNotifier(chainService.OperationNotifier()),
-		)
+			service := NewService(
+				ctx,
+				WithP2P(p2p),
+				WithDataColumnStorage(storage),
+				WithChainService(chainService),
+				WithOperationNotifier(chainService.OperationNotifier()),
+			)
 
-		minimumCount := peerdas.MinimumColumnCountToReconstruct()
-		receivedBeforeReconstruction := verifiedRoDataColumns[:minimumCount]
+			minimumCount := peerdas.MinimumColumnCountToReconstruct()
+			receivedBeforeReconstruction := verifiedRoDataColumns[:minimumCount]
 
-		err = service.receiveDataColumnSidecars(ctx, receivedBeforeReconstruction)
-		require.NoError(t, err)
+			err = service.receiveDataColumnSidecars(ctx, receivedBeforeReconstruction)
+			require.NoError(t, err)
 
-		err = storage.Save(receivedBeforeReconstruction)
-		require.NoError(t, err)
+			err = storage.Save(receivedBeforeReconstruction)
+			require.NoError(t, err)
 
-		require.Equal(t, false, p2p.BroadcastCalled.Load())
+			require.Equal(t, false, p2p.BroadcastCalled.Load())
 
-		// Check received indices before reconstruction.
-		require.Equal(t, minimumCount, uint64(len(chainService.DataColumns)))
-		for i, actual := range chainService.DataColumns {
-			require.Equal(t, uint64(i), actual.Index())
-		}
+			// Check received indices before reconstruction.
+			require.Equal(t, minimumCount, uint64(len(chainService.DataColumns)))
+			for i, actual := range chainService.DataColumns {
+				require.Equal(t, uint64(i), actual.Index())
+			}
 
-		// Run the reconstruction.
-		err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
-		require.NoError(t, err)
+			// Run the reconstruction.
+			err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
+			require.NoError(t, err)
 
-		expected := make(map[uint64]bool, minimumCount+cgc)
-		for i := range minimumCount {
-			expected[i] = true
-		}
+			expected := make(map[uint64]bool, minimumCount+cgc)
+			for i := range minimumCount {
+				expected[i] = true
+			}
 
-		// The node should custody these indices.
-		for _, i := range [...]uint64{75, 87, 102, 117} {
-			expected[i] = true
-		}
+			// The node should custody these indices.
+			for _, i := range [...]uint64{75, 87, 102, 117} {
+				expected[i] = true
+			}
 
-		block := roBlock.Block()
-		slot := block.Slot()
-		proposerIndex := block.ProposerIndex()
+			block := roBlock.Block()
+			slot := block.Slot()
+			proposerIndex := block.ProposerIndex()
 
-		require.Equal(t, len(expected), len(chainService.DataColumns))
-		for _, actual := range chainService.DataColumns {
-			require.Equal(t, true, expected[actual.Index()])
-			require.Equal(t, true, service.hasSeenDataColumnIndex(slot, proposerIndex, actual.Index()))
-		}
+			require.Equal(t, len(expected), len(chainService.DataColumns))
+			for _, actual := range chainService.DataColumns {
+				require.Equal(t, true, expected[actual.Index()])
+				require.Equal(t, true, service.hasSeenDataColumnIndex(slot, proposerIndex, actual.Index()))
+			}
 
-		require.Equal(t, true, p2p.BroadcastCalled.Load())
+			require.Equal(t, true, p2p.BroadcastCalled.Load())
 
-		unseenExpected := map[uint64]bool{75: true, 87: true, 102: true, 117: true}
-		broadcastedPartials := p2p.BroadcastedPartialColumns()
-		require.Equal(t, len(unseenExpected), len(broadcastedPartials))
-		for _, partial := range broadcastedPartials {
-			require.Equal(t, true, unseenExpected[partial.Index])
-		}
+			unseenExpected := map[uint64]bool{75: true, 87: true, 102: true, 117: true}
+			broadcastedPartials := p2p.BroadcastedPartialColumns()
+			require.Equal(t, len(unseenExpected), len(broadcastedPartials))
+			for _, partial := range broadcastedPartials {
+				require.Equal(t, true, unseenExpected[partial.Index])
+			}
+		})
 	})
 }
 
@@ -153,8 +160,6 @@ func TestSemiSupernodeReconstruction(t *testing.T) {
 		numberOfColumns = uint64(fieldparams.NumberOfColumns)
 	)
 
-	ctx := t.Context()
-
 	// Start the trusted setup.
 	err := kzg.Start()
 	require.NoError(t, err)
@@ -165,100 +170,106 @@ func TestSemiSupernodeReconstruction(t *testing.T) {
 	minimumCount := peerdas.MinimumColumnCountToReconstruct()
 
 	t.Run("semi-supernode reconstruction with exactly 64 columns", func(t *testing.T) {
-		// Test that reconstruction works with exactly the minimum number of columns (64).
-		// This simulates semi-supernode mode which custodies exactly 64 columns.
-		require.Equal(t, uint64(64), minimumCount, "Expected minimum column count to be 64")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			// Test that reconstruction works with exactly the minimum number of columns (64).
+			// This simulates semi-supernode mode which custodies exactly 64 columns.
+			require.Equal(t, uint64(64), minimumCount, "Expected minimum column count to be 64")
 
-		chainService := &mockChain.ChainService{}
-		p2p := p2ptest.NewTestP2P(t)
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
+			chainService := &mockChain.ChainService{}
+			p2p := p2ptest.NewTestP2P(t)
+			storage := filesystem.NewEphemeralDataColumnStorage(t)
 
-		service := NewService(
-			ctx,
-			WithP2P(p2p),
-			WithDataColumnStorage(storage),
-			WithChainService(chainService),
-			WithOperationNotifier(chainService.OperationNotifier()),
-		)
+			service := NewService(
+				ctx,
+				WithP2P(p2p),
+				WithDataColumnStorage(storage),
+				WithChainService(chainService),
+				WithOperationNotifier(chainService.OperationNotifier()),
+			)
 
-		// Use exactly 64 columns (minimum for reconstruction) to simulate semi-supernode mode.
-		// Select the first 64 columns.
-		semiSupernodeColumns := verifiedRoDataColumns[:minimumCount]
+			// Use exactly 64 columns (minimum for reconstruction) to simulate semi-supernode mode.
+			// Select the first 64 columns.
+			semiSupernodeColumns := verifiedRoDataColumns[:minimumCount]
 
-		err = service.receiveDataColumnSidecars(ctx, semiSupernodeColumns)
-		require.NoError(t, err)
+			err = service.receiveDataColumnSidecars(ctx, semiSupernodeColumns)
+			require.NoError(t, err)
 
-		err = storage.Save(semiSupernodeColumns)
-		require.NoError(t, err)
+			err = storage.Save(semiSupernodeColumns)
+			require.NoError(t, err)
 
-		require.Equal(t, false, p2p.BroadcastCalled.Load())
+			require.Equal(t, false, p2p.BroadcastCalled.Load())
 
-		// Check received indices before reconstruction.
-		require.Equal(t, minimumCount, uint64(len(chainService.DataColumns)))
-		for i, actual := range chainService.DataColumns {
-			require.Equal(t, uint64(i), actual.Index())
-		}
-
-		// Run the reconstruction.
-		err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
-		require.NoError(t, err)
-
-		// Verify we can reconstruct all columns from just 64.
-		// The node should have received the initial 64 columns.
-		if len(chainService.DataColumns) < int(minimumCount) {
-			t.Fatalf("Expected at least %d columns but got %d", minimumCount, len(chainService.DataColumns))
-		}
-
-		block := roBlock.Block()
-		slot := block.Slot()
-		proposerIndex := block.ProposerIndex()
-
-		// Verify that we have seen at least the minimum number of columns.
-		seenCount := 0
-		for i := range numberOfColumns {
-			if service.hasSeenDataColumnIndex(slot, proposerIndex, i) {
-				seenCount++
+			// Check received indices before reconstruction.
+			require.Equal(t, minimumCount, uint64(len(chainService.DataColumns)))
+			for i, actual := range chainService.DataColumns {
+				require.Equal(t, uint64(i), actual.Index())
 			}
-		}
-		if seenCount < int(minimumCount) {
-			t.Fatalf("Expected to see at least %d columns but saw %d", minimumCount, seenCount)
-		}
+
+			// Run the reconstruction.
+			err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
+			require.NoError(t, err)
+
+			// Verify we can reconstruct all columns from just 64.
+			// The node should have received the initial 64 columns.
+			if len(chainService.DataColumns) < int(minimumCount) {
+				t.Fatalf("Expected at least %d columns but got %d", minimumCount, len(chainService.DataColumns))
+			}
+
+			block := roBlock.Block()
+			slot := block.Slot()
+			proposerIndex := block.ProposerIndex()
+
+			// Verify that we have seen at least the minimum number of columns.
+			seenCount := 0
+			for i := range numberOfColumns {
+				if service.hasSeenDataColumnIndex(slot, proposerIndex, i) {
+					seenCount++
+				}
+			}
+			if seenCount < int(minimumCount) {
+				t.Fatalf("Expected to see at least %d columns but saw %d", minimumCount, seenCount)
+			}
+		})
 	})
 
 	t.Run("semi-supernode reconstruction with random 64 columns", func(t *testing.T) {
-		// Test reconstruction with 64 non-contiguous columns to simulate a real scenario.
-		chainService := &mockChain.ChainService{}
-		p2p := p2ptest.NewTestP2P(t)
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			// Test reconstruction with 64 non-contiguous columns to simulate a real scenario.
+			chainService := &mockChain.ChainService{}
+			p2p := p2ptest.NewTestP2P(t)
+			storage := filesystem.NewEphemeralDataColumnStorage(t)
 
-		service := NewService(
-			ctx,
-			WithP2P(p2p),
-			WithDataColumnStorage(storage),
-			WithChainService(chainService),
-			WithOperationNotifier(chainService.OperationNotifier()),
-		)
+			service := NewService(
+				ctx,
+				WithP2P(p2p),
+				WithDataColumnStorage(storage),
+				WithChainService(chainService),
+				WithOperationNotifier(chainService.OperationNotifier()),
+			)
 
-		// Select every other column to get 64 non-contiguous columns.
-		semiSupernodeColumns := make([]blocks.VerifiedRODataColumn, 0, minimumCount)
-		for i := uint64(0); i < numberOfColumns && uint64(len(semiSupernodeColumns)) < minimumCount; i += 2 {
-			semiSupernodeColumns = append(semiSupernodeColumns, verifiedRoDataColumns[i])
-		}
-		require.Equal(t, minimumCount, uint64(len(semiSupernodeColumns)))
+			// Select every other column to get 64 non-contiguous columns.
+			semiSupernodeColumns := make([]blocks.VerifiedRODataColumn, 0, minimumCount)
+			for i := uint64(0); i < numberOfColumns && uint64(len(semiSupernodeColumns)) < minimumCount; i += 2 {
+				semiSupernodeColumns = append(semiSupernodeColumns, verifiedRoDataColumns[i])
+			}
+			require.Equal(t, minimumCount, uint64(len(semiSupernodeColumns)))
 
-		err = service.receiveDataColumnSidecars(ctx, semiSupernodeColumns)
-		require.NoError(t, err)
+			err = service.receiveDataColumnSidecars(ctx, semiSupernodeColumns)
+			require.NoError(t, err)
 
-		err = storage.Save(semiSupernodeColumns)
-		require.NoError(t, err)
+			err = storage.Save(semiSupernodeColumns)
+			require.NoError(t, err)
 
-		// Run the reconstruction.
-		err = service.processDataColumnSidecarsFromReconstruction(ctx, semiSupernodeColumns[0])
-		require.NoError(t, err)
+			// Run the reconstruction.
+			err = service.processDataColumnSidecarsFromReconstruction(ctx, semiSupernodeColumns[0])
+			require.NoError(t, err)
 
-		// Verify we received the columns.
-		if len(chainService.DataColumns) < int(minimumCount) {
-			t.Fatalf("Expected at least %d columns but got %d", minimumCount, len(chainService.DataColumns))
-		}
+			// Verify we received the columns.
+			if len(chainService.DataColumns) < int(minimumCount) {
+				t.Fatalf("Expected at least %d columns but got %d", minimumCount, len(chainService.DataColumns))
+			}
+		})
 	})
 }

--- a/beacon-chain/sync/error_test.go
+++ b/beacon-chain/sync/error_test.go
@@ -11,18 +11,20 @@ import (
 )
 
 func TestRegularSync_generateErrorResponse(t *testing.T) {
-	r := &Service{
-		cfg: &config{p2p: p2ptest.NewTestP2P(t)},
-	}
-	data, err := r.generateErrorResponse(responseCodeServerError, "something bad happened")
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		r := &Service{
+			cfg: &config{p2p: p2ptest.NewTestP2P(t)},
+		}
+		data, err := r.generateErrorResponse(responseCodeServerError, "something bad happened")
+		require.NoError(t, err)
 
-	buf := bytes.NewBuffer(data)
-	b := make([]byte, 1)
-	_, err = buf.Read(b)
-	require.NoError(t, err)
-	assert.Equal(t, responseCodeServerError, b[0], "The first byte was not the status code")
-	msg := &types.ErrorMessage{}
-	require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(buf, msg))
-	assert.Equal(t, "something bad happened", string(*msg), "Received the wrong message")
+		buf := bytes.NewBuffer(data)
+		b := make([]byte, 1)
+		_, err = buf.Read(b)
+		require.NoError(t, err)
+		assert.Equal(t, responseCodeServerError, b[0], "The first byte was not the status code")
+		msg := &types.ErrorMessage{}
+		require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(buf, msg))
+		assert.Equal(t, "something bad happened", string(*msg), "Received the wrong message")
+	})
 }

--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -15,6 +15,8 @@ import (
 // - We are subscribed to the correct gossipsub topics (for the current and upcoming epoch).
 // - We have registered the correct RPC stream handlers (for the current and upcoming epoch).
 // - We have cleaned up gossipsub topics and RPC stream handlers that are no longer needed.
+//
+// It prunes slot-keyed caches (proposer preferences, payload bids, pending gloas columns).
 func (s *Service) p2pHandlerControlLoop() {
 	// At startup, launch registration and peer discovery loops, and register rpc stream handlers.
 	startEntry := params.GetNetworkScheduleEntry(s.cfg.clock.CurrentEpoch())
@@ -29,6 +31,7 @@ func (s *Service) p2pHandlerControlLoop() {
 		case currentSlot := <-slotTicker.C():
 			s.proposerPreferencesCache.PruneBefore(currentSlot)
 			s.highestExecutionPayloadBidCache.PruneBefore(currentSlot)
+			s.pruneStaleGloasColumns(currentSlot)
 			current := s.cfg.clock.CurrentEpoch()
 			if err := s.ensureRegistrationsForEpoch(current); err != nil {
 				log.WithError(err).Error("Unable to check for fork in the next epoch")

--- a/beacon-chain/sync/fork_watcher_test.go
+++ b/beacon-chain/sync/fork_watcher_test.go
@@ -55,28 +55,30 @@ func testForkWatcherService(t *testing.T, current primitives.Epoch) *Service {
 }
 
 func TestRegisterSubscriptions_Idempotent(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	genesis.StoreEmbeddedDuringTest(t, params.BeaconConfig().ConfigName)
-	fulu := params.BeaconConfig().ElectraForkEpoch + 4096*2
-	params.BeaconConfig().FuluForkEpoch = fulu
-	params.BeaconConfig().GloasForkEpoch = params.BeaconConfig().FarFutureEpoch
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		genesis.StoreEmbeddedDuringTest(t, params.BeaconConfig().ConfigName)
+		fulu := params.BeaconConfig().ElectraForkEpoch + 4096*2
+		params.BeaconConfig().FuluForkEpoch = fulu
+		params.BeaconConfig().GloasForkEpoch = params.BeaconConfig().FarFutureEpoch
+		params.BeaconConfig().InitializeForkSchedule()
 
-	current := fulu - 1
-	s := testForkWatcherService(t, current)
-	next := params.GetNetworkScheduleEntry(fulu)
-	wg := attachSpawner(s)
-	require.Equal(t, true, s.registerSubscribers(next))
-	done := make(chan struct{})
-	go func() { wg.Wait(); close(done) }()
-	select {
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for subscriptions to be registered")
-	case <-done:
-	}
-	// the goal of this callback is just to assert that spawn is never called.
-	s.subscriptionSpawner = func(func()) { t.Error("registration routines spawned twice for the same digest") }
-	require.NoError(t, s.ensureRegistrationsForEpoch(fulu))
+		current := fulu - 1
+		s := testForkWatcherService(t, current)
+		next := params.GetNetworkScheduleEntry(fulu)
+		wg := attachSpawner(s)
+		require.Equal(t, true, s.registerSubscribers(next))
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for subscriptions to be registered")
+		case <-done:
+		}
+		// the goal of this callback is just to assert that spawn is never called.
+		s.subscriptionSpawner = func(func()) { t.Error("registration routines spawned twice for the same digest") }
+		require.NoError(t, s.ensureRegistrationsForEpoch(fulu))
+	})
 }
 
 func TestService_CheckForNextEpochFork(t *testing.T) {
@@ -198,40 +200,42 @@ func TestService_CheckForNextEpochFork(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			current := tt.epochAtRegistration(tt.forkEpoch)
-			s := testForkWatcherService(t, current)
-			wg := attachSpawner(s)
-			require.NoError(t, s.ensureRegistrationsForEpoch(s.cfg.clock.CurrentEpoch()))
-			wg.Wait()
-			tt.checkRegistration(t, s)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				current := tt.epochAtRegistration(tt.forkEpoch)
+				s := testForkWatcherService(t, current)
+				wg := attachSpawner(s)
+				require.NoError(t, s.ensureRegistrationsForEpoch(s.cfg.clock.CurrentEpoch()))
+				wg.Wait()
+				tt.checkRegistration(t, s)
 
-			if current != tt.forkEpoch-1 {
-				return
-			}
+				if current != tt.forkEpoch-1 {
+					return
+				}
 
-			// Ensure the topics were registered for the upcoming fork
-			digest := params.ForkDigest(tt.forkEpoch)
-			assert.Equal(t, true, s.subHandler.digestExists(digest))
+				// Ensure the topics were registered for the upcoming fork
+				digest := params.ForkDigest(tt.forkEpoch)
+				assert.Equal(t, true, s.subHandler.digestExists(digest))
 
-			// After this point we are checking deregistration, which doesn't apply if there isn't a higher
-			// nextForkEpoch.
-			if tt.forkEpoch >= tt.nextForkEpoch {
-				return
-			}
+				// After this point we are checking deregistration, which doesn't apply if there isn't a higher
+				// nextForkEpoch.
+				if tt.forkEpoch >= tt.nextForkEpoch {
+					return
+				}
 
-			nextDigest := params.ForkDigest(tt.nextForkEpoch)
-			// Move the clock to just before the next fork epoch and ensure deregistration is correct
-			wg = attachSpawner(s)
-			s.cfg.clock = defaultClockWithTimeAtEpoch(tt.nextForkEpoch - 1)
-			require.NoError(t, s.ensureRegistrationsForEpoch(s.cfg.clock.CurrentEpoch()))
-			wg.Wait()
+				nextDigest := params.ForkDigest(tt.nextForkEpoch)
+				// Move the clock to just before the next fork epoch and ensure deregistration is correct
+				wg = attachSpawner(s)
+				s.cfg.clock = defaultClockWithTimeAtEpoch(tt.nextForkEpoch - 1)
+				require.NoError(t, s.ensureRegistrationsForEpoch(s.cfg.clock.CurrentEpoch()))
+				wg.Wait()
 
-			require.NoError(t, s.ensureDeregistrationForEpoch(tt.nextForkEpoch))
-			assert.Equal(t, true, s.subHandler.digestExists(digest))
-			// deregister as if it is the epoch after the next fork epoch
-			require.NoError(t, s.ensureDeregistrationForEpoch(tt.nextForkEpoch+1))
-			assert.Equal(t, false, s.subHandler.digestExists(digest))
-			assert.Equal(t, true, s.subHandler.digestExists(nextDigest))
+				require.NoError(t, s.ensureDeregistrationForEpoch(tt.nextForkEpoch))
+				assert.Equal(t, true, s.subHandler.digestExists(digest))
+				// deregister as if it is the epoch after the next fork epoch
+				require.NoError(t, s.ensureDeregistrationForEpoch(tt.nextForkEpoch+1))
+				assert.Equal(t, false, s.subHandler.digestExists(digest))
+				assert.Equal(t, true, s.subHandler.digestExists(nextDigest))
+			})
 		})
 	}
 }
@@ -283,37 +287,39 @@ func (p *p2pWithPartialBroadcaster) PartialColumnBroadcaster() partialdatacolumn
 // ensureDeregistrationForEpoch unsubscribes the partial-column broadcaster from previous-fork-digest
 // data column topics (and only those), in addition to removing the full gossip subscriptions.
 func TestEnsureDeregistration_UnsubscribesPartialColumns(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	genesis.StoreEmbeddedDuringTest(t, params.BeaconConfig().ConfigName)
-	// Place forks at epochs 1 and 2 so that, one epoch later, there is a "previous" fork digest
-	// (altair) distinct from the "current" one (bellatrix) for the deregistration logic to act on.
-	params.BeaconConfig().AltairForkEpoch = 1
-	params.BeaconConfig().BellatrixForkEpoch = 2
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		genesis.StoreEmbeddedDuringTest(t, params.BeaconConfig().ConfigName)
+		// Place forks at epochs 1 and 2 so that, one epoch later, there is a "previous" fork digest
+		// (altair) distinct from the "current" one (bellatrix) for the deregistration logic to act on.
+		params.BeaconConfig().AltairForkEpoch = 1
+		params.BeaconConfig().BellatrixForkEpoch = 2
+		params.BeaconConfig().InitializeForkSchedule()
 
-	const currentEpoch = 3
-	current := params.GetNetworkScheduleEntry(currentEpoch)
-	previous := params.GetNetworkScheduleEntry(current.Epoch - 1)
-	require.NotEqual(t, previous.ForkDigest, current.ForkDigest)
+		const currentEpoch = 3
+		current := params.GetNetworkScheduleEntry(currentEpoch)
+		previous := params.GetNetworkScheduleEntry(current.Epoch - 1)
+		require.NotEqual(t, previous.ForkDigest, current.ForkDigest)
 
-	s := testForkWatcherService(t, currentEpoch)
-	fake := &fakePartialBroadcaster{}
-	s.cfg.p2p = &p2pWithPartialBroadcaster{P2P: s.cfg.p2p, broadcaster: fake}
-	suffix := s.cfg.p2p.Encoding().ProtocolSuffix()
+		s := testForkWatcherService(t, currentEpoch)
+		fake := &fakePartialBroadcaster{}
+		s.cfg.p2p = &p2pWithPartialBroadcaster{P2P: s.cfg.p2p, broadcaster: fake}
+		suffix := s.cfg.p2p.Encoding().ProtocolSuffix()
 
-	prevDataCol := fmt.Sprintf(p2p.DataColumnSubnetTopicFormat, previous.ForkDigest, 7) + suffix
-	prevBlock := fmt.Sprintf(p2p.BlockSubnetTopicFormat, previous.ForkDigest) + suffix
-	currDataCol := fmt.Sprintf(p2p.DataColumnSubnetTopicFormat, current.ForkDigest, 7) + suffix
-	for _, topic := range []string{prevDataCol, prevBlock, currDataCol} {
-		s.subHandler.addTopic(topic, nil)
-	}
+		prevDataCol := fmt.Sprintf(p2p.DataColumnSubnetTopicFormat, previous.ForkDigest, 7) + suffix
+		prevBlock := fmt.Sprintf(p2p.BlockSubnetTopicFormat, previous.ForkDigest) + suffix
+		currDataCol := fmt.Sprintf(p2p.DataColumnSubnetTopicFormat, current.ForkDigest, 7) + suffix
+		for _, topic := range []string{prevDataCol, prevBlock, currDataCol} {
+			s.subHandler.addTopic(topic, nil)
+		}
 
-	require.NoError(t, s.ensureDeregistrationForEpoch(currentEpoch))
+		require.NoError(t, s.ensureDeregistrationForEpoch(currentEpoch))
 
-	require.DeepEqual(t, []string{prevDataCol}, fake.unsubscribed)
+		require.DeepEqual(t, []string{prevDataCol}, fake.unsubscribed)
 
-	// Both previous-digest topics are removed from the subHandler; the current-digest topic remains.
-	assert.Equal(t, false, s.subHandler.topicExists(prevDataCol))
-	assert.Equal(t, false, s.subHandler.topicExists(prevBlock))
-	assert.Equal(t, true, s.subHandler.topicExists(currDataCol))
+		// Both previous-digest topics are removed from the subHandler; the current-digest topic remains.
+		assert.Equal(t, false, s.subHandler.topicExists(prevDataCol))
+		assert.Equal(t, false, s.subHandler.topicExists(prevBlock))
+		assert.Equal(t, true, s.subHandler.topicExists(currDataCol))
+	})
 }

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -553,7 +553,7 @@ func TestBlocksFetcher_RequestBlocksRateLimitingLocks(t *testing.T) {
 	topic := p2p.RPCBlocksByRangeTopicV1
 	protocol := libp2pcore.ProtocolID(topic + p2.Encoding().ProtocolSuffix())
 	streamHandlerFn := func(stream network.Stream) {
-		assert.NoError(t, stream.Close())
+		assert.NoError(t, stream.CloseWrite())
 	}
 	p2.BHost.SetStreamHandler(protocol, streamHandlerFn)
 	p3.BHost.SetStreamHandler(protocol, streamHandlerFn)
@@ -620,7 +620,7 @@ func TestBlocksFetcher_WaitForBandwidth(t *testing.T) {
 	topic := p2p.RPCBlocksByRangeTopicV1
 	protocol := libp2pcore.ProtocolID(topic + p2.Encoding().ProtocolSuffix())
 	streamHandlerFn := func(stream network.Stream) {
-		assert.NoError(t, stream.Close())
+		assert.NoError(t, stream.CloseWrite())
 	}
 	p2.BHost.SetStreamHandler(protocol, streamHandlerFn)
 
@@ -670,7 +670,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 						require.NoError(t, err)
 						assert.NoError(t, beaconsync.WriteBlockChunk(stream, tor, p1.Encoding(), wsb))
 					}
-					assert.NoError(t, stream.Close())
+					assert.NoError(t, stream.CloseWrite())
 				}
 			},
 			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
@@ -694,7 +694,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 						require.NoError(t, err)
 						assert.NoError(t, beaconsync.WriteBlockChunk(stream, tor, p1.Encoding(), wsb))
 					}
-					assert.NoError(t, stream.Close())
+					assert.NoError(t, stream.CloseWrite())
 				}
 			},
 			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
@@ -723,7 +723,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					wsb, err = blocks.NewSignedBeaconBlock(blk)
 					require.NoError(t, err)
 					assert.NoError(t, beaconsync.WriteBlockChunk(stream, tor, p1.Encoding(), wsb))
-					assert.NoError(t, stream.Close())
+					assert.NoError(t, stream.CloseWrite())
 				}
 			},
 			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
@@ -753,7 +753,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					wsb, err = blocks.NewSignedBeaconBlock(blk)
 					require.NoError(t, err)
 					assert.NoError(t, beaconsync.WriteBlockChunk(stream, tor, p1.Encoding(), wsb))
-					assert.NoError(t, stream.Close())
+					assert.NoError(t, stream.CloseWrite())
 				}
 			},
 			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
@@ -771,7 +771,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 			handlerGenFn: func(req *ethpb.BeaconBlocksByRangeRequest) func(stream network.Stream) {
 				return func(stream network.Stream) {
 					defer func() {
-						assert.NoError(t, stream.Close())
+						assert.NoError(t, stream.CloseWrite())
 					}()
 					for i := req.StartSlot; i < req.StartSlot.Add(req.Count*req.Step); i += primitives.Slot(req.Step) {
 						blk := util.NewBeaconBlock()
@@ -806,7 +806,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 			handlerGenFn: func(req *ethpb.BeaconBlocksByRangeRequest) func(stream network.Stream) {
 				return func(stream network.Stream) {
 					defer func() {
-						assert.NoError(t, stream.Close())
+						assert.NoError(t, stream.CloseWrite())
 					}()
 					for i := req.StartSlot; i < req.StartSlot.Add(req.Count*req.Step); i += primitives.Slot(req.Step) {
 						blk := util.NewBeaconBlock()
@@ -852,7 +852,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					wsb, err = blocks.NewSignedBeaconBlock(blk)
 					require.NoError(t, err)
 					assert.NoError(t, beaconsync.WriteBlockChunk(stream, tor, p1.Encoding(), wsb))
-					assert.NoError(t, stream.Close())
+					assert.NoError(t, stream.CloseWrite())
 				}
 			},
 			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
@@ -880,7 +880,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					wsb, err = blocks.NewSignedBeaconBlock(blk)
 					require.NoError(t, err)
 					assert.NoError(t, beaconsync.WriteBlockChunk(stream, tor, p1.Encoding(), wsb))
-					assert.NoError(t, stream.Close())
+					assert.NoError(t, stream.CloseWrite())
 				}
 			},
 			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
@@ -946,7 +946,7 @@ func TestBlocksFetcher_requestBlocksDownscoreOnInvalidData(t *testing.T) {
 		wsb, err = blocks.NewSignedBeaconBlock(blk)
 		require.NoError(t, err)
 		assert.NoError(t, beaconsync.WriteBlockChunk(stream, tor, p1.Encoding(), wsb))
-		assert.NoError(t, stream.Close())
+		assert.NoError(t, stream.CloseWrite())
 	})
 
 	// Verify the peer has no bad responses before the request

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils_test.go
@@ -457,7 +457,7 @@ func TestTestForkStartSlot(t *testing.T) {
 func consumeBlockRootRequest(t *testing.T, p *p2pt.TestP2P) func(network.Stream) {
 	return func(stream network.Stream) {
 		defer func() {
-			_err := stream.Close()
+			_err := stream.CloseWrite()
 			_ = _err
 		}()
 

--- a/beacon-chain/sync/initial-sync/initial_sync_test.go
+++ b/beacon-chain/sync/initial-sync/initial_sync_test.go
@@ -174,7 +174,7 @@ func connectPeer(t *testing.T, host *p2pt.TestP2P, datum *peerData, peerStatus *
 	p := p2pt.NewTestP2P(t)
 	p.SetStreamHandler(topic, func(stream network.Stream) {
 		defer func() {
-			assert.NoError(t, stream.Close())
+			assert.NoError(t, stream.CloseWrite())
 		}()
 
 		req := &ethpb.BeaconBlocksByRangeRequest{}
@@ -282,7 +282,7 @@ func connectPeerHavingBlocks(
 
 	p.SetStreamHandler("/eth2/beacon_chain/req/beacon_blocks_by_range/1/ssz_snappy", func(stream network.Stream) {
 		defer func() {
-			_err := stream.Close()
+			_err := stream.CloseWrite()
 			_ = _err
 		}()
 
@@ -301,7 +301,7 @@ func connectPeerHavingBlocks(
 
 	p.SetStreamHandler("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy", func(stream network.Stream) {
 		defer func() {
-			_err := stream.Close()
+			_err := stream.CloseWrite()
 			_ = _err
 		}()
 

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -43,775 +43,791 @@ import (
 var verifierLimit = 1000
 
 func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
-	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+		p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
 
-	// Create and save block 'A' to DB
-	blockA := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, blockA)
-	rootA, err := blockA.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Create and save block 'A' to DB
+		blockA := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, blockA)
+		rootA, err := blockA.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Save state for block 'A'
-	stateA, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), stateA, rootA))
+		// Save state for block 'A'
+		stateA, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), stateA, rootA))
 
-	// Setup chain service with only block 'A' in forkchoice
-	chain := &mock.ChainService{
-		Genesis:             prysmTime.Now(),
-		FinalizedCheckPoint: &ethpb.Checkpoint{},
-		ForkchoiceRoots:     map[[32]byte]bool{rootA: true},
-	}
+		// Setup chain service with only block 'A' in forkchoice
+		chain := &mock.ChainService{
+			Genesis:             prysmTime.Now(),
+			FinalizedCheckPoint: &ethpb.Checkpoint{},
+			ForkchoiceRoots:     map[[32]byte]bool{rootA: true},
+		}
 
-	r := &Service{
-		cfg:                  &config{p2p: p1, beaconDB: db, chain: chain, clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot)},
-		blkRootToPendingAtts: make(map[[32]byte][]any),
-		seenPendingBlocks:    make(map[[32]byte]bool),
-		chainStarted:         &atomic.Bool{},
-	}
+		r := &Service{
+			cfg:                  &config{p2p: p1, beaconDB: db, chain: chain, clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot)},
+			blkRootToPendingAtts: make(map[[32]byte][]any),
+			seenPendingBlocks:    make(map[[32]byte]bool),
+			chainStarted:         &atomic.Bool{},
+		}
 
-	// Add pending attestations for OTHER block roots (not block A)
-	// These are blocks we don't have yet, so they should be requested
-	attB := &ethpb.Attestation{Data: &ethpb.AttestationData{
-		BeaconBlockRoot: bytesutil.PadTo([]byte{'B'}, 32),
-		Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
-	}}
-	attC := &ethpb.Attestation{Data: &ethpb.AttestationData{
-		BeaconBlockRoot: bytesutil.PadTo([]byte{'C'}, 32),
-		Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
-	}}
-	r.blkRootToPendingAtts[[32]byte{'B'}] = []any{attB}
-	r.blkRootToPendingAtts[[32]byte{'C'}] = []any{attC}
+		// Add pending attestations for OTHER block roots (not block A)
+		// These are blocks we don't have yet, so they should be requested
+		attB := &ethpb.Attestation{Data: &ethpb.AttestationData{
+			BeaconBlockRoot: bytesutil.PadTo([]byte{'B'}, 32),
+			Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+		}}
+		attC := &ethpb.Attestation{Data: &ethpb.AttestationData{
+			BeaconBlockRoot: bytesutil.PadTo([]byte{'C'}, 32),
+			Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+		}}
+		r.blkRootToPendingAtts[[32]byte{'B'}] = []any{attB}
+		r.blkRootToPendingAtts[[32]byte{'C'}] = []any{attC}
 
-	// Process block A (which exists and has no pending attestations)
-	// This should skip processing attestations for A and request blocks B and C
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), rootA))
-	require.LogsContain(t, hook, "Requesting blocks by root")
+		// Process block A (which exists and has no pending attestations)
+		// This should skip processing attestations for A and request blocks B and C
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), rootA))
+		require.LogsContain(t, hook, "Requesting blocks by root")
+	})
 }
 
 func TestProcessPendingAtts_HasBlockSaveUnaggregatedAtt(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(8)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
-
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	for _, i := range attestingIndices {
-		att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
-	}
-
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	chain := &mock.ChainService{Genesis: time.Now(),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  att.Data.BeaconBlockRoot,
-			Epoch: 0,
-		},
-	}
-
-	done := make(chan *feed.Event, 1)
-	defer close(done)
-	opn := mock.NewEventFeedWrapper()
-	sub := opn.Subscribe(done)
-	defer sub.Unsubscribe()
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p1,
-			beaconDB:            db,
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: &mock.SimpleNotifier{Feed: opn},
-		},
-		blkRootToPendingAtts:             make(map[[32]byte][]any),
-		seenUnAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	r.blkRootToPendingAtts[root] = []any{att}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
-
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case received := <-done:
-				// make sure a single att was sent
-				require.Equal(t, operation.UnaggregatedAttReceived, int(received.Type))
-				return
-			case <-ctx.Done():
-				return
-			}
+		aggBits := bitfield.NewBitlist(8)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
 		}
+
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		for _, i := range attestingIndices {
+			att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
+		}
+
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+
+		chain := &mock.ChainService{Genesis: time.Now(),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  att.Data.BeaconBlockRoot,
+				Epoch: 0,
+			},
+		}
+
+		done := make(chan *feed.Event, 1)
+		defer close(done)
+		opn := mock.NewEventFeedWrapper()
+		sub := opn.Subscribe(done)
+		defer sub.Unsubscribe()
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p1,
+				beaconDB:            db,
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: &mock.SimpleNotifier{Feed: opn},
+			},
+			blkRootToPendingAtts:             make(map[[32]byte][]any),
+			seenUnAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		r.blkRootToPendingAtts[root] = []any{att}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case received := <-done:
+					// make sure a single att was sent
+					require.Equal(t, operation.UnaggregatedAttReceived, int(received.Type))
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		assert.Equal(t, 1, len(atts), "Did not save unaggregated att")
+		assert.DeepEqual(t, att, atts[0], "Incorrect saved att")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		wg.Wait()
+		cancel()
 	})
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	assert.Equal(t, 1, len(atts), "Did not save unaggregated att")
-	assert.DeepEqual(t, att, atts[0], "Incorrect saved att")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	wg.Wait()
-	cancel()
 }
 
 func TestProcessPendingAtts_HasBlockSaveUnaggregatedAttElectra(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
 
-	sb := util.NewBeaconBlockElectra()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlockElectra()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	att := &ethpb.SingleAttestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-	}
-
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	att.AttesterIndex = committee[0]
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	att.Signature = privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal()
-
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	chain := &mock.ChainService{Genesis: time.Now(),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  att.Data.BeaconBlockRoot,
-			Epoch: 0,
-		},
-	}
-	done := make(chan *feed.Event, 1)
-	defer close(done)
-	opn := mock.NewEventFeedWrapper()
-	sub := opn.Subscribe(done)
-	defer sub.Unsubscribe()
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p1,
-			beaconDB:            db,
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: &mock.SimpleNotifier{Feed: opn},
-		},
-		blkRootToPendingAtts:             make(map[[32]byte][]any),
-		seenUnAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-
-	s, err := util.NewBeaconStateElectra()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	r.blkRootToPendingAtts[root] = []any{att}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case received := <-done:
-				// make sure a single att was sent
-				require.Equal(t, operation.SingleAttReceived, int(received.Type))
-				return
-			case <-ctx.Done():
-				return
-			}
+		att := &ethpb.SingleAttestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
 		}
+
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		att.AttesterIndex = committee[0]
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		att.Signature = privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal()
+
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+
+		chain := &mock.ChainService{Genesis: time.Now(),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  att.Data.BeaconBlockRoot,
+				Epoch: 0,
+			},
+		}
+		done := make(chan *feed.Event, 1)
+		defer close(done)
+		opn := mock.NewEventFeedWrapper()
+		sub := opn.Subscribe(done)
+		defer sub.Unsubscribe()
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p1,
+				beaconDB:            db,
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: &mock.SimpleNotifier{Feed: opn},
+			},
+			blkRootToPendingAtts:             make(map[[32]byte][]any),
+			seenUnAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+
+		s, err := util.NewBeaconStateElectra()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		r.blkRootToPendingAtts[root] = []any{att}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case received := <-done:
+					// make sure a single att was sent
+					require.Equal(t, operation.SingleAttReceived, int(received.Type))
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		require.Equal(t, 1, len(atts), "Did not save unaggregated att")
+		assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		wg.Wait()
+		cancel()
 	})
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	require.Equal(t, 1, len(atts), "Did not save unaggregated att")
-	assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	wg.Wait()
-	cancel()
 }
 
 func TestProcessPendingAtts_HasBlockSaveUnAggregatedAttElectra_VerifyAlreadySeen(t *testing.T) {
-	// Setup configuration and fork version schedule.
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		// Setup configuration and fork version schedule.
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
 
-	// Initialize logging, database, and P2P components.
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
-	currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
-	genesisOffset := time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
-	clock := startup.NewClock(time.Now().Add(-1*genesisOffset), params.BeaconConfig().GenesisValidatorsRoot)
+		// Initialize logging, database, and P2P components.
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
+		currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
+		genesisOffset := time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+		clock := startup.NewClock(time.Now().Add(-1*genesisOffset), params.BeaconConfig().GenesisValidatorsRoot)
 
-	// Create genesis state and associated keys.
-	beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
-	require.NoError(t, beaconState.SetSlot(clock.CurrentSlot()))
+		// Create genesis state and associated keys.
+		beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
+		require.NoError(t, beaconState.SetSlot(clock.CurrentSlot()))
 
-	sb := util.NewBeaconBlockElectra()
-	sb.Block.Slot = clock.CurrentSlot()
-	util.SaveBlock(t, t.Context(), db, sb)
+		sb := util.NewBeaconBlockElectra()
+		sb.Block.Slot = clock.CurrentSlot()
+		util.SaveBlock(t, t.Context(), db, sb)
 
-	// Save state with block root.
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Save state with block root.
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Build a new attestation and its aggregate proof.
-	att := &ethpb.SingleAttestation{
-		CommitteeId: 8, // choose a non 0
-		Data: &ethpb.AttestationData{
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch() - 1, Root: make([]byte, fieldparams.RootLength)},
-			Target:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch(), Root: root[:]},
-			CommitteeIndex:  0,
-		},
-	}
-
-	// Retrieve the beacon committee and set the attester index.
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.CommitteeId)
-	assert.NoError(t, err)
-	att.AttesterIndex = committee[0]
-
-	// Compute attester domain and signature.
-	attesterDomain, err := signing.Domain(beaconState.Fork(), clock.CurrentEpoch(), params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	att.SetSignature(privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal())
-
-	// Set the genesis time.
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	// Setup the chain service mock.
-	chain := &mock.ChainService{
-		Genesis: time.Now(),
-		State:   beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  att.Data.BeaconBlockRoot,
-			Epoch: clock.CurrentEpoch() - 2,
-		},
-	}
-
-	// Setup event feed and subscription.
-	done := make(chan *feed.Event, 1)
-	defer close(done)
-	opn := mock.NewEventFeedWrapper()
-	sub := opn.Subscribe(done)
-	defer sub.Unsubscribe()
-
-	// Create context and service configuration.
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			initialSync:         &mockSync.Sync{IsSyncing: false},
-			p2p:                 p1,
-			beaconDB:            db,
-			chain:               chain,
-			clock:               clock,
-			attPool:             attestations.NewPool(),
-			attestationNotifier: &mock.SimpleNotifier{Feed: opn},
-		},
-		blkRootToPendingAtts:             make(map[[32]byte][]any),
-		seenUnAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-
-	// Save a new beacon state and link it with the block root.
-	slotOpt := func(s *ethpb.BeaconStateElectra) error { s.Slot = clock.CurrentSlot(); return nil }
-	s, err := util.NewBeaconStateElectra(slotOpt)
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	// Add the pending attestation.
-	r.blkRootToPendingAtts[root] = []any{
-		att,
-	}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
-
-	// Verify that the event feed receives the expected attestation.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case received := <-done:
-				// Ensure a single attestation event was sent.
-				require.Equal(t, operation.SingleAttReceived, int(received.Type))
-				return
-			case <-ctx.Done():
-				return
-			}
+		// Build a new attestation and its aggregate proof.
+		att := &ethpb.SingleAttestation{
+			CommitteeId: 8, // choose a non 0
+			Data: &ethpb.AttestationData{
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch() - 1, Root: make([]byte, fieldparams.RootLength)},
+				Target:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch(), Root: root[:]},
+				CommitteeIndex:  0,
+			},
 		}
+
+		// Retrieve the beacon committee and set the attester index.
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.CommitteeId)
+		assert.NoError(t, err)
+		att.AttesterIndex = committee[0]
+
+		// Compute attester domain and signature.
+		attesterDomain, err := signing.Domain(beaconState.Fork(), clock.CurrentEpoch(), params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		att.SetSignature(privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal())
+
+		// Set the genesis time.
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+
+		// Setup the chain service mock.
+		chain := &mock.ChainService{
+			Genesis: time.Now(),
+			State:   beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  att.Data.BeaconBlockRoot,
+				Epoch: clock.CurrentEpoch() - 2,
+			},
+		}
+
+		// Setup event feed and subscription.
+		done := make(chan *feed.Event, 1)
+		defer close(done)
+		opn := mock.NewEventFeedWrapper()
+		sub := opn.Subscribe(done)
+		defer sub.Unsubscribe()
+
+		// Create context and service configuration.
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				initialSync:         &mockSync.Sync{IsSyncing: false},
+				p2p:                 p1,
+				beaconDB:            db,
+				chain:               chain,
+				clock:               clock,
+				attPool:             attestations.NewPool(),
+				attestationNotifier: &mock.SimpleNotifier{Feed: opn},
+			},
+			blkRootToPendingAtts:             make(map[[32]byte][]any),
+			seenUnAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+
+		// Save a new beacon state and link it with the block root.
+		slotOpt := func(s *ethpb.BeaconStateElectra) error { s.Slot = clock.CurrentSlot(); return nil }
+		s, err := util.NewBeaconStateElectra(slotOpt)
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		// Add the pending attestation.
+		r.blkRootToPendingAtts[root] = []any{
+			att,
+		}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+
+		// Verify that the event feed receives the expected attestation.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case received := <-done:
+					// Ensure a single attestation event was sent.
+					require.Equal(t, operation.SingleAttReceived, int(received.Type))
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+
+		// Verify unaggregated attestations are saved correctly.
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		require.Equal(t, 1, len(atts), "Did not save unaggregated att")
+		assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+
+		// Encode the attestation for pubsub and decode the message.
+		buf := new(bytes.Buffer)
+		_, err = p1.Encoding().EncodeGossip(buf, att)
+		require.NoError(t, err)
+		digest := r.currentForkDigest()
+		topic := fmt.Sprintf("/eth2/%x/beacon_attestation_1", digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		_, err = r.decodePubsubMessage(m)
+		require.NoError(t, err)
+
+		// Validate the pubsub message and ignore it as it should already been seen.
+		res, err := r.validateCommitteeIndexBeaconAttestation(ctx, "", m)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+
+		// Wait for the event to complete.
+		wg.Wait()
+		cancel()
 	})
-
-	// Verify unaggregated attestations are saved correctly.
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	require.Equal(t, 1, len(atts), "Did not save unaggregated att")
-	assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-
-	// Encode the attestation for pubsub and decode the message.
-	buf := new(bytes.Buffer)
-	_, err = p1.Encoding().EncodeGossip(buf, att)
-	require.NoError(t, err)
-	digest := r.currentForkDigest()
-	topic := fmt.Sprintf("/eth2/%x/beacon_attestation_1", digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	_, err = r.decodePubsubMessage(m)
-	require.NoError(t, err)
-
-	// Validate the pubsub message and ignore it as it should already been seen.
-	res, err := r.validateCommitteeIndexBeaconAttestation(ctx, "", m)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-
-	// Wait for the event to complete.
-	wg.Wait()
-	cancel()
 }
 
 func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
 
-	db := dbtest.SetupDB(t)
-	p2p := p2ptest.NewTestP2P(t)
-	st, privKeys := util.DeterministicGenesisState(t, 256)
-	require.NoError(t, st.SetGenesisTime(time.Now()))
-	b := util.NewBeaconBlock()
-	r32, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	util.SaveBlock(t, t.Context(), db, b)
-	require.NoError(t, db.SaveState(t.Context(), st, r32))
+		db := dbtest.SetupDB(t)
+		p2p := p2ptest.NewTestP2P(t)
+		st, privKeys := util.DeterministicGenesisState(t, 256)
+		require.NoError(t, st.SetGenesisTime(time.Now()))
+		b := util.NewBeaconBlock()
+		r32, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		util.SaveBlock(t, t.Context(), db, b)
+		require.NoError(t, db.SaveState(t.Context(), st, r32))
 
-	chain := &mock.ChainService{
-		State:   st,
-		Genesis: prysmTime.Now(),
-		DB:      db,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  r32[:],
-			Epoch: 0,
-		},
-	}
+		chain := &mock.ChainService{
+			State:   st,
+			Genesis: prysmTime.Now(),
+			DB:      db,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  r32[:],
+				Epoch: 0,
+			},
+		}
 
-	s := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p2p,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	go s.verifierRoutine()
+		s := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p2p,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		go s.verifierRoutine()
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), st, 0, 0)
-	assert.NoError(t, err)
-	// Arbitrary aggregator index for testing purposes.
-	aggregatorIndex := committee[0]
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), st, 0, 0)
+		assert.NoError(t, err)
+		// Arbitrary aggregator index for testing purposes.
+		aggregatorIndex := committee[0]
 
-	priv, err := bls.RandKey()
-	require.NoError(t, err)
-	aggBits := bitfield.NewBitlist(8)
-	aggBits.SetBitAt(1, true)
+		priv, err := bls.RandKey()
+		require.NoError(t, err)
+		aggBits := bitfield.NewBitlist(8)
+		aggBits.SetBitAt(1, true)
 
-	a := &ethpb.AggregateAttestationAndProof{
-		Aggregate: &ethpb.Attestation{
-			Signature:       priv.Sign([]byte("foo")).Marshal(),
+		a := &ethpb.AggregateAttestationAndProof{
+			Aggregate: &ethpb.Attestation{
+				Signature:       priv.Sign([]byte("foo")).Marshal(),
+				AggregationBits: aggBits,
+				Data:            util.HydrateAttestationData(&ethpb.AttestationData{}),
+			},
+			AggregatorIndex: aggregatorIndex,
+			SelectionProof:  make([]byte, fieldparams.BLSSignatureLength),
+		}
+
+		s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: a, Signature: make([]byte, fieldparams.BLSSignatureLength)}}
+		require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
+
+		assert.Equal(t, false, p2p.BroadcastCalled.Load(), "Broadcasted bad aggregate")
+
+		// Clear pool.
+		err = s.cfg.attPool.DeleteUnaggregatedAttestation(a.Aggregate)
+		require.NoError(t, err)
+
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: r32[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: r32[:]},
+			},
 			AggregationBits: aggBits,
-			Data:            util.HydrateAttestationData(&ethpb.AttestationData{}),
-		},
-		AggregatorIndex: aggregatorIndex,
-		SelectionProof:  make([]byte, fieldparams.BLSSignatureLength),
-	}
+		}
 
-	s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: a, Signature: make([]byte, fieldparams.BLSSignatureLength)}}
-	require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(st.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		for _, i := range attestingIndices {
+			att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
+		}
 
-	assert.Equal(t, false, p2p.BroadcastCalled.Load(), "Broadcasted bad aggregate")
+		sszSlot := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(st, 0, &sszSlot, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: aggregatorIndex,
+		}
+		aggreSig, err := signing.ComputeDomainAndSign(st, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
 
-	// Clear pool.
-	err = s.cfg.attPool.DeleteUnaggregatedAttestation(a.Aggregate)
-	require.NoError(t, err)
+		s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
+		require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
 
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: r32[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: r32[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		assert.Equal(t, true, p2p.BroadcastCalled.Load(), "The good aggregate was not broadcasted")
 
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(st.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	for _, i := range attestingIndices {
-		att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
-	}
-
-	sszSlot := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(st, 0, &sszSlot, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: aggregatorIndex,
-	}
-	aggreSig, err := signing.ComputeDomainAndSign(st, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-
-	s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
-
-	assert.Equal(t, true, p2p.BroadcastCalled.Load(), "The good aggregate was not broadcasted")
-
-	cancel()
+		cancel()
+	})
 }
 
 func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
 
-	// Arbitrary aggregator index for testing purposes.
-	aggregatorIndex := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: aggregatorIndex,
-	}
-	aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
+		// Arbitrary aggregator index for testing purposes.
+		aggregatorIndex := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: aggregatorIndex,
+		}
+		aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	chain := &mock.ChainService{Genesis: time.Now(),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-			Epoch: 0,
-		}}
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		chain := &mock.ChainService{Genesis: time.Now(),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+				Epoch: 0,
+			}}
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+		r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
-	assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
-	assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	assert.Equal(t, 0, len(atts), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	cancel()
+		assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
+		assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		assert.Equal(t, 0, len(atts), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		cancel()
+	})
 }
 
 func TestProcessPendingAtts_HasBlockSaveAggregatedAttElectra(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	committeeBits := primitives.NewAttestationCommitteeBits()
-	committeeBits.SetBitAt(0, true)
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.AttestationElectra{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		CommitteeBits:   committeeBits,
-		AggregationBits: aggBits,
-	}
+		committeeBits := primitives.NewAttestationCommitteeBits()
+		committeeBits.SetBitAt(0, true)
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.AttestationElectra{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			CommitteeBits:   committeeBits,
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.GetCommitteeIndex())
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.GetCommitteeIndex())
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
 
-	// Arbitrary aggregator index for testing purposes.
-	aggregatorIndex := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProofElectra{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: aggregatorIndex,
-	}
-	aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
+		// Arbitrary aggregator index for testing purposes.
+		aggregatorIndex := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProofElectra{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: aggregatorIndex,
+		}
+		aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	chain := &mock.ChainService{Genesis: time.Now(),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-			Epoch: 0,
-		}}
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		chain := &mock.ChainService{Genesis: time.Now(),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+				Epoch: 0,
+			}}
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProofElectra{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+		r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProofElectra{Message: aggregateAndProof, Signature: aggreSig}}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
-	assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
-	assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	assert.Equal(t, 0, len(atts), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	cancel()
+		assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
+		assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		assert.Equal(t, 0, len(atts), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		cancel()
+	})
 }
 
 func TestProcessPendingAtts_BlockNotInForkChoice(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(8)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(8)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	for _, i := range attestingIndices {
-		att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
-	}
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		for _, i := range attestingIndices {
+			att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
+		}
 
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		Aggregate: att,
-	}
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			Aggregate: att,
+		}
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	// Mock chain service that returns false for InForkchoice
-	chain := &mock.ChainService{Genesis: time.Now(),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-			Epoch: 0,
-		},
-		// Set NotFinalized to true so InForkchoice returns false
-		NotFinalized: true,
-	}
+		// Mock chain service that returns false for InForkchoice
+		chain := &mock.ChainService{Genesis: time.Now(),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+				Epoch: 0,
+			},
+			// Set NotFinalized to true so InForkchoice returns false
+			NotFinalized: true,
+		}
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts: make(map[[32]byte][]any),
-	}
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts: make(map[[32]byte][]any),
+		}
 
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	// Add pending attestation
-	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}}
+		// Add pending attestation
+		r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}}
 
-	// Process pending attestations - should return error because block is not in fork choice
-	require.ErrorContains(t, "could not process unknown block root", r.processPendingAttsForBlock(t.Context(), root))
+		// Process pending attestations - should return error because block is not in fork choice
+		require.ErrorContains(t, "could not process unknown block root", r.processPendingAttsForBlock(t.Context(), root))
 
-	// Verify attestations were not processed (should still be pending)
-	assert.Equal(t, 1, len(r.blkRootToPendingAtts[root]), "Attestations should still be pending")
-	assert.Equal(t, 0, len(r.cfg.attPool.UnaggregatedAttestations()), "Should not save attestation when block not in fork choice")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Should not save attestation when block not in fork choice")
-	require.LogsDoNotContain(t, hook, "Verified and saved pending attestations to pool")
+		// Verify attestations were not processed (should still be pending)
+		assert.Equal(t, 1, len(r.blkRootToPendingAtts[root]), "Attestations should still be pending")
+		assert.Equal(t, 0, len(r.cfg.attPool.UnaggregatedAttestations()), "Should not save attestation when block not in fork choice")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Should not save attestation when block not in fork choice")
+		require.LogsDoNotContain(t, hook, "Verified and saved pending attestations to pool")
+	})
 }
 
 func TestValidatePendingAtts_CanPruneOldAtts(t *testing.T) {

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -43,776 +43,792 @@ import (
 var verifierLimit = 1000
 
 func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
-	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+		p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
 
-	// Create and save block 'A' to DB
-	blockA := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, blockA)
-	rootA, err := blockA.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Create and save block 'A' to DB
+		blockA := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, blockA)
+		rootA, err := blockA.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Save state for block 'A'
-	stateA, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), stateA, rootA))
+		// Save state for block 'A'
+		stateA, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), stateA, rootA))
 
-	// Setup chain service with only block 'A' in forkchoice
-	chain := &mock.ChainService{
-		Genesis:             prysmTime.Now(),
-		FinalizedCheckPoint: &ethpb.Checkpoint{},
-		ForkchoiceRoots:     map[[32]byte]bool{rootA: true},
-	}
+		// Setup chain service with only block 'A' in forkchoice
+		chain := &mock.ChainService{
+			Genesis:             prysmTime.Now(),
+			FinalizedCheckPoint: &ethpb.Checkpoint{},
+			ForkchoiceRoots:     map[[32]byte]bool{rootA: true},
+		}
 
-	r := &Service{
-		cfg:                  &config{p2p: p1, beaconDB: db, chain: chain, clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot)},
-		blkRootToPendingAtts: make(map[[32]byte][]any),
-		seenPendingBlocks:    make(map[[32]byte]bool),
-		chainStarted:         &atomic.Bool{},
-	}
+		r := &Service{
+			cfg:                  &config{p2p: p1, beaconDB: db, chain: chain, clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot)},
+			blkRootToPendingAtts: make(map[[32]byte][]any),
+			seenPendingBlocks:    make(map[[32]byte]bool),
+			chainStarted:         &atomic.Bool{},
+		}
 
-	// Add pending attestations for OTHER block roots (not block A)
-	// These are blocks we don't have yet, so they should be requested
-	attB := &ethpb.Attestation{Data: &ethpb.AttestationData{
-		BeaconBlockRoot: bytesutil.PadTo([]byte{'B'}, 32),
-		Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
-	}}
-	attC := &ethpb.Attestation{Data: &ethpb.AttestationData{
-		BeaconBlockRoot: bytesutil.PadTo([]byte{'C'}, 32),
-		Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
-	}}
-	r.blkRootToPendingAtts[[32]byte{'B'}] = []any{attB}
-	r.blkRootToPendingAtts[[32]byte{'C'}] = []any{attC}
+		// Add pending attestations for OTHER block roots (not block A)
+		// These are blocks we don't have yet, so they should be requested
+		attB := &ethpb.Attestation{Data: &ethpb.AttestationData{
+			BeaconBlockRoot: bytesutil.PadTo([]byte{'B'}, 32),
+			Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+		}}
+		attC := &ethpb.Attestation{Data: &ethpb.AttestationData{
+			BeaconBlockRoot: bytesutil.PadTo([]byte{'C'}, 32),
+			Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+		}}
+		r.blkRootToPendingAtts[[32]byte{'B'}] = []any{attB}
+		r.blkRootToPendingAtts[[32]byte{'C'}] = []any{attC}
 
-	// Process block A (which exists and has no pending attestations)
-	// This should skip processing attestations for A and request blocks B and C
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), rootA))
-	require.LogsContain(t, hook, "Requesting blocks by root")
+		// Process block A (which exists and has no pending attestations)
+		// This should skip processing attestations for A and request blocks B and C
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), rootA))
+		require.LogsContain(t, hook, "Requesting blocks by root")
+	})
 }
 
 func TestProcessPendingAtts_HasBlockSaveUnaggregatedAtt(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(8)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
-
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	for _, i := range attestingIndices {
-		att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
-	}
-
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	chain := &mock.ChainService{Genesis: time.Now(),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  att.Data.BeaconBlockRoot,
-			Epoch: 0,
-		},
-	}
-
-	done := make(chan *feed.Event, 1)
-	defer close(done)
-	opn := mock.NewEventFeedWrapper()
-	sub := opn.Subscribe(done)
-	defer sub.Unsubscribe()
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p1,
-			beaconDB:            db,
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: &mock.SimpleNotifier{Feed: opn},
-		},
-		blkRootToPendingAtts:             make(map[[32]byte][]any),
-		seenUnAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	r.blkRootToPendingAtts[root] = []any{att}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
-
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case received := <-done:
-				// make sure a single att was sent
-				require.Equal(t, operation.UnaggregatedAttReceived, int(received.Type))
-				return
-			case <-ctx.Done():
-				return
-			}
+		aggBits := bitfield.NewBitlist(8)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
 		}
+
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		for _, i := range attestingIndices {
+			att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
+		}
+
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+
+		chain := &mock.ChainService{Genesis: time.Now(),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  att.Data.BeaconBlockRoot,
+				Epoch: 0,
+			},
+		}
+
+		done := make(chan *feed.Event, 1)
+		defer close(done)
+		opn := mock.NewEventFeedWrapper()
+		sub := opn.Subscribe(done)
+		defer sub.Unsubscribe()
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p1,
+				beaconDB:            db,
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: &mock.SimpleNotifier{Feed: opn},
+			},
+			blkRootToPendingAtts:             make(map[[32]byte][]any),
+			seenUnAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		r.blkRootToPendingAtts[root] = []any{att}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case received := <-done:
+					// make sure a single att was sent
+					require.Equal(t, operation.UnaggregatedAttReceived, int(received.Type))
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		assert.Equal(t, 1, len(atts), "Did not save unaggregated att")
+		assert.DeepEqual(t, att, atts[0], "Incorrect saved att")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		wg.Wait()
+		cancel()
 	})
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	assert.Equal(t, 1, len(atts), "Did not save unaggregated att")
-	assert.DeepEqual(t, att, atts[0], "Incorrect saved att")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	wg.Wait()
-	cancel()
 }
 
 func TestProcessPendingAtts_HasBlockSaveUnaggregatedAttElectra(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
 
-	sb := util.NewBeaconBlockElectra()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlockElectra()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	att := &ethpb.SingleAttestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-	}
-
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	att.AttesterIndex = committee[0]
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	att.Signature = privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal()
-
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	chain := &mock.ChainService{Genesis: time.Now(),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  att.Data.BeaconBlockRoot,
-			Epoch: 0,
-		},
-	}
-	done := make(chan *feed.Event, 1)
-	defer close(done)
-	opn := mock.NewEventFeedWrapper()
-	sub := opn.Subscribe(done)
-	defer sub.Unsubscribe()
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p1,
-			beaconDB:            db,
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: &mock.SimpleNotifier{Feed: opn},
-		},
-		blkRootToPendingAtts:             make(map[[32]byte][]any),
-		seenUnAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-
-	s, err := util.NewBeaconStateElectra()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	r.blkRootToPendingAtts[root] = []any{att}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case received := <-done:
-				// make sure a single att was sent
-				require.Equal(t, operation.SingleAttReceived, int(received.Type))
-				return
-			case <-ctx.Done():
-				return
-			}
+		att := &ethpb.SingleAttestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
 		}
+
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		att.AttesterIndex = committee[0]
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		att.Signature = privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal()
+
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+
+		chain := &mock.ChainService{Genesis: time.Now(),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  att.Data.BeaconBlockRoot,
+				Epoch: 0,
+			},
+		}
+		done := make(chan *feed.Event, 1)
+		defer close(done)
+		opn := mock.NewEventFeedWrapper()
+		sub := opn.Subscribe(done)
+		defer sub.Unsubscribe()
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p1,
+				beaconDB:            db,
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: &mock.SimpleNotifier{Feed: opn},
+			},
+			blkRootToPendingAtts:             make(map[[32]byte][]any),
+			seenUnAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+
+		s, err := util.NewBeaconStateElectra()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		r.blkRootToPendingAtts[root] = []any{att}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case received := <-done:
+					// make sure a single att was sent
+					require.Equal(t, operation.SingleAttReceived, int(received.Type))
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		require.Equal(t, 1, len(atts), "Did not save unaggregated att")
+		assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		wg.Wait()
+		cancel()
 	})
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	require.Equal(t, 1, len(atts), "Did not save unaggregated att")
-	assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	wg.Wait()
-	cancel()
 }
 
 func TestProcessPendingAtts_HasBlockSaveUnAggregatedAttElectra_VerifyAlreadySeen(t *testing.T) {
-	// Setup configuration and fork version schedule.
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		// Setup configuration and fork version schedule.
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
 
-	// Initialize logging, database, and P2P components.
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
-	currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
-	genesisOffset := time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
-	clock := startup.NewClock(time.Now().Add(-1*genesisOffset), params.BeaconConfig().GenesisValidatorsRoot)
+		// Initialize logging, database, and P2P components.
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
+		currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
+		genesisOffset := time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+		clock := startup.NewClock(time.Now().Add(-1*genesisOffset), params.BeaconConfig().GenesisValidatorsRoot)
 
-	// Create genesis state and associated keys.
-	beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
-	require.NoError(t, beaconState.SetSlot(clock.CurrentSlot()))
+		// Create genesis state and associated keys.
+		beaconState, privKeys := util.DeterministicGenesisStateElectra(t, validators)
+		require.NoError(t, beaconState.SetSlot(clock.CurrentSlot()))
 
-	sb := util.NewBeaconBlockElectra()
-	sb.Block.Slot = clock.CurrentSlot()
-	util.SaveBlock(t, t.Context(), db, sb)
+		sb := util.NewBeaconBlockElectra()
+		sb.Block.Slot = clock.CurrentSlot()
+		util.SaveBlock(t, t.Context(), db, sb)
 
-	// Save state with block root.
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Save state with block root.
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Build a new attestation and its aggregate proof.
-	att := &ethpb.SingleAttestation{
-		CommitteeId: 8, // choose a non 0
-		Data: &ethpb.AttestationData{
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch() - 1, Root: make([]byte, fieldparams.RootLength)},
-			Target:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch(), Root: root[:]},
-			CommitteeIndex:  0,
-		},
-	}
-
-	// Retrieve the beacon committee and set the attester index.
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.CommitteeId)
-	assert.NoError(t, err)
-	att.AttesterIndex = committee[0]
-
-	// Compute attester domain and signature.
-	attesterDomain, err := signing.Domain(beaconState.Fork(), clock.CurrentEpoch(), params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	att.SetSignature(privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal())
-
-	// Set the genesis time.
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	// Setup the chain service mock.
-	chain := &mock.ChainService{
-		Genesis: time.Now(),
-		State:   beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  att.Data.BeaconBlockRoot,
-			Epoch: clock.CurrentEpoch() - 2,
-		},
-	}
-
-	// Setup event feed and subscription.
-	done := make(chan *feed.Event, 1)
-	defer close(done)
-	opn := mock.NewEventFeedWrapper()
-	sub := opn.Subscribe(done)
-	defer sub.Unsubscribe()
-
-	// Create context and service configuration.
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			initialSync:         &mockSync.Sync{IsSyncing: false},
-			p2p:                 p1,
-			beaconDB:            db,
-			chain:               chain,
-			clock:               clock,
-			attPool:             attestations.NewPool(),
-			attestationNotifier: &mock.SimpleNotifier{Feed: opn},
-		},
-		blkRootToPendingAtts:             make(map[[32]byte][]any),
-		seenUnAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-
-	// Save a new beacon state and link it with the block root.
-	slotOpt := func(s *ethpb.BeaconStateElectra) error { s.Slot = clock.CurrentSlot(); return nil }
-	s, err := util.NewBeaconStateElectra(slotOpt)
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
-
-	// Add the pending attestation.
-	r.blkRootToPendingAtts[root] = []any{
-		att,
-	}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
-
-	// Verify that the event feed receives the expected attestation.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case received := <-done:
-				// Ensure a single attestation event was sent.
-				require.Equal(t, operation.SingleAttReceived, int(received.Type))
-				return
-			case <-ctx.Done():
-				return
-			}
+		// Build a new attestation and its aggregate proof.
+		att := &ethpb.SingleAttestation{
+			CommitteeId: 8, // choose a non 0
+			Data: &ethpb.AttestationData{
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch() - 1, Root: make([]byte, fieldparams.RootLength)},
+				Target:          &ethpb.Checkpoint{Epoch: clock.CurrentEpoch(), Root: root[:]},
+				CommitteeIndex:  0,
+			},
 		}
+
+		// Retrieve the beacon committee and set the attester index.
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.CommitteeId)
+		assert.NoError(t, err)
+		att.AttesterIndex = committee[0]
+
+		// Compute attester domain and signature.
+		attesterDomain, err := signing.Domain(beaconState.Fork(), clock.CurrentEpoch(), params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		att.SetSignature(privKeys[committee[0]].Sign(hashTreeRoot[:]).Marshal())
+
+		// Set the genesis time.
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+
+		// Setup the chain service mock.
+		chain := &mock.ChainService{
+			Genesis: time.Now(),
+			State:   beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  att.Data.BeaconBlockRoot,
+				Epoch: clock.CurrentEpoch() - 2,
+			},
+		}
+
+		// Setup event feed and subscription.
+		done := make(chan *feed.Event, 1)
+		defer close(done)
+		opn := mock.NewEventFeedWrapper()
+		sub := opn.Subscribe(done)
+		defer sub.Unsubscribe()
+
+		// Create context and service configuration.
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				initialSync:         &mockSync.Sync{IsSyncing: false},
+				p2p:                 p1,
+				beaconDB:            db,
+				chain:               chain,
+				clock:               clock,
+				attPool:             attestations.NewPool(),
+				attestationNotifier: &mock.SimpleNotifier{Feed: opn},
+			},
+			blkRootToPendingAtts:             make(map[[32]byte][]any),
+			seenUnAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+
+		// Save a new beacon state and link it with the block root.
+		slotOpt := func(s *ethpb.BeaconStateElectra) error { s.Slot = clock.CurrentSlot(); return nil }
+		s, err := util.NewBeaconStateElectra(slotOpt)
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+
+		// Add the pending attestation.
+		r.blkRootToPendingAtts[root] = []any{
+			att,
+		}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+
+		// Verify that the event feed receives the expected attestation.
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case received := <-done:
+					// Ensure a single attestation event was sent.
+					require.Equal(t, operation.SingleAttReceived, int(received.Type))
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+
+		// Verify unaggregated attestations are saved correctly.
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		require.Equal(t, 1, len(atts), "Did not save unaggregated att")
+		assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+
+		// Encode the attestation for pubsub and decode the message.
+		buf := new(bytes.Buffer)
+		_, err = p1.Encoding().EncodeGossip(buf, att)
+		require.NoError(t, err)
+		digest, err := r.currentForkDigest()
+		require.NoError(t, err)
+		topic := fmt.Sprintf("/eth2/%x/beacon_attestation_1", digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		_, err = r.decodePubsubMessage(m)
+		require.NoError(t, err)
+
+		// Validate the pubsub message and ignore it as it should already been seen.
+		res, err := r.validateCommitteeIndexBeaconAttestation(ctx, "", m)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+
+		// Wait for the event to complete.
+		wg.Wait()
+		cancel()
 	})
-
-	// Verify unaggregated attestations are saved correctly.
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	require.Equal(t, 1, len(atts), "Did not save unaggregated att")
-	assert.DeepEqual(t, att.ToAttestationElectra(committee), atts[0], "Incorrect saved att")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-
-	// Encode the attestation for pubsub and decode the message.
-	buf := new(bytes.Buffer)
-	_, err = p1.Encoding().EncodeGossip(buf, att)
-	require.NoError(t, err)
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
-	topic := fmt.Sprintf("/eth2/%x/beacon_attestation_1", digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	_, err = r.decodePubsubMessage(m)
-	require.NoError(t, err)
-
-	// Validate the pubsub message and ignore it as it should already been seen.
-	res, err := r.validateCommitteeIndexBeaconAttestation(ctx, "", m)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-
-	// Wait for the event to complete.
-	wg.Wait()
-	cancel()
 }
 
 func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
 
-	db := dbtest.SetupDB(t)
-	p2p := p2ptest.NewTestP2P(t)
-	st, privKeys := util.DeterministicGenesisState(t, 256)
-	require.NoError(t, st.SetGenesisTime(time.Now()))
-	b := util.NewBeaconBlock()
-	r32, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	util.SaveBlock(t, t.Context(), db, b)
-	require.NoError(t, db.SaveState(t.Context(), st, r32))
+		db := dbtest.SetupDB(t)
+		p2p := p2ptest.NewTestP2P(t)
+		st, privKeys := util.DeterministicGenesisState(t, 256)
+		require.NoError(t, st.SetGenesisTime(time.Now()))
+		b := util.NewBeaconBlock()
+		r32, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		util.SaveBlock(t, t.Context(), db, b)
+		require.NoError(t, db.SaveState(t.Context(), st, r32))
 
-	chain := &mock.ChainService{
-		State:   st,
-		Genesis: prysmTime.Now(),
-		DB:      db,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  r32[:],
-			Epoch: 0,
-		},
-	}
+		chain := &mock.ChainService{
+			State:   st,
+			Genesis: prysmTime.Now(),
+			DB:      db,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  r32[:],
+				Epoch: 0,
+			},
+		}
 
-	s := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p2p,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	go s.verifierRoutine()
+		s := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p2p,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		go s.verifierRoutine()
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), st, 0, 0)
-	assert.NoError(t, err)
-	// Arbitrary aggregator index for testing purposes.
-	aggregatorIndex := committee[0]
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), st, 0, 0)
+		assert.NoError(t, err)
+		// Arbitrary aggregator index for testing purposes.
+		aggregatorIndex := committee[0]
 
-	priv, err := bls.RandKey()
-	require.NoError(t, err)
-	aggBits := bitfield.NewBitlist(8)
-	aggBits.SetBitAt(1, true)
+		priv, err := bls.RandKey()
+		require.NoError(t, err)
+		aggBits := bitfield.NewBitlist(8)
+		aggBits.SetBitAt(1, true)
 
-	a := &ethpb.AggregateAttestationAndProof{
-		Aggregate: &ethpb.Attestation{
-			Signature:       priv.Sign([]byte("foo")).Marshal(),
+		a := &ethpb.AggregateAttestationAndProof{
+			Aggregate: &ethpb.Attestation{
+				Signature:       priv.Sign([]byte("foo")).Marshal(),
+				AggregationBits: aggBits,
+				Data:            util.HydrateAttestationData(&ethpb.AttestationData{}),
+			},
+			AggregatorIndex: aggregatorIndex,
+			SelectionProof:  make([]byte, fieldparams.BLSSignatureLength),
+		}
+
+		s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: a, Signature: make([]byte, fieldparams.BLSSignatureLength)}}
+		require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
+
+		assert.Equal(t, false, p2p.BroadcastCalled.Load(), "Broadcasted bad aggregate")
+
+		// Clear pool.
+		err = s.cfg.attPool.DeleteUnaggregatedAttestation(a.Aggregate)
+		require.NoError(t, err)
+
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: r32[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: r32[:]},
+			},
 			AggregationBits: aggBits,
-			Data:            util.HydrateAttestationData(&ethpb.AttestationData{}),
-		},
-		AggregatorIndex: aggregatorIndex,
-		SelectionProof:  make([]byte, fieldparams.BLSSignatureLength),
-	}
+		}
 
-	s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: a, Signature: make([]byte, fieldparams.BLSSignatureLength)}}
-	require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(st.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		for _, i := range attestingIndices {
+			att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
+		}
 
-	assert.Equal(t, false, p2p.BroadcastCalled.Load(), "Broadcasted bad aggregate")
+		sszSlot := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(st, 0, &sszSlot, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: aggregatorIndex,
+		}
+		aggreSig, err := signing.ComputeDomainAndSign(st, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
 
-	// Clear pool.
-	err = s.cfg.attPool.DeleteUnaggregatedAttestation(a.Aggregate)
-	require.NoError(t, err)
+		s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
+		require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
 
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: r32[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: r32[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		assert.Equal(t, true, p2p.BroadcastCalled.Load(), "The good aggregate was not broadcasted")
 
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(st.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	for _, i := range attestingIndices {
-		att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
-	}
-
-	sszSlot := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(st, 0, &sszSlot, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: aggregatorIndex,
-	}
-	aggreSig, err := signing.ComputeDomainAndSign(st, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-
-	s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
-
-	assert.Equal(t, true, p2p.BroadcastCalled.Load(), "The good aggregate was not broadcasted")
-
-	cancel()
+		cancel()
+	})
 }
 
 func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
 
-	// Arbitrary aggregator index for testing purposes.
-	aggregatorIndex := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: aggregatorIndex,
-	}
-	aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
+		// Arbitrary aggregator index for testing purposes.
+		aggregatorIndex := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: aggregatorIndex,
+		}
+		aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	chain := &mock.ChainService{Genesis: time.Now(),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-			Epoch: 0,
-		}}
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		chain := &mock.ChainService{Genesis: time.Now(),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+				Epoch: 0,
+			}}
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+		r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
-	assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
-	assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	assert.Equal(t, 0, len(atts), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	cancel()
+		assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
+		assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		assert.Equal(t, 0, len(atts), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		cancel()
+	})
 }
 
 func TestProcessPendingAtts_HasBlockSaveAggregatedAttElectra(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	committeeBits := primitives.NewAttestationCommitteeBits()
-	committeeBits.SetBitAt(0, true)
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.AttestationElectra{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		CommitteeBits:   committeeBits,
-		AggregationBits: aggBits,
-	}
+		committeeBits := primitives.NewAttestationCommitteeBits()
+		committeeBits.SetBitAt(0, true)
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.AttestationElectra{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			CommitteeBits:   committeeBits,
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.GetCommitteeIndex())
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.GetCommitteeIndex())
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
 
-	// Arbitrary aggregator index for testing purposes.
-	aggregatorIndex := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProofElectra{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: aggregatorIndex,
-	}
-	aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
-	require.NoError(t, err)
+		// Arbitrary aggregator index for testing purposes.
+		aggregatorIndex := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProofElectra{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: aggregatorIndex,
+		}
+		aggreSig, err := signing.ComputeDomainAndSign(beaconState, 0, aggregateAndProof, params.BeaconConfig().DomainAggregateAndProof, privKeys[aggregatorIndex])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	chain := &mock.ChainService{Genesis: time.Now(),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-			Epoch: 0,
-		}}
-	ctx, cancel := context.WithCancel(t.Context())
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	go r.verifierRoutine()
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		chain := &mock.ChainService{Genesis: time.Now(),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+				Epoch: 0,
+			}}
+		ctx, cancel := context.WithCancel(t.Context())
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		go r.verifierRoutine()
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProofElectra{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+		r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProofElectra{Message: aggregateAndProof, Signature: aggreSig}}
+		require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
-	assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
-	assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
-	atts := r.cfg.attPool.UnaggregatedAttestations()
-	assert.Equal(t, 0, len(atts), "Did save aggregated att")
-	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
-	cancel()
+		assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
+		assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
+		atts := r.cfg.attPool.UnaggregatedAttestations()
+		assert.Equal(t, 0, len(atts), "Did save aggregated att")
+		require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
+		cancel()
+	})
 }
 
 func TestProcessPendingAtts_BlockNotInForkChoice(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	validators := uint64(256)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		validators := uint64(256)
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	sb := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, sb)
-	root, err := sb.Block.HashTreeRoot()
-	require.NoError(t, err)
+		sb := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, sb)
+		root, err := sb.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(8)
-	aggBits.SetBitAt(1, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(8)
+		aggBits.SetBitAt(1, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	for _, i := range attestingIndices {
-		att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
-	}
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		for _, i := range attestingIndices {
+			att.Signature = privKeys[i].Sign(hashTreeRoot[:]).Marshal()
+		}
 
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		Aggregate: att,
-	}
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			Aggregate: att,
+		}
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	// Mock chain service that returns false for InForkchoice
-	chain := &mock.ChainService{Genesis: time.Now(),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-			Epoch: 0,
-		},
-		// Set NotFinalized to true so InForkchoice returns false
-		NotFinalized: true,
-	}
+		// Mock chain service that returns false for InForkchoice
+		chain := &mock.ChainService{Genesis: time.Now(),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+				Epoch: 0,
+			},
+			// Set NotFinalized to true so InForkchoice returns false
+			NotFinalized: true,
+		}
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:  attestations.NewPool(),
-		},
-		blkRootToPendingAtts: make(map[[32]byte][]any),
-	}
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:  attestations.NewPool(),
+			},
+			blkRootToPendingAtts: make(map[[32]byte][]any),
+		}
 
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
-	// Add pending attestation
-	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}}
+		// Add pending attestation
+		r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}}
 
-	// Process pending attestations - should return error because block is not in fork choice
-	require.ErrorContains(t, "could not process unknown block root", r.processPendingAttsForBlock(t.Context(), root))
+		// Process pending attestations - should return error because block is not in fork choice
+		require.ErrorContains(t, "could not process unknown block root", r.processPendingAttsForBlock(t.Context(), root))
 
-	// Verify attestations were not processed (should still be pending)
-	assert.Equal(t, 1, len(r.blkRootToPendingAtts[root]), "Attestations should still be pending")
-	assert.Equal(t, 0, len(r.cfg.attPool.UnaggregatedAttestations()), "Should not save attestation when block not in fork choice")
-	assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Should not save attestation when block not in fork choice")
-	require.LogsDoNotContain(t, hook, "Verified and saved pending attestations to pool")
+		// Verify attestations were not processed (should still be pending)
+		assert.Equal(t, 1, len(r.blkRootToPendingAtts[root]), "Attestations should still be pending")
+		assert.Equal(t, 0, len(r.cfg.attPool.UnaggregatedAttestations()), "Should not save attestation when block not in fork choice")
+		assert.Equal(t, 0, len(r.cfg.attPool.AggregatedAttestations()), "Should not save attestation when block not in fork choice")
+		require.LogsDoNotContain(t, hook, "Verified and saved pending attestations to pool")
+	})
 }
 
 func TestValidatePendingAtts_CanPruneOldAtts(t *testing.T) {

--- a/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
@@ -69,46 +69,48 @@ func newEnvelopeFetchService(t *testing.T, p1 p2p.P2P) *Service {
 // block for that root exists in the queue. This locks in the PR's removal of the
 // per-block pendingBlockByRoot gate.
 func TestFetchAndQueuePayloadEnvelopesForRoots_QueuesWithoutPendingBlock(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig()
-	cfg.FuluForkEpoch = 0
-	cfg.GloasForkEpoch = 0
-	params.OverrideBeaconConfig(cfg)
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+		params.BeaconConfig().InitializeForkSchedule()
 
-	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
+		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
 
-	r := newEnvelopeFetchService(t, p1)
+		r := newEnvelopeFetchService(t, p1)
 
-	root := [32]byte{0xAA}
-	env := makeSignedEnvelope(root, 1)
+		root := [32]byte{0xAA}
+		env := makeSignedEnvelope(root, 1)
 
-	protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.SetStreamHandler(protocolID, func(stream network.Stream) {
-		defer wg.Done()
-		req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
-		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
-		require.Equal(t, 1, len(*req))
-		assert.Equal(t, root, (*req)[0])
-		assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
-		assert.NoError(t, stream.CloseWrite())
+		protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.SetStreamHandler(protocolID, func(stream network.Stream) {
+			defer wg.Done()
+			req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+			require.Equal(t, 1, len(*req))
+			assert.Equal(t, root, (*req)[0])
+			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
+			assert.NoError(t, stream.CloseWrite())
+		})
+
+		r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{root})
+
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive envelope-by-root request within 1 sec")
+		}
+
+		r.pendingEnvelopeLock.RLock()
+		defer r.pendingEnvelopeLock.RUnlock()
+		inner, ok := r.pendingPayloadEnvelopes[root]
+		require.Equal(t, true, ok)
+		require.Equal(t, 1, len(inner))
+		assert.NotNil(t, inner[0])
 	})
-
-	r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{root})
-
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive envelope-by-root request within 1 sec")
-	}
-
-	r.pendingEnvelopeLock.RLock()
-	defer r.pendingEnvelopeLock.RUnlock()
-	inner, ok := r.pendingPayloadEnvelopes[root]
-	require.Equal(t, true, ok)
-	require.Equal(t, 1, len(inner))
-	assert.NotNil(t, inner[0])
 }
 
 // A future slot must not defeat finalization based pruning by pinning memory.
@@ -159,53 +161,57 @@ func TestQueuePendingPayloadEnvelopeFromRootRequest_BuildersPerRootCap(t *testin
 // Pre-Gloas: the chain-level CurrentSlot() < gloasStartSlot gate short-circuits
 // before any request is sent.
 func TestFetchAndQueuePayloadEnvelopesForRoots_PreGloasNoRequest(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig()
-	cfg.FuluForkEpoch = 0
-	cfg.GloasForkEpoch = 1_000_000 // far enough ahead that CurrentSlot() is well before it
-	params.OverrideBeaconConfig(cfg)
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 1_000_000 // far enough ahead that CurrentSlot() is well before it
+		params.OverrideBeaconConfig(cfg)
+		params.BeaconConfig().InitializeForkSchedule()
 
-	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
+		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
 
-	r := newEnvelopeFetchService(t, p1)
+		r := newEnvelopeFetchService(t, p1)
 
-	protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
-	p2.SetStreamHandler(protocolID, func(network.Stream) {
-		t.Error("envelope request should not be sent before Gloas")
+		protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
+		p2.SetStreamHandler(protocolID, func(network.Stream) {
+			t.Error("envelope request should not be sent before Gloas")
+		})
+
+		r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{{0xAA}})
+
+		assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
 	})
-
-	r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{{0xAA}})
-
-	assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
 }
 
 // Post-Gloas: a root whose envelope is already in the DB is filtered out, so no
 // request is sent for it.
 func TestFetchAndQueuePayloadEnvelopesForRoots_SkipsRootAlreadyInDB(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig()
-	cfg.FuluForkEpoch = 0
-	cfg.GloasForkEpoch = 0
-	params.OverrideBeaconConfig(cfg)
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+		params.BeaconConfig().InitializeForkSchedule()
 
-	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
+		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
 
-	r := newEnvelopeFetchService(t, p1)
+		r := newEnvelopeFetchService(t, p1)
 
-	root := bytesutil.ToBytes32([]byte{0xCC})
-	env := makeSignedEnvelope(root, 1)
-	require.NoError(t, r.cfg.beaconDB.SaveExecutionPayloadEnvelope(t.Context(), env))
+		root := bytesutil.ToBytes32([]byte{0xCC})
+		env := makeSignedEnvelope(root, 1)
+		require.NoError(t, r.cfg.beaconDB.SaveExecutionPayloadEnvelope(t.Context(), env))
 
-	protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
-	p2.SetStreamHandler(protocolID, func(network.Stream) {
-		t.Error("no request should be sent for a root already present in the DB")
+		protocolID := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
+		p2.SetStreamHandler(protocolID, func(network.Stream) {
+			t.Error("no request should be sent for a root already present in the DB")
+		})
+
+		r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{root})
+
+		assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
 	})
-
-	r.fetchAndQueuePayloadEnvelopesForRoots(t.Context(), p2.PeerID(), p2ptypes.BeaconBlockByRootsReq{root})
-
-	assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
 }

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -40,342 +40,352 @@ import (
 //
 // Test b1 was missing then received and we can process b0 -> b1 -> b2
 func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
 
-	p1 := p2ptest.NewTestP2P(t)
-	mockChain := &mock.ChainService{
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    mockChain,
-			clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
-			stateGen: stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		p1 := p2ptest.NewTestP2P(t)
+		mockChain := &mock.ChainService{
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    mockChain,
+				clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				stateGen: stategen.New(db, doublylinkedtree.New()),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	b0 := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b0 := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Setup head state for blockVerifyingState logic
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-	mockChain.Root = b0Root[:]
-	mockChain.State = st
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b0Root[:]
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
-	// Incomplete block link
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ParentRoot = b0Root[:]
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 2
-	b2.Block.ParentRoot = b1Root[:]
-	b2Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Setup head state for blockVerifyingState logic
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		mockChain.Root = b0Root[:]
+		mockChain.State = st
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b0Root[:]
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
+		// Incomplete block link
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ParentRoot = b0Root[:]
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 2
+		b2.Block.ParentRoot = b1Root[:]
+		b2Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Add b2 to the cache
-	wsb, err := blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
+		// Add b2 to the cache
+		wsb, err := blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
 
-	require.NoError(t, r.processPendingBlocks(t.Context()))
-	assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 1, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		require.NoError(t, r.processPendingBlocks(t.Context()))
+		assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 1, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
 
-	// Add b1 to the cache
-	wsb, err = blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
+		// Add b1 to the cache
+		wsb, err = blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
 
-	nBlock := util.NewBeaconBlock()
-	nBlock.Block.Slot = b1.Block.Slot
-	nRoot, err := nBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
+		nBlock := util.NewBeaconBlock()
+		nBlock.Block.Slot = b1.Block.Slot
+		nRoot, err := nBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Insert bad b1 in the cache to verify the good one doesn't get replaced.
-	wsb, err = blocks.NewSignedBeaconBlock(nBlock)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(nBlock.Block.Slot, wsb, nRoot))
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
+		// Insert bad b1 in the cache to verify the good one doesn't get replaced.
+		wsb, err = blocks.NewSignedBeaconBlock(nBlock)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(nBlock.Block.Slot, wsb, nRoot))
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
 
-	assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+	})
 }
 
 func TestRegularSyncBeaconBlockSubscriber_OptimisticStatus(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
 
-	p1 := p2ptest.NewTestP2P(t)
-	mockChain := &mock.ChainService{
-		Optimistic: true,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    mockChain,
-			clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
-			stateGen: stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		p1 := p2ptest.NewTestP2P(t)
+		mockChain := &mock.ChainService{
+			Optimistic: true,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    mockChain,
+				clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				stateGen: stategen.New(db, doublylinkedtree.New()),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	b0 := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b0 := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Setup head state for blockVerifyingState logic
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-	mockChain.Root = b0Root[:]
-	mockChain.State = st
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b0Root[:]
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
-	// Incomplete block link
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ParentRoot = b0Root[:]
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 2
-	b2.Block.ParentRoot = b1Root[:]
-	b2Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Setup head state for blockVerifyingState logic
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		mockChain.Root = b0Root[:]
+		mockChain.State = st
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b0Root[:]
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
+		// Incomplete block link
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ParentRoot = b0Root[:]
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 2
+		b2.Block.ParentRoot = b1Root[:]
+		b2Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Add b2 to the cache
-	wsb, err := blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
+		// Add b2 to the cache
+		wsb, err := blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
 
-	require.NoError(t, r.processPendingBlocks(t.Context()))
-	assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 1, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		require.NoError(t, r.processPendingBlocks(t.Context()))
+		assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 1, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
 
-	// Add b1 to the cache
-	wsb, err = blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
+		// Add b1 to the cache
+		wsb, err = blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
 
-	nBlock := util.NewBeaconBlock()
-	nBlock.Block.Slot = b1.Block.Slot
-	nRoot, err := nBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
+		nBlock := util.NewBeaconBlock()
+		nBlock.Block.Slot = b1.Block.Slot
+		nRoot, err := nBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Insert bad b1 in the cache to verify the good one doesn't get replaced.
-	wsb, err = blocks.NewSignedBeaconBlock(nBlock)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(nBlock.Block.Slot, wsb, nRoot))
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
+		// Insert bad b1 in the cache to verify the good one doesn't get replaced.
+		wsb, err = blocks.NewSignedBeaconBlock(nBlock)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(nBlock.Block.Slot, wsb, nRoot))
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
 
-	assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+	})
 }
 
 func TestRegularSyncBeaconBlockSubscriber_ExecutionEngineTimesOut(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
 
-	p1 := p2ptest.NewTestP2P(t)
-	fcs := doublylinkedtree.New()
-	mockChain := &mock.ChainService{
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-		ReceiveBlockMockErr: execution.ErrHTTPTimeout,
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    mockChain,
-			clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
-			stateGen: stategen.New(db, fcs),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		p1 := p2ptest.NewTestP2P(t)
+		fcs := doublylinkedtree.New()
+		mockChain := &mock.ChainService{
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+			ReceiveBlockMockErr: execution.ErrHTTPTimeout,
+		}
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    mockChain,
+				clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				stateGen: stategen.New(db, fcs),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	b0 := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b0 := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Setup head state for blockVerifyingState logic
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-	mockChain.Root = b0Root[:]
-	mockChain.State = st
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b0Root[:]
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
-	// Incomplete block link
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ParentRoot = b0Root[:]
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 2
-	b2.Block.ParentRoot = b1Root[:]
-	b2Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Setup head state for blockVerifyingState logic
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		mockChain.Root = b0Root[:]
+		mockChain.State = st
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b0Root[:]
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
+		// Incomplete block link
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ParentRoot = b0Root[:]
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 2
+		b2.Block.ParentRoot = b1Root[:]
+		b2Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Add b2 to the cache
-	wsb, err := blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
+		// Add b2 to the cache
+		wsb, err := blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
 
-	require.NoError(t, r.processPendingBlocks(t.Context()))
-	assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 1, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		require.NoError(t, r.processPendingBlocks(t.Context()))
+		assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 1, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
 
-	// Add b1 to the cache
-	wsb, err = blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
+		// Add b1 to the cache
+		wsb, err = blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
 
-	nBlock := util.NewBeaconBlock()
-	nBlock.Block.Slot = b1.Block.Slot
-	nRoot, err := nBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
+		nBlock := util.NewBeaconBlock()
+		nBlock.Block.Slot = b1.Block.Slot
+		nRoot, err := nBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Insert bad b1 in the cache to verify the good one doesn't get replaced.
-	wsb, err = blocks.NewSignedBeaconBlock(nBlock)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(nBlock.Block.Slot, wsb, nRoot))
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
+		// Insert bad b1 in the cache to verify the good one doesn't get replaced.
+		wsb, err = blocks.NewSignedBeaconBlock(nBlock)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(nBlock.Block.Slot, wsb, nRoot))
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
 
-	assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
-	require.Equal(t, 0, len(r.badBlockCache.Keys())) // Account for the bad block above
-	require.Equal(t, 0, len(r.seenBlockCache.Keys()))
+		assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		require.Equal(t, 0, len(r.badBlockCache.Keys())) // Account for the bad block above
+		require.Equal(t, 0, len(r.seenBlockCache.Keys()))
+	})
 }
 
 func TestRegularSync_InsertDuplicateBlocks(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
 
-	p1 := p2ptest.NewTestP2P(t)
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain: &mock.ChainService{
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  make([]byte, 32),
+		p1 := p2ptest.NewTestP2P(t)
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain: &mock.ChainService{
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  make([]byte, 32),
+					},
 				},
 			},
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	b0 := util.NewBeaconBlock()
-	b0r := [32]byte{'a'}
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ParentRoot = b0Root[:]
-	b1r := [32]byte{'b'}
+		b0 := util.NewBeaconBlock()
+		b0r := [32]byte{'a'}
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ParentRoot = b0Root[:]
+		b1r := [32]byte{'b'}
 
-	wsb, err := blocks.NewSignedBeaconBlock(b0)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b0.Block.Slot, wsb, b0r))
-	require.Equal(t, 1, len(r.pendingBlocksInCache(b0.Block.Slot)), "Block was not added to map")
+		wsb, err := blocks.NewSignedBeaconBlock(b0)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b0.Block.Slot, wsb, b0r))
+		require.Equal(t, 1, len(r.pendingBlocksInCache(b0.Block.Slot)), "Block was not added to map")
 
-	wsb, err = blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1r))
-	require.Equal(t, 1, len(r.pendingBlocksInCache(b1.Block.Slot)), "Block was not added to map")
+		wsb, err = blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1r))
+		require.Equal(t, 1, len(r.pendingBlocksInCache(b1.Block.Slot)), "Block was not added to map")
 
-	// Add duplicate block which should not be saved.
-	wsb, err = blocks.NewSignedBeaconBlock(b0)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b0.Block.Slot, wsb, b0r))
-	require.Equal(t, 1, len(r.pendingBlocksInCache(b0.Block.Slot)), "Block was added to map")
+		// Add duplicate block which should not be saved.
+		wsb, err = blocks.NewSignedBeaconBlock(b0)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b0.Block.Slot, wsb, b0r))
+		require.Equal(t, 1, len(r.pendingBlocksInCache(b0.Block.Slot)), "Block was added to map")
 
-	// Add duplicate block which should not be saved.
-	wsb, err = blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1r))
-	require.Equal(t, 1, len(r.pendingBlocksInCache(b1.Block.Slot)), "Block was added to map")
+		// Add duplicate block which should not be saved.
+		wsb, err = blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1r))
+		require.Equal(t, 1, len(r.pendingBlocksInCache(b1.Block.Slot)), "Block was added to map")
 
+	})
 }
 
 func TestRegularSyncBeaconBlockSubscriber_DoNotReprocessBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
 
-	p1 := p2ptest.NewTestP2P(t)
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain: &mock.ChainService{
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
+		p1 := p2ptest.NewTestP2P(t)
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain: &mock.ChainService{
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+					},
 				},
+				clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				stateGen: stategen.New(db, doublylinkedtree.New()),
 			},
-			clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
-			stateGen: stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	b0 := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b0Root[:]
-	b3Root, err := b3.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b0 := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b0Root[:]
+		b3Root, err := b3.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
 
-	// Add b3 to the cache
-	wsb, err := blocks.NewSignedBeaconBlock(b3)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
+		// Add b3 to the cache
+		wsb, err := blocks.NewSignedBeaconBlock(b3)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
 
-	require.NoError(t, r.processPendingBlocks(t.Context()))
-	assert.Equal(t, 0, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 0, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		require.NoError(t, r.processPendingBlocks(t.Context()))
+		assert.Equal(t, 0, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 0, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+	})
 }
 
 //	/- b1 - b2 - b5
@@ -386,210 +396,214 @@ func TestRegularSyncBeaconBlockSubscriber_DoNotReprocessBlock(t *testing.T) {
 //
 // Test b2 and b3 were missed, after receiving them we can process 2 chains.
 func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks_2Chains(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	pcl := protocol.ID("/eth2/beacon_chain/req/hello/1/ssz_snappy")
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		code, errMsg, err := ReadStatusCode(stream, p1.Encoding())
-		assert.NoError(t, err)
-		if code == 0 {
-			t.Error("Expected a non-zero code")
-		}
-		if errMsg != p2ptypes.ErrWrongForkDigestVersion.Error() {
-			t.Logf("Received error string len %d, wanted error string len %d", len(errMsg), len(p2ptypes.ErrWrongForkDigestVersion.Error()))
-			t.Errorf("Received unexpected message response in the stream: %s. Wanted %s.", errMsg, p2ptypes.ErrWrongForkDigestVersion.Error())
-		}
-	})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		pcl := protocol.ID("/eth2/beacon_chain/req/hello/1/ssz_snappy")
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			code, errMsg, err := ReadStatusCode(stream, p1.Encoding())
+			assert.NoError(t, err)
+			if code == 0 {
+				t.Error("Expected a non-zero code")
+			}
+			if errMsg != p2ptypes.ErrWrongForkDigestVersion.Error() {
+				t.Logf("Received error string len %d, wanted error string len %d", len(errMsg), len(p2ptypes.ErrWrongForkDigestVersion.Error()))
+				t.Errorf("Received unexpected message response in the stream: %s. Wanted %s.", errMsg, p2ptypes.ErrWrongForkDigestVersion.Error())
+			}
+		})
 
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain: &mock.ChainService{
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  make([]byte, 32),
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain: &mock.ChainService{
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  make([]byte, 32),
+					},
 				},
+				clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				stateGen: stategen.New(db, doublylinkedtree.New()),
 			},
-			clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
-			stateGen: stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
-	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
+		p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+		p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
 
-	b0 := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b0 := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Setup head state for blockVerifyingState logic
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-	mockChain := r.cfg.chain.(*mock.ChainService)
-	mockChain.Root = b0Root[:]
-	mockChain.State = st
+		// Setup head state for blockVerifyingState logic
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		mockChain := r.cfg.chain.(*mock.ChainService)
+		mockChain.Root = b0Root[:]
+		mockChain.State = st
 
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ParentRoot = b0Root[:]
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ParentRoot = b0Root[:]
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Incomplete block links
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 2
-	b2.Block.ParentRoot = b1Root[:]
-	b2Root, err := b2.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b5 := util.NewBeaconBlock()
-	b5.Block.Slot = 5
-	b5.Block.ParentRoot = b2Root[:]
-	b5Root, err := b5.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b0Root[:]
-	b3Root, err := b3.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b4 := util.NewBeaconBlock()
-	b4.Block.Slot = 4
-	b4.Block.ParentRoot = b3Root[:]
-	b4Root, err := b4.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Incomplete block links
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 2
+		b2.Block.ParentRoot = b1Root[:]
+		b2Root, err := b2.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b5 := util.NewBeaconBlock()
+		b5.Block.Slot = 5
+		b5.Block.ParentRoot = b2Root[:]
+		b5Root, err := b5.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b0Root[:]
+		b3Root, err := b3.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b4 := util.NewBeaconBlock()
+		b4.Block.Slot = 4
+		b4.Block.ParentRoot = b3Root[:]
+		b4Root, err := b4.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	wsb, err := blocks.NewSignedBeaconBlock(b4)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b4.Block.Slot, wsb, b4Root))
-	wsb, err = blocks.NewSignedBeaconBlock(b5)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b5.Block.Slot, wsb, b5Root))
+		wsb, err := blocks.NewSignedBeaconBlock(b4)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b4.Block.Slot, wsb, b4Root))
+		wsb, err = blocks.NewSignedBeaconBlock(b5)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b5.Block.Slot, wsb, b5Root))
 
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
 
-	assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
 
-	// Add b3 to the cache
-	wsb, err = blocks.NewSignedBeaconBlock(b3)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
+		// Add b3 to the cache
+		wsb, err = blocks.NewSignedBeaconBlock(b3)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b3)
 
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
 
-	assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
 
-	// Add b2 to the cache
-	wsb, err = blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
+		// Add b2 to the cache
+		wsb, err = blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
 
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b2)
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b2)
 
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
-	require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Marks a block as bad
+		require.NoError(t, r.processPendingBlocks(t.Context())) // Bad block removed on second run
 
-	assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 2, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+	})
 }
 
 func TestRegularSyncBeaconBlockSubscriber_PruneOldPendingBlocks(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain: &mock.ChainService{
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 1,
-					Root:  make([]byte, 32),
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain: &mock.ChainService{
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 1,
+						Root:  make([]byte, 32),
+					},
 				},
 			},
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	p1.Peers().Add(new(enr.Record), p1.PeerID(), nil, network.DirOutbound)
-	p1.Peers().SetConnectionState(p1.PeerID(), peers.Connected)
-	p1.Peers().SetChainState(p1.PeerID(), &ethpb.StatusV2{})
+		p1.Peers().Add(new(enr.Record), p1.PeerID(), nil, network.DirOutbound)
+		p1.Peers().SetConnectionState(p1.PeerID(), peers.Connected)
+		p1.Peers().SetChainState(p1.PeerID(), &ethpb.StatusV2{})
 
-	b0 := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ParentRoot = b0Root[:]
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b0 := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ParentRoot = b0Root[:]
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Incomplete block links
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 2
-	b2.Block.ParentRoot = b1Root[:]
-	b2Root, err := b2.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b5 := util.NewBeaconBlock()
-	b5.Block.Slot = 5
-	b5.Block.ParentRoot = b2Root[:]
-	b5Root, err := b5.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b0Root[:]
-	b3Root, err := b3.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b4 := util.NewBeaconBlock()
-	b4.Block.Slot = 4
-	b4.Block.ParentRoot = b3Root[:]
-	b4Root, err := b4.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Incomplete block links
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 2
+		b2.Block.ParentRoot = b1Root[:]
+		b2Root, err := b2.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b5 := util.NewBeaconBlock()
+		b5.Block.Slot = 5
+		b5.Block.ParentRoot = b2Root[:]
+		b5Root, err := b5.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b0Root[:]
+		b3Root, err := b3.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b4 := util.NewBeaconBlock()
+		b4.Block.Slot = 4
+		b4.Block.ParentRoot = b3Root[:]
+		b4Root, err := b4.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	wsb, err := blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
-	wsb, err = blocks.NewSignedBeaconBlock(b3)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
-	wsb, err = blocks.NewSignedBeaconBlock(b4)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b4.Block.Slot, wsb, b4Root))
-	wsb, err = blocks.NewSignedBeaconBlock(b5)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b5.Block.Slot, wsb, b5Root))
+		wsb, err := blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
+		wsb, err = blocks.NewSignedBeaconBlock(b3)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
+		wsb, err = blocks.NewSignedBeaconBlock(b4)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b4.Block.Slot, wsb, b4Root))
+		wsb, err = blocks.NewSignedBeaconBlock(b5)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b5.Block.Slot, wsb, b5Root))
 
-	require.NoError(t, r.processPendingBlocks(t.Context()))
-	assert.Equal(t, 0, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 0, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+		require.NoError(t, r.processPendingBlocks(t.Context()))
+		assert.Equal(t, 0, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 0, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
+	})
 }
 
 func TestService_sortedPendingSlots(t *testing.T) {
 	r := &Service{
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
+		slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 	}
 
@@ -612,109 +626,111 @@ func TestService_sortedPendingSlots(t *testing.T) {
 }
 
 func TestService_BatchRootRequest(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-	st, keys := util.DeterministicGenesisState(t, 64)
-	chain := &mock.ChainService{
-		State: st,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 1,
-			Root:  make([]byte, 32),
-		},
-		ValidatorsRoot: [32]byte{},
-		Genesis:        time.Now(),
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
-
-	p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
-	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 2})
-
-	b0 := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
-	b0Root, err := b0.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ParentRoot = b0Root[:]
-	util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 2
-	b2.Block.ParentRoot = b1Root[:]
-	b2Root, err := b2.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b5 := util.NewBeaconBlock()
-	b5.Block.Slot = 5
-	b5.Block.ParentRoot = b2Root[:]
-	b5Root, err := b5.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b0Root[:]
-	b3Root, err := b3.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b4 := util.NewBeaconBlock()
-	b4.Block.Slot = 4
-	b4.Block.ParentRoot = b3Root[:]
-	b4Root, err := b4.Block.HashTreeRoot()
-	require.NoError(t, err)
-
-	for _, blk := range []*ethpb.SignedBeaconBlock{b2, b3, b4, b5} {
-		blk.Signature, err = signing.ComputeDomainAndSign(st, 0, blk.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
-		require.NoError(t, err)
-	}
-
-	// Send in duplicated roots to also test deduplication.
-	sentRoots := p2ptypes.BeaconBlockByRootsReq{b2Root, b2Root, b3Root, b3Root, b4Root, b5Root}
-	expectedRoots := p2ptypes.BeaconBlockByRootsReq{b2Root, b3Root, b4Root, b5Root}
-
-	pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		var out p2ptypes.BeaconBlockByRootsReq
-		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, &out))
-		assert.DeepEqual(t, expectedRoots, out, "Did not receive expected message")
-		response := []*ethpb.SignedBeaconBlock{b2, b3, b4, b5}
-		for _, blk := range response {
-			_, err := stream.Write([]byte{responseCodeSuccess})
-			assert.NoError(t, err, "Could not write to stream")
-			_, err = p2.Encoding().EncodeWithMaxLength(stream, blk)
-			assert.NoError(t, err, "Could not send response back")
+		st, keys := util.DeterministicGenesisState(t, 64)
+		chain := &mock.ChainService{
+			State: st,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 1,
+				Root:  make([]byte, 32),
+			},
+			ValidatorsRoot: [32]byte{},
+			Genesis:        time.Now(),
 		}
-		assert.NoError(t, stream.Close())
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
+
+		p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+		p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 2})
+
+		b0 := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b0)
+		b0Root, err := b0.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ParentRoot = b0Root[:]
+		util.SaveBlock(t, t.Context(), r.cfg.beaconDB, b1)
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 2
+		b2.Block.ParentRoot = b1Root[:]
+		b2Root, err := b2.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b5 := util.NewBeaconBlock()
+		b5.Block.Slot = 5
+		b5.Block.ParentRoot = b2Root[:]
+		b5Root, err := b5.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b0Root[:]
+		b3Root, err := b3.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b4 := util.NewBeaconBlock()
+		b4.Block.Slot = 4
+		b4.Block.ParentRoot = b3Root[:]
+		b4Root, err := b4.Block.HashTreeRoot()
+		require.NoError(t, err)
+
+		for _, blk := range []*ethpb.SignedBeaconBlock{b2, b3, b4, b5} {
+			blk.Signature, err = signing.ComputeDomainAndSign(st, 0, blk.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
+			require.NoError(t, err)
+		}
+
+		// Send in duplicated roots to also test deduplication.
+		sentRoots := p2ptypes.BeaconBlockByRootsReq{b2Root, b2Root, b3Root, b3Root, b4Root, b5Root}
+		expectedRoots := p2ptypes.BeaconBlockByRootsReq{b2Root, b3Root, b4Root, b5Root}
+
+		pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			var out p2ptypes.BeaconBlockByRootsReq
+			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, &out))
+			assert.DeepEqual(t, expectedRoots, out, "Did not receive expected message")
+			response := []*ethpb.SignedBeaconBlock{b2, b3, b4, b5}
+			for _, blk := range response {
+				_, err := stream.Write([]byte{responseCodeSuccess})
+				assert.NoError(t, err, "Could not write to stream")
+				_, err = p2.Encoding().EncodeWithMaxLength(stream, blk)
+				assert.NoError(t, err, "Could not send response back")
+			}
+			assert.NoError(t, stream.Close())
+		})
+
+		require.NoError(t, r.sendBatchRootRequest(t.Context(), sentRoots, rand.NewGenerator()))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+		assert.Equal(t, 4, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		assert.Equal(t, 4, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
 	})
-
-	require.NoError(t, r.sendBatchRootRequest(t.Context(), sentRoots, rand.NewGenerator()))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-	assert.Equal(t, 4, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
-	assert.Equal(t, 4, len(r.seenPendingBlocks), "Incorrect size for seen pending block")
 }
 
 func TestService_AddPendingBlockToQueueOverMax(t *testing.T) {
 	r := &Service{
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
+		slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 	}
 
@@ -742,178 +758,184 @@ func TestService_AddPendingBlockToQueueOverMax(t *testing.T) {
 }
 
 func TestService_ProcessPendingBlockOnCorrectSlot(t *testing.T) {
-	ctx := t.Context()
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		db := dbtest.SetupDB(t)
 
-	p1 := p2ptest.NewTestP2P(t)
-	fcs := doublylinkedtree.New()
-	mockChain := mock.ChainService{
-		Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    &mockChain,
-			clock:    startup.NewClock(mockChain.Genesis, mockChain.ValidatorsRoot),
-			stateGen: stategen.New(db, fcs),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		p1 := p2ptest.NewTestP2P(t)
+		fcs := doublylinkedtree.New()
+		mockChain := mock.ChainService{
+			Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    &mockChain,
+				clock:    startup.NewClock(mockChain.Genesis, mockChain.ValidatorsRoot),
+				stateGen: stategen.New(db, fcs),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	mockChain.Root = bRoot[:]
-	mockChain.State = beaconState
+		mockChain.Root = bRoot[:]
+		mockChain.State = beaconState
 
-	b1 := util.NewBeaconBlock()
-	b1.Block.ParentRoot = bRoot[:]
-	b1.Block.Slot = 1
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b1.Block.ProposerIndex = proposerIdx
-	b1.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, b1.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		b1 := util.NewBeaconBlock()
+		b1.Block.ParentRoot = bRoot[:]
+		b1.Block.Slot = 1
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b1.Block.ProposerIndex = proposerIdx
+		b1.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, b1.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 2
-	b2.Block.ParentRoot = bRoot[:]
-	b2Root, err := b2.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 2
+		b2.Block.ParentRoot = bRoot[:]
+		b2Root, err := b2.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	b3 := util.NewBeaconBlock()
-	b3.Block.Slot = 3
-	b3.Block.ParentRoot = b2Root[:]
-	b3Root, err := b3.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b3 := util.NewBeaconBlock()
+		b3.Block.Slot = 3
+		b3.Block.ParentRoot = b2Root[:]
+		b3Root, err := b3.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	// Add block1 for slot1
-	wsb, err := blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
-	// Add block2 for slot2
-	wsb, err = blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
-	// Add block3 for slot3
-	wsb, err = blocks.NewSignedBeaconBlock(b3)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
+		// Add block1 for slot1
+		wsb, err := blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b1.Block.Slot, wsb, b1Root))
+		// Add block2 for slot2
+		wsb, err = blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b2.Block.Slot, wsb, b2Root))
+		// Add block3 for slot3
+		wsb, err = blocks.NewSignedBeaconBlock(b3)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b3.Block.Slot, wsb, b3Root))
 
-	// processPendingBlocks should process only blocks of the current slot. i.e. slot 1.
-	// Then check if the other two blocks are still in the pendingQueue.
-	require.NoError(t, r.processPendingBlocks(t.Context()))
-	assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+		// processPendingBlocks should process only blocks of the current slot. i.e. slot 1.
+		// Then check if the other two blocks are still in the pendingQueue.
+		require.NoError(t, r.processPendingBlocks(t.Context()))
+		assert.Equal(t, 2, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
+	})
 }
 
 func TestService_ProcessBadPendingBlocks(t *testing.T) {
-	ctx := t.Context()
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		db := dbtest.SetupDB(t)
 
-	p1 := p2ptest.NewTestP2P(t)
-	mockChain := mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    &mockChain,
-			stateGen: stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		p1 := p2ptest.NewTestP2P(t)
+		mockChain := mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    &mockChain,
+				stateGen: stategen.New(db, doublylinkedtree.New()),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	mockChain.Root = bRoot[:]
-	mockChain.State = beaconState
+		mockChain.Root = bRoot[:]
+		mockChain.State = beaconState
 
-	b1 := util.NewBeaconBlock()
-	b1.Block.ParentRoot = bRoot[:]
-	b1.Block.Slot = 1
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-	b1.Block.ProposerIndex = proposerIdx
-	b1.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, b1.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		b1 := util.NewBeaconBlock()
+		b1.Block.ParentRoot = bRoot[:]
+		b1.Block.Slot = 1
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+		b1.Block.ProposerIndex = proposerIdx
+		b1.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, b1.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	b := util.NewBeaconBlock()
-	b.Block.Slot = 55
-	b.Block.ParentRoot = []byte{'A', 'B', 'C'}
-	bA, err := blocks.NewSignedBeaconBlock(b)
-	assert.NoError(t, err)
+		b := util.NewBeaconBlock()
+		b.Block.Slot = 55
+		b.Block.ParentRoot = []byte{'A', 'B', 'C'}
+		bA, err := blocks.NewSignedBeaconBlock(b)
+		assert.NoError(t, err)
 
-	// Add block1 for slot 55
-	require.NoError(t, r.insertBlockToPendingQueue(b.Block.Slot, bA, b1Root))
-	bB, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
-	assert.NoError(t, err)
-	// remove with a different block from the same slot.
-	require.NoError(t, r.deleteBlockFromPendingQueue(b.Block.Slot, bB, b1Root))
+		// Add block1 for slot 55
+		require.NoError(t, r.insertBlockToPendingQueue(b.Block.Slot, bA, b1Root))
+		bB, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
+		assert.NoError(t, err)
+		// remove with a different block from the same slot.
+		require.NoError(t, r.deleteBlockFromPendingQueue(b.Block.Slot, bB, b1Root))
+	})
 }
 
 func TestAlreadySyncingBlock(t *testing.T) {
-	ctx := t.Context()
-	db := dbtest.SetupDB(t)
-	hook := logTest.NewGlobal()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		db := dbtest.SetupDB(t)
+		hook := logTest.NewGlobal()
 
-	mockChain := &mock.ChainService{
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-	}
+		mockChain := &mock.ChainService{
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+		}
 
-	p1 := p2ptest.NewTestP2P(t)
-	r := &Service{
-		cfg: &config{
-			p2p:      p1,
-			beaconDB: db,
-			chain:    mockChain,
-			clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
-			stateGen: stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		p1 := p2ptest.NewTestP2P(t)
+		r := &Service{
+			cfg: &config{
+				p2p:      p1,
+				beaconDB: db,
+				chain:    mockChain,
+				clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				stateGen: stategen.New(db, doublylinkedtree.New()),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	b := util.NewBeaconBlock()
-	b.Block.Slot = 2
-	bRoot, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	wsb, err := blocks.NewSignedBeaconBlock(b)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(b.Block.Slot, wsb, bRoot))
-	mockChain.SyncingRoot = bRoot
-	require.NoError(t, r.processPendingBlocks(ctx))
-	require.LogsContain(t, hook, "Skipping pending block already being processed")
+		b := util.NewBeaconBlock()
+		b.Block.Slot = 2
+		bRoot, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		wsb, err := blocks.NewSignedBeaconBlock(b)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(b.Block.Slot, wsb, bRoot))
+		mockChain.SyncingRoot = bRoot
+		require.NoError(t, r.processPendingBlocks(ctx))
+		require.LogsContain(t, hook, "Skipping pending block already being processed")
+	})
 }
 
 func TestExpirationCache_PruneOldBlocksCorrectly(t *testing.T) {

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -917,59 +917,61 @@ func TestAlreadySyncingBlock(t *testing.T) {
 }
 
 func TestExpirationCache_PruneOldBlocksCorrectly(t *testing.T) {
-	ctx := t.Context()
-	db := dbtest.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		db := dbtest.SetupDB(t)
 
-	mockChain := &mock.ChainService{
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-	}
+		mockChain := &mock.ChainService{
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+		}
 
-	p1 := p2ptest.NewTestP2P(t)
-	// Reset expiration time
-	currExpTime := pendingBlockExpTime
-	defer func() {
-		pendingBlockExpTime = currExpTime
-	}()
-	pendingBlockExpTime = 500 * time.Millisecond
+		p1 := p2ptest.NewTestP2P(t)
+		// Reset expiration time
+		currExpTime := pendingBlockExpTime
+		defer func() {
+			pendingBlockExpTime = currExpTime
+		}()
+		pendingBlockExpTime = 500 * time.Millisecond
 
-	r := NewService(ctx,
-		WithStateGen(stategen.New(db, doublylinkedtree.New())),
-		WithDatabase(db),
-		WithChainService(mockChain),
-		WithP2P(p1),
-	)
-	b1 := util.NewBeaconBlock()
-	b1.Block.Slot = 1
-	b1.Block.ProposerIndex = 10
-	b1Root, err := b1.Block.HashTreeRoot()
-	require.NoError(t, err)
-	wsb, err := blocks.NewSignedBeaconBlock(b1)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b1Root))
+		r := NewService(ctx,
+			WithStateGen(stategen.New(db, doublylinkedtree.New())),
+			WithDatabase(db),
+			WithChainService(mockChain),
+			WithP2P(p1),
+		)
+		b1 := util.NewBeaconBlock()
+		b1.Block.Slot = 1
+		b1.Block.ProposerIndex = 10
+		b1Root, err := b1.Block.HashTreeRoot()
+		require.NoError(t, err)
+		wsb, err := blocks.NewSignedBeaconBlock(b1)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b1Root))
 
-	// Add new block with the same slot.
-	b2 := util.NewBeaconBlock()
-	b2.Block.Slot = 1
-	b2.Block.ProposerIndex = 11
-	b2Root, err := b2.Block.HashTreeRoot()
-	require.NoError(t, err)
-	wsb, err = blocks.NewSignedBeaconBlock(b2)
-	require.NoError(t, err)
-	require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b2Root))
+		// Add new block with the same slot.
+		b2 := util.NewBeaconBlock()
+		b2.Block.Slot = 1
+		b2.Block.ProposerIndex = 11
+		b2Root, err := b2.Block.HashTreeRoot()
+		require.NoError(t, err)
+		wsb, err = blocks.NewSignedBeaconBlock(b2)
+		require.NoError(t, err)
+		require.NoError(t, r.insertBlockToPendingQueue(1, wsb, b2Root))
 
-	require.Equal(t, true, r.seenPendingBlocks[b1Root])
-	require.Equal(t, true, r.seenPendingBlocks[b2Root])
-	require.Equal(t, 2, len(r.pendingBlocksInCache(1)))
+		require.Equal(t, true, r.seenPendingBlocks[b1Root])
+		require.Equal(t, true, r.seenPendingBlocks[b2Root])
+		require.Equal(t, 2, len(r.pendingBlocksInCache(1)))
 
-	// Wait for expiration cache to cleanup and remove old block.
-	time.Sleep(2 * pendingBlockExpTime)
+		// Wait for expiration cache to cleanup and remove old block.
+		time.Sleep(2 * pendingBlockExpTime)
 
-	// Run pending queue with expired blocks.
-	require.NoError(t, r.processPendingBlocks(ctx))
+		// Run pending queue with expired blocks.
+		require.NoError(t, r.processPendingBlocks(ctx))
 
-	assert.Equal(t, false, r.seenPendingBlocks[b1Root])
-	assert.Equal(t, false, r.seenPendingBlocks[b2Root])
-	assert.Equal(t, 0, len(r.pendingBlocksInCache(1)))
+		assert.Equal(t, false, r.seenPendingBlocks[b1Root])
+		assert.Equal(t, false, r.seenPendingBlocks[b2Root])
+		assert.Equal(t, 0, len(r.pendingBlocksInCache(1)))
+	})
 }

--- a/beacon-chain/sync/pending_payload_attestation_test.go
+++ b/beacon-chain/sync/pending_payload_attestation_test.go
@@ -55,69 +55,79 @@ func validSigVerifier() verification.PayloadAttestationMsgVerifier {
 }
 
 func TestQueuePendingPayloadAttestation_Queues(t *testing.T) {
-	s := queueTestService(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		s := queueTestService(t)
 
-	att, pa := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
-	res, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-	require.Equal(t, 1, len(s.pendingPayloadAttestations[pa.BeaconBlockRoot()]))
+		att, pa := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
+		res, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+		require.Equal(t, 1, len(s.pendingPayloadAttestations[pa.BeaconBlockRoot()]))
+	})
 }
 
 func TestQueuePendingPayloadAttestation_DeduplicatesByValidator(t *testing.T) {
-	s := queueTestService(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		s := queueTestService(t)
 
-	att, pa := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
-	_, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
-	require.NoError(t, err)
-	_, err = s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(s.pendingPayloadAttestations[pa.BeaconBlockRoot()]))
+		att, pa := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
+		_, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
+		require.NoError(t, err)
+		_, err = s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(s.pendingPayloadAttestations[pa.BeaconBlockRoot()]))
 
-	att2, pa2 := pendingPayloadAtt(t, []byte{'a'}, 2, 1)
-	_, err = s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att2)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(s.pendingPayloadAttestations[pa2.BeaconBlockRoot()]))
+		att2, pa2 := pendingPayloadAtt(t, []byte{'a'}, 2, 1)
+		_, err = s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att2)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(s.pendingPayloadAttestations[pa2.BeaconBlockRoot()]))
+	})
 }
 
 func TestQueuePendingPayloadAttestation_RootCap(t *testing.T) {
-	s := queueTestService(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		s := queueTestService(t)
 
-	for i := range maxPendingPayloadAttestationRoots {
-		att, _ := pendingPayloadAtt(t, []byte{byte(i)}, 1, 1)
+		for i := range maxPendingPayloadAttestationRoots {
+			att, _ := pendingPayloadAtt(t, []byte{byte(i)}, 1, 1)
+			_, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
+			require.NoError(t, err)
+		}
+		require.Equal(t, maxPendingPayloadAttestationRoots, len(s.pendingPayloadAttestations))
+
+		att, pa := pendingPayloadAtt(t, []byte("overflow"), 1, 1)
 		_, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
 		require.NoError(t, err)
-	}
-	require.Equal(t, maxPendingPayloadAttestationRoots, len(s.pendingPayloadAttestations))
-
-	att, pa := pendingPayloadAtt(t, []byte("overflow"), 1, 1)
-	_, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
-	require.NoError(t, err)
-	require.Equal(t, maxPendingPayloadAttestationRoots, len(s.pendingPayloadAttestations))
-	_, ok := s.pendingPayloadAttestations[pa.BeaconBlockRoot()]
-	require.Equal(t, false, ok)
+		require.Equal(t, maxPendingPayloadAttestationRoots, len(s.pendingPayloadAttestations))
+		_, ok := s.pendingPayloadAttestations[pa.BeaconBlockRoot()]
+		require.Equal(t, false, ok)
+	})
 }
 
 func TestQueuePendingPayloadAttestation_IgnoresBadSignature(t *testing.T) {
-	s := queueTestService(t)
-	v := &verification.MockPayloadAttestation{ErrInvalidMessageSignature: errors.New("bad signature")}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		s := queueTestService(t)
+		v := &verification.MockPayloadAttestation{ErrInvalidMessageSignature: errors.New("bad signature")}
 
-	att, _ := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
-	res, err := s.queuePendingPayloadAttestation(t.Context(), v, att)
-	require.ErrorContains(t, "bad signature", err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-	require.Equal(t, 0, len(s.pendingPayloadAttestations))
+		att, _ := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
+		res, err := s.queuePendingPayloadAttestation(t.Context(), v, att)
+		require.ErrorContains(t, "bad signature", err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+		require.Equal(t, 0, len(s.pendingPayloadAttestations))
+	})
 }
 
 func TestQueuePendingPayloadAttestation_IgnoresNonCommittee(t *testing.T) {
-	s := queueTestService(t)
-	v := &verification.MockPayloadAttestation{ErrIncorrectPayloadAttValidator: errors.New("not in PTC")}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		s := queueTestService(t)
+		v := &verification.MockPayloadAttestation{ErrIncorrectPayloadAttValidator: errors.New("not in PTC")}
 
-	att, _ := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
-	res, err := s.queuePendingPayloadAttestation(t.Context(), v, att)
-	require.ErrorContains(t, "not in PTC", err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-	require.Equal(t, 0, len(s.pendingPayloadAttestations))
+		att, _ := pendingPayloadAtt(t, []byte{'a'}, 1, 1)
+		res, err := s.queuePendingPayloadAttestation(t.Context(), v, att)
+		require.ErrorContains(t, "not in PTC", err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+		require.Equal(t, 0, len(s.pendingPayloadAttestations))
+	})
 }
 
 func TestQueuePendingPayloadAttestation_DropsWhenNoState(t *testing.T) {
@@ -135,34 +145,36 @@ func TestQueuePendingPayloadAttestation_DropsWhenNoState(t *testing.T) {
 }
 
 func TestQueuePendingPayloadAttestation_DrainsWhenBlockInForkchoice(t *testing.T) {
-	st, _ := util.DeterministicGenesisStateGloas(t, 64)
-	ptc, err := st.PayloadCommitteeReadOnly(0)
-	require.NoError(t, err)
-	require.NotEmpty(t, ptc)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		st, _ := util.DeterministicGenesisStateGloas(t, 64)
+		ptc, err := st.PayloadCommitteeReadOnly(0)
+		require.NoError(t, err)
+		require.NotEmpty(t, ptc)
 
-	pool := payloadattestation.NewPool()
-	s := &Service{
-		payloadAttestationCache:    &cache.PayloadAttestationCache{},
-		pendingPayloadAttestations: make(map[[32]byte][]*ethpb.PayloadAttestationMessage),
-		seenPendingBlocks:          make(map[[32]byte]bool),
-		cfg: &config{
-			chain:                  &mock.ChainService{State: st}, // InForkchoice true: block already arrived.
-			p2p:                    p2ptest.NewTestP2P(t),
-			payloadAttestationPool: pool,
-			operationNotifier:      &mock.MockOperationNotifier{},
-		},
-	}
+		pool := payloadattestation.NewPool()
+		s := &Service{
+			payloadAttestationCache:    &cache.PayloadAttestationCache{},
+			pendingPayloadAttestations: make(map[[32]byte][]*ethpb.PayloadAttestationMessage),
+			seenPendingBlocks:          make(map[[32]byte]bool),
+			cfg: &config{
+				chain:                  &mock.ChainService{State: st}, // InForkchoice true: block already arrived.
+				p2p:                    p2ptest.NewTestP2P(t),
+				payloadAttestationPool: pool,
+				operationNotifier:      &mock.MockOperationNotifier{},
+			},
+		}
 
-	att, _ := pendingPayloadAtt(t, []byte{'a'}, ptc[0], 0)
-	res, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
+		att, _ := pendingPayloadAtt(t, []byte{'a'}, ptc[0], 0)
+		res, err := s.queuePendingPayloadAttestation(t.Context(), validSigVerifier(), att)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && len(pool.PendingPayloadAttestations(0)) == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
-	require.Equal(t, 1, len(pool.PendingPayloadAttestations(0)))
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) && len(pool.PendingPayloadAttestations(0)) == 0 {
+			time.Sleep(10 * time.Millisecond)
+		}
+		require.Equal(t, 1, len(pool.PendingPayloadAttestations(0)))
+	})
 }
 
 func TestPrunePendingPayloadAttestations(t *testing.T) {
@@ -191,31 +203,33 @@ func TestPrunePendingPayloadAttestations(t *testing.T) {
 }
 
 func TestProcessPendingPayloadAttestation_DrainsAndProcesses(t *testing.T) {
-	st, _ := util.DeterministicGenesisStateGloas(t, 64)
-	ptc, err := st.PayloadCommitteeReadOnly(0)
-	require.NoError(t, err)
-	require.NotEmpty(t, ptc)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		st, _ := util.DeterministicGenesisStateGloas(t, 64)
+		ptc, err := st.PayloadCommitteeReadOnly(0)
+		require.NoError(t, err)
+		require.NotEmpty(t, ptc)
 
-	pool := payloadattestation.NewPool()
-	s := &Service{
-		payloadAttestationCache:    &cache.PayloadAttestationCache{},
-		pendingPayloadAttestations: make(map[[32]byte][]*ethpb.PayloadAttestationMessage),
-		cfg: &config{
-			chain:                  &mock.ChainService{State: st, Genesis: genesisForSlot(0)},
-			p2p:                    p2ptest.NewTestP2P(t),
-			clock:                  startup.NewClock(genesisForSlot(0), [32]byte{}),
-			payloadAttestationPool: pool,
-			operationNotifier:      &mock.MockOperationNotifier{},
-		},
-	}
+		pool := payloadattestation.NewPool()
+		s := &Service{
+			payloadAttestationCache:    &cache.PayloadAttestationCache{},
+			pendingPayloadAttestations: make(map[[32]byte][]*ethpb.PayloadAttestationMessage),
+			cfg: &config{
+				chain:                  &mock.ChainService{State: st, Genesis: genesisForSlot(0)},
+				p2p:                    p2ptest.NewTestP2P(t),
+				clock:                  startup.NewClock(genesisForSlot(0), [32]byte{}),
+				payloadAttestationPool: pool,
+				operationNotifier:      &mock.MockOperationNotifier{},
+			},
+		}
 
-	root := []byte{'a'}
-	att, pa := pendingPayloadAtt(t, root, ptc[0], 0)
-	s.pendingPayloadAttestations[pa.BeaconBlockRoot()] = []*ethpb.PayloadAttestationMessage{att}
+		root := []byte{'a'}
+		att, pa := pendingPayloadAtt(t, root, ptc[0], 0)
+		s.pendingPayloadAttestations[pa.BeaconBlockRoot()] = []*ethpb.PayloadAttestationMessage{att}
 
-	s.processPendingPayloadAttestation(t.Context(), pa.BeaconBlockRoot())
+		s.processPendingPayloadAttestation(t.Context(), pa.BeaconBlockRoot())
 
-	_, stillQueued := s.pendingPayloadAttestations[pa.BeaconBlockRoot()]
-	require.Equal(t, false, stillQueued)
-	require.Equal(t, 1, len(pool.PendingPayloadAttestations(0)))
+		_, stillQueued := s.pendingPayloadAttestations[pa.BeaconBlockRoot()]
+		require.Equal(t, false, stillQueued)
+		require.Equal(t, 1, len(pool.PendingPayloadAttestations(0)))
+	})
 }

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -71,144 +71,150 @@ func TestProcessPendingPayloadEnvelope_AlreadySeen(t *testing.T) {
 }
 
 func TestProcessPendingPayloadEnvelope_HappyPath(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.SetupDB(t)
-	chainService := &mock.ChainService{
-		Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{},
-		DB:                  db,
-	}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	broadcaster := p2ptesting.NewTestP2P(t)
-	s := &Service{
-		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-		seenPayloadEnvelopeCache: lruwrpr.New(10),
-		badBlockCache:            lruwrpr.New(10),
-		cfg: &config{
-			chain:    chainService,
-			beaconDB: db,
-			stateGen: stateGen,
-			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			p2p:      broadcaster,
-		},
-	}
+	p2ptesting.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		db := dbtest.SetupDB(t)
+		chainService := &mock.ChainService{
+			Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{},
+			DB:                  db,
+		}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		broadcaster := p2ptesting.NewTestP2P(t)
+		s := &Service{
+			pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+			seenPayloadEnvelopeCache: lruwrpr.New(10),
+			badBlockCache:            lruwrpr.New(10),
+			cfg: &config{
+				chain:    chainService,
+				beaconDB: db,
+				stateGen: stateGen,
+				clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				p2p:      broadcaster,
+			},
+		}
 
-	bid := util.GenerateTestSignedExecutionPayloadBid(1)
-	sb := util.NewBeaconBlockGloas()
-	sb.Block.Slot = 1
-	sb.Block.Body.SignedExecutionPayloadBid = bid
-	signedBlock, err := blocks.NewSignedBeaconBlock(sb)
-	require.NoError(t, err)
-	root, err := signedBlock.Block().HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveBlock(ctx, signedBlock))
+		bid := util.GenerateTestSignedExecutionPayloadBid(1)
+		sb := util.NewBeaconBlockGloas()
+		sb.Block.Slot = 1
+		sb.Block.Body.SignedExecutionPayloadBid = bid
+		signedBlock, err := blocks.NewSignedBeaconBlock(sb)
+		require.NoError(t, err)
+		root, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveBlock(ctx, signedBlock))
 
-	st, err := util.NewBeaconStateFulu()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, st, root))
+		st, err := util.NewBeaconStateFulu()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, st, root))
 
-	builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
-	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
-	env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
-	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
+		builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
+		blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
+		env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
+		s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
 
-	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
-	s.processPendingPayloadEnvelope(ctx, root)
-	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
-	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
-	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
+		require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+		s.processPendingPayloadEnvelope(ctx, root)
+		require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
+		require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+		require.Equal(t, true, broadcaster.BroadcastCalled.Load())
+	})
 }
 
 func TestProcessPendingPayloadEnvelope_DoesNotBroadcastOnReceiveError(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.SetupDB(t)
-	chainService := &mock.ChainService{
-		Genesis:                   time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint:       &ethpb.Checkpoint{},
-		DB:                        db,
-		ReceivePayloadEnvelopeErr: errors.New("receive failed"),
-	}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	broadcaster := p2ptesting.NewTestP2P(t)
-	s := &Service{
-		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-		seenPayloadEnvelopeCache: lruwrpr.New(10),
-		badBlockCache:            lruwrpr.New(10),
-		cfg: &config{
-			chain:    chainService,
-			beaconDB: db,
-			stateGen: stateGen,
-			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			p2p:      broadcaster,
-		},
-	}
+	p2ptesting.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		db := dbtest.SetupDB(t)
+		chainService := &mock.ChainService{
+			Genesis:                   time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint:       &ethpb.Checkpoint{},
+			DB:                        db,
+			ReceivePayloadEnvelopeErr: errors.New("receive failed"),
+		}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		broadcaster := p2ptesting.NewTestP2P(t)
+		s := &Service{
+			pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+			seenPayloadEnvelopeCache: lruwrpr.New(10),
+			badBlockCache:            lruwrpr.New(10),
+			cfg: &config{
+				chain:    chainService,
+				beaconDB: db,
+				stateGen: stateGen,
+				clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				p2p:      broadcaster,
+			},
+		}
 
-	bid := util.GenerateTestSignedExecutionPayloadBid(1)
-	sb := util.NewBeaconBlockGloas()
-	sb.Block.Slot = 1
-	sb.Block.Body.SignedExecutionPayloadBid = bid
-	signedBlock, err := blocks.NewSignedBeaconBlock(sb)
-	require.NoError(t, err)
-	root, err := signedBlock.Block().HashTreeRoot()
-	require.NoError(t, err)
+		bid := util.GenerateTestSignedExecutionPayloadBid(1)
+		sb := util.NewBeaconBlockGloas()
+		sb.Block.Slot = 1
+		sb.Block.Body.SignedExecutionPayloadBid = bid
+		signedBlock, err := blocks.NewSignedBeaconBlock(sb)
+		require.NoError(t, err)
+		root, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
 
-	builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
-	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
-	env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
-	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
+		builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
+		blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
+		env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
+		s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
 
-	s.processPendingPayloadEnvelope(ctx, root)
-	require.Equal(t, false, broadcaster.BroadcastCalled.Load())
-	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+		s.processPendingPayloadEnvelope(ctx, root)
+		require.Equal(t, false, broadcaster.BroadcastCalled.Load())
+		require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+	})
 }
 
 func TestProcessPendingPayloadEnvelopes_Sweep(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.SetupDB(t)
-	chainService := &mock.ChainService{
-		Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{},
-		DB:                  db,
-	}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	s := &Service{
-		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-		seenPayloadEnvelopeCache: lruwrpr.New(10),
-		badBlockCache:            lruwrpr.New(10),
-		cfg: &config{
-			chain:    chainService,
-			beaconDB: db,
-			stateGen: stateGen,
-			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			p2p:      p2ptesting.NewTestP2P(t),
-		},
-	}
+	p2ptesting.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		db := dbtest.SetupDB(t)
+		chainService := &mock.ChainService{
+			Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{},
+			DB:                  db,
+		}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		s := &Service{
+			pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+			seenPayloadEnvelopeCache: lruwrpr.New(10),
+			badBlockCache:            lruwrpr.New(10),
+			cfg: &config{
+				chain:    chainService,
+				beaconDB: db,
+				stateGen: stateGen,
+				clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				p2p:      p2ptesting.NewTestP2P(t),
+			},
+		}
 
-	bid := util.GenerateTestSignedExecutionPayloadBid(1)
-	sb := util.NewBeaconBlockGloas()
-	sb.Block.Slot = 1
-	sb.Block.Body.SignedExecutionPayloadBid = bid
-	signedBlock, err := blocks.NewSignedBeaconBlock(sb)
-	require.NoError(t, err)
-	root, err := signedBlock.Block().HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveBlock(ctx, signedBlock))
+		bid := util.GenerateTestSignedExecutionPayloadBid(1)
+		sb := util.NewBeaconBlockGloas()
+		sb.Block.Slot = 1
+		sb.Block.Body.SignedExecutionPayloadBid = bid
+		signedBlock, err := blocks.NewSignedBeaconBlock(sb)
+		require.NoError(t, err)
+		root, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveBlock(ctx, signedBlock))
 
-	st, err := util.NewBeaconStateFulu()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, st, root))
+		st, err := util.NewBeaconStateFulu()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, st, root))
 
-	builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
-	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
-	env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
-	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
-	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+		builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
+		blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
+		env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
+		s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
+		s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
 
-	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+		require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
 
-	s.processPendingPayloadEnvelopes(ctx)
-	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
-	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+		s.processPendingPayloadEnvelopes(ctx)
+		require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
+		require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+	})
 }
 
 func TestProcessPendingPayloadEnvelopes_SkipsUnknownRoot(t *testing.T) {

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -71,143 +71,149 @@ func TestProcessPendingPayloadEnvelope_AlreadySeen(t *testing.T) {
 }
 
 func TestProcessPendingPayloadEnvelope_HappyPath(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.SetupDB(t)
-	chainService := &mock.ChainService{
-		Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{},
-		DB:                  db,
-	}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	broadcaster := p2ptesting.NewTestP2P(t)
-	s := &Service{
-		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-		seenPayloadEnvelopeCache: lruwrpr.New(10),
-		badBlockCache:            lruwrpr.New(10),
-		cfg: &config{
-			chain:    chainService,
-			beaconDB: db,
-			stateGen: stateGen,
-			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			p2p:      broadcaster,
-		},
-	}
+	p2ptesting.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		db := dbtest.SetupDB(t)
+		chainService := &mock.ChainService{
+			Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{},
+			DB:                  db,
+		}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		broadcaster := p2ptesting.NewTestP2P(t)
+		s := &Service{
+			pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+			seenPayloadEnvelopeCache: lruwrpr.New(10),
+			badBlockCache:            lruwrpr.New(10),
+			cfg: &config{
+				chain:    chainService,
+				beaconDB: db,
+				stateGen: stateGen,
+				clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				p2p:      broadcaster,
+			},
+		}
 
-	bid := util.GenerateTestSignedExecutionPayloadBid(1)
-	sb := util.NewBeaconBlockGloas()
-	sb.Block.Slot = 1
-	sb.Block.Body.SignedExecutionPayloadBid = bid
-	signedBlock, err := blocks.NewSignedBeaconBlock(sb)
-	require.NoError(t, err)
-	root, err := signedBlock.Block().HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveBlock(ctx, signedBlock))
+		bid := util.GenerateTestSignedExecutionPayloadBid(1)
+		sb := util.NewBeaconBlockGloas()
+		sb.Block.Slot = 1
+		sb.Block.Body.SignedExecutionPayloadBid = bid
+		signedBlock, err := blocks.NewSignedBeaconBlock(sb)
+		require.NoError(t, err)
+		root, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveBlock(ctx, signedBlock))
 
-	st, err := util.NewBeaconStateFulu()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, st, root))
+		st, err := util.NewBeaconStateFulu()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, st, root))
 
-	builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
-	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
-	env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
-	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
+		builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
+		blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
+		env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
+		s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
 
-	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
-	s.processPendingPayloadEnvelope(ctx, root)
-	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
-	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
-	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
+		require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+		s.processPendingPayloadEnvelope(ctx, root)
+		require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
+		require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+		require.Equal(t, true, broadcaster.BroadcastCalled.Load())
+	})
 }
 
 func TestProcessPendingPayloadEnvelope_DoesNotBroadcastOnReceiveError(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.SetupDB(t)
-	chainService := &mock.ChainService{
-		Genesis:                   time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint:       &ethpb.Checkpoint{},
-		DB:                        db,
-		ReceivePayloadEnvelopeErr: errors.New("receive failed"),
-	}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	broadcaster := p2ptesting.NewTestP2P(t)
-	s := &Service{
-		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-		seenPayloadEnvelopeCache: lruwrpr.New(10),
-		badBlockCache:            lruwrpr.New(10),
-		cfg: &config{
-			chain:    chainService,
-			beaconDB: db,
-			stateGen: stateGen,
-			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			p2p:      broadcaster,
-		},
-	}
+	p2ptesting.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		db := dbtest.SetupDB(t)
+		chainService := &mock.ChainService{
+			Genesis:                   time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint:       &ethpb.Checkpoint{},
+			DB:                        db,
+			ReceivePayloadEnvelopeErr: errors.New("receive failed"),
+		}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		broadcaster := p2ptesting.NewTestP2P(t)
+		s := &Service{
+			pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+			seenPayloadEnvelopeCache: lruwrpr.New(10),
+			badBlockCache:            lruwrpr.New(10),
+			cfg: &config{
+				chain:    chainService,
+				beaconDB: db,
+				stateGen: stateGen,
+				clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				p2p:      broadcaster,
+			},
+		}
 
-	bid := util.GenerateTestSignedExecutionPayloadBid(1)
-	sb := util.NewBeaconBlockGloas()
-	sb.Block.Slot = 1
-	sb.Block.Body.SignedExecutionPayloadBid = bid
-	signedBlock, err := blocks.NewSignedBeaconBlock(sb)
-	require.NoError(t, err)
-	root, err := signedBlock.Block().HashTreeRoot()
-	require.NoError(t, err)
+		bid := util.GenerateTestSignedExecutionPayloadBid(1)
+		sb := util.NewBeaconBlockGloas()
+		sb.Block.Slot = 1
+		sb.Block.Body.SignedExecutionPayloadBid = bid
+		signedBlock, err := blocks.NewSignedBeaconBlock(sb)
+		require.NoError(t, err)
+		root, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
 
-	builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
-	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
-	env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
-	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
+		builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
+		blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
+		env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
+		s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
 
-	s.processPendingPayloadEnvelope(ctx, root)
-	require.Equal(t, false, broadcaster.BroadcastCalled.Load())
+		s.processPendingPayloadEnvelope(ctx, root)
+		require.Equal(t, false, broadcaster.BroadcastCalled.Load())
+	})
 }
 
 func TestProcessPendingPayloadEnvelopes_Sweep(t *testing.T) {
-	ctx := context.Background()
-	db := dbtest.SetupDB(t)
-	chainService := &mock.ChainService{
-		Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{},
-		DB:                  db,
-	}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	s := &Service{
-		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-		seenPayloadEnvelopeCache: lruwrpr.New(10),
-		badBlockCache:            lruwrpr.New(10),
-		cfg: &config{
-			chain:    chainService,
-			beaconDB: db,
-			stateGen: stateGen,
-			clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			p2p:      p2ptesting.NewTestP2P(t),
-		},
-	}
+	p2ptesting.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		db := dbtest.SetupDB(t)
+		chainService := &mock.ChainService{
+			Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{},
+			DB:                  db,
+		}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		s := &Service{
+			pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+			seenPayloadEnvelopeCache: lruwrpr.New(10),
+			badBlockCache:            lruwrpr.New(10),
+			cfg: &config{
+				chain:    chainService,
+				beaconDB: db,
+				stateGen: stateGen,
+				clock:    startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				p2p:      p2ptesting.NewTestP2P(t),
+			},
+		}
 
-	bid := util.GenerateTestSignedExecutionPayloadBid(1)
-	sb := util.NewBeaconBlockGloas()
-	sb.Block.Slot = 1
-	sb.Block.Body.SignedExecutionPayloadBid = bid
-	signedBlock, err := blocks.NewSignedBeaconBlock(sb)
-	require.NoError(t, err)
-	root, err := signedBlock.Block().HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveBlock(ctx, signedBlock))
+		bid := util.GenerateTestSignedExecutionPayloadBid(1)
+		sb := util.NewBeaconBlockGloas()
+		sb.Block.Slot = 1
+		sb.Block.Body.SignedExecutionPayloadBid = bid
+		signedBlock, err := blocks.NewSignedBeaconBlock(sb)
+		require.NoError(t, err)
+		root, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveBlock(ctx, signedBlock))
 
-	st, err := util.NewBeaconStateFulu()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, st, root))
+		st, err := util.NewBeaconStateFulu()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, st, root))
 
-	builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
-	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
-	env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
-	s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
-	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+		builderIdx := primitives.BuilderIndex(bid.Message.BuilderIndex)
+		blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
+		env := testSignedExecutionPayloadEnvelope(t, 1, builderIdx, root, blockHash)
+		s.pendingPayloadEnvelopes[root] = map[uint64]*ethpb.SignedExecutionPayloadEnvelope{uint64(builderIdx): env}
+		s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
 
-	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+		require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
 
-	s.processPendingPayloadEnvelopes(ctx)
-	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
-	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+		s.processPendingPayloadEnvelopes(ctx)
+		require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
+		require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+	})
 }
 
 func TestProcessPendingPayloadEnvelopes_SkipsUnknownRoot(t *testing.T) {

--- a/beacon-chain/sync/rate_limiter_test.go
+++ b/beacon-chain/sync/rate_limiter_test.go
@@ -16,93 +16,101 @@ import (
 )
 
 func TestNewRateLimiter(t *testing.T) {
-	rlimiter := newRateLimiter(mockp2p.NewTestP2P(t))
-	expectedTopics := len(p2p.RPCTopicMappings) + 1 // +1 for rpcLimiterTopic
-	assert.Equal(t, expectedTopics, len(rlimiter.limiterMap), "correct number of topics not registered")
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		rlimiter := newRateLimiter(mockp2p.NewTestP2P(t))
+		expectedTopics := len(p2p.RPCTopicMappings) + 1 // +1 for rpcLimiterTopic
+		assert.Equal(t, expectedTopics, len(rlimiter.limiterMap), "correct number of topics not registered")
+	})
 }
 
 func TestNewRateLimiter_FreeCorrectly(t *testing.T) {
-	rlimiter := newRateLimiter(mockp2p.NewTestP2P(t))
-	rlimiter.free()
-	assert.Equal(t, 0, len(rlimiter.limiterMap), "rate limiter not freed correctly")
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		rlimiter := newRateLimiter(mockp2p.NewTestP2P(t))
+		rlimiter.free()
+		assert.Equal(t, 0, len(rlimiter.limiterMap), "rate limiter not freed correctly")
+	})
 }
 
 func TestRateLimiter_ExceedCapacity(t *testing.T) {
-	p1 := mockp2p.NewTestP2P(t)
-	p2 := mockp2p.NewTestP2P(t)
-	p1.Connect(p2)
-	rlimiter := newRateLimiter(p1)
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		p1 := mockp2p.NewTestP2P(t)
+		p2 := mockp2p.NewTestP2P(t)
+		p1.Connect(p2)
+		rlimiter := newRateLimiter(p1)
 
-	// BlockByRange
-	topic := p2p.RPCBlocksByRangeTopicV1 + p1.Encoding().ProtocolSuffix()
+		// BlockByRange
+		topic := p2p.RPCBlocksByRangeTopicV1 + p1.Encoding().ProtocolSuffix()
 
-	wg := sync.WaitGroup{}
-	p2.BHost.SetStreamHandler(protocol.ID(topic), func(stream network.Stream) {
-		defer wg.Done()
-		code, errMsg, err := readStatusCodeNoDeadline(stream, p2.Encoding())
-		require.NoError(t, err, "could not read incoming stream")
-		assert.Equal(t, responseCodeInvalidRequest, code, "not equal response codes")
-		assert.Equal(t, p2ptypes.ErrRateLimited.Error(), errMsg, "not equal errors")
+		wg := sync.WaitGroup{}
+		p2.BHost.SetStreamHandler(protocol.ID(topic), func(stream network.Stream) {
+			defer wg.Done()
+			code, errMsg, err := readStatusCodeNoDeadline(stream, p2.Encoding())
+			require.NoError(t, err, "could not read incoming stream")
+			assert.Equal(t, responseCodeInvalidRequest, code, "not equal response codes")
+			assert.Equal(t, p2ptypes.ErrRateLimited.Error(), errMsg, "not equal errors")
+		})
+		wg.Add(1)
+		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), protocol.ID(topic))
+		require.NoError(t, err, "could not create stream")
+
+		err = rlimiter.validateRequest(stream, 64)
+		require.NoError(t, err, "could not validate incoming request")
+
+		// Attempt to create an error, rate limit and lead to disconnect
+		err = rlimiter.validateRequest(stream, 1000)
+		require.NotNil(t, err, "could not get error from leaky bucket")
+
+		require.NoError(t, stream.Close(), "could not close stream")
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
 	})
-	wg.Add(1)
-	stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), protocol.ID(topic))
-	require.NoError(t, err, "could not create stream")
-
-	err = rlimiter.validateRequest(stream, 64)
-	require.NoError(t, err, "could not validate incoming request")
-
-	// Attempt to create an error, rate limit and lead to disconnect
-	err = rlimiter.validateRequest(stream, 1000)
-	require.NotNil(t, err, "could not get error from leaky bucket")
-
-	require.NoError(t, stream.Close(), "could not close stream")
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRateLimiter_ExceedRawCapacity(t *testing.T) {
-	p1 := mockp2p.NewTestP2P(t)
-	p2 := mockp2p.NewTestP2P(t)
-	p1.Connect(p2)
-	p1.Peers().Add(nil, p2.PeerID(), p2.BHost.Addrs()[0], network.DirOutbound)
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		p1 := mockp2p.NewTestP2P(t)
+		p2 := mockp2p.NewTestP2P(t)
+		p1.Connect(p2)
+		p1.Peers().Add(nil, p2.PeerID(), p2.BHost.Addrs()[0], network.DirOutbound)
 
-	rlimiter := newRateLimiter(p1)
+		rlimiter := newRateLimiter(p1)
 
-	// BlockByRange
-	topic := p2p.RPCBlocksByRangeTopicV1 + p1.Encoding().ProtocolSuffix()
+		// BlockByRange
+		topic := p2p.RPCBlocksByRangeTopicV1 + p1.Encoding().ProtocolSuffix()
 
-	wg := sync.WaitGroup{}
-	p2.BHost.SetStreamHandler(protocol.ID(topic), func(stream network.Stream) {
-		defer wg.Done()
-		code, errMsg, err := readStatusCodeNoDeadline(stream, p2.Encoding())
-		require.NoError(t, err, "could not read incoming stream")
-		assert.Equal(t, responseCodeInvalidRequest, code, "not equal response codes")
-		assert.Equal(t, p2ptypes.ErrRateLimited.Error(), errMsg, "not equal errors")
-	})
-	wg.Add(1)
-	stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), protocol.ID(topic))
-	require.NoError(t, err, "could not create stream")
+		wg := sync.WaitGroup{}
+		p2.BHost.SetStreamHandler(protocol.ID(topic), func(stream network.Stream) {
+			defer wg.Done()
+			code, errMsg, err := readStatusCodeNoDeadline(stream, p2.Encoding())
+			require.NoError(t, err, "could not read incoming stream")
+			assert.Equal(t, responseCodeInvalidRequest, code, "not equal response codes")
+			assert.Equal(t, p2ptypes.ErrRateLimited.Error(), errMsg, "not equal errors")
+		})
+		wg.Add(1)
+		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), protocol.ID(topic))
+		require.NoError(t, err, "could not create stream")
 
-	for range 4 * defaultBurstLimit {
-		err = rlimiter.validateRawRpcRequest(stream, 1)
-		rlimiter.addRawStream(stream)
-		require.NoError(t, err, "could not validate incoming request")
-	}
-	// Triggers rate limit error on burst.
-	assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream, 1))
-
-	// Make Peer bad.
-	for range defaultBurstLimit {
+		for range 4 * defaultBurstLimit {
+			err = rlimiter.validateRawRpcRequest(stream, 1)
+			rlimiter.addRawStream(stream)
+			require.NoError(t, err, "could not validate incoming request")
+		}
+		// Triggers rate limit error on burst.
 		assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream, 1))
-	}
-	assert.NotNil(t, p1.Peers().IsBad(p2.PeerID()), "peer is not marked as a bad peer")
-	require.NoError(t, stream.Close(), "could not close stream")
 
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
+		// Make Peer bad.
+		for range defaultBurstLimit {
+			assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream, 1))
+		}
+		assert.NotNil(t, p1.Peers().IsBad(p2.PeerID()), "peer is not marked as a bad peer")
+		require.NoError(t, stream.Close(), "could not close stream")
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+	})
 }
 
 func Test_limiter_retrieveCollector_requiresLock(t *testing.T) {
@@ -112,14 +120,16 @@ func Test_limiter_retrieveCollector_requiresLock(t *testing.T) {
 }
 
 func TestRateLimiter_RemovePeer(t *testing.T) {
-	p1 := mockp2p.NewTestP2P(t)
-	rlimiter := newRateLimiter(p1)
-	pid := p1.PeerID()
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		p1 := mockp2p.NewTestP2P(t)
+		rlimiter := newRateLimiter(p1)
+		pid := p1.PeerID()
 
-	c := rlimiter.limiterMap[rpcLimiterTopic]
-	c.Add(pid.String(), 1)
-	require.Equal(t, int64(1), c.Count(pid.String()))
+		c := rlimiter.limiterMap[rpcLimiterTopic]
+		c.Add(pid.String(), 1)
+		require.Equal(t, int64(1), c.Count(pid.String()))
 
-	rlimiter.removePeer(pid)
-	require.Equal(t, int64(0), c.Count(pid.String()))
+		rlimiter.removePeer(pid)
+		require.Equal(t, int64(0), c.Count(pid.String()))
+	})
 }

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -212,7 +212,10 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 		// https://github.com/quic-go/quic-go/issues/3291
 		defer func() {
 			if strings.Contains(stream.Conn().RemoteMultiaddr().String(), "quic-v1") {
-				time.Sleep(2 * time.Second)
+				select {
+				case <-time.After(2 * time.Second):
+				case <-s.ctx.Done():
+				}
 			}
 
 			_err := stream.Reset()

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -38,498 +38,510 @@ import (
 )
 
 func TestRPCBeaconBlocksByRange_RPCHandlerReturnsBlocks(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	req := &ethpb.BeaconBlocksByRangeRequest{
-		StartSlot: 100,
-		Step:      64,
-		Count:     16,
-	}
+		req := &ethpb.BeaconBlocksByRangeRequest{
+			StartSlot: 100,
+			Step:      64,
+			Count:     16,
+		}
 
-	// Populate the database with blocks that would match the request.
-	var prevRoot [32]byte
-	var err error
-	for i := req.StartSlot; i < req.StartSlot.Add(req.Count); i += primitives.Slot(1) {
-		blk := util.NewBeaconBlock()
-		blk.Block.Slot = i
-		copy(blk.Block.ParentRoot, prevRoot[:])
-		prevRoot, err = blk.Block.HashTreeRoot()
-		require.NoError(t, err)
-		util.SaveBlock(t, t.Context(), d, blk)
-	}
-
-	clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-	// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
-	r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
+		// Populate the database with blocks that would match the request.
+		var prevRoot [32]byte
+		var err error
 		for i := req.StartSlot; i < req.StartSlot.Add(req.Count); i += primitives.Slot(1) {
-			expectSuccess(t, stream)
-			res := util.NewBeaconBlock()
-			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
-			if res.Block.Slot.SubSlot(req.StartSlot).Mod(1) != 0 {
-				t.Errorf("Received unexpected block slot %d", res.Block.Slot)
+			blk := util.NewBeaconBlock()
+			blk.Block.Slot = i
+			copy(blk.Block.ParentRoot, prevRoot[:])
+			prevRoot, err = blk.Block.HashTreeRoot()
+			require.NoError(t, err)
+			util.SaveBlock(t, t.Context(), d, blk)
+		}
+
+		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+		// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
+		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			for i := req.StartSlot; i < req.StartSlot.Add(req.Count); i += primitives.Slot(1) {
+				expectSuccess(t, stream)
+				res := util.NewBeaconBlock()
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+				if res.Block.Slot.SubSlot(req.StartSlot).Mod(1) != 0 {
+					t.Errorf("Received unexpected block slot %d", res.Block.Slot)
+				}
 			}
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+
+		err = r.beaconBlocksByRangeRPCHandler(t.Context(), req, stream1)
+		require.NoError(t, err)
+
+		// Make sure that rate limiter doesn't limit capacity exceedingly.
+		remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
+		expectedCapacity := int64(req.Count*10 - req.Count)
+		require.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
 		}
 	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-
-	err = r.beaconBlocksByRangeRPCHandler(t.Context(), req, stream1)
-	require.NoError(t, err)
-
-	// Make sure that rate limiter doesn't limit capacity exceedingly.
-	remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
-	expectedCapacity := int64(req.Count*10 - req.Count)
-	require.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRPCBeaconBlocksByRange_ReturnCorrectNumberBack(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	req := &ethpb.BeaconBlocksByRangeRequest{
-		StartSlot: 0,
-		Step:      1,
-		Count:     200,
-	}
-
-	var genRoot [32]byte
-	// Populate the database with blocks that would match the request.
-	for i := req.StartSlot; i < req.StartSlot.Add(req.Step*req.Count); i += primitives.Slot(req.Step) {
-		blk := util.NewBeaconBlock()
-		blk.Block.Slot = i
-		if i == 0 {
-			rt, err := blk.Block.HashTreeRoot()
-			require.NoError(t, err)
-			genRoot = rt
+		req := &ethpb.BeaconBlocksByRangeRequest{
+			StartSlot: 0,
+			Step:      1,
+			Count:     200,
 		}
-		util.SaveBlock(t, t.Context(), d, blk)
-	}
-	require.NoError(t, d.SaveGenesisBlockRoot(t.Context(), genRoot))
 
-	clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-	// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
-	r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	// Use a new request to test this out
-	newReq := &ethpb.BeaconBlocksByRangeRequest{StartSlot: 0, Step: 1, Count: 1}
-
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		for i := newReq.StartSlot; i < newReq.StartSlot.Add(newReq.Count*newReq.Step); i += primitives.Slot(newReq.Step) {
-			expectSuccess(t, stream)
-			res := util.NewBeaconBlock()
-			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
-			if res.Block.Slot.SubSlot(newReq.StartSlot).Mod(newReq.Step) != 0 {
-				t.Errorf("Received unexpected block slot %d", res.Block.Slot)
+		var genRoot [32]byte
+		// Populate the database with blocks that would match the request.
+		for i := req.StartSlot; i < req.StartSlot.Add(req.Step*req.Count); i += primitives.Slot(req.Step) {
+			blk := util.NewBeaconBlock()
+			blk.Block.Slot = i
+			if i == 0 {
+				rt, err := blk.Block.HashTreeRoot()
+				require.NoError(t, err)
+				genRoot = rt
 			}
-			// Expect EOF
-			b := make([]byte, 1)
-			_, err := stream.Read(b)
-			require.ErrorContains(t, io.EOF.Error(), err)
+			util.SaveBlock(t, t.Context(), d, blk)
+		}
+		require.NoError(t, d.SaveGenesisBlockRoot(t.Context(), genRoot))
+
+		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+		// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
+		r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		// Use a new request to test this out
+		newReq := &ethpb.BeaconBlocksByRangeRequest{StartSlot: 0, Step: 1, Count: 1}
+
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			for i := newReq.StartSlot; i < newReq.StartSlot.Add(newReq.Count*newReq.Step); i += primitives.Slot(newReq.Step) {
+				expectSuccess(t, stream)
+				res := util.NewBeaconBlock()
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+				if res.Block.Slot.SubSlot(newReq.StartSlot).Mod(newReq.Step) != 0 {
+					t.Errorf("Received unexpected block slot %d", res.Block.Slot)
+				}
+				// Expect EOF
+				b := make([]byte, 1)
+				_, err := stream.Read(b)
+				require.ErrorContains(t, io.EOF.Error(), err)
+			}
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+
+		err = r.beaconBlocksByRangeRPCHandler(t.Context(), newReq, stream1)
+		require.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
 		}
 	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-
-	err = r.beaconBlocksByRangeRPCHandler(t.Context(), newReq, stream1)
-	require.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRPCBeaconBlocksByRange_ReconstructsPayloads(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	req := &ethpb.BeaconBlocksByRangeRequest{
-		StartSlot: 0,
-		Step:      1,
-		Count:     200,
-	}
-
-	parent := bytesutil.PadTo([]byte("parentHash"), fieldparams.RootLength)
-	stateRoot := bytesutil.PadTo([]byte("stateRoot"), fieldparams.RootLength)
-	receiptsRoot := bytesutil.PadTo([]byte("receiptsRoot"), fieldparams.RootLength)
-	logsBloom := bytesutil.PadTo([]byte("logs"), fieldparams.LogsBloomLength)
-	tx := gethTypes.NewTransaction(
-		0,
-		common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"),
-		big.NewInt(0), 0, big.NewInt(0),
-		nil,
-	)
-	txs := []*gethTypes.Transaction{tx}
-	encodedBinaryTxs := make([][]byte, 1)
-	var err error
-	encodedBinaryTxs[0], err = txs[0].MarshalBinary()
-	require.NoError(t, err)
-	blockHash := bytesutil.ToBytes32([]byte("foo"))
-	payload := &enginev1.ExecutionPayload{
-		ParentHash:    parent,
-		FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
-		StateRoot:     stateRoot,
-		ReceiptsRoot:  receiptsRoot,
-		LogsBloom:     logsBloom,
-		PrevRandao:    blockHash[:],
-		BlockNumber:   0,
-		GasLimit:      0,
-		GasUsed:       0,
-		Timestamp:     0,
-		ExtraData:     make([]byte, 0),
-		BlockHash:     blockHash[:],
-		BaseFeePerGas: bytesutil.PadTo([]byte("baseFeePerGas"), fieldparams.RootLength),
-		Transactions:  encodedBinaryTxs,
-	}
-	mockEngine := &mockExecution.EngineClient{
-		ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
-			blockHash: payload,
-		},
-	}
-	wrappedPayload, err := blocks.WrappedExecutionPayload(payload)
-	require.NoError(t, err)
-	header, err := blocks.PayloadToHeader(wrappedPayload)
-	require.NoError(t, err)
-
-	var genRoot [32]byte
-	// Populate the database with blocks that would match the request.
-	for i := req.StartSlot; i < req.StartSlot.Add(req.Step*req.Count); i += primitives.Slot(req.Step) {
-		blk := util.NewBlindedBeaconBlockBellatrix()
-		blk.Block.Slot = i
-		blk.Block.Body.ExecutionPayloadHeader = header
-		if i == 0 {
-			rt, err := blk.Block.HashTreeRoot()
-			require.NoError(t, err)
-			genRoot = rt
+		req := &ethpb.BeaconBlocksByRangeRequest{
+			StartSlot: 0,
+			Step:      1,
+			Count:     200,
 		}
-		util.SaveBlock(t, t.Context(), d, blk)
-	}
-	require.NoError(t, d.SaveGenesisBlockRoot(t.Context(), genRoot))
 
-	clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-	// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
-	r := &Service{
-		cfg: &config{
-			p2p:                    p1,
-			beaconDB:               d,
-			chain:                  &chainMock.ChainService{},
-			clock:                  clock,
-			executionReconstructor: mockEngine,
-		},
-		rateLimiter:      newRateLimiter(p1),
-		availableBlocker: mockBlocker{avail: true},
-	}
-	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	// Use a new request to test this out
-	newReq := &ethpb.BeaconBlocksByRangeRequest{StartSlot: 0, Step: 1, Count: 1}
-
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		for i := newReq.StartSlot; i < newReq.StartSlot.Add(newReq.Count*newReq.Step); i += primitives.Slot(newReq.Step) {
-			expectSuccess(t, stream)
-			res := util.NewBeaconBlockBellatrix()
-			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
-			if res.Block.Slot.SubSlot(newReq.StartSlot).Mod(newReq.Step) != 0 {
-				t.Errorf("Received unexpected block slot %d", res.Block.Slot)
-			}
-			// Expect EOF
-			b := make([]byte, 1)
-			_, err := stream.Read(b)
-			require.ErrorContains(t, io.EOF.Error(), err)
-		}
-		require.Equal(t, uint64(1), mockEngine.NumReconstructedPayloads)
-	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-
-	err = r.beaconBlocksByRangeRPCHandler(t.Context(), newReq, stream1)
-	require.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-}
-
-func TestWriteBlockBatchToStream_ReconstructedBlocksPreserveCanonicalOrder(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	require.Equal(t, 1, len(p1.BHost.Network().Peers()))
-
-	clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-
-	makePayload := func(tag byte) *enginev1.ExecutionPayload {
-		blockHash := bytesutil.PadTo([]byte{tag}, fieldparams.RootLength)
-		return &enginev1.ExecutionPayload{
-			ParentHash:    bytesutil.PadTo([]byte{'p', tag}, fieldparams.RootLength),
+		parent := bytesutil.PadTo([]byte("parentHash"), fieldparams.RootLength)
+		stateRoot := bytesutil.PadTo([]byte("stateRoot"), fieldparams.RootLength)
+		receiptsRoot := bytesutil.PadTo([]byte("receiptsRoot"), fieldparams.RootLength)
+		logsBloom := bytesutil.PadTo([]byte("logs"), fieldparams.LogsBloomLength)
+		tx := gethTypes.NewTransaction(
+			0,
+			common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"),
+			big.NewInt(0), 0, big.NewInt(0),
+			nil,
+		)
+		txs := []*gethTypes.Transaction{tx}
+		encodedBinaryTxs := make([][]byte, 1)
+		var err error
+		encodedBinaryTxs[0], err = txs[0].MarshalBinary()
+		require.NoError(t, err)
+		blockHash := bytesutil.ToBytes32([]byte("foo"))
+		payload := &enginev1.ExecutionPayload{
+			ParentHash:    parent,
 			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
-			StateRoot:     bytesutil.PadTo([]byte{'s', tag}, fieldparams.RootLength),
-			ReceiptsRoot:  bytesutil.PadTo([]byte{'r', tag}, fieldparams.RootLength),
-			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
-			PrevRandao:    blockHash,
+			StateRoot:     stateRoot,
+			ReceiptsRoot:  receiptsRoot,
+			LogsBloom:     logsBloom,
+			PrevRandao:    blockHash[:],
 			BlockNumber:   0,
 			GasLimit:      0,
 			GasUsed:       0,
 			Timestamp:     0,
-			ExtraData:     nil,
-			BlockHash:     blockHash,
-			BaseFeePerGas: bytesutil.PadTo([]byte{'b', tag}, fieldparams.RootLength),
-			Transactions:  nil,
+			ExtraData:     make([]byte, 0),
+			BlockHash:     blockHash[:],
+			BaseFeePerGas: bytesutil.PadTo([]byte("baseFeePerGas"), fieldparams.RootLength),
+			Transactions:  encodedBinaryTxs,
 		}
-	}
-
-	makeBlindedROBlock := func(slot primitives.Slot, payload *enginev1.ExecutionPayload) blocks.ROBlock {
-		blinded := util.NewBlindedBeaconBlockBellatrix()
-		blinded.Block.Slot = slot
+		mockEngine := &mockExecution.EngineClient{
+			ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
+				blockHash: payload,
+			},
+		}
 		wrappedPayload, err := blocks.WrappedExecutionPayload(payload)
 		require.NoError(t, err)
 		header, err := blocks.PayloadToHeader(wrappedPayload)
 		require.NoError(t, err)
-		blinded.Block.Body.ExecutionPayloadHeader = header
-		signed, err := blocks.NewSignedBeaconBlock(blinded)
-		require.NoError(t, err)
-		root, err := blinded.Block.HashTreeRoot()
-		require.NoError(t, err)
-		ro, err := blocks.NewROBlockWithRoot(signed, root)
-		require.NoError(t, err)
-		return ro
-	}
 
-	makeFullROBlock := func(slot primitives.Slot) blocks.ROBlock {
-		full := util.NewBeaconBlockBellatrix()
-		full.Block.Slot = slot
-		signed, err := blocks.NewSignedBeaconBlock(full)
-		require.NoError(t, err)
-		root, err := full.Block.HashTreeRoot()
-		require.NoError(t, err)
-		ro, err := blocks.NewROBlockWithRoot(signed, root)
-		require.NoError(t, err)
-		return ro
-	}
-
-	payload1 := makePayload(0x11)
-	payload3 := makePayload(0x33)
-	block1 := makeBlindedROBlock(1, payload1)
-	block2 := makeFullROBlock(2)
-	block3 := makeBlindedROBlock(3, payload3)
-
-	mockEngine := &mockExecution.EngineClient{
-		ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
-			bytesutil.ToBytes32(payload1.BlockHash): payload1,
-			bytesutil.ToBytes32(payload3.BlockHash): payload3,
-		},
-	}
-
-	r := &Service{cfg: &config{p2p: p1, clock: clock, executionReconstructor: mockEngine}}
-	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-
-	slotsCh := make(chan []primitives.Slot, 1)
-	errCh := make(chan error, 1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		got := make([]primitives.Slot, 0, 3)
-		for range 3 {
-			expectSuccess(t, stream)
-			blk := util.NewBeaconBlockBellatrix()
-			if err := p2.Encoding().DecodeWithMaxLength(stream, blk); err != nil {
-				errCh <- err
-				return
+		var genRoot [32]byte
+		// Populate the database with blocks that would match the request.
+		for i := req.StartSlot; i < req.StartSlot.Add(req.Step*req.Count); i += primitives.Slot(req.Step) {
+			blk := util.NewBlindedBeaconBlockBellatrix()
+			blk.Block.Slot = i
+			blk.Block.Body.ExecutionPayloadHeader = header
+			if i == 0 {
+				rt, err := blk.Block.HashTreeRoot()
+				require.NoError(t, err)
+				genRoot = rt
 			}
-			wrapped, err := blocks.NewSignedBeaconBlock(blk)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			if wrapped.IsBlinded() {
-				errCh <- errors.New("expected reconstructed full block, got blinded block")
-				return
-			}
-			got = append(got, wrapped.Block().Slot())
+			util.SaveBlock(t, t.Context(), d, blk)
 		}
-		slotsCh <- got
-	})
+		require.NoError(t, d.SaveGenesisBlockRoot(t.Context(), genRoot))
 
-	stream, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
+		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+		// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
+		r := &Service{
+			cfg: &config{
+				p2p:                    p1,
+				beaconDB:               d,
+				chain:                  &chainMock.ChainService{},
+				clock:                  clock,
+				executionReconstructor: mockEngine,
+			},
+			rateLimiter:      newRateLimiter(p1),
+			availableBlocker: mockBlocker{avail: true},
+		}
+		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
 
-	err = r.writeBlockBatchToStream(
-		t.Context(),
-		blockBatch{lin: []blocks.ROBlock{block1, block2, block3}},
-		stream,
-	)
-	require.NoError(t, err)
-	require.NoError(t, stream.Close())
+		// Use a new request to test this out
+		newReq := &ethpb.BeaconBlocksByRangeRequest{StartSlot: 0, Step: 1, Count: 1}
 
-	select {
-	case err := <-errCh:
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			for i := newReq.StartSlot; i < newReq.StartSlot.Add(newReq.Count*newReq.Step); i += primitives.Slot(newReq.Step) {
+				expectSuccess(t, stream)
+				res := util.NewBeaconBlockBellatrix()
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+				if res.Block.Slot.SubSlot(newReq.StartSlot).Mod(newReq.Step) != 0 {
+					t.Errorf("Received unexpected block slot %d", res.Block.Slot)
+				}
+				// Expect EOF
+				b := make([]byte, 1)
+				_, err := stream.Read(b)
+				require.ErrorContains(t, io.EOF.Error(), err)
+			}
+			require.Equal(t, uint64(1), mockEngine.NumReconstructedPayloads)
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
 		require.NoError(t, err)
-	case got := <-slotsCh:
-		assert.DeepEqual(t, []primitives.Slot{1, 2, 3}, got)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for streamed blocks")
-	}
 
-	require.Equal(t, uint64(2), mockEngine.NumReconstructedPayloads)
+		err = r.beaconBlocksByRangeRPCHandler(t.Context(), newReq, stream1)
+		require.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+	})
+}
+
+func TestWriteBlockBatchToStream_ReconstructedBlocksPreserveCanonicalOrder(t *testing.T) {
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		require.Equal(t, 1, len(p1.BHost.Network().Peers()))
+
+		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+
+		makePayload := func(tag byte) *enginev1.ExecutionPayload {
+			blockHash := bytesutil.PadTo([]byte{tag}, fieldparams.RootLength)
+			return &enginev1.ExecutionPayload{
+				ParentHash:    bytesutil.PadTo([]byte{'p', tag}, fieldparams.RootLength),
+				FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+				StateRoot:     bytesutil.PadTo([]byte{'s', tag}, fieldparams.RootLength),
+				ReceiptsRoot:  bytesutil.PadTo([]byte{'r', tag}, fieldparams.RootLength),
+				LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+				PrevRandao:    blockHash,
+				BlockNumber:   0,
+				GasLimit:      0,
+				GasUsed:       0,
+				Timestamp:     0,
+				ExtraData:     nil,
+				BlockHash:     blockHash,
+				BaseFeePerGas: bytesutil.PadTo([]byte{'b', tag}, fieldparams.RootLength),
+				Transactions:  nil,
+			}
+		}
+
+		makeBlindedROBlock := func(slot primitives.Slot, payload *enginev1.ExecutionPayload) blocks.ROBlock {
+			blinded := util.NewBlindedBeaconBlockBellatrix()
+			blinded.Block.Slot = slot
+			wrappedPayload, err := blocks.WrappedExecutionPayload(payload)
+			require.NoError(t, err)
+			header, err := blocks.PayloadToHeader(wrappedPayload)
+			require.NoError(t, err)
+			blinded.Block.Body.ExecutionPayloadHeader = header
+			signed, err := blocks.NewSignedBeaconBlock(blinded)
+			require.NoError(t, err)
+			root, err := blinded.Block.HashTreeRoot()
+			require.NoError(t, err)
+			ro, err := blocks.NewROBlockWithRoot(signed, root)
+			require.NoError(t, err)
+			return ro
+		}
+
+		makeFullROBlock := func(slot primitives.Slot) blocks.ROBlock {
+			full := util.NewBeaconBlockBellatrix()
+			full.Block.Slot = slot
+			signed, err := blocks.NewSignedBeaconBlock(full)
+			require.NoError(t, err)
+			root, err := full.Block.HashTreeRoot()
+			require.NoError(t, err)
+			ro, err := blocks.NewROBlockWithRoot(signed, root)
+			require.NoError(t, err)
+			return ro
+		}
+
+		payload1 := makePayload(0x11)
+		payload3 := makePayload(0x33)
+		block1 := makeBlindedROBlock(1, payload1)
+		block2 := makeFullROBlock(2)
+		block3 := makeBlindedROBlock(3, payload3)
+
+		mockEngine := &mockExecution.EngineClient{
+			ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
+				bytesutil.ToBytes32(payload1.BlockHash): payload1,
+				bytesutil.ToBytes32(payload3.BlockHash): payload3,
+			},
+		}
+
+		r := &Service{cfg: &config{p2p: p1, clock: clock, executionReconstructor: mockEngine}}
+		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+
+		slotsCh := make(chan []primitives.Slot, 1)
+		errCh := make(chan error, 1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			got := make([]primitives.Slot, 0, 3)
+			for range 3 {
+				expectSuccess(t, stream)
+				blk := util.NewBeaconBlockBellatrix()
+				if err := p2.Encoding().DecodeWithMaxLength(stream, blk); err != nil {
+					errCh <- err
+					return
+				}
+				wrapped, err := blocks.NewSignedBeaconBlock(blk)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if wrapped.IsBlinded() {
+					errCh <- errors.New("expected reconstructed full block, got blinded block")
+					return
+				}
+				got = append(got, wrapped.Block().Slot())
+			}
+			slotsCh <- got
+		})
+
+		stream, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+
+		err = r.writeBlockBatchToStream(
+			t.Context(),
+			blockBatch{lin: []blocks.ROBlock{block1, block2, block3}},
+			stream,
+		)
+		require.NoError(t, err)
+		require.NoError(t, stream.Close())
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case got := <-slotsCh:
+			assert.DeepEqual(t, []primitives.Slot{1, 2, 3}, got)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for streamed blocks")
+		}
+
+		require.Equal(t, uint64(2), mockEngine.NumReconstructedPayloads)
+	})
 }
 
 func TestRPCBeaconBlocksByRange_RPCHandlerReturnsSortedBlocks(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	req := &ethpb.BeaconBlocksByRangeRequest{
-		StartSlot: 200,
-		Step:      21,
-		Count:     33,
-	}
+		req := &ethpb.BeaconBlocksByRangeRequest{
+			StartSlot: 200,
+			Step:      21,
+			Count:     33,
+		}
 
-	endSlot := req.StartSlot.Add(req.Count - 1)
-	expectedRoots := make([][32]byte, req.Count)
-	// Populate the database with blocks that would match the request.
-	var prevRoot [32]byte
-	for i, j := req.StartSlot, 0; i <= endSlot; i++ {
-		blk := util.NewBeaconBlock()
-		blk.Block.Slot = i
-		copy(blk.Block.ParentRoot, prevRoot[:])
-		rt, err := blk.Block.HashTreeRoot()
-		require.NoError(t, err)
-		expectedRoots[j] = rt
-		prevRoot = rt
-		util.SaveBlock(t, t.Context(), d, blk)
-		j++
-	}
-
-	clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-	// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
-	r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		prevSlot := primitives.Slot(0)
-		require.Equal(t, uint64(len(expectedRoots)), req.Count, "Number of roots not expected")
-		for i, j := req.StartSlot, 0; i < req.StartSlot.Add(req.Count); i += primitives.Slot(1) {
-			expectSuccess(t, stream)
-			res := &ethpb.SignedBeaconBlock{}
-			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
-			if res.Block.Slot < prevSlot {
-				t.Errorf("Received block is unsorted with slot %d lower than previous slot %d", res.Block.Slot, prevSlot)
-			}
-			rt, err := res.Block.HashTreeRoot()
+		endSlot := req.StartSlot.Add(req.Count - 1)
+		expectedRoots := make([][32]byte, req.Count)
+		// Populate the database with blocks that would match the request.
+		var prevRoot [32]byte
+		for i, j := req.StartSlot, 0; i <= endSlot; i++ {
+			blk := util.NewBeaconBlock()
+			blk.Block.Slot = i
+			copy(blk.Block.ParentRoot, prevRoot[:])
+			rt, err := blk.Block.HashTreeRoot()
 			require.NoError(t, err)
-			assert.Equal(t, expectedRoots[j], rt, "roots not equal")
-			prevSlot = res.Block.Slot
+			expectedRoots[j] = rt
+			prevRoot = rt
+			util.SaveBlock(t, t.Context(), d, blk)
 			j++
 		}
+
+		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+		// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
+		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(req.Count*10), time.Second, false)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			prevSlot := primitives.Slot(0)
+			require.Equal(t, uint64(len(expectedRoots)), req.Count, "Number of roots not expected")
+			for i, j := req.StartSlot, 0; i < req.StartSlot.Add(req.Count); i += primitives.Slot(1) {
+				expectSuccess(t, stream)
+				res := &ethpb.SignedBeaconBlock{}
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+				if res.Block.Slot < prevSlot {
+					t.Errorf("Received block is unsorted with slot %d lower than previous slot %d", res.Block.Slot, prevSlot)
+				}
+				rt, err := res.Block.HashTreeRoot()
+				require.NoError(t, err)
+				assert.Equal(t, expectedRoots[j], rt, "roots not equal")
+				prevSlot = res.Block.Slot
+				j++
+			}
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		require.NoError(t, r.beaconBlocksByRangeRPCHandler(t.Context(), req, stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
 	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	require.NoError(t, r.beaconBlocksByRangeRPCHandler(t.Context(), req, stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRPCBeaconBlocksByRange_ReturnsGenesisBlock(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	req := &ethpb.BeaconBlocksByRangeRequest{
-		StartSlot: 0,
-		Step:      1,
-		Count:     4,
-	}
-
-	var prevRoot [32]byte
-	// Populate the database with blocks that would match the request.
-	for i := req.StartSlot; i < req.StartSlot.Add(req.Step*req.Count); i++ {
-		blk := util.NewBeaconBlock()
-		blk.Block.Slot = i
-		blk.Block.ParentRoot = prevRoot[:]
-		rt, err := blk.Block.HashTreeRoot()
-		require.NoError(t, err)
-
-		// Save genesis block
-		if i == 0 {
-			require.NoError(t, d.SaveGenesisBlockRoot(t.Context(), rt))
+		req := &ethpb.BeaconBlocksByRangeRequest{
+			StartSlot: 0,
+			Step:      1,
+			Count:     4,
 		}
-		util.SaveBlock(t, t.Context(), d, blk)
-		prevRoot = rt
-	}
 
-	clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-	r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
+		var prevRoot [32]byte
+		// Populate the database with blocks that would match the request.
+		for i := req.StartSlot; i < req.StartSlot.Add(req.Step*req.Count); i++ {
+			blk := util.NewBeaconBlock()
+			blk.Block.Slot = i
+			blk.Block.ParentRoot = prevRoot[:]
+			rt, err := blk.Block.HashTreeRoot()
+			require.NoError(t, err)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		// check for genesis block
-		expectSuccess(t, stream)
-		res := &ethpb.SignedBeaconBlock{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
-		assert.Equal(t, primitives.Slot(0), res.Block.Slot, "genesis block was not returned")
-		for i := req.StartSlot.Add(req.Step); i < primitives.Slot(req.Count*req.Step); i += primitives.Slot(req.Step) {
+			// Save genesis block
+			if i == 0 {
+				require.NoError(t, d.SaveGenesisBlockRoot(t.Context(), rt))
+			}
+			util.SaveBlock(t, t.Context(), d, blk)
+			prevRoot = rt
+		}
+
+		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			// check for genesis block
 			expectSuccess(t, stream)
 			res := &ethpb.SignedBeaconBlock{}
 			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+			assert.Equal(t, primitives.Slot(0), res.Block.Slot, "genesis block was not returned")
+			for i := req.StartSlot.Add(req.Step); i < primitives.Slot(req.Count*req.Step); i += primitives.Slot(req.Step) {
+				expectSuccess(t, stream)
+				res := &ethpb.SignedBeaconBlock{}
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+			}
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		require.NoError(t, r.beaconBlocksByRangeRPCHandler(t.Context(), req, stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
 		}
 	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	require.NoError(t, r.beaconBlocksByRangeRPCHandler(t.Context(), req, stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRPCBeaconBlocksByRange_RPCHandlerRateLimitOverflow(t *testing.T) {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -546,7 +546,7 @@ func TestRPCBeaconBlocksByRange_ReturnsGenesisBlock(t *testing.T) {
 
 func TestRPCBeaconBlocksByRange_RPCHandlerRateLimitOverflow(t *testing.T) {
 	d := db.SetupDB(t)
-	saveBlocks := func(req *ethpb.BeaconBlocksByRangeRequest) {
+	saveBlocks := func(t *testing.T, req *ethpb.BeaconBlocksByRangeRequest) {
 		// Populate the database with blocks that would match the request.
 		var parentRoot [32]byte
 		// Default to 1 to be inline with the spec.
@@ -563,7 +563,7 @@ func TestRPCBeaconBlocksByRange_RPCHandlerRateLimitOverflow(t *testing.T) {
 			parentRoot = rt
 		}
 	}
-	sendRequest := func(p1, p2 *p2ptest.TestP2P, r *Service,
+	sendRequest := func(t *testing.T, p1, p2 *p2ptest.TestP2P, r *Service,
 		req *ethpb.BeaconBlocksByRangeRequest, validateBlocks bool, success bool) error {
 		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
 		reqAnswered := false
@@ -597,95 +597,101 @@ func TestRPCBeaconBlocksByRange_RPCHandlerRateLimitOverflow(t *testing.T) {
 	}
 
 	t.Run("high request count param and no overflow", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		reqSize := params.MaxRequestBlock(slots.ToEpoch(clock.CurrentSlot()))
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			reqSize := params.MaxRequestBlock(slots.ToEpoch(clock.CurrentSlot()))
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
 
-		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-		topic := string(pcl)
-		defaultBlockBurstFactor := 2 // TODO: can we update the default value set in TestMain to match flags?
-		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(flags.Get().BlockBatchLimit*defaultBlockBurstFactor), time.Second, false)
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 100,
-			Count:     reqSize,
-		}
-		saveBlocks(req)
+			pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+			topic := string(pcl)
+			defaultBlockBurstFactor := 2 // TODO: can we update the default value set in TestMain to match flags?
+			r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(flags.Get().BlockBatchLimit*defaultBlockBurstFactor), time.Second, false)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 100,
+				Count:     reqSize,
+			}
+			saveBlocks(t, req)
 
-		// This doesn't error because reqSize by default is 128, which is exactly the burst factor * batch limit
-		assert.NoError(t, sendRequest(p1, p2, r, req, true, true))
+			// This doesn't error because reqSize by default is 128, which is exactly the burst factor * batch limit
+			assert.NoError(t, sendRequest(t, p1, p2, r, req, true, true))
 
-		remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
-		expectedCapacity := int64(0) // Whole capacity is used, but no overflow.
-		assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+			remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
+			expectedCapacity := int64(0) // Whole capacity is used, but no overflow.
+			assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+		})
 	})
 
 	t.Run("high request count param and overflow", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		reqSize := params.MaxRequestBlock(slots.ToEpoch(clock.CurrentSlot())) - 1
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			reqSize := params.MaxRequestBlock(slots.ToEpoch(clock.CurrentSlot())) - 1
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
 
-		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-		topic := string(pcl)
-		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(flags.Get().BlockBatchLimit), time.Second, false)
+			pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+			topic := string(pcl)
+			r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, int64(flags.Get().BlockBatchLimit), time.Second, false)
 
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 100,
-			Count:     reqSize,
-		}
-		saveBlocks(req)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 100,
+				Count:     reqSize,
+			}
+			saveBlocks(t, req)
 
-		for i := 0; i < p2.Peers().Scorers().BadResponsesScorer().Params().Threshold; i++ {
-			err := sendRequest(p1, p2, r, req, false, true)
-			assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), err)
-		}
+			for i := 0; i < p2.Peers().Scorers().BadResponsesScorer().Params().Threshold; i++ {
+				err := sendRequest(t, p1, p2, r, req, false, true)
+				assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), err)
+			}
 
-		remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
-		expectedCapacity := int64(0) // Whole capacity is used.
-		assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+			remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
+			expectedCapacity := int64(0) // Whole capacity is used.
+			assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+		})
 	})
 
 	t.Run("many requests with count set to max blocks per second", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		capacity := int64(flags.Get().BlockBatchLimit * flags.Get().BlockBatchLimitBurstFactor)
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-		pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-		topic := string(pcl)
-		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, capacity, time.Second, false)
+			capacity := int64(flags.Get().BlockBatchLimit * flags.Get().BlockBatchLimitBurstFactor)
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+			topic := string(pcl)
+			r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, capacity, time.Second, false)
 
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 100,
-			Count:     uint64(flags.Get().BlockBatchLimit),
-		}
-		saveBlocks(req)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 100,
+				Count:     uint64(flags.Get().BlockBatchLimit),
+			}
+			saveBlocks(t, req)
 
-		for i := 0; i < flags.Get().BlockBatchLimitBurstFactor; i++ {
-			assert.NoError(t, sendRequest(p1, p2, r, req, true, false))
-		}
+			for i := 0; i < flags.Get().BlockBatchLimitBurstFactor; i++ {
+				assert.NoError(t, sendRequest(t, p1, p2, r, req, true, false))
+			}
 
-		// One more request should result in overflow.
-		for i := 0; i < p2.Peers().Scorers().BadResponsesScorer().Params().Threshold; i++ {
-			err := sendRequest(p1, p2, r, req, false, false)
-			assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), err)
-		}
+			// One more request should result in overflow.
+			for i := 0; i < p2.Peers().Scorers().BadResponsesScorer().Params().Threshold; i++ {
+				err := sendRequest(t, p1, p2, r, req, false, false)
+				assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), err)
+			}
 
-		remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
-		expectedCapacity := int64(0) // Whole capacity is used.
-		assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+			remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
+			expectedCapacity := int64(0) // Whole capacity is used.
+			assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+		})
 	})
 }
 
@@ -803,7 +809,7 @@ func TestRPCBeaconBlocksByRange_validateRangeRequest(t *testing.T) {
 func TestRPCBeaconBlocksByRange_EnforceResponseInvariants(t *testing.T) {
 	d := db.SetupDB(t)
 	hook := logTest.NewGlobal()
-	saveBlocks := func(req *ethpb.BeaconBlocksByRangeRequest) {
+	saveBlocks := func(t *testing.T, req *ethpb.BeaconBlocksByRangeRequest) {
 		// Populate the database with blocks that would match the request.
 		var parentRoot [32]byte
 		for i := req.StartSlot; i < req.StartSlot.Add(req.Step*req.Count); i += primitives.Slot(req.Step) {
@@ -817,7 +823,7 @@ func TestRPCBeaconBlocksByRange_EnforceResponseInvariants(t *testing.T) {
 		}
 	}
 	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-	sendRequest := func(p1, p2 *p2ptest.TestP2P, r *Service,
+	sendRequest := func(t *testing.T, p1, p2 *p2ptest.TestP2P, r *Service,
 		req *ethpb.BeaconBlocksByRangeRequest, processBlocks func([]*ethpb.SignedBeaconBlock)) error {
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -847,40 +853,42 @@ func TestRPCBeaconBlocksByRange_EnforceResponseInvariants(t *testing.T) {
 	}
 
 	t.Run("assert range", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-		r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 448,
-			Step:      1,
-			Count:     64,
-		}
-		saveBlocks(req)
-
-		hook.Reset()
-		err := sendRequest(p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
-			assert.Equal(t, req.Count, uint64(len(blocks)))
-			for _, blk := range blocks {
-				if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
-					t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
-						blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
-				}
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 448,
+				Step:      1,
+				Count:     64,
 			}
+			saveBlocks(t, req)
+
+			hook.Reset()
+			err := sendRequest(t, p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
+				assert.Equal(t, req.Count, uint64(len(blocks)))
+				for _, blk := range blocks {
+					if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
+						t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
+							blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
+					}
+				}
+			})
+			assert.NoError(t, err)
+			require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 		})
-		assert.NoError(t, err)
-		require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 	})
 }
 
 func TestRPCBeaconBlocksByRange_FilterBlocks(t *testing.T) {
 	hook := logTest.NewGlobal()
 
-	saveBlocks := func(d db2.Database, chain *chainMock.ChainService, req *ethpb.BeaconBlocksByRangeRequest, finalized bool) {
+	saveBlocks := func(t *testing.T, d db2.Database, chain *chainMock.ChainService, req *ethpb.BeaconBlocksByRangeRequest, finalized bool) {
 		blk := util.NewBeaconBlock()
 		blk.Block.Slot = 0
 		previousRoot, err := blk.Block.HashTreeRoot()
@@ -926,7 +934,7 @@ func TestRPCBeaconBlocksByRange_FilterBlocks(t *testing.T) {
 			}))
 		}
 	}
-	saveBadBlocks := func(d db2.Database, chain *chainMock.ChainService,
+	saveBadBlocks := func(t *testing.T, d db2.Database, chain *chainMock.ChainService,
 		req *ethpb.BeaconBlocksByRangeRequest, badBlockNum uint64, finalized bool) {
 		blk := util.NewBeaconBlock()
 		blk.Block.Slot = 0
@@ -978,7 +986,7 @@ func TestRPCBeaconBlocksByRange_FilterBlocks(t *testing.T) {
 		}
 	}
 	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
-	sendRequest := func(p1, p2 *p2ptest.TestP2P, r *Service,
+	sendRequest := func(t *testing.T, p1, p2 *p2ptest.TestP2P, r *Service,
 		req *ethpb.BeaconBlocksByRangeRequest, processBlocks func([]*ethpb.SignedBeaconBlock)) error {
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -1014,191 +1022,201 @@ func TestRPCBeaconBlocksByRange_FilterBlocks(t *testing.T) {
 	}
 
 	t.Run("process normal range", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		d := db.SetupDB(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			d := db.SetupDB(t)
 
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-		r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 1,
-			Step:      1,
-			Count:     64,
-		}
-		saveBlocks(d, r.cfg.chain.(*chainMock.ChainService), req, true)
-
-		hook.Reset()
-		err := sendRequest(p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
-			assert.Equal(t, req.Count, uint64(len(blocks)))
-			for _, blk := range blocks {
-				if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
-					t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
-						blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
-				}
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 1,
+				Step:      1,
+				Count:     64,
 			}
+			saveBlocks(t, d, r.cfg.chain.(*chainMock.ChainService), req, true)
+
+			hook.Reset()
+			err := sendRequest(t, p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
+				assert.Equal(t, req.Count, uint64(len(blocks)))
+				for _, blk := range blocks {
+					if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
+						t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
+							blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
+					}
+				}
+			})
+			assert.NoError(t, err)
+			require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 		})
-		assert.NoError(t, err)
-		require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 	})
 
 	t.Run("process non linear blocks", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		d := db.SetupDB(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			d := db.SetupDB(t)
 
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-		r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 1,
-			Step:      1,
-			Count:     64,
-		}
-		saveBadBlocks(d, r.cfg.chain.(*chainMock.ChainService), req, 2, true)
-
-		hook.Reset()
-		err := sendRequest(p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
-			assert.Equal(t, uint64(2), uint64(len(blocks)))
-			var prevRoot [32]byte
-			for _, blk := range blocks {
-				if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
-					t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
-						blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
-				}
-				if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
-					t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
-				}
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: clock, chain: &chainMock.ChainService{}}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 1,
+				Step:      1,
+				Count:     64,
 			}
+			saveBadBlocks(t, d, r.cfg.chain.(*chainMock.ChainService), req, 2, true)
+
+			hook.Reset()
+			err := sendRequest(t, p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
+				assert.Equal(t, uint64(2), uint64(len(blocks)))
+				var prevRoot [32]byte
+				for _, blk := range blocks {
+					if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
+						t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
+							blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
+					}
+					if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
+						t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
+					}
+				}
+			})
+			assert.NoError(t, err)
+			require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 		})
-		assert.NoError(t, err)
-		require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 	})
 
 	t.Run("process non linear blocks with 2nd bad batch", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		d := db.SetupDB(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			d := db.SetupDB(t)
 
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-		r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 1,
-			Step:      1,
-			Count:     128,
-		}
-		saveBadBlocks(d, r.cfg.chain.(*chainMock.ChainService), req, 65, true)
-
-		hook.Reset()
-		err := sendRequest(p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
-			assert.Equal(t, uint64(65), uint64(len(blocks)))
-			var prevRoot [32]byte
-			for _, blk := range blocks {
-				if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
-					t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
-						blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
-				}
-				if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
-					t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
-				}
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 1,
+				Step:      1,
+				Count:     128,
 			}
+			saveBadBlocks(t, d, r.cfg.chain.(*chainMock.ChainService), req, 65, true)
+
+			hook.Reset()
+			err := sendRequest(t, p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
+				assert.Equal(t, uint64(65), uint64(len(blocks)))
+				var prevRoot [32]byte
+				for _, blk := range blocks {
+					if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= req.StartSlot.Add(req.Count*req.Step) {
+						t.Errorf("Block slot is out of range: %d is not within [%d, %d)",
+							blk.Block.Slot, req.StartSlot, req.StartSlot.Add(req.Count*req.Step))
+					}
+					if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
+						t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
+					}
+				}
+			})
+			assert.NoError(t, err)
+			require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 		})
-		assert.NoError(t, err)
-		require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 	})
 
 	t.Run("only return finalized blocks", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		d := db.SetupDB(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			d := db.SetupDB(t)
 
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-		r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 1,
-			Step:      1,
-			Count:     64,
-		}
-		saveBlocks(d, r.cfg.chain.(*chainMock.ChainService), req, true)
-		req.StartSlot = 65
-		req.Step = 1
-		req.Count = 128
-		// Save unfinalized chain.
-		saveBlocks(d, r.cfg.chain.(*chainMock.ChainService), req, false)
-
-		req.StartSlot = 1
-		hook.Reset()
-		err := sendRequest(p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
-			assert.Equal(t, uint64(64), uint64(len(blocks)))
-			var prevRoot [32]byte
-			for _, blk := range blocks {
-				if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= 65 {
-					t.Errorf("Block slot is out of range: %d is not within [%d, 64)",
-						blk.Block.Slot, req.StartSlot)
-				}
-				if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
-					t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
-				}
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 1,
+				Step:      1,
+				Count:     64,
 			}
+			saveBlocks(t, d, r.cfg.chain.(*chainMock.ChainService), req, true)
+			req.StartSlot = 65
+			req.Step = 1
+			req.Count = 128
+			// Save unfinalized chain.
+			saveBlocks(t, d, r.cfg.chain.(*chainMock.ChainService), req, false)
+
+			req.StartSlot = 1
+			hook.Reset()
+			err := sendRequest(t, p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
+				assert.Equal(t, uint64(64), uint64(len(blocks)))
+				var prevRoot [32]byte
+				for _, blk := range blocks {
+					if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= 65 {
+						t.Errorf("Block slot is out of range: %d is not within [%d, 64)",
+							blk.Block.Slot, req.StartSlot)
+					}
+					if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
+						t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
+					}
+				}
+			})
+			assert.NoError(t, err)
+			require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 		})
-		assert.NoError(t, err)
-		require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 	})
 	t.Run("reject duplicate and non canonical blocks", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		d := db.SetupDB(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			d := db.SetupDB(t)
 
-		p1.Connect(p2)
-		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+			p1.Connect(p2)
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-		clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
-		r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
-		r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 1,
-			Step:      1,
-			Count:     64,
-		}
-		saveBlocks(d, r.cfg.chain.(*chainMock.ChainService), req, true)
-
-		// Create a duplicate set of unfinalized blocks.
-		req.StartSlot = 1
-		req.Step = 1
-		req.Count = 300
-		// Save unfinalized chain.
-		saveBlocks(d, r.cfg.chain.(*chainMock.ChainService), req, false)
-
-		req.Count = 64
-		hook.Reset()
-		err := sendRequest(p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
-			assert.Equal(t, uint64(64), uint64(len(blocks)))
-			var prevRoot [32]byte
-			for _, blk := range blocks {
-				if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= 65 {
-					t.Errorf("Block slot is out of range: %d is not within [%d, 64)",
-						blk.Block.Slot, req.StartSlot)
-				}
-				if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
-					t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
-				}
+			clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+			r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}, clock: clock}, availableBlocker: mockBlocker{avail: true}, rateLimiter: newRateLimiter(p1)}
+			r.rateLimiter.limiterMap[string(pcl)] = leakybucket.NewCollector(0.000001, 640, time.Second, false)
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 1,
+				Step:      1,
+				Count:     64,
 			}
+			saveBlocks(t, d, r.cfg.chain.(*chainMock.ChainService), req, true)
+
+			// Create a duplicate set of unfinalized blocks.
+			req.StartSlot = 1
+			req.Step = 1
+			req.Count = 300
+			// Save unfinalized chain.
+			saveBlocks(t, d, r.cfg.chain.(*chainMock.ChainService), req, false)
+
+			req.Count = 64
+			hook.Reset()
+			err := sendRequest(t, p1, p2, r, req, func(blocks []*ethpb.SignedBeaconBlock) {
+				assert.Equal(t, uint64(64), uint64(len(blocks)))
+				var prevRoot [32]byte
+				for _, blk := range blocks {
+					if blk.Block.Slot < req.StartSlot || blk.Block.Slot >= 65 {
+						t.Errorf("Block slot is out of range: %d is not within [%d, 64)",
+							blk.Block.Slot, req.StartSlot)
+					}
+					if prevRoot != [32]byte{} && bytesutil.ToBytes32(blk.Block.ParentRoot) != prevRoot {
+						t.Errorf("non linear chain received, expected %#x but got %#x", prevRoot, blk.Block.ParentRoot)
+					}
+				}
+			})
+			assert.NoError(t, err)
+			require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 		})
-		assert.NoError(t, err)
-		require.LogsDoNotContain(t, hook, "Disconnecting bad peer")
 	})
 }
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -39,151 +39,155 @@ import (
 )
 
 func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	var blkRoots p2pTypes.BeaconBlockByRootsReq
-	// Populate the database with blocks that would match the request.
-	for i := primitives.Slot(1); i < 11; i++ {
-		blk := util.NewBeaconBlock()
-		blk.Block.Slot = i
-		root, err := blk.Block.HashTreeRoot()
-		require.NoError(t, err)
-		util.SaveBlock(t, t.Context(), d, blk)
-		blkRoots = append(blkRoots, root)
-	}
+		var blkRoots p2pTypes.BeaconBlockByRootsReq
+		// Populate the database with blocks that would match the request.
+		for i := primitives.Slot(1); i < 11; i++ {
+			blk := util.NewBeaconBlock()
+			blk.Block.Slot = i
+			root, err := blk.Block.HashTreeRoot()
+			require.NoError(t, err)
+			util.SaveBlock(t, t.Context(), d, blk)
+			blkRoots = append(blkRoots, root)
+		}
 
-	r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: startup.NewClock(time.Unix(0, 0), [32]byte{})}, rateLimiter: newRateLimiter(p1)}
-	r.cfg.chain = &mock.ChainService{ValidatorsRoot: [32]byte{}}
-	pcl := protocol.ID(p2p.RPCBlocksByRootTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
+		r := &Service{cfg: &config{p2p: p1, beaconDB: d, clock: startup.NewClock(time.Unix(0, 0), [32]byte{})}, rateLimiter: newRateLimiter(p1)}
+		r.cfg.chain = &mock.ChainService{ValidatorsRoot: [32]byte{}}
+		pcl := protocol.ID(p2p.RPCBlocksByRootTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		for i := range blkRoots {
-			expectSuccess(t, stream)
-			res := util.NewBeaconBlock()
-			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
-			if uint64(res.Block.Slot) != uint64(i+1) {
-				t.Errorf("Received unexpected block slot %d but wanted %d", res.Block.Slot, i+1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			for i := range blkRoots {
+				expectSuccess(t, stream)
+				res := util.NewBeaconBlock()
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+				if uint64(res.Block.Slot) != uint64(i+1) {
+					t.Errorf("Received unexpected block slot %d but wanted %d", res.Block.Slot, i+1)
+				}
 			}
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		err = r.beaconBlocksRootRPCHandler(t.Context(), &blkRoots, stream1)
+		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
 		}
 	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	err = r.beaconBlocksRootRPCHandler(t.Context(), &blkRoots, stream1)
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks_ReconstructsPayload(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
-	parent := bytesutil.PadTo([]byte("parentHash"), fieldparams.RootLength)
-	stateRoot := bytesutil.PadTo([]byte("stateRoot"), fieldparams.RootLength)
-	receiptsRoot := bytesutil.PadTo([]byte("receiptsRoot"), fieldparams.RootLength)
-	logsBloom := bytesutil.PadTo([]byte("logs"), fieldparams.LogsBloomLength)
-	tx := gethTypes.NewTransaction(
-		0,
-		common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"),
-		big.NewInt(0), 0, big.NewInt(0),
-		nil,
-	)
-	txs := []*gethTypes.Transaction{tx}
-	encodedBinaryTxs := make([][]byte, 1)
-	var err error
-	encodedBinaryTxs[0], err = txs[0].MarshalBinary()
-	require.NoError(t, err)
-	blockHash := bytesutil.ToBytes32([]byte("foo"))
-	payload := &enginev1.ExecutionPayload{
-		ParentHash:    parent,
-		FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
-		StateRoot:     stateRoot,
-		ReceiptsRoot:  receiptsRoot,
-		LogsBloom:     logsBloom,
-		PrevRandao:    blockHash[:],
-		BlockNumber:   0,
-		GasLimit:      0,
-		GasUsed:       0,
-		Timestamp:     0,
-		ExtraData:     make([]byte, 0),
-		BlockHash:     blockHash[:],
-		BaseFeePerGas: bytesutil.PadTo([]byte("baseFeePerGas"), fieldparams.RootLength),
-		Transactions:  encodedBinaryTxs,
-	}
-	wrappedPayload, err := blocks.WrappedExecutionPayload(payload)
-	require.NoError(t, err)
-	header, err := blocks.PayloadToHeader(wrappedPayload)
-	require.NoError(t, err)
-
-	var blkRoots p2pTypes.BeaconBlockByRootsReq
-	// Populate the database with blocks that would match the request.
-	for i := primitives.Slot(1); i < 11; i++ {
-		blk := util.NewBlindedBeaconBlockBellatrix()
-		blk.Block.Body.ExecutionPayloadHeader = header
-		blk.Block.Slot = i
-		root, err := blk.Block.HashTreeRoot()
+		// Start service with 160 as allowed blocks capacity (and almost zero capacity recovery).
+		parent := bytesutil.PadTo([]byte("parentHash"), fieldparams.RootLength)
+		stateRoot := bytesutil.PadTo([]byte("stateRoot"), fieldparams.RootLength)
+		receiptsRoot := bytesutil.PadTo([]byte("receiptsRoot"), fieldparams.RootLength)
+		logsBloom := bytesutil.PadTo([]byte("logs"), fieldparams.LogsBloomLength)
+		tx := gethTypes.NewTransaction(
+			0,
+			common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"),
+			big.NewInt(0), 0, big.NewInt(0),
+			nil,
+		)
+		txs := []*gethTypes.Transaction{tx}
+		encodedBinaryTxs := make([][]byte, 1)
+		var err error
+		encodedBinaryTxs[0], err = txs[0].MarshalBinary()
 		require.NoError(t, err)
-		wsb, err := blocks.NewSignedBeaconBlock(blk)
-		require.NoError(t, err)
-		require.NoError(t, d.SaveBlock(t.Context(), wsb))
-		blkRoots = append(blkRoots, root)
-	}
-
-	mockEngine := &mockExecution.EngineClient{
-		ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
-			blockHash: payload,
-		},
-	}
-	r := &Service{cfg: &config{
-		p2p:                    p1,
-		beaconDB:               d,
-		executionReconstructor: mockEngine,
-		chain:                  &mock.ChainService{ValidatorsRoot: [32]byte{}},
-		clock:                  startup.NewClock(time.Unix(0, 0), [32]byte{}),
-	}, rateLimiter: newRateLimiter(p1)}
-	pcl := protocol.ID(p2p.RPCBlocksByRootTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		for i := range blkRoots {
-			expectSuccess(t, stream)
-			res := util.NewBeaconBlockBellatrix()
-			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
-			if uint64(res.Block.Slot) != uint64(i+1) {
-				t.Errorf("Received unexpected block slot %d but wanted %d", res.Block.Slot, i+1)
-			}
+		blockHash := bytesutil.ToBytes32([]byte("foo"))
+		payload := &enginev1.ExecutionPayload{
+			ParentHash:    parent,
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     stateRoot,
+			ReceiptsRoot:  receiptsRoot,
+			LogsBloom:     logsBloom,
+			PrevRandao:    blockHash[:],
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     make([]byte, 0),
+			BlockHash:     blockHash[:],
+			BaseFeePerGas: bytesutil.PadTo([]byte("baseFeePerGas"), fieldparams.RootLength),
+			Transactions:  encodedBinaryTxs,
 		}
-		require.Equal(t, uint64(10), mockEngine.NumReconstructedPayloads)
+		wrappedPayload, err := blocks.WrappedExecutionPayload(payload)
+		require.NoError(t, err)
+		header, err := blocks.PayloadToHeader(wrappedPayload)
+		require.NoError(t, err)
+
+		var blkRoots p2pTypes.BeaconBlockByRootsReq
+		// Populate the database with blocks that would match the request.
+		for i := primitives.Slot(1); i < 11; i++ {
+			blk := util.NewBlindedBeaconBlockBellatrix()
+			blk.Block.Body.ExecutionPayloadHeader = header
+			blk.Block.Slot = i
+			root, err := blk.Block.HashTreeRoot()
+			require.NoError(t, err)
+			wsb, err := blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			require.NoError(t, d.SaveBlock(t.Context(), wsb))
+			blkRoots = append(blkRoots, root)
+		}
+
+		mockEngine := &mockExecution.EngineClient{
+			ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
+				blockHash: payload,
+			},
+		}
+		r := &Service{cfg: &config{
+			p2p:                    p1,
+			beaconDB:               d,
+			executionReconstructor: mockEngine,
+			chain:                  &mock.ChainService{ValidatorsRoot: [32]byte{}},
+			clock:                  startup.NewClock(time.Unix(0, 0), [32]byte{}),
+		}, rateLimiter: newRateLimiter(p1)}
+		pcl := protocol.ID(p2p.RPCBlocksByRootTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			for i := range blkRoots {
+				expectSuccess(t, stream)
+				res := util.NewBeaconBlockBellatrix()
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+				if uint64(res.Block.Slot) != uint64(i+1) {
+					t.Errorf("Received unexpected block slot %d but wanted %d", res.Block.Slot, i+1)
+				}
+			}
+			require.Equal(t, uint64(10), mockEngine.NumReconstructedPayloads)
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		err = r.beaconBlocksRootRPCHandler(t.Context(), &blkRoots, stream1)
+		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
 	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	err = r.beaconBlocksRootRPCHandler(t.Context(), &blkRoots, stream1)
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRecentBeaconBlocks_RPCRequestSent(t *testing.T) {
@@ -401,87 +405,95 @@ func TestRecentBeaconBlocks_RPCRequestSent_InvalidSignature(t *testing.T) {
 }
 
 func TestRecentBeaconBlocksRPCHandler_HandleZeroBlocks(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	d := db.SetupDB(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		d := db.SetupDB(t)
 
-	r := &Service{cfg: &config{p2p: p1, beaconDB: d}, rateLimiter: newRateLimiter(p1)}
-	pcl := protocol.ID(p2p.RPCBlocksByRootTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		r := &Service{cfg: &config{p2p: p1, beaconDB: d}, rateLimiter: newRateLimiter(p1)}
+		pcl := protocol.ID(p2p.RPCBlocksByRootTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectFailure(t, 1, "no block roots provided in request", stream)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectFailure(t, 1, "no block roots provided in request", stream)
+		})
+
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		err = r.beaconBlocksRootRPCHandler(t.Context(), &p2pTypes.BeaconBlockByRootsReq{}, stream1)
+		assert.ErrorContains(t, "no block roots provided", err)
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		r.rateLimiter.RLock() // retrieveCollector requires a lock to be held.
+		defer r.rateLimiter.RUnlock()
+		lter, err := r.rateLimiter.retrieveCollector(topic)
+		require.NoError(t, err)
+		assert.Equal(t, 1, int(lter.Count(stream1.Conn().RemotePeer().String())))
 	})
-
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	err = r.beaconBlocksRootRPCHandler(t.Context(), &p2pTypes.BeaconBlockByRootsReq{}, stream1)
-	assert.ErrorContains(t, "no block roots provided", err)
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	r.rateLimiter.RLock() // retrieveCollector requires a lock to be held.
-	defer r.rateLimiter.RUnlock()
-	lter, err := r.rateLimiter.retrieveCollector(topic)
-	require.NoError(t, err)
-	assert.Equal(t, 1, int(lter.Count(stream1.Conn().RemotePeer().String())))
 }
 
 func TestRequestPendingBlobs(t *testing.T) {
 	s := &Service{cfg: &config{blobStorage: filesystem.NewEphemeralBlobStorage(t)}}
 	t.Run("old block should not fail", func(t *testing.T) {
-		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
-		require.NoError(t, err)
-		request, err := s.pendingBlobsRequestForBlock([32]byte{}, b)
-		require.NoError(t, err)
-		require.NoError(t, s.sendAndSaveBlobSidecars(t.Context(), request, "test", b))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
+			require.NoError(t, err)
+			request, err := s.pendingBlobsRequestForBlock([32]byte{}, b)
+			require.NoError(t, err)
+			require.NoError(t, s.sendAndSaveBlobSidecars(t.Context(), request, "test", b))
+		})
 	})
 	t.Run("empty commitment block should not fail", func(t *testing.T) {
-		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
-		require.NoError(t, err)
-		request, err := s.pendingBlobsRequestForBlock([32]byte{}, b)
-		require.NoError(t, err)
-		require.NoError(t, s.sendAndSaveBlobSidecars(t.Context(), request, "test", b))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
+			require.NoError(t, err)
+			request, err := s.pendingBlobsRequestForBlock([32]byte{}, b)
+			require.NoError(t, err)
+			require.NoError(t, s.sendAndSaveBlobSidecars(t.Context(), request, "test", b))
+		})
 	})
 	t.Run("unsupported protocol", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		require.Equal(t, 1, len(p1.BHost.Network().Peers()))
-		chain := &mock.ChainService{
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Epoch: 1,
-				Root:  make([]byte, 32),
-			},
-			ValidatorsRoot: [32]byte{},
-			Genesis:        time.Now(),
-		}
-		p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
-		p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
-		p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 1})
-		s := &Service{
-			cfg: &config{
-				p2p:         p1,
-				chain:       chain,
-				clock:       startup.NewClock(time.Unix(0, 0), [32]byte{}),
-				beaconDB:    db.SetupDB(t),
-				blobStorage: filesystem.NewEphemeralBlobStorage(t),
-			},
-		}
-		b := util.NewBeaconBlockDeneb()
-		b.Block.Body.BlobKzgCommitments = make([][]byte, 1)
-		b1, err := blocks.NewSignedBeaconBlock(b)
-		require.NoError(t, err)
-		request, err := s.pendingBlobsRequestForBlock([32]byte{}, b1)
-		require.NoError(t, err)
-		require.ErrorContains(t, "protocols not supported", s.sendAndSaveBlobSidecars(t.Context(), request, p2.PeerID(), b1))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			require.Equal(t, 1, len(p1.BHost.Network().Peers()))
+			chain := &mock.ChainService{
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Epoch: 1,
+					Root:  make([]byte, 32),
+				},
+				ValidatorsRoot: [32]byte{},
+				Genesis:        time.Now(),
+			}
+			p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
+			p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+			p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 1})
+			s := &Service{
+				cfg: &config{
+					p2p:         p1,
+					chain:       chain,
+					clock:       startup.NewClock(time.Unix(0, 0), [32]byte{}),
+					beaconDB:    db.SetupDB(t),
+					blobStorage: filesystem.NewEphemeralBlobStorage(t),
+				},
+			}
+			b := util.NewBeaconBlockDeneb()
+			b.Block.Body.BlobKzgCommitments = make([][]byte, 1)
+			b1, err := blocks.NewSignedBeaconBlock(b)
+			require.NoError(t, err)
+			request, err := s.pendingBlobsRequestForBlock([32]byte{}, b1)
+			require.NoError(t, err)
+			require.ErrorContains(t, "protocols not supported", s.sendAndSaveBlobSidecars(t.Context(), request, p2.PeerID(), b1))
+		})
 	})
 }
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -191,151 +191,155 @@ func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks_ReconstructsPayload(t *testi
 }
 
 func TestRecentBeaconBlocks_RPCRequestSent(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.DelaySend = true
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.DelaySend = true
 
-	blockA := util.NewBeaconBlock()
-	blockA.Block.Slot = 111
-	blockB := util.NewBeaconBlock()
-	blockB.Block.Slot = 40
-	// Set up a head state with data we expect.
-	blockARoot, err := blockA.Block.HashTreeRoot()
-	require.NoError(t, err)
-	blockBRoot, err := blockB.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, keys := util.DeterministicGenesisState(t, 64)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), blockARoot))
-	blockA.Signature, err = signing.ComputeDomainAndSign(genesisState, slots.ToEpoch(blockA.Block.Slot), blockA.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
-	require.NoError(t, err)
-	blockB.Signature, err = signing.ComputeDomainAndSign(genesisState, slots.ToEpoch(blockB.Block.Slot), blockB.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
-	require.NoError(t, err)
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 5,
-		Root:  blockBRoot[:],
-	}
-
-	expectedRoots := p2pTypes.BeaconBlockByRootsReq{blockBRoot, blockARoot}
-
-	chain := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                blockARoot[:],
-		Genesis:             time.Now(),
-		ValidatorsRoot:      [32]byte{},
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:   p1,
-			chain: chain,
-			clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-		ctx:                 t.Context(),
-		rateLimiter:         newRateLimiter(p1),
-	}
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(p2pTypes.BeaconBlockByRootsReq)
-		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, out))
-		assert.DeepEqual(t, &expectedRoots, out, "Did not receive expected message")
-		response := []*ethpb.SignedBeaconBlock{blockB, blockA}
-		for _, blk := range response {
-			_, err := stream.Write([]byte{responseCodeSuccess})
-			assert.NoError(t, err, "Could not write to stream")
-			_, err = p2.Encoding().EncodeWithMaxLength(stream, blk)
-			assert.NoError(t, err, "Could not send response back")
+		blockA := util.NewBeaconBlock()
+		blockA.Block.Slot = 111
+		blockB := util.NewBeaconBlock()
+		blockB.Block.Slot = 40
+		// Set up a head state with data we expect.
+		blockARoot, err := blockA.Block.HashTreeRoot()
+		require.NoError(t, err)
+		blockBRoot, err := blockB.Block.HashTreeRoot()
+		require.NoError(t, err)
+		genesisState, keys := util.DeterministicGenesisState(t, 64)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), blockARoot))
+		blockA.Signature, err = signing.ComputeDomainAndSign(genesisState, slots.ToEpoch(blockA.Block.Slot), blockA.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
+		require.NoError(t, err)
+		blockB.Signature, err = signing.ComputeDomainAndSign(genesisState, slots.ToEpoch(blockB.Block.Slot), blockB.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
+		require.NoError(t, err)
+		finalizedCheckpt := &ethpb.Checkpoint{
+			Epoch: 5,
+			Root:  blockBRoot[:],
 		}
-		assert.NoError(t, stream.Close())
+
+		expectedRoots := p2pTypes.BeaconBlockByRootsReq{blockBRoot, blockARoot}
+
+		chain := &mock.ChainService{
+			State:               genesisState,
+			FinalizedCheckPoint: finalizedCheckpt,
+			Root:                blockARoot[:],
+			Genesis:             time.Now(),
+			ValidatorsRoot:      [32]byte{},
+		}
+		r := &Service{
+			cfg: &config{
+				p2p:   p1,
+				chain: chain,
+				clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+			ctx:                 t.Context(),
+			rateLimiter:         newRateLimiter(p1),
+		}
+
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(p2pTypes.BeaconBlockByRootsReq)
+			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, out))
+			assert.DeepEqual(t, &expectedRoots, out, "Did not receive expected message")
+			response := []*ethpb.SignedBeaconBlock{blockB, blockA}
+			for _, blk := range response {
+				_, err := stream.Write([]byte{responseCodeSuccess})
+				assert.NoError(t, err, "Could not write to stream")
+				_, err = p2.Encoding().EncodeWithMaxLength(stream, blk)
+				assert.NoError(t, err, "Could not send response back")
+			}
+			assert.NoError(t, stream.Close())
+		})
+
+		p1.Connect(p2)
+		require.NoError(t, r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
 	})
-
-	p1.Connect(p2)
-	require.NoError(t, r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestRecentBeaconBlocks_RPCRequestSent_IncorrectRoot(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.DelaySend = true
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.DelaySend = true
 
-	blockA := util.NewBeaconBlock()
-	blockA.Block.Slot = 111
-	blockB := util.NewBeaconBlock()
-	blockB.Block.Slot = 40
-	// Set up a head state with data we expect.
-	blockARoot, err := blockA.Block.HashTreeRoot()
-	require.NoError(t, err)
-	blockBRoot, err := blockB.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(t.Context(), nil, 0, &ethpb.Eth1Data{})
-	require.NoError(t, err)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), blockARoot))
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 5,
-		Root:  blockBRoot[:],
-	}
-
-	expectedRoots := p2pTypes.BeaconBlockByRootsReq{blockBRoot, blockARoot}
-
-	chain := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                blockARoot[:],
-		Genesis:             time.Now(),
-		ValidatorsRoot:      [32]byte{},
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:   p1,
-			chain: chain,
-			clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-		ctx:                 t.Context(),
-		rateLimiter:         newRateLimiter(p1),
-	}
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(p2pTypes.BeaconBlockByRootsReq)
-		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, out))
-		assert.DeepEqual(t, &expectedRoots, out, "Did not receive expected message")
-		blockB.Block.Slot = 123123 // Give it a bad slot
-		response := []*ethpb.SignedBeaconBlock{blockB, blockA}
-		for _, blk := range response {
-			_, err := stream.Write([]byte{responseCodeSuccess})
-			assert.NoError(t, err, "Could not write to stream")
-			_, err = p2.Encoding().EncodeWithMaxLength(stream, blk)
-			assert.NoError(t, err, "Could not send response back")
+		blockA := util.NewBeaconBlock()
+		blockA.Block.Slot = 111
+		blockB := util.NewBeaconBlock()
+		blockB.Block.Slot = 40
+		// Set up a head state with data we expect.
+		blockARoot, err := blockA.Block.HashTreeRoot()
+		require.NoError(t, err)
+		blockBRoot, err := blockB.Block.HashTreeRoot()
+		require.NoError(t, err)
+		genesisState, err := transition.GenesisBeaconState(t.Context(), nil, 0, &ethpb.Eth1Data{})
+		require.NoError(t, err)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), blockARoot))
+		finalizedCheckpt := &ethpb.Checkpoint{
+			Epoch: 5,
+			Root:  blockBRoot[:],
 		}
-		assert.NoError(t, stream.Close())
-	})
 
-	p1.Connect(p2)
-	require.ErrorContains(t, "received unexpected block with root", r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
+		expectedRoots := p2pTypes.BeaconBlockByRootsReq{blockBRoot, blockARoot}
+
+		chain := &mock.ChainService{
+			State:               genesisState,
+			FinalizedCheckPoint: finalizedCheckpt,
+			Root:                blockARoot[:],
+			Genesis:             time.Now(),
+			ValidatorsRoot:      [32]byte{},
+		}
+		r := &Service{
+			cfg: &config{
+				p2p:   p1,
+				chain: chain,
+				clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+			ctx:                 t.Context(),
+			rateLimiter:         newRateLimiter(p1),
+		}
+
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(p2pTypes.BeaconBlockByRootsReq)
+			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, out))
+			assert.DeepEqual(t, &expectedRoots, out, "Did not receive expected message")
+			blockB.Block.Slot = 123123 // Give it a bad slot
+			response := []*ethpb.SignedBeaconBlock{blockB, blockA}
+			for _, blk := range response {
+				_, err := stream.Write([]byte{responseCodeSuccess})
+				assert.NoError(t, err, "Could not write to stream")
+				_, err = p2.Encoding().EncodeWithMaxLength(stream, blk)
+				assert.NoError(t, err, "Could not send response back")
+			}
+			assert.NoError(t, stream.Close())
+		})
+
+		p1.Connect(p2)
+		require.ErrorContains(t, "received unexpected block with root", r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
+	})
 }
 
 func TestRecentBeaconBlocks_RPCRequestSent_InvalidSignature(t *testing.T) {

--- a/beacon-chain/sync/rpc_blob_sidecars_by_range_test.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_range_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -145,7 +146,9 @@ func TestBlobByRangeOK(t *testing.T) {
 	for _, c := range cases {
 		c.clock = clock
 		t.Run(c.name, func(t *testing.T) {
-			c.runTestBlobSidecarsByRange(t)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				c.runTestBlobSidecarsByRange(t)
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/rpc_blob_sidecars_by_root_test.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	p2pTypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -150,7 +151,9 @@ func TestReadChunkEncodedBlobs(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			c.runTestBlobSidecarsByRoot(t)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				c.runTestBlobSidecarsByRoot(t)
+			})
 		})
 	}
 }
@@ -243,8 +246,10 @@ func TestBlobsByRootValidation(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			c.clock = clock
-			c.runTestBlobSidecarsByRoot(t)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				c.clock = clock
+				c.runTestBlobSidecarsByRoot(t)
+			})
 		})
 	}
 }
@@ -266,7 +271,9 @@ func TestBlobsByRootOK(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			c.runTestBlobSidecarsByRoot(t)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				c.runTestBlobSidecarsByRoot(t)
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range_test.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range_test.go
@@ -37,9 +37,11 @@ func TestDataColumnSidecarsByRangeRPCHandler(t *testing.T) {
 	params.BeaconConfig().InitializeForkSchedule()
 	ctx := context.Background()
 	t.Run("wrong message type", func(t *testing.T) {
-		service := &Service{}
-		err := service.dataColumnSidecarsByRangeRPCHandler(ctx, nil, nil)
-		require.ErrorIs(t, err, notDataColumnsByRangeIdentifiersError)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			service := &Service{}
+			err := service.dataColumnSidecarsByRangeRPCHandler(ctx, nil, nil)
+			require.ErrorIs(t, err, notDataColumnsByRangeIdentifiersError)
+		})
 	})
 	mockNower := &startup.MockNower{}
 	clock := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithNower(mockNower.Now))
@@ -48,50 +50,52 @@ func TestDataColumnSidecarsByRangeRPCHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("invalid request", func(t *testing.T) {
-		slot := primitives.Slot(400)
-		mockNower.SetSlot(t, clock, slot)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			slot := primitives.Slot(400)
+			mockNower.SetSlot(t, clock, slot)
 
-		localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
 
-		service := &Service{
-			cfg: &config{
-				p2p: localP2P,
-				chain: &chainMock.ChainService{
-					Slot: &slot,
+			service := &Service{
+				cfg: &config{
+					p2p: localP2P,
+					chain: &chainMock.ChainService{
+						Slot: &slot,
+					},
+					clock: clock,
 				},
-				clock: clock,
-			},
-			rateLimiter: newRateLimiter(localP2P),
-		}
+				rateLimiter: newRateLimiter(localP2P),
+			}
 
-		protocolID := protocol.ID(fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1))
+			protocolID := protocol.ID(fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1))
 
-		var wg sync.WaitGroup
-		wg.Add(1)
+			var wg sync.WaitGroup
+			wg.Add(1)
 
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
-			code, _, err := readStatusCodeNoDeadline(stream, localP2P.Encoding())
-			assert.NoError(t, err)
-			assert.Equal(t, responseCodeInvalidRequest, code)
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
+				code, _, err := readStatusCodeNoDeadline(stream, localP2P.Encoding())
+				assert.NoError(t, err)
+				assert.Equal(t, responseCodeInvalidRequest, code)
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
+			require.NoError(t, err)
+
+			msg := &pb.DataColumnSidecarsByRangeRequest{
+				Count: 0, // Invalid count
+			}
+			require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) >= 0)
+
+			err = service.dataColumnSidecarsByRangeRPCHandler(ctx, msg, stream)
+			require.NotNil(t, err)
+			require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) < 0)
+
+			if util.WaitTimeout(&wg, 1*time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, err)
-
-		msg := &pb.DataColumnSidecarsByRangeRequest{
-			Count: 0, // Invalid count
-		}
-		require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) >= 0)
-
-		err = service.dataColumnSidecarsByRangeRPCHandler(ctx, msg, stream)
-		require.NotNil(t, err)
-		require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) < 0)
-
-		if util.WaitTimeout(&wg, 1*time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("in the future", func(t *testing.T) {

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range_test.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range_test.go
@@ -99,167 +99,179 @@ func TestDataColumnSidecarsByRangeRPCHandler(t *testing.T) {
 	})
 
 	t.Run("in the future", func(t *testing.T) {
-		slot := primitives.Slot(400)
-		mockNower.SetSlot(t, clock, slot)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			slot := primitives.Slot(400)
+			mockNower.SetSlot(t, clock, slot)
 
-		localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		protocolID := protocol.ID(fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1))
+			localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			protocolID := protocol.ID(fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1))
 
-		service := &Service{
-			cfg: &config{
-				p2p: localP2P,
-				chain: &chainMock.ChainService{
-					Slot: &slot,
+			service := &Service{
+				cfg: &config{
+					p2p: localP2P,
+					chain: &chainMock.ChainService{
+						Slot: &slot,
+					},
+					clock: clock,
 				},
-				clock: clock,
-			},
-			rateLimiter: newRateLimiter(localP2P),
-		}
+				rateLimiter: newRateLimiter(localP2P),
+			}
 
-		var wg sync.WaitGroup
-		wg.Add(1)
+			var wg sync.WaitGroup
+			wg.Add(1)
 
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
 
-			_, err := readChunkedDataColumnSidecar(stream, remoteP2P, ctxMap)
-			assert.Equal(t, true, errors.Is(err, io.EOF))
+				_, err := readChunkedDataColumnSidecar(stream, remoteP2P, ctxMap)
+				assert.Equal(t, true, errors.Is(err, io.EOF))
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
+			require.NoError(t, err)
+
+			msg := &pb.DataColumnSidecarsByRangeRequest{
+				StartSlot: slot + 1,
+				Count:     50,
+				Columns:   []uint64{1, 2, 3, 4, 6, 7, 8, 9, 10},
+			}
+
+			err = service.dataColumnSidecarsByRangeRPCHandler(ctx, msg, stream)
+			require.NoError(t, err)
+
+			if util.WaitTimeout(&wg, 1*time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, err)
-
-		msg := &pb.DataColumnSidecarsByRangeRequest{
-			StartSlot: slot + 1,
-			Count:     50,
-			Columns:   []uint64{1, 2, 3, 4, 6, 7, 8, 9, 10},
-		}
-
-		err = service.dataColumnSidecarsByRangeRPCHandler(ctx, msg, stream)
-		require.NoError(t, err)
 	})
 
 	t.Run("nominal", func(t *testing.T) {
-		slot := primitives.Slot(400)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			slot := primitives.Slot(400)
 
-		params := []util.DataColumnParam{
-			{Slot: 10, Index: 1}, {Slot: 10, Index: 2}, {Slot: 10, Index: 3},
-			{Slot: 40, Index: 4}, {Slot: 40, Index: 6},
-			{Slot: 45, Index: 7}, {Slot: 45, Index: 8}, {Slot: 45, Index: 9},
-		}
-
-		_, verifiedRODataColumns := util.CreateTestVerifiedRoDataColumnSidecars(t, params)
-
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
-		err = storage.Save(verifiedRODataColumns)
-		require.NoError(t, err)
-
-		localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		protocolID := protocol.ID(fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1))
-
-		roots := [][fieldparams.RootLength]byte{
-			verifiedRODataColumns[0].BlockRoot(),
-			verifiedRODataColumns[3].BlockRoot(),
-			verifiedRODataColumns[5].BlockRoot(),
-		}
-
-		slots := []primitives.Slot{
-			verifiedRODataColumns[0].Slot(),
-			verifiedRODataColumns[3].Slot(),
-			verifiedRODataColumns[5].Slot(),
-		}
-
-		beaconDB := testDB.SetupDB(t)
-		roBlocks := make([]blocks.ROBlock, 0, len(roots))
-		for i := range 3 {
-			signedBeaconBlockPb := util.NewBeaconBlock()
-			signedBeaconBlockPb.Block.Slot = slots[i]
-			if i != 0 {
-				signedBeaconBlockPb.Block.ParentRoot = roots[i-1][:]
+			params := []util.DataColumnParam{
+				{Slot: 10, Index: 1}, {Slot: 10, Index: 2}, {Slot: 10, Index: 3},
+				{Slot: 40, Index: 4}, {Slot: 40, Index: 6},
+				{Slot: 45, Index: 7}, {Slot: 45, Index: 8}, {Slot: 45, Index: 9},
 			}
 
-			signedBeaconBlock, err := blocks.NewSignedBeaconBlock(signedBeaconBlockPb)
+			_, verifiedRODataColumns := util.CreateTestVerifiedRoDataColumnSidecars(t, params)
+
+			storage := filesystem.NewEphemeralDataColumnStorage(t)
+			err = storage.Save(verifiedRODataColumns)
 			require.NoError(t, err)
 
-			// There is a discrepancy between the root of the beacon block and the rodata column root,
-			// but for the sake of this test, we actually don't care.
-			roblock, err := blocks.NewROBlockWithRoot(signedBeaconBlock, roots[i])
-			require.NoError(t, err)
+			localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			protocolID := protocol.ID(fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1))
 
-			roBlocks = append(roBlocks, roblock)
-		}
+			roots := [][fieldparams.RootLength]byte{
+				verifiedRODataColumns[0].BlockRoot(),
+				verifiedRODataColumns[3].BlockRoot(),
+				verifiedRODataColumns[5].BlockRoot(),
+			}
 
-		err = beaconDB.SaveROBlocks(ctx, roBlocks, false /*cache*/)
-		require.NoError(t, err)
+			slots := []primitives.Slot{
+				verifiedRODataColumns[0].Slot(),
+				verifiedRODataColumns[3].Slot(),
+				verifiedRODataColumns[5].Slot(),
+			}
 
-		mockNower.SetSlot(t, clock, slot)
-		service := &Service{
-			cfg: &config{
-				p2p:               localP2P,
-				beaconDB:          beaconDB,
-				chain:             &chainMock.ChainService{},
-				dataColumnStorage: storage,
-				clock:             clock,
-			},
-			rateLimiter: newRateLimiter(localP2P),
-		}
-
-		root0 := verifiedRODataColumns[0].BlockRoot()
-		root3 := verifiedRODataColumns[3].BlockRoot()
-		root5 := verifiedRODataColumns[5].BlockRoot()
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
-
-			sidecars := make([]*blocks.RODataColumn, 0, 5)
-
-			for i := uint64(0); ; /* no stop condition */ i++ {
-				sidecar, err := readChunkedDataColumnSidecar(stream, remoteP2P, ctxMap)
-				if errors.Is(err, io.EOF) {
-					// End of stream.
-					break
+			beaconDB := testDB.SetupDB(t)
+			roBlocks := make([]blocks.ROBlock, 0, len(roots))
+			for i := range 3 {
+				signedBeaconBlockPb := util.NewBeaconBlock()
+				signedBeaconBlockPb.Block.Slot = slots[i]
+				if i != 0 {
+					signedBeaconBlockPb.Block.ParentRoot = roots[i-1][:]
 				}
 
-				assert.NoError(t, err)
-				sidecars = append(sidecars, sidecar)
+				signedBeaconBlock, err := blocks.NewSignedBeaconBlock(signedBeaconBlockPb)
+				require.NoError(t, err)
+
+				// There is a discrepancy between the root of the beacon block and the rodata column root,
+				// but for the sake of this test, we actually don't care.
+				roblock, err := blocks.NewROBlockWithRoot(signedBeaconBlock, roots[i])
+				require.NoError(t, err)
+
+				roBlocks = append(roBlocks, roblock)
 			}
 
-			assert.Equal(t, 8, len(sidecars))
-			assert.Equal(t, root0, sidecars[0].BlockRoot())
-			assert.Equal(t, root0, sidecars[1].BlockRoot())
-			assert.Equal(t, root0, sidecars[2].BlockRoot())
-			assert.Equal(t, root3, sidecars[3].BlockRoot())
-			assert.Equal(t, root3, sidecars[4].BlockRoot())
-			assert.Equal(t, root5, sidecars[5].BlockRoot())
-			assert.Equal(t, root5, sidecars[6].BlockRoot())
-			assert.Equal(t, root5, sidecars[7].BlockRoot())
+			err = beaconDB.SaveROBlocks(ctx, roBlocks, false /*cache*/)
+			require.NoError(t, err)
 
-			assert.Equal(t, uint64(1), sidecars[0].Index())
-			assert.Equal(t, uint64(2), sidecars[1].Index())
-			assert.Equal(t, uint64(3), sidecars[2].Index())
-			assert.Equal(t, uint64(4), sidecars[3].Index())
-			assert.Equal(t, uint64(6), sidecars[4].Index())
-			assert.Equal(t, uint64(7), sidecars[5].Index())
-			assert.Equal(t, uint64(8), sidecars[6].Index())
-			assert.Equal(t, uint64(9), sidecars[7].Index())
+			mockNower.SetSlot(t, clock, slot)
+			service := &Service{
+				cfg: &config{
+					p2p:               localP2P,
+					beaconDB:          beaconDB,
+					chain:             &chainMock.ChainService{},
+					dataColumnStorage: storage,
+					clock:             clock,
+				},
+				rateLimiter: newRateLimiter(localP2P),
+			}
+
+			root0 := verifiedRODataColumns[0].BlockRoot()
+			root3 := verifiedRODataColumns[3].BlockRoot()
+			root5 := verifiedRODataColumns[5].BlockRoot()
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
+
+				sidecars := make([]*blocks.RODataColumn, 0, 5)
+
+				for i := uint64(0); ; /* no stop condition */ i++ {
+					sidecar, err := readChunkedDataColumnSidecar(stream, remoteP2P, ctxMap)
+					if errors.Is(err, io.EOF) {
+						// End of stream.
+						break
+					}
+
+					assert.NoError(t, err)
+					sidecars = append(sidecars, sidecar)
+				}
+
+				assert.Equal(t, 8, len(sidecars))
+				assert.Equal(t, root0, sidecars[0].BlockRoot())
+				assert.Equal(t, root0, sidecars[1].BlockRoot())
+				assert.Equal(t, root0, sidecars[2].BlockRoot())
+				assert.Equal(t, root3, sidecars[3].BlockRoot())
+				assert.Equal(t, root3, sidecars[4].BlockRoot())
+				assert.Equal(t, root5, sidecars[5].BlockRoot())
+				assert.Equal(t, root5, sidecars[6].BlockRoot())
+				assert.Equal(t, root5, sidecars[7].BlockRoot())
+
+				assert.Equal(t, uint64(1), sidecars[0].Index())
+				assert.Equal(t, uint64(2), sidecars[1].Index())
+				assert.Equal(t, uint64(3), sidecars[2].Index())
+				assert.Equal(t, uint64(4), sidecars[3].Index())
+				assert.Equal(t, uint64(6), sidecars[4].Index())
+				assert.Equal(t, uint64(7), sidecars[5].Index())
+				assert.Equal(t, uint64(8), sidecars[6].Index())
+				assert.Equal(t, uint64(9), sidecars[7].Index())
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
+			require.NoError(t, err)
+
+			msg := &pb.DataColumnSidecarsByRangeRequest{
+				StartSlot: 5,
+				Count:     50,
+				Columns:   []uint64{1, 2, 3, 4, 6, 7, 8, 9, 10},
+			}
+
+			err = service.dataColumnSidecarsByRangeRPCHandler(ctx, msg, stream)
+			require.NoError(t, err)
+
+			if util.WaitTimeout(&wg, 1*time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, err)
-
-		msg := &pb.DataColumnSidecarsByRangeRequest{
-			StartSlot: 5,
-			Count:     50,
-			Columns:   []uint64{1, 2, 3, 4, 6, 7, 8, 9, 10},
-		}
-
-		err = service.dataColumnSidecarsByRangeRPCHandler(ctx, msg, stream)
-		require.NoError(t, err)
 	})
 
 	t.Run("gloas skips columns of empty slots", func(t *testing.T) {

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root_test.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root_test.go
@@ -35,186 +35,192 @@ func TestDataColumnSidecarsByRootRPCHandler(t *testing.T) {
 	params.BeaconConfig().InitializeForkSchedule()
 	ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
 	require.NoError(t, err)
-	ctx := t.Context()
 
 	protocolID := protocol.ID(p2p.RPCDataColumnSidecarsByRootTopicV1) + "/" + encoder.ProtocolSuffixSSZSnappy
 
 	t.Run("wrong message type", func(t *testing.T) {
-		service := &Service{}
-		err := service.dataColumnSidecarByRootRPCHandler(t.Context(), nil, nil)
-		require.ErrorIs(t, err, notDataColumnsByRootIdentifiersError)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			service := &Service{}
+			err := service.dataColumnSidecarByRootRPCHandler(t.Context(), nil, nil)
+			require.ErrorIs(t, err, notDataColumnsByRootIdentifiersError)
+		})
 	})
 
 	t.Run("invalid request", func(t *testing.T) {
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.MaxRequestDataColumnSidecars = 1
-		params.OverrideBeaconConfig(cfg)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.MaxRequestDataColumnSidecars = 1
+			params.OverrideBeaconConfig(cfg)
 
-		localP2P := p2ptest.NewTestP2P(t)
-		service := &Service{cfg: &config{p2p: localP2P}, rateLimiter: newRateLimiter(localP2P)}
-		remoteP2P := p2ptest.NewTestP2P(t)
+			localP2P := p2ptest.NewTestP2P(t)
+			service := &Service{cfg: &config{p2p: localP2P}, rateLimiter: newRateLimiter(localP2P)}
+			remoteP2P := p2ptest.NewTestP2P(t)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
+			var wg sync.WaitGroup
+			wg.Add(1)
 
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
-			code, errMsg, err := readStatusCodeNoDeadline(stream, localP2P.Encoding())
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
+				code, errMsg, err := readStatusCodeNoDeadline(stream, localP2P.Encoding())
+				require.NoError(t, err)
+				require.Equal(t, responseCodeInvalidRequest, code)
+				require.Equal(t, types.ErrMaxDataColumnReqExceeded.Error(), errMsg)
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, err := localP2P.BHost.NewStream(t.Context(), remoteP2P.BHost.ID(), protocolID)
 			require.NoError(t, err)
-			require.Equal(t, responseCodeInvalidRequest, code)
-			require.Equal(t, types.ErrMaxDataColumnReqExceeded.Error(), errMsg)
+
+			msg := types.DataColumnsByRootIdentifiers{{Columns: []uint64{1, 2, 3}}}
+			require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) >= 0)
+
+			err = service.dataColumnSidecarByRootRPCHandler(t.Context(), msg, stream)
+			require.NotNil(t, err)
+			require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) < 0)
+
+			if util.WaitTimeout(&wg, 1*time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, err := localP2P.BHost.NewStream(t.Context(), remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, err)
-
-		msg := types.DataColumnsByRootIdentifiers{{Columns: []uint64{1, 2, 3}}}
-		require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) >= 0)
-
-		err = service.dataColumnSidecarByRootRPCHandler(t.Context(), msg, stream)
-		require.NotNil(t, err)
-		require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) < 0)
-
-		if util.WaitTimeout(&wg, 1*time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("nominal", func(t *testing.T) {
-		// Setting the ticker to 0 will cause the ticker to panic.
-		// Setting it to the minimum value instead.
-		refTickerDelay := tickerDelay
-		tickerDelay = time.Nanosecond
-		defer func() {
-			tickerDelay = refTickerDelay
-		}()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			// Setting the ticker to 0 will cause the ticker to panic.
+			// Setting it to the minimum value instead.
+			refTickerDelay := tickerDelay
+			tickerDelay = time.Nanosecond
+			defer func() {
+				tickerDelay = refTickerDelay
+			}()
 
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 1
-		params.OverrideBeaconConfig(cfg)
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 1
+			params.OverrideBeaconConfig(cfg)
 
-		localP2P := p2ptest.NewTestP2P(t)
-		clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
+			localP2P := p2ptest.NewTestP2P(t)
+			clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
 
-		_, verifiedRODataColumns := util.CreateTestVerifiedRoDataColumnSidecars(
-			t,
-			[]util.DataColumnParam{
-				{Slot: 10, Index: 1}, {Slot: 10, Index: 2}, {Slot: 10, Index: 3},
-				{Slot: 40, Index: 4}, {Slot: 40, Index: 6},
-				{Slot: 45, Index: 7}, {Slot: 45, Index: 8}, {Slot: 45, Index: 9},
-				{Slot: 46, Index: 10}, // Corresponding block won't be saved in DB
-			},
-		)
+			_, verifiedRODataColumns := util.CreateTestVerifiedRoDataColumnSidecars(
+				t,
+				[]util.DataColumnParam{
+					{Slot: 10, Index: 1}, {Slot: 10, Index: 2}, {Slot: 10, Index: 3},
+					{Slot: 40, Index: 4}, {Slot: 40, Index: 6},
+					{Slot: 45, Index: 7}, {Slot: 45, Index: 8}, {Slot: 45, Index: 9},
+					{Slot: 46, Index: 10}, // Corresponding block won't be saved in DB
+				},
+			)
 
-		dataColumnStorage := filesystem.NewEphemeralDataColumnStorage(t)
-		err := dataColumnStorage.Save(verifiedRODataColumns)
-		require.NoError(t, err)
-
-		beaconDB := testDB.SetupDB(t)
-		indices := [...]int{0, 3, 5}
-
-		roBlocks := make([]blocks.ROBlock, 0, len(indices))
-		for _, i := range indices {
-			blockPb := util.NewBeaconBlock()
-
-			signedBeaconBlock, err := blocks.NewSignedBeaconBlock(blockPb)
+			dataColumnStorage := filesystem.NewEphemeralDataColumnStorage(t)
+			err := dataColumnStorage.Save(verifiedRODataColumns)
 			require.NoError(t, err)
 
-			// Here the block root has to match the sidecar's block root.
-			// (However, the block root does not match the actual root of the block, but we don't care for this test.)
-			roBlock, err := blocks.NewROBlockWithRoot(signedBeaconBlock, verifiedRODataColumns[i].BlockRoot())
-			require.NoError(t, err)
+			beaconDB := testDB.SetupDB(t)
+			indices := [...]int{0, 3, 5}
 
-			roBlocks = append(roBlocks, roBlock)
-		}
+			roBlocks := make([]blocks.ROBlock, 0, len(indices))
+			for _, i := range indices {
+				blockPb := util.NewBeaconBlock()
 
-		err = beaconDB.SaveROBlocks(ctx, roBlocks, false /*cache*/)
-		require.NoError(t, err)
+				signedBeaconBlock, err := blocks.NewSignedBeaconBlock(blockPb)
+				require.NoError(t, err)
 
-		service := &Service{
-			cfg: &config{
-				p2p:               localP2P,
-				beaconDB:          beaconDB,
-				clock:             clock,
-				dataColumnStorage: dataColumnStorage,
-				chain:             &chainMock.ChainService{},
-			},
-			rateLimiter: newRateLimiter(localP2P),
-		}
+				// Here the block root has to match the sidecar's block root.
+				// (However, the block root does not match the actual root of the block, but we don't care for this test.)
+				roBlock, err := blocks.NewROBlockWithRoot(signedBeaconBlock, verifiedRODataColumns[i].BlockRoot())
+				require.NoError(t, err)
 
-		remoteP2P := p2ptest.NewTestP2P(t)
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-
-		root0 := verifiedRODataColumns[0].BlockRoot()
-		root3 := verifiedRODataColumns[3].BlockRoot()
-		root5 := verifiedRODataColumns[5].BlockRoot()
-		root8 := verifiedRODataColumns[8].BlockRoot()
-
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
-
-			sidecars := make([]*blocks.RODataColumn, 0, 5)
-
-			for i := uint64(0); ; /* no stop condition */ i++ {
-				sidecar, err := readChunkedDataColumnSidecar(stream, remoteP2P, ctxMap)
-				if errors.Is(err, io.EOF) {
-					// End of stream.
-					break
-				}
-
-				assert.NoError(t, err)
-				sidecars = append(sidecars, sidecar)
+				roBlocks = append(roBlocks, roBlock)
 			}
 
-			assert.Equal(t, 5, len(sidecars))
-			assert.Equal(t, root3, sidecars[0].BlockRoot())
-			assert.Equal(t, root3, sidecars[1].BlockRoot())
-			assert.Equal(t, root5, sidecars[2].BlockRoot())
-			assert.Equal(t, root5, sidecars[3].BlockRoot())
-			assert.Equal(t, root5, sidecars[4].BlockRoot())
+			err = beaconDB.SaveROBlocks(ctx, roBlocks, false /*cache*/)
+			require.NoError(t, err)
 
-			assert.Equal(t, uint64(4), sidecars[0].Index())
-			assert.Equal(t, uint64(6), sidecars[1].Index())
-			assert.Equal(t, uint64(7), sidecars[2].Index())
-			assert.Equal(t, uint64(8), sidecars[3].Index())
-			assert.Equal(t, uint64(9), sidecars[4].Index())
+			service := &Service{
+				cfg: &config{
+					p2p:               localP2P,
+					beaconDB:          beaconDB,
+					clock:             clock,
+					dataColumnStorage: dataColumnStorage,
+					chain:             &chainMock.ChainService{},
+				},
+				rateLimiter: newRateLimiter(localP2P),
+			}
+
+			remoteP2P := p2ptest.NewTestP2P(t)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+
+			root0 := verifiedRODataColumns[0].BlockRoot()
+			root3 := verifiedRODataColumns[3].BlockRoot()
+			root5 := verifiedRODataColumns[5].BlockRoot()
+			root8 := verifiedRODataColumns[8].BlockRoot()
+
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
+
+				sidecars := make([]*blocks.RODataColumn, 0, 5)
+
+				for i := uint64(0); ; /* no stop condition */ i++ {
+					sidecar, err := readChunkedDataColumnSidecar(stream, remoteP2P, ctxMap)
+					if errors.Is(err, io.EOF) {
+						// End of stream.
+						break
+					}
+
+					assert.NoError(t, err)
+					sidecars = append(sidecars, sidecar)
+				}
+
+				assert.Equal(t, 5, len(sidecars))
+				assert.Equal(t, root3, sidecars[0].BlockRoot())
+				assert.Equal(t, root3, sidecars[1].BlockRoot())
+				assert.Equal(t, root5, sidecars[2].BlockRoot())
+				assert.Equal(t, root5, sidecars[3].BlockRoot())
+				assert.Equal(t, root5, sidecars[4].BlockRoot())
+
+				assert.Equal(t, uint64(4), sidecars[0].Index())
+				assert.Equal(t, uint64(6), sidecars[1].Index())
+				assert.Equal(t, uint64(7), sidecars[2].Index())
+				assert.Equal(t, uint64(8), sidecars[3].Index())
+				assert.Equal(t, uint64(9), sidecars[4].Index())
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
+			require.NoError(t, err)
+
+			msg := types.DataColumnsByRootIdentifiers{
+				{
+					BlockRoot: root0[:],
+					Columns:   []uint64{1, 2, 3},
+				},
+				{
+					BlockRoot: root3[:],
+					Columns:   []uint64{4, 5, 6},
+				},
+				{
+					BlockRoot: root5[:],
+					Columns:   []uint64{7, 8, 9},
+				},
+				{
+					BlockRoot: root8[:],
+					Columns:   []uint64{10},
+				},
+			}
+
+			err = service.dataColumnSidecarByRootRPCHandler(ctx, msg, stream)
+			require.NoError(t, err)
+			require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) >= 0)
+
+			if util.WaitTimeout(&wg, 1*time.Minute) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, err := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, err)
-
-		msg := types.DataColumnsByRootIdentifiers{
-			{
-				BlockRoot: root0[:],
-				Columns:   []uint64{1, 2, 3},
-			},
-			{
-				BlockRoot: root3[:],
-				Columns:   []uint64{4, 5, 6},
-			},
-			{
-				BlockRoot: root5[:],
-				Columns:   []uint64{7, 8, 9},
-			},
-			{
-				BlockRoot: root8[:],
-				Columns:   []uint64{10},
-			},
-		}
-
-		err = service.dataColumnSidecarByRootRPCHandler(ctx, msg, stream)
-		require.NoError(t, err)
-		require.Equal(t, true, localP2P.Peers().Scorers().BadResponsesScorer().Score(remoteP2P.PeerID()) >= 0)
-
-		if util.WaitTimeout(&wg, 1*time.Minute) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 }
 

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
@@ -459,7 +459,6 @@ func TestSendExecutionPayloadEnvelopesByRangeRequest(t *testing.T) {
 	params.BeaconConfig().InitializeForkSchedule()
 
 	topic := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRangeTopicV1)
-	ctx := t.Context()
 
 	// Set the clock such that the current slot is in the Gloas fork.
 	s := uint64(10) * params.BeaconConfig().SecondsPerSlot
@@ -468,133 +467,148 @@ func TestSendExecutionPayloadEnvelopesByRangeRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("receives envelopes from remote peer", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-		startSlot := primitives.Slot(5)
-		count := uint64(3)
+			startSlot := primitives.Slot(5)
+			count := uint64(3)
 
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
-			defer func() {
-				assert.NoError(t, stream.Close())
-			}()
-			// Read and discard the request.
-			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
+				// Read and discard the request.
+				req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
 
-			// Write one envelope per slot.
-			for i := range count {
-				sl := startSlot + primitives.Slot(i)
-				env := testSignedEnvelope(sl, make([]byte, 32))
-				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
-			}
+				// Write one envelope per slot.
+				for i := range count {
+					sl := startSlot + primitives.Slot(i)
+					env := testSignedEnvelope(sl, make([]byte, 32))
+					assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
+				}
+			})
+
+			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: count}
+			envelopes, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
+			require.NoError(t, recvErr)
+			require.Equal(t, int(count), len(envelopes))
+			assert.Equal(t, startSlot, primitives.Slot(envelopes[0].Message.Payload.SlotNumber))
+			assert.Equal(t, startSlot+1, primitives.Slot(envelopes[1].Message.Payload.SlotNumber))
+			assert.Equal(t, startSlot+2, primitives.Slot(envelopes[2].Message.Payload.SlotNumber))
 		})
-
-		req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: count}
-		envelopes, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
-		require.NoError(t, recvErr)
-		require.Equal(t, int(count), len(envelopes))
-		assert.Equal(t, startSlot, primitives.Slot(envelopes[0].Message.Payload.SlotNumber))
-		assert.Equal(t, startSlot+1, primitives.Slot(envelopes[1].Message.Payload.SlotNumber))
-		assert.Equal(t, startSlot+2, primitives.Slot(envelopes[2].Message.Payload.SlotNumber))
 	})
 
 	t.Run("empty response from remote peer", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
-			defer func() {
-				assert.NoError(t, stream.Close())
-			}()
-			// Read and discard request; send nothing.
-			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
+				// Read and discard request; send nothing.
+				req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+			})
+
+			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 5, Count: 10}
+			envelopes, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
+			require.NoError(t, recvErr)
+			assert.Equal(t, 0, len(envelopes))
 		})
-
-		req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 5, Count: 10}
-		envelopes, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
-		require.NoError(t, recvErr)
-		assert.Equal(t, 0, len(envelopes))
 	})
 
 	t.Run("slot out of requested range returns error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-		startSlot := primitives.Slot(5)
-		count := uint64(3)
+			startSlot := primitives.Slot(5)
+			count := uint64(3)
 
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
-			defer func() {
-				assert.NoError(t, stream.Close())
-			}()
-			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
-			// Send an envelope with a slot BEFORE the requested range.
-			env := testSignedEnvelope(startSlot-1, make([]byte, 32))
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
+				req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+				// Send an envelope with a slot BEFORE the requested range.
+				env := testSignedEnvelope(startSlot-1, make([]byte, 32))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
+			})
+
+			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: count}
+			_, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
+			require.NotNil(t, recvErr)
+			assert.ErrorContains(t, "outside requested range", recvErr)
 		})
-
-		req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: count}
-		_, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
-		require.NotNil(t, recvErr)
-		assert.ErrorContains(t, "outside requested range", recvErr)
 	})
 
 	t.Run("slots not monotonically increasing returns error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-		startSlot := primitives.Slot(5)
+			startSlot := primitives.Slot(5)
 
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
-			defer func() {
-				assert.NoError(t, stream.Close())
-			}()
-			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
-			// Send slot 6 first, then slot 5 (going backwards).
-			env1 := testSignedEnvelope(startSlot+1, make([]byte, 32))
-			env2 := testSignedEnvelope(startSlot, make([]byte, 32))
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env1))
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env2))
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
+				req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+				// Send slot 6 first, then slot 5 (going backwards).
+				env1 := testSignedEnvelope(startSlot+1, make([]byte, 32))
+				env2 := testSignedEnvelope(startSlot, make([]byte, 32))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env1))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env2))
+			})
+
+			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: 10}
+			_, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
+			require.NotNil(t, recvErr)
+			assert.ErrorContains(t, "not greater than previous slot", recvErr)
 		})
-
-		req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: 10}
-		_, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
-		require.NotNil(t, recvErr)
-		assert.ErrorContains(t, "not greater than previous slot", recvErr)
 	})
 
 	t.Run("peer exceeds requested count returns error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-		startSlot := primitives.Slot(5)
-		count := uint64(2)
+			startSlot := primitives.Slot(5)
+			count := uint64(2)
 
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
-			defer func() {
-				assert.NoError(t, stream.Close())
-			}()
-			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
-			// Send count+1 envelopes (one more than requested).
-			for i := uint64(0); i <= count; i++ {
-				env := testSignedEnvelope(startSlot+primitives.Slot(i), make([]byte, 32))
-				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
-			}
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
+				req := &pb.ExecutionPayloadEnvelopesByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+				// Send count+1 envelopes (one more than requested).
+				for i := uint64(0); i <= count; i++ {
+					env := testSignedEnvelope(startSlot+primitives.Slot(i), make([]byte, 32))
+					assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), env))
+				}
+			})
+
+			req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: count}
+			_, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
+			require.NotNil(t, recvErr)
+			assert.ErrorContains(t, "more execution payload envelopes than requested", recvErr)
 		})
-
-		req := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: startSlot, Count: count}
-		_, recvErr := SendExecutionPayloadEnvelopesByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxMap, req)
-		require.NotNil(t, recvErr)
-		assert.ErrorContains(t, "more execution payload envelopes than requested", recvErr)
 	})
 }

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
@@ -175,265 +175,273 @@ func TestExecutionPayloadEnvelopesByRangeRPCHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("wrong message type", func(t *testing.T) {
-		slot := primitives.Slot(100)
-		localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		pid := protocol.ID(topicFmt)
-		clock2 := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(slot))
-		svc2 := &Service{
-			cfg:         &config{p2p: localP2P, chain: &chainMock.ChainService{Slot: &slot}, clock: clock2},
-			rateLimiter: newRateLimiter(localP2P),
-		}
-		// Install a no-op handler so the stream can be opened.
-		remoteP2P.BHost.SetStreamHandler(pid, func(s network.Stream) { _ = s.Reset() })
-		localP2P.Connect(remoteP2P)
-		stream, sErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), pid)
-		require.NoError(t, sErr)
-		herr := svc2.executionPayloadEnvelopesByRangeRPCHandler(ctx, "not-a-request", stream)
-		require.ErrorContains(t, "message is not type", herr)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			slot := primitives.Slot(100)
+			localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			pid := protocol.ID(topicFmt)
+			clock2 := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(slot))
+			svc2 := &Service{
+				cfg:         &config{p2p: localP2P, chain: &chainMock.ChainService{Slot: &slot}, clock: clock2},
+				rateLimiter: newRateLimiter(localP2P),
+			}
+			// Install a no-op handler so the stream can be opened.
+			remoteP2P.BHost.SetStreamHandler(pid, func(s network.Stream) { _ = s.Reset() })
+			localP2P.Connect(remoteP2P)
+			stream, sErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), pid)
+			require.NoError(t, sErr)
+			herr := svc2.executionPayloadEnvelopesByRangeRPCHandler(ctx, "not-a-request", stream)
+			require.ErrorContains(t, "message is not type", herr)
+		})
 	})
 
 	t.Run("invalid request count=0", func(t *testing.T) {
-		slot := primitives.Slot(100)
-		localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		protocolID := protocol.ID(topicFmt)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			slot := primitives.Slot(100)
+			localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			protocolID := protocol.ID(topicFmt)
 
-		clock := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(slot))
-		svc := &Service{
-			cfg: &config{
-				p2p:   localP2P,
-				chain: &chainMock.ChainService{Slot: &slot},
-				clock: clock,
-			},
-			rateLimiter: newRateLimiter(localP2P),
-		}
+			clock := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(slot))
+			svc := &Service{
+				cfg: &config{
+					p2p:   localP2P,
+					chain: &chainMock.ChainService{Slot: &slot},
+					clock: clock,
+				},
+				rateLimiter: newRateLimiter(localP2P),
+			}
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
-			code, _, readErr := readStatusCodeNoDeadline(stream, localP2P.Encoding())
-			assert.NoError(t, readErr)
-			assert.Equal(t, responseCodeInvalidRequest, code)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
+				code, _, readErr := readStatusCodeNoDeadline(stream, localP2P.Encoding())
+				assert.NoError(t, readErr)
+				assert.Equal(t, responseCodeInvalidRequest, code)
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, streamErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
+			require.NoError(t, streamErr)
+
+			msg := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 10, Count: 0}
+			handlerErr := svc.executionPayloadEnvelopesByRangeRPCHandler(ctx, msg, stream)
+			require.NotNil(t, handlerErr)
+
+			if util.WaitTimeout(&wg, 2*time.Second) {
+				t.Fatal("timed out waiting for remote stream handler")
+			}
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, streamErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, streamErr)
-
-		msg := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 10, Count: 0}
-		handlerErr := svc.executionPayloadEnvelopesByRangeRPCHandler(ctx, msg, stream)
-		require.NotNil(t, handlerErr)
-
-		if util.WaitTimeout(&wg, 2*time.Second) {
-			t.Fatal("timed out waiting for remote stream handler")
-		}
 	})
 
 	t.Run("nominal sends chunks for saved envelopes", func(t *testing.T) {
-		beaconDB := testDB.SetupDB(t)
-		localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		protocolID := protocol.ID(topicFmt)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			beaconDB := testDB.SetupDB(t)
+			localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			protocolID := protocol.ID(topicFmt)
 
-		currentSlot := primitives.Slot(50)
-		clock := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(currentSlot))
+			currentSlot := primitives.Slot(50)
+			clock := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(currentSlot))
 
-		// Build blocks at slots 10, 20, 30 (in range) and slot 40 (successor).
-		// Each child's bid.ParentBlockHash = parent's envelope BlockHash (= parent's root).
-		blockSlots := []primitives.Slot{10, 20, 30, 40}
-		roots := make([][32]byte, len(blockSlots))
-		var prevRoot [32]byte
+			// Build blocks at slots 10, 20, 30 (in range) and slot 40 (successor).
+			// Each child's bid.ParentBlockHash = parent's envelope BlockHash (= parent's root).
+			blockSlots := []primitives.Slot{10, 20, 30, 40}
+			roots := make([][32]byte, len(blockSlots))
+			var prevRoot [32]byte
 
-		for i, sl := range blockSlots {
-			parentRoot := prevRoot
-			blk := util.NewBeaconBlockGloas()
-			blk.Block.Slot = sl
-			copy(blk.Block.ParentRoot, parentRoot[:])
-			copy(blk.Block.Body.SignedExecutionPayloadBid.Message.ParentBlockHash, parentRoot[:])
-			wsb := util.SaveBlock(t, ctx, beaconDB, blk)
-			htr, hErr := wsb.Block().HashTreeRoot()
-			require.NoError(t, hErr)
-			roots[i] = htr
-			prevRoot = htr
+			for i, sl := range blockSlots {
+				parentRoot := prevRoot
+				blk := util.NewBeaconBlockGloas()
+				blk.Block.Slot = sl
+				copy(blk.Block.ParentRoot, parentRoot[:])
+				copy(blk.Block.Body.SignedExecutionPayloadBid.Message.ParentBlockHash, parentRoot[:])
+				wsb := util.SaveBlock(t, ctx, beaconDB, blk)
+				htr, hErr := wsb.Block().HashTreeRoot()
+				require.NoError(t, hErr)
+				roots[i] = htr
+				prevRoot = htr
 
-			// Save envelopes for the in-range blocks only.
-			if sl <= 30 {
-				env := testSignedEnvelope(sl, htr[:])
-				copy(env.Message.Payload.ParentHash, parentRoot[:])
-				require.NoError(t, beaconDB.SaveExecutionPayloadEnvelope(ctx, env))
-			}
-		}
-
-		mockEngine := &mockExecution.EngineClient{
-			ExecutionPayloadByBlockHash: make(map[[32]byte]*engpb.ExecutionPayload, len(roots)),
-			SlotByBlockHash:             make(map[[32]byte]primitives.Slot, len(roots)),
-		}
-		for i, root := range roots[:3] {
-			mockEngine.ExecutionPayloadByBlockHash[root] = &engpb.ExecutionPayload{
-				ParentHash:    make([]byte, 32),
-				FeeRecipient:  make([]byte, 20),
-				StateRoot:     make([]byte, 32),
-				ReceiptsRoot:  make([]byte, 32),
-				LogsBloom:     make([]byte, 256),
-				PrevRandao:    make([]byte, 32),
-				BaseFeePerGas: make([]byte, 32),
-				BlockHash:     root[:],
-			}
-			mockEngine.SlotByBlockHash[root] = blockSlots[i]
-		}
-
-		svc := &Service{
-			cfg: &config{
-				p2p:                    localP2P,
-				beaconDB:               beaconDB,
-				chain:                  &chainMock.ChainService{},
-				clock:                  clock,
-				executionReconstructor: mockEngine,
-			},
-			availableBlocker: mockBlocker{avail: true},
-			rateLimiter:      newRateLimiter(localP2P),
-		}
-
-		receivedSlots := make([]primitives.Slot, 0)
-		var wg sync.WaitGroup
-		wg.Add(1)
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
-			for {
-				env, readErr := readChunkedExecutionPayloadEnvelope(stream, remoteP2P.Encoding(), ctxMap)
-				if errors.Is(readErr, io.EOF) {
-					break
-				}
-				assert.NoError(t, readErr)
-				if env != nil {
-					receivedSlots = append(receivedSlots, primitives.Slot(env.Message.Payload.SlotNumber))
+				// Save envelopes for the in-range blocks only.
+				if sl <= 30 {
+					env := testSignedEnvelope(sl, htr[:])
+					copy(env.Message.Payload.ParentHash, parentRoot[:])
+					require.NoError(t, beaconDB.SaveExecutionPayloadEnvelope(ctx, env))
 				}
 			}
+
+			mockEngine := &mockExecution.EngineClient{
+				ExecutionPayloadByBlockHash: make(map[[32]byte]*engpb.ExecutionPayload, len(roots)),
+				SlotByBlockHash:             make(map[[32]byte]primitives.Slot, len(roots)),
+			}
+			for i, root := range roots[:3] {
+				mockEngine.ExecutionPayloadByBlockHash[root] = &engpb.ExecutionPayload{
+					ParentHash:    make([]byte, 32),
+					FeeRecipient:  make([]byte, 20),
+					StateRoot:     make([]byte, 32),
+					ReceiptsRoot:  make([]byte, 32),
+					LogsBloom:     make([]byte, 256),
+					PrevRandao:    make([]byte, 32),
+					BaseFeePerGas: make([]byte, 32),
+					BlockHash:     root[:],
+				}
+				mockEngine.SlotByBlockHash[root] = blockSlots[i]
+			}
+
+			svc := &Service{
+				cfg: &config{
+					p2p:                    localP2P,
+					beaconDB:               beaconDB,
+					chain:                  &chainMock.ChainService{},
+					clock:                  clock,
+					executionReconstructor: mockEngine,
+				},
+				availableBlocker: mockBlocker{avail: true},
+				rateLimiter:      newRateLimiter(localP2P),
+			}
+
+			receivedSlots := make([]primitives.Slot, 0)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
+				for {
+					env, readErr := readChunkedExecutionPayloadEnvelope(stream, remoteP2P.Encoding(), ctxMap)
+					if errors.Is(readErr, io.EOF) {
+						break
+					}
+					assert.NoError(t, readErr)
+					if env != nil {
+						receivedSlots = append(receivedSlots, primitives.Slot(env.Message.Payload.SlotNumber))
+					}
+				}
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, streamErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
+			require.NoError(t, streamErr)
+
+			// Request slots 5–35; blocks at 10, 20, 30 are in range, successor at 40.
+			msg := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 5, Count: 31}
+			handlerErr := svc.executionPayloadEnvelopesByRangeRPCHandler(ctx, msg, stream)
+			require.NoError(t, handlerErr)
+
+			if util.WaitTimeout(&wg, 2*time.Second) {
+				t.Fatal("timed out waiting for remote stream handler")
+			}
+
+			assert.Equal(t, 3, len(receivedSlots))
+			assert.Equal(t, primitives.Slot(10), receivedSlots[0])
+			assert.Equal(t, primitives.Slot(20), receivedSlots[1])
+			assert.Equal(t, primitives.Slot(30), receivedSlots[2])
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, streamErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, streamErr)
-
-		// Request slots 5–35; blocks at 10, 20, 30 are in range, successor at 40.
-		msg := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 5, Count: 31}
-		handlerErr := svc.executionPayloadEnvelopesByRangeRPCHandler(ctx, msg, stream)
-		require.NoError(t, handlerErr)
-
-		if util.WaitTimeout(&wg, 2*time.Second) {
-			t.Fatal("timed out waiting for remote stream handler")
-		}
-
-		assert.Equal(t, 3, len(receivedSlots))
-		assert.Equal(t, primitives.Slot(10), receivedSlots[0])
-		assert.Equal(t, primitives.Slot(20), receivedSlots[1])
-		assert.Equal(t, primitives.Slot(30), receivedSlots[2])
 	})
 
 	t.Run("skips envelopes where payload was empty", func(t *testing.T) {
-		beaconDB := testDB.SetupDB(t)
-		localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		protocolID := protocol.ID(topicFmt)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			beaconDB := testDB.SetupDB(t)
+			localP2P, remoteP2P := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			protocolID := protocol.ID(topicFmt)
 
-		currentSlot := primitives.Slot(50)
-		clock := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(currentSlot))
+			currentSlot := primitives.Slot(50)
+			clock := startup.NewClock(time.Now(), params.BeaconConfig().GenesisValidatorsRoot, startup.WithSlotAsNow(currentSlot))
 
-		// Build blocks at slots 10, 20, 30 (in range) and slot 40 (successor).
-		// Block at slot 20 builds on EMPTY parent (bid.ParentBlockHash != slot 10's envelope BlockHash).
-		// This means the backward walk from slot 40 will find slot 30 → slot 20 but NOT slot 10.
-		blockSlots := []primitives.Slot{10, 20, 30, 40}
-		roots := make([][32]byte, len(blockSlots))
-		var prevRoot [32]byte
+			// Build blocks at slots 10, 20, 30 (in range) and slot 40 (successor).
+			// Block at slot 20 builds on EMPTY parent (bid.ParentBlockHash != slot 10's envelope BlockHash).
+			// This means the backward walk from slot 40 will find slot 30 → slot 20 but NOT slot 10.
+			blockSlots := []primitives.Slot{10, 20, 30, 40}
+			roots := make([][32]byte, len(blockSlots))
+			var prevRoot [32]byte
 
-		for i, sl := range blockSlots {
-			parentRoot := prevRoot
-			blk := util.NewBeaconBlockGloas()
-			blk.Block.Slot = sl
-			copy(blk.Block.ParentRoot, parentRoot[:])
-			if i == 1 {
-				// Slot 20's bid.ParentBlockHash is zero → does NOT match slot 10's envelope BlockHash.
-				// The walk will stop here (no envelope found for the zero hash).
-			} else {
-				copy(blk.Block.Body.SignedExecutionPayloadBid.Message.ParentBlockHash, parentRoot[:])
-			}
-			wsb := util.SaveBlock(t, ctx, beaconDB, blk)
-			htr, hErr := wsb.Block().HashTreeRoot()
-			require.NoError(t, hErr)
-			roots[i] = htr
-			prevRoot = htr
-
-			if sl <= 30 {
-				env := testSignedEnvelope(sl, htr[:])
-				if i != 1 {
-					copy(env.Message.Payload.ParentHash, parentRoot[:])
+			for i, sl := range blockSlots {
+				parentRoot := prevRoot
+				blk := util.NewBeaconBlockGloas()
+				blk.Block.Slot = sl
+				copy(blk.Block.ParentRoot, parentRoot[:])
+				if i == 1 {
+					// Slot 20's bid.ParentBlockHash is zero → does NOT match slot 10's envelope BlockHash.
+					// The walk will stop here (no envelope found for the zero hash).
+				} else {
+					copy(blk.Block.Body.SignedExecutionPayloadBid.Message.ParentBlockHash, parentRoot[:])
 				}
-				require.NoError(t, beaconDB.SaveExecutionPayloadEnvelope(ctx, env))
-			}
-		}
+				wsb := util.SaveBlock(t, ctx, beaconDB, blk)
+				htr, hErr := wsb.Block().HashTreeRoot()
+				require.NoError(t, hErr)
+				roots[i] = htr
+				prevRoot = htr
 
-		mockEngine := &mockExecution.EngineClient{
-			ExecutionPayloadByBlockHash: make(map[[32]byte]*engpb.ExecutionPayload, len(roots)),
-			SlotByBlockHash:             make(map[[32]byte]primitives.Slot, len(roots)),
-		}
-		for i, root := range roots[:3] {
-			mockEngine.ExecutionPayloadByBlockHash[root] = &engpb.ExecutionPayload{
-				ParentHash:    make([]byte, 32),
-				FeeRecipient:  make([]byte, 20),
-				StateRoot:     make([]byte, 32),
-				ReceiptsRoot:  make([]byte, 32),
-				LogsBloom:     make([]byte, 256),
-				PrevRandao:    make([]byte, 32),
-				BaseFeePerGas: make([]byte, 32),
-				BlockHash:     root[:],
-			}
-			mockEngine.SlotByBlockHash[root] = blockSlots[i]
-		}
-
-		svc := &Service{
-			cfg: &config{
-				p2p:                    localP2P,
-				beaconDB:               beaconDB,
-				chain:                  &chainMock.ChainService{},
-				clock:                  clock,
-				executionReconstructor: mockEngine,
-			},
-			availableBlocker: mockBlocker{avail: true},
-			rateLimiter:      newRateLimiter(localP2P),
-		}
-
-		receivedSlots := make([]primitives.Slot, 0)
-		var wg sync.WaitGroup
-		wg.Add(1)
-		remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-			defer wg.Done()
-			for {
-				env, readErr := readChunkedExecutionPayloadEnvelope(stream, remoteP2P.Encoding(), ctxMap)
-				if errors.Is(readErr, io.EOF) {
-					break
-				}
-				assert.NoError(t, readErr)
-				if env != nil {
-					receivedSlots = append(receivedSlots, primitives.Slot(env.Message.Payload.SlotNumber))
+				if sl <= 30 {
+					env := testSignedEnvelope(sl, htr[:])
+					if i != 1 {
+						copy(env.Message.Payload.ParentHash, parentRoot[:])
+					}
+					require.NoError(t, beaconDB.SaveExecutionPayloadEnvelope(ctx, env))
 				}
 			}
+
+			mockEngine := &mockExecution.EngineClient{
+				ExecutionPayloadByBlockHash: make(map[[32]byte]*engpb.ExecutionPayload, len(roots)),
+				SlotByBlockHash:             make(map[[32]byte]primitives.Slot, len(roots)),
+			}
+			for i, root := range roots[:3] {
+				mockEngine.ExecutionPayloadByBlockHash[root] = &engpb.ExecutionPayload{
+					ParentHash:    make([]byte, 32),
+					FeeRecipient:  make([]byte, 20),
+					StateRoot:     make([]byte, 32),
+					ReceiptsRoot:  make([]byte, 32),
+					LogsBloom:     make([]byte, 256),
+					PrevRandao:    make([]byte, 32),
+					BaseFeePerGas: make([]byte, 32),
+					BlockHash:     root[:],
+				}
+				mockEngine.SlotByBlockHash[root] = blockSlots[i]
+			}
+
+			svc := &Service{
+				cfg: &config{
+					p2p:                    localP2P,
+					beaconDB:               beaconDB,
+					chain:                  &chainMock.ChainService{},
+					clock:                  clock,
+					executionReconstructor: mockEngine,
+				},
+				availableBlocker: mockBlocker{avail: true},
+				rateLimiter:      newRateLimiter(localP2P),
+			}
+
+			receivedSlots := make([]primitives.Slot, 0)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			remoteP2P.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+				defer wg.Done()
+				for {
+					env, readErr := readChunkedExecutionPayloadEnvelope(stream, remoteP2P.Encoding(), ctxMap)
+					if errors.Is(readErr, io.EOF) {
+						break
+					}
+					assert.NoError(t, readErr)
+					if env != nil {
+						receivedSlots = append(receivedSlots, primitives.Slot(env.Message.Payload.SlotNumber))
+					}
+				}
+			})
+
+			localP2P.Connect(remoteP2P)
+			stream, streamErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
+			require.NoError(t, streamErr)
+
+			msg := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 5, Count: 31}
+			handlerErr := svc.executionPayloadEnvelopesByRangeRPCHandler(ctx, msg, stream)
+			require.NoError(t, handlerErr)
+
+			if util.WaitTimeout(&wg, 2*time.Second) {
+				t.Fatal("timed out waiting for remote stream handler")
+			}
+
+			// Slot 10's envelope is NOT reachable via the backward walk (slot 20 built on empty).
+			// Only slots 20 and 30 should be served.
+			assert.Equal(t, 2, len(receivedSlots))
+			assert.Equal(t, primitives.Slot(20), receivedSlots[0])
+			assert.Equal(t, primitives.Slot(30), receivedSlots[1])
 		})
-
-		localP2P.Connect(remoteP2P)
-		stream, streamErr := localP2P.BHost.NewStream(ctx, remoteP2P.BHost.ID(), protocolID)
-		require.NoError(t, streamErr)
-
-		msg := &pb.ExecutionPayloadEnvelopesByRangeRequest{StartSlot: 5, Count: 31}
-		handlerErr := svc.executionPayloadEnvelopesByRangeRPCHandler(ctx, msg, stream)
-		require.NoError(t, handlerErr)
-
-		if util.WaitTimeout(&wg, 2*time.Second) {
-			t.Fatal("timed out waiting for remote stream handler")
-		}
-
-		// Slot 10's envelope is NOT reachable via the backward walk (slot 20 built on empty).
-		// Only slots 20 and 30 should be served.
-		assert.Equal(t, 2, len(receivedSlots))
-		assert.Equal(t, primitives.Slot(20), receivedSlots[0])
-		assert.Equal(t, primitives.Slot(30), receivedSlots[1])
 	})
 
 }

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_root_test.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_root_test.go
@@ -63,205 +63,219 @@ func TestSendExecutionPayloadEnvelopesByRootRequest(t *testing.T) {
 	rootC := [32]byte{0xCC}
 
 	t.Run("short valid subset response", func(t *testing.T) {
-		// Request [A, B], server responds with only [A] — should accept.
-		p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		p1.Connect(p2p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			// Request [A, B], server responds with only [A] — should accept.
+			p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1.Connect(p2p2)
 
-		envelopeA := makeEnvelope(rootA, 1)
+			envelopeA := makeEnvelope(rootA, 1)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
+				defer wg.Done()
 
-			req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
-			assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
+				req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+				assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
 
-			// Only respond with envelope A (skip B).
-			err := WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA)
-			assert.NoError(t, err)
+				// Only respond with envelope A (skip B).
+				err := WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA)
+				assert.NoError(t, err)
 
-			assert.NoError(t, stream.CloseWrite())
+				assert.NoError(t, stream.CloseWrite())
+			})
+
+			reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
+			envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(envelopes))
+			assert.Equal(t, rootA, bytesutil.ToBytes32(envelopes[0].Message.BeaconBlockRoot))
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
-		envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(envelopes))
-		assert.Equal(t, rootA, bytesutil.ToBytes32(envelopes[0].Message.BeaconBlockRoot))
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("duplicate response for same root rejected", func(t *testing.T) {
-		// Request [A, B], server responds with [A, A] — should reject (duplicate).
-		p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		p1.Connect(p2p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			// Request [A, B], server responds with [A, A] — should reject (duplicate).
+			p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1.Connect(p2p2)
 
-		envelopeA := makeEnvelope(rootA, 1)
+			envelopeA := makeEnvelope(rootA, 1)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
+				defer wg.Done()
 
-			req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
-			assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
+				req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+				assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
 
-			// Respond with A twice.
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
+				// Respond with A twice.
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
 
-			assert.NoError(t, stream.CloseWrite())
+				assert.NoError(t, stream.CloseWrite())
+			})
+
+			reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
+			_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
+			require.ErrorContains(t, "unrequested or duplicate", err)
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
-		_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
-		require.ErrorContains(t, "unrequested or duplicate", err)
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("unrequested root rejected", func(t *testing.T) {
-		// Request [A, B], server responds with [C] — should reject.
-		p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		p1.Connect(p2p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			// Request [A, B], server responds with [C] — should reject.
+			p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1.Connect(p2p2)
 
-		envelopeC := makeEnvelope(rootC, 1)
+			envelopeC := makeEnvelope(rootC, 1)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
+				defer wg.Done()
 
-			req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
-			assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
+				req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+				assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
 
-			// Respond with envelope for rootC, which was not requested.
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeC))
+				// Respond with envelope for rootC, which was not requested.
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeC))
 
-			assert.NoError(t, stream.CloseWrite())
+				assert.NoError(t, stream.CloseWrite())
+			})
+
+			reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
+			_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
+			require.ErrorContains(t, "unrequested or duplicate", err)
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
-		_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
-		require.ErrorContains(t, "unrequested or duplicate", err)
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("more responses than requested rejected", func(t *testing.T) {
-		// Request [A, B], server responds with [A, B, A] — should reject (too many).
-		p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		p1.Connect(p2p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			// Request [A, B], server responds with [A, B, A] — should reject (too many).
+			p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1.Connect(p2p2)
 
-		envelopeA := makeEnvelope(rootA, 1)
-		envelopeB := makeEnvelope(rootB, 1)
+			envelopeA := makeEnvelope(rootA, 1)
+			envelopeB := makeEnvelope(rootB, 1)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
+				defer wg.Done()
 
-			req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
-			assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
+				req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+				assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
 
-			// Respond with 3 envelopes for a request of 2.
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeB))
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
+				// Respond with 3 envelopes for a request of 2.
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeB))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
 
-			assert.NoError(t, stream.CloseWrite())
+				assert.NoError(t, stream.CloseWrite())
+			})
+
+			reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
+			_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
+			require.ErrorContains(t, "more execution payload envelopes than requested", err)
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
-		_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
-		require.ErrorContains(t, "more execution payload envelopes than requested", err)
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("perfect match response accepted", func(t *testing.T) {
-		// Request [A, B], server responds with [A, B] — should accept.
-		p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		p1.Connect(p2p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			// Request [A, B], server responds with [A, B] — should accept.
+			p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1.Connect(p2p2)
 
-		envelopeA := makeEnvelope(rootA, 1)
-		envelopeB := makeEnvelope(rootB, 1)
+			envelopeA := makeEnvelope(rootA, 1)
+			envelopeB := makeEnvelope(rootB, 1)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
+				defer wg.Done()
 
-			req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
-			assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
+				req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+				assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
 
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
-			assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeB))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeA))
+				assert.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2p2.Encoding(), envelopeB))
 
-			assert.NoError(t, stream.CloseWrite())
+				assert.NoError(t, stream.CloseWrite())
+			})
+
+			reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
+			envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
+			require.NoError(t, err)
+			require.Equal(t, 2, len(envelopes))
+			assert.Equal(t, rootA, bytesutil.ToBytes32(envelopes[0].Message.BeaconBlockRoot))
+			assert.Equal(t, rootB, bytesutil.ToBytes32(envelopes[1].Message.BeaconBlockRoot))
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB}
-		envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
-		require.NoError(t, err)
-		require.Equal(t, 2, len(envelopes))
-		assert.Equal(t, rootA, bytesutil.ToBytes32(envelopes[0].Message.BeaconBlockRoot))
-		assert.Equal(t, rootB, bytesutil.ToBytes32(envelopes[1].Message.BeaconBlockRoot))
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("exceeds max request payloads", func(t *testing.T) {
-		// Request more than MaxRequestPayloads — should error immediately.
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 0
-		cfg.GloasForkEpoch = 0
-		cfg.MaxRequestPayloads = 2
-		params.OverrideBeaconConfig(cfg)
-		params.BeaconConfig().InitializeForkSchedule()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			// Request more than MaxRequestPayloads — should error immediately.
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 0
+			cfg.GloasForkEpoch = 0
+			cfg.MaxRequestPayloads = 2
+			params.OverrideBeaconConfig(cfg)
+			params.BeaconConfig().InitializeForkSchedule()
 
-		reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB, rootC}
-		_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, nil, "", ctxMap, &reqRoots)
-		require.ErrorContains(t, "requested more than MAX_REQUEST_PAYLOADS", err)
+			reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA, rootB, rootC}
+			_, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, nil, "", ctxMap, &reqRoots)
+			require.ErrorContains(t, "requested more than MAX_REQUEST_PAYLOADS", err)
+		})
 	})
 
 	t.Run("empty response accepted", func(t *testing.T) {
-		// Request [A], server responds with nothing — should accept with empty result.
-		p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-		p1.Connect(p2p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			// Request [A], server responds with nothing — should accept with empty result.
+			p1, p2p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1.Connect(p2p2)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2p2.SetStreamHandler(protocol, func(stream network.Stream) {
+				defer wg.Done()
 
-			req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
-			assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
+				req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+				assert.NoError(t, p2p2.Encoding().DecodeWithMaxLength(stream, req))
 
-			// Close immediately — no envelopes.
-			assert.NoError(t, stream.CloseWrite())
+				// Close immediately — no envelopes.
+				assert.NoError(t, stream.CloseWrite())
+			})
+
+			reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA}
+			envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(envelopes))
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		reqRoots := p2ptypes.ExecutionPayloadEnvelopesByRootReq{rootA}
-		envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(t.Context(), clock, p1, p2p2.PeerID(), ctxMap, &reqRoots)
-		require.NoError(t, err)
-		require.Equal(t, 0, len(envelopes))
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 }

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -21,219 +21,227 @@ import (
 )
 
 func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig()
-	cfg.SlotDurationMilliseconds = 1000
-	params.OverrideBeaconConfig(cfg)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.MainnetConfig()
+		cfg.SlotDurationMilliseconds = 1000
+		params.OverrideBeaconConfig(cfg)
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Setup streams
-	pcl := protocol.ID("/testing")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectResetStream(t, stream)
+		// Setup streams
+		pcl := protocol.ID("/testing")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectResetStream(t, stream)
+		})
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		failureCode := p2ptypes.GoodbyeCodeClientShutdown
+
+		assert.NoError(t, r.goodbyeRPCHandler(t.Context(), &failureCode, stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
+		if len(conns) > 0 {
+			t.Error("Peer is still not disconnected despite sending a goodbye message")
+		}
 	})
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	failureCode := p2ptypes.GoodbyeCodeClientShutdown
-
-	assert.NoError(t, r.goodbyeRPCHandler(t.Context(), &failureCode, stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
-	if len(conns) > 0 {
-		t.Error("Peer is still not disconnected despite sending a goodbye message")
-	}
 }
 
 func TestGoodByeRPCHandler_BackOffPeer(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p3 := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p3 := p2ptest.NewTestP2P(t)
 
-	p1.Connect(p2)
-	p1.Connect(p3)
-	assert.Equal(t, 2, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p1.Connect(p2)
+		p1.Connect(p3)
+		assert.Equal(t, 2, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Setup streams
-	pcl := protocol.ID("/testing")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectResetStream(t, stream)
+		// Setup streams
+		pcl := protocol.ID("/testing")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectResetStream(t, stream)
+		})
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		failureCode := p2ptypes.GoodbyeCodeClientShutdown
+
+		assert.NoError(t, r.goodbyeRPCHandler(t.Context(), &failureCode, stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
+		if len(conns) > 0 {
+			t.Error("Peer is still not disconnected despite sending a goodbye message")
+		}
+		valTime, err := p1.Peers().NextValidTime(p2.BHost.ID())
+		require.NoError(t, err)
+		expectedTime := time.Now().Add(backOffTime[failureCode])
+		diff := expectedTime.Sub(valTime)
+		// Add a little bit of allowance
+		require.Equal(t, true, diff.Seconds() <= 1)
+
+		wg.Add(1)
+		p3.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectResetStream(t, stream)
+		})
+
+		stream2, err := p1.BHost.NewStream(t.Context(), p3.BHost.ID(), pcl)
+		require.NoError(t, err)
+		failureCode = p2ptypes.GoodbyeCodeBanned
+
+		assert.NoError(t, r.goodbyeRPCHandler(t.Context(), &failureCode, stream2))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns = p1.BHost.Network().ConnsToPeer(p3.BHost.ID())
+		if len(conns) > 0 {
+			t.Error("Peer is still not disconnected despite sending a goodbye message")
+		}
+		valTime, err = p1.Peers().NextValidTime(p3.BHost.ID())
+		require.NoError(t, err)
+		expectedTime = time.Now().Add(backOffTime[failureCode])
+		diff = expectedTime.Sub(valTime)
+		// Add a little bit of allowance
+		require.Equal(t, true, diff.Seconds() <= 1)
 	})
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	failureCode := p2ptypes.GoodbyeCodeClientShutdown
-
-	assert.NoError(t, r.goodbyeRPCHandler(t.Context(), &failureCode, stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
-	if len(conns) > 0 {
-		t.Error("Peer is still not disconnected despite sending a goodbye message")
-	}
-	valTime, err := p1.Peers().NextValidTime(p2.BHost.ID())
-	require.NoError(t, err)
-	expectedTime := time.Now().Add(backOffTime[failureCode])
-	diff := expectedTime.Sub(valTime)
-	// Add a little bit of allowance
-	require.Equal(t, true, diff.Seconds() <= 1)
-
-	wg.Add(1)
-	p3.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectResetStream(t, stream)
-	})
-
-	stream2, err := p1.BHost.NewStream(t.Context(), p3.BHost.ID(), pcl)
-	require.NoError(t, err)
-	failureCode = p2ptypes.GoodbyeCodeBanned
-
-	assert.NoError(t, r.goodbyeRPCHandler(t.Context(), &failureCode, stream2))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns = p1.BHost.Network().ConnsToPeer(p3.BHost.ID())
-	if len(conns) > 0 {
-		t.Error("Peer is still not disconnected despite sending a goodbye message")
-	}
-	valTime, err = p1.Peers().NextValidTime(p3.BHost.ID())
-	require.NoError(t, err)
-	expectedTime = time.Now().Add(backOffTime[failureCode])
-	diff = expectedTime.Sub(valTime)
-	// Add a little bit of allowance
-	require.Equal(t, true, diff.Seconds() <= 1)
 }
 
 func TestSendGoodbye_SendsMessage(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	chain := &mock.ChainService{ValidatorsRoot: [32]byte{}, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	failureCode := p2ptypes.GoodbyeCodeClientShutdown
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		chain := &mock.ChainService{ValidatorsRoot: [32]byte{}, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
+		failureCode := p2ptypes.GoodbyeCodeClientShutdown
 
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(primitives.SSZUint64)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.Equal(t, failureCode, *out)
-		assert.NoError(t, stream.Close())
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(primitives.SSZUint64)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.Equal(t, failureCode, *out)
+			assert.NoError(t, stream.Close())
+		})
+
+		err := r.sendGoodByeMessage(t.Context(), failureCode, p2.BHost.ID())
+		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns := p1.BHost.Network().ConnsToPeer(p1.BHost.ID())
+		if len(conns) > 0 {
+			t.Error("Peer is still not disconnected despite sending a goodbye message")
+		}
 	})
-
-	err := r.sendGoodByeMessage(t.Context(), failureCode, p2.BHost.ID())
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns := p1.BHost.Network().ConnsToPeer(p1.BHost.ID())
-	if len(conns) > 0 {
-		t.Error("Peer is still not disconnected despite sending a goodbye message")
-	}
 }
 
 func TestSendGoodbye_DisconnectWithPeer(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	chain := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	failureCode := p2ptypes.GoodbyeCodeClientShutdown
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		chain := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
+		failureCode := p2ptypes.GoodbyeCodeClientShutdown
 
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(primitives.SSZUint64)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.Equal(t, failureCode, *out)
-		assert.NoError(t, stream.Close())
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(primitives.SSZUint64)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.Equal(t, failureCode, *out)
+			assert.NoError(t, stream.Close())
+		})
+
+		assert.NoError(t, r.sendGoodByeAndDisconnect(t.Context(), failureCode, p2.BHost.ID()))
+		conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
+		if len(conns) > 0 {
+			t.Error("Peer is still not disconnected despite sending a goodbye message")
+		}
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
 	})
-
-	assert.NoError(t, r.sendGoodByeAndDisconnect(t.Context(), failureCode, p2.BHost.ID()))
-	conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
-	if len(conns) > 0 {
-		t.Error("Peer is still not disconnected despite sending a goodbye message")
-	}
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
 }

--- a/beacon-chain/sync/rpc_metadata_test.go
+++ b/beacon-chain/sync/rpc_metadata_test.go
@@ -21,62 +21,62 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
-	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	libp2pquic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 )
 
 func TestMetaDataRPCHandler_ReceivesMetadata(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	bitfield := [8]byte{'A', 'B'}
-	p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   bitfield[:],
-	})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		bitfield := [8]byte{'A', 'B'}
+		p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   bitfield[:],
+		})
 
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain: &mock.ChainService{
-				ValidatorsRoot: [32]byte{},
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain: &mock.ChainService{
+					ValidatorsRoot: [32]byte{},
+				},
 			},
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Setup streams
-	pcl := protocol.ID(p2p.RPCMetaDataTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := new(pb.MetaDataV0)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.DeepEqual(t, p1.LocalMetadata.InnerObject(), out, "MetadataV0 unequal")
+		// Setup streams
+		pcl := protocol.ID(p2p.RPCMetaDataTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := new(pb.MetaDataV0)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.DeepEqual(t, p1.LocalMetadata.InnerObject(), out, "MetadataV0 unequal")
+		})
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+
+		assert.NoError(t, r.metaDataHandler(t.Context(), new(any), stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
+		if len(conns) == 0 {
+			t.Error("Peer is disconnected despite receiving a valid ping")
+		}
 	})
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-
-	assert.NoError(t, r.metaDataHandler(t.Context(), new(any), stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
-	if len(conns) == 0 {
-		t.Error("Peer is disconnected despite receiving a valid ping")
-	}
 }
 
 func createService(peer p2p.P2P, chain *mock.ChainService) *Service {
@@ -265,146 +265,150 @@ func TestMetadataRPCHandler_SendMetadataRequest(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var wg sync.WaitGroup
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				var wg sync.WaitGroup
 
-			ctx := context.Background()
+				ctx := context.Background()
 
-			// Setup and connect peers.
-			peer1, peer2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-			peer1.Connect(peer2)
+				// Setup and connect peers.
+				peer1, peer2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+				peer1.Connect(peer2)
 
-			// Ensure the peers are connected.
-			peersCount := len(peer1.BHost.Network().Peers())
-			require.Equal(t, 1, peersCount, "Expected peers to be connected")
+				// Ensure the peers are connected.
+				peersCount := len(peer1.BHost.Network().Peers())
+				require.Equal(t, 1, peersCount, "Expected peers to be connected")
 
-			// Setup sync services.
-			genesisPeer1 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer1) * secondsPerEpoch)
-			genesisPeer2 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer2) * secondsPerEpoch)
+				// Setup sync services.
+				genesisPeer1 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer1) * secondsPerEpoch)
+				genesisPeer2 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer2) * secondsPerEpoch)
 
-			chainPeer1 := &mock.ChainService{Genesis: genesisPeer1, ValidatorsRoot: [32]byte{}}
-			chainPeer2 := &mock.ChainService{Genesis: genesisPeer2, ValidatorsRoot: [32]byte{}}
+				chainPeer1 := &mock.ChainService{Genesis: genesisPeer1, ValidatorsRoot: [32]byte{}}
+				chainPeer2 := &mock.ChainService{Genesis: genesisPeer2, ValidatorsRoot: [32]byte{}}
 
-			servicePeer1 := createService(peer1, chainPeer1)
-			servicePeer2 := createService(peer2, chainPeer2)
+				servicePeer1 := createService(peer1, chainPeer1)
+				servicePeer2 := createService(peer2, chainPeer2)
 
-			// Define the behavior of peer2 when receiving a METADATA request.
-			protocolSuffix := servicePeer2.cfg.p2p.Encoding().ProtocolSuffix()
-			protocolID := protocol.ID(tc.topic + protocolSuffix)
-			peer2.LocalMetadata = tc.metadataPeer2
+				// Define the behavior of peer2 when receiving a METADATA request.
+				protocolSuffix := servicePeer2.cfg.p2p.Encoding().ProtocolSuffix()
+				protocolID := protocol.ID(tc.topic + protocolSuffix)
+				peer2.LocalMetadata = tc.metadataPeer2
 
-			wg.Add(1)
-			peer2.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
-				defer wg.Done()
-				err := servicePeer2.metaDataHandler(ctx, new(any), stream)
+				wg.Add(1)
+				peer2.BHost.SetStreamHandler(protocolID, func(stream network.Stream) {
+					defer wg.Done()
+					err := servicePeer2.metaDataHandler(ctx, new(any), stream)
+					require.NoError(t, err)
+				})
+
+				// Send a METADATA request from peer1 to peer2.
+				actual, err := servicePeer1.sendMetaDataRequest(ctx, peer2.BHost.ID())
 				require.NoError(t, err)
+
+				// Wait until the METADATA request is received by peer2 or timeout.
+				timeOutReached := util.WaitTimeout(&wg, requestTimeout)
+				require.Equal(t, false, timeOutReached, "Did not receive METADATA request within timeout")
+
+				// Compare the received METADATA object with the expected METADATA object.
+				require.DeepSSZEqual(t, tc.expected.InnerObject(), actual.InnerObject(), "Metadata unequal")
+
+				// Ensure the peers are still connected.
+				peersCount = len(peer1.BHost.Network().Peers())
+				assert.Equal(t, 1, peersCount, "Expected peers to be connected")
 			})
-
-			// Send a METADATA request from peer1 to peer2.
-			actual, err := servicePeer1.sendMetaDataRequest(ctx, peer2.BHost.ID())
-			require.NoError(t, err)
-
-			// Wait until the METADATA request is received by peer2 or timeout.
-			timeOutReached := util.WaitTimeout(&wg, requestTimeout)
-			require.Equal(t, false, timeOutReached, "Did not receive METADATA request within timeout")
-
-			// Compare the received METADATA object with the expected METADATA object.
-			require.DeepSSZEqual(t, tc.expected.InnerObject(), actual.InnerObject(), "Metadata unequal")
-
-			// Ensure the peers are still connected.
-			peersCount = len(peer1.BHost.Network().Peers())
-			assert.Equal(t, 1, peersCount, "Expected peers to be connected")
 		})
 	}
 }
 
 func TestMetadataRPCHandler_SendsMetadataQUIC(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	bCfg := params.BeaconConfig().Copy()
-	bCfg.AltairForkEpoch = 5
-	params.OverrideBeaconConfig(bCfg)
-	params.BeaconConfig().InitializeForkSchedule()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		bCfg := params.BeaconConfig().Copy()
+		bCfg.AltairForkEpoch = 5
+		params.OverrideBeaconConfig(bCfg)
+		params.BeaconConfig().InitializeForkSchedule()
 
-	p1 := p2ptest.NewTestP2P(t, libp2p.Transport(libp2pquic.NewTransport))
-	p2 := p2ptest.NewTestP2P(t, libp2p.Transport(libp2pquic.NewTransport))
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	bitfield := [8]byte{'A', 'B'}
-	p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   bitfield[:],
-	})
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		bitfield := [8]byte{'A', 'B'}
+		p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   bitfield[:],
+		})
 
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	chain := &mock.ChainService{Genesis: time.Now().Add(-5 * oneEpoch()), ValidatorsRoot: [32]byte{}}
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		chain := &mock.ChainService{Genesis: time.Now().Add(-5 * oneEpoch()), ValidatorsRoot: [32]byte{}}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	chain2 := &mock.ChainService{Genesis: time.Now().Add(-5 * oneEpoch()), ValidatorsRoot: [32]byte{}}
-	r2 := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p2,
-			chain:    chain2,
-			clock:    startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
-		},
-		rateLimiter: newRateLimiter(p2),
-	}
+		chain2 := &mock.ChainService{Genesis: time.Now().Add(-5 * oneEpoch()), ValidatorsRoot: [32]byte{}}
+		r2 := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p2,
+				chain:    chain2,
+				clock:    startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
+			},
+			rateLimiter: newRateLimiter(p2),
+		}
 
-	// Setup streams
-	pcl := protocol.ID(p2p.RPCMetaDataTopicV2 + r.cfg.p2p.Encoding().ProtocolSuffix())
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(2, 2, time.Second, false)
-	r2.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(2, 2, time.Second, false)
+		// Setup streams
+		pcl := protocol.ID(p2p.RPCMetaDataTopicV2 + r.cfg.p2p.Encoding().ProtocolSuffix())
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(2, 2, time.Second, false)
+		r2.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(2, 2, time.Second, false)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		err := r2.metaDataHandler(t.Context(), new(any), stream)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			err := r2.metaDataHandler(t.Context(), new(any), stream)
+			assert.NoError(t, err)
+		})
+
+		_, err := r.sendMetaDataRequest(t.Context(), p2.BHost.ID())
 		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		// Fix up peer with the correct metadata.
+		p2.LocalMetadata = wrapper.WrappedMetadataV1(&pb.MetaDataV1{
+			SeqNumber: 2,
+			Attnets:   bitfield[:],
+			Syncnets:  []byte{0x0},
+		})
+
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			assert.NoError(t, r2.metaDataHandler(t.Context(), new(any), stream))
+		})
+
+		md, err := r.sendMetaDataRequest(t.Context(), p2.BHost.ID())
+		assert.NoError(t, err)
+
+		if !equality.DeepEqual(md.InnerObject(), p2.LocalMetadata.InnerObject()) {
+			t.Fatalf("MetadataV1 unequal, received %v but wanted %v", md, p2.LocalMetadata)
+		}
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
+		if len(conns) == 0 {
+			t.Error("Peer is disconnected despite receiving a valid ping")
+		}
 	})
-
-	_, err := r.sendMetaDataRequest(t.Context(), p2.BHost.ID())
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	// Fix up peer with the correct metadata.
-	p2.LocalMetadata = wrapper.WrappedMetadataV1(&pb.MetaDataV1{
-		SeqNumber: 2,
-		Attnets:   bitfield[:],
-		Syncnets:  []byte{0x0},
-	})
-
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		assert.NoError(t, r2.metaDataHandler(t.Context(), new(any), stream))
-	})
-
-	md, err := r.sendMetaDataRequest(t.Context(), p2.BHost.ID())
-	assert.NoError(t, err)
-
-	if !equality.DeepEqual(md.InnerObject(), p2.LocalMetadata.InnerObject()) {
-		t.Fatalf("MetadataV1 unequal, received %v but wanted %v", md, p2.LocalMetadata)
-	}
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
-	if len(conns) == 0 {
-		t.Error("Peer is disconnected despite receiving a valid ping")
-	}
 }

--- a/beacon-chain/sync/rpc_ping_test.go
+++ b/beacon-chain/sync/rpc_ping_test.go
@@ -24,189 +24,195 @@ import (
 )
 
 func TestPingRPCHandler_ReceivesPing(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   []byte{'A', 'B'},
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   []byte{'A', 'B'},
+		})
+
+		p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   []byte{'C', 'D'},
+		})
+
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
+
+		p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
+		p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
+
+		// Setup streams
+		pcl := protocol.ID(p2p.RPCPingTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := new(primitives.SSZUint64)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.Equal(t, uint64(2), uint64(*out))
+		})
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		seqNumber := primitives.SSZUint64(2)
+
+		assert.NoError(t, r.pingHandler(t.Context(), &seqNumber, stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
+		if len(conns) == 0 {
+			t.Error("Peer is disconnected despite receiving a valid ping")
+		}
 	})
-
-	p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   []byte{'C', 'D'},
-	})
-
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-
-	p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
-	p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
-
-	// Setup streams
-	pcl := protocol.ID(p2p.RPCPingTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := new(primitives.SSZUint64)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.Equal(t, uint64(2), uint64(*out))
-	})
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	seqNumber := primitives.SSZUint64(2)
-
-	assert.NoError(t, r.pingHandler(t.Context(), &seqNumber, stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
-	if len(conns) == 0 {
-		t.Error("Peer is disconnected despite receiving a valid ping")
-	}
 }
 
 func TestPingRPCHandler_SendsPing(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   []byte{'A', 'B'},
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   []byte{'A', 'B'},
+		})
+
+		p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   []byte{'C', 'D'},
+		})
+
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		chain := &mock.ChainService{ValidatorsRoot: [32]byte{}, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
+
+		p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
+		p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
+
+		p2.Peers().Add(new(enr.Record), p1.BHost.ID(), p1.BHost.Addrs()[0], network.DirUnknown)
+		p2.Peers().SetMetadata(p1.BHost.ID(), p1.LocalMetadata)
+
+		chain2 := &mock.ChainService{ValidatorsRoot: [32]byte{}, Genesis: time.Now()}
+		r2 := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p2,
+				chain:    chain2,
+				clock:    startup.NewClock(chain2.Genesis, chain.ValidatorsRoot),
+			},
+			rateLimiter: newRateLimiter(p2),
+		}
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/ping/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(primitives.SSZUint64)
+			assert.NoError(t, r2.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.Equal(t, uint64(2), uint64(*out))
+			assert.NoError(t, r2.pingHandler(t.Context(), out, stream))
+		})
+
+		assert.NoError(t, r.sendPingRequest(t.Context(), p2.BHost.ID()))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
+		if len(conns) == 0 {
+			t.Error("Peer is disconnected despite receiving a valid ping")
+		}
 	})
-
-	p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   []byte{'C', 'D'},
-	})
-
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	chain := &mock.ChainService{ValidatorsRoot: [32]byte{}, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-
-	p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
-	p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
-
-	p2.Peers().Add(new(enr.Record), p1.BHost.ID(), p1.BHost.Addrs()[0], network.DirUnknown)
-	p2.Peers().SetMetadata(p1.BHost.ID(), p1.LocalMetadata)
-
-	chain2 := &mock.ChainService{ValidatorsRoot: [32]byte{}, Genesis: time.Now()}
-	r2 := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p2,
-			chain:    chain2,
-			clock:    startup.NewClock(chain2.Genesis, chain.ValidatorsRoot),
-		},
-		rateLimiter: newRateLimiter(p2),
-	}
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/ping/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(primitives.SSZUint64)
-		assert.NoError(t, r2.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.Equal(t, uint64(2), uint64(*out))
-		assert.NoError(t, r2.pingHandler(t.Context(), out, stream))
-	})
-
-	assert.NoError(t, r.sendPingRequest(t.Context(), p2.BHost.ID()))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	conns := p1.BHost.Network().ConnsToPeer(p2.BHost.ID())
-	if len(conns) == 0 {
-		t.Error("Peer is disconnected despite receiving a valid ping")
-	}
 }
 
 func TestPingRPCHandler_BadSequenceNumber(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   []byte{'A', 'B'},
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		p1.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   []byte{'A', 'B'},
+		})
+
+		p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   []byte{'C', 'D'},
+		})
+
+		// Set up a head state in the database with data we expect.
+		d := db.SetupDB(t)
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
+
+		badMetadata := &pb.MetaDataV0{
+			SeqNumber: 3,
+			Attnets:   []byte{'E', 'F'},
+		}
+
+		p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
+		p1.Peers().SetMetadata(p2.BHost.ID(), wrapper.WrappedMetadataV0(badMetadata))
+
+		// Setup streams
+		pcl := protocol.ID("/testing")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectFailure(t, responseCodeInvalidRequest, p2ptypes.ErrInvalidSequenceNum.Error(), stream)
+
+		})
+		stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+
+		wantedSeq := primitives.SSZUint64(p2.LocalMetadata.SequenceNumber())
+		err = r.pingHandler(t.Context(), &wantedSeq, stream1)
+		assert.ErrorContains(t, p2ptypes.ErrInvalidSequenceNum.Error(), err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		res, err := p1.Peers().Scorers().BadResponsesScorer().Count(p2.BHost.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, res, "Peer wasn't penalised for providing a bad sequence number")
 	})
-
-	p2.LocalMetadata = wrapper.WrappedMetadataV0(&pb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   []byte{'C', 'D'},
-	})
-
-	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-
-	badMetadata := &pb.MetaDataV0{
-		SeqNumber: 3,
-		Attnets:   []byte{'E', 'F'},
-	}
-
-	p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
-	p1.Peers().SetMetadata(p2.BHost.ID(), wrapper.WrappedMetadataV0(badMetadata))
-
-	// Setup streams
-	pcl := protocol.ID("/testing")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectFailure(t, responseCodeInvalidRequest, p2ptypes.ErrInvalidSequenceNum.Error(), stream)
-
-	})
-	stream1, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-
-	wantedSeq := primitives.SSZUint64(p2.LocalMetadata.SequenceNumber())
-	err = r.pingHandler(t.Context(), &wantedSeq, stream1)
-	assert.ErrorContains(t, p2ptypes.ErrInvalidSequenceNum.Error(), err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	res, err := p1.Peers().Scorers().BadResponsesScorer().Count(p2.BHost.ID())
-	assert.NoError(t, err)
-	assert.Equal(t, 1, res, "Peer wasn't penalised for providing a bad sequence number")
 }

--- a/beacon-chain/sync/rpc_send_request_test.go
+++ b/beacon-chain/sync/rpc_send_request_test.go
@@ -916,21 +916,25 @@ func TestSendDataColumnSidecarsByRangeRequest(t *testing.T) {
 
 	for _, tc := range nilTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := SendDataColumnSidecarsByRangeRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", tc.request)
-			require.NoError(t, err)
-			require.IsNil(t, actual)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				actual, err := SendDataColumnSidecarsByRangeRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", tc.request)
+				require.NoError(t, err)
+				require.IsNil(t, actual)
+			})
 		})
 	}
 
 	t.Run("too many columns in request", func(t *testing.T) {
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.MaxRequestDataColumnSidecars = 0
-		params.OverrideBeaconConfig(cfg)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.MaxRequestDataColumnSidecars = 0
+			params.OverrideBeaconConfig(cfg)
 
-		request := &ethpb.DataColumnSidecarsByRangeRequest{Count: 1, Columns: []uint64{1, 2, 3}}
-		_, err := SendDataColumnSidecarsByRangeRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", request)
-		require.ErrorContains(t, errMaxRequestDataColumnSidecarsExceeded.Error(), err)
+			request := &ethpb.DataColumnSidecarsByRangeRequest{Count: 1, Columns: []uint64{1, 2, 3}}
+			_, err := SendDataColumnSidecarsByRangeRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", request)
+			require.ErrorContains(t, errMaxRequestDataColumnSidecarsExceeded.Error(), err)
+		})
 	})
 
 	type slotIndex struct {
@@ -1003,67 +1007,69 @@ func TestSendDataColumnSidecarsByRangeRequest(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
-			clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+				clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
 
-			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-			p1.Connect(p2)
+				p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+				p1.Connect(p2)
 
-			expected := make([]*ethpb.DataColumnSidecar, 0, len(tc.slotIndices))
-			for _, slotIndex := range tc.slotIndices {
-				sidecar := createSidecar(slotIndex)
-				expected = append(expected, sidecar)
-			}
-
-			requestSent := &ethpb.DataColumnSidecarsByRangeRequest{
-				StartSlot: 0,
-				Count:     2,
-				Columns:   []uint64{1, 3, 2},
-			}
-
-			var wg sync.WaitGroup
-			wg.Add(1)
-
-			p2.SetStreamHandler(protocol, func(stream network.Stream) {
-				wg.Done()
-
-				requestReceived := new(ethpb.DataColumnSidecarsByRangeRequest)
-				err := p2.Encoding().DecodeWithMaxLength(stream, requestReceived)
-				assert.NoError(t, err)
-				assert.DeepSSZEqual(t, requestSent, requestReceived)
-
-				for _, sidecar := range expected {
-					ro, err := blocks.NewRODataColumn(sidecar)
-					assert.NoError(t, err)
-					err = WriteDataColumnSidecarChunk(stream, clock, p2.Encoding(), ro)
-					assert.NoError(t, err)
+				expected := make([]*ethpb.DataColumnSidecar, 0, len(tc.slotIndices))
+				for _, slotIndex := range tc.slotIndices {
+					sidecar := createSidecar(slotIndex)
+					expected = append(expected, sidecar)
 				}
 
-				err = stream.CloseWrite()
-				assert.NoError(t, err)
+				requestSent := &ethpb.DataColumnSidecarsByRangeRequest{
+					StartSlot: 0,
+					Count:     2,
+					Columns:   []uint64{1, 3, 2},
+				}
+
+				var wg sync.WaitGroup
+				wg.Add(1)
+
+				p2.SetStreamHandler(protocol, func(stream network.Stream) {
+					wg.Done()
+
+					requestReceived := new(ethpb.DataColumnSidecarsByRangeRequest)
+					err := p2.Encoding().DecodeWithMaxLength(stream, requestReceived)
+					assert.NoError(t, err)
+					assert.DeepSSZEqual(t, requestSent, requestReceived)
+
+					for _, sidecar := range expected {
+						ro, err := blocks.NewRODataColumn(sidecar)
+						assert.NoError(t, err)
+						err = WriteDataColumnSidecarChunk(stream, clock, p2.Encoding(), ro)
+						assert.NoError(t, err)
+					}
+
+					err = stream.CloseWrite()
+					assert.NoError(t, err)
+				})
+
+				parameters := DataColumnSidecarsParams{
+					Ctx:    t.Context(),
+					Tor:    clock,
+					P2P:    p1,
+					CtxMap: ctxMap,
+				}
+
+				actual, err := SendDataColumnSidecarsByRangeRequest(parameters, p2.PeerID(), requestSent)
+				if tc.expectedError != nil {
+					require.ErrorContains(t, tc.expectedError.Error(), err)
+					if util.WaitTimeout(&wg, time.Second) {
+						t.Fatal("Did not receive stream within 1 sec")
+					}
+
+					return
+				}
+
+				require.Equal(t, len(expected), len(actual))
+				for i := range expected {
+					require.DeepSSZEqual(t, expected[i], actual[i].DataColumnSidecar())
+				}
 			})
-
-			parameters := DataColumnSidecarsParams{
-				Ctx:    t.Context(),
-				Tor:    clock,
-				P2P:    p1,
-				CtxMap: ctxMap,
-			}
-
-			actual, err := SendDataColumnSidecarsByRangeRequest(parameters, p2.PeerID(), requestSent)
-			if tc.expectedError != nil {
-				require.ErrorContains(t, tc.expectedError.Error(), err)
-				if util.WaitTimeout(&wg, time.Second) {
-					t.Fatal("Did not receive stream within 1 sec")
-				}
-
-				return
-			}
-
-			require.Equal(t, len(expected), len(actual))
-			for i := range expected {
-				require.DeepSSZEqual(t, expected[i], actual[i].DataColumnSidecar())
-			}
 		})
 	}
 }
@@ -1264,25 +1270,29 @@ func TestSendDataColumnSidecarsByRootRequest(t *testing.T) {
 
 	for _, tc := range nilTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := SendDataColumnSidecarsByRootRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", tc.request)
-			require.NoError(t, err)
-			require.IsNil(t, actual)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				actual, err := SendDataColumnSidecarsByRootRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", tc.request)
+				require.NoError(t, err)
+				require.IsNil(t, actual)
+			})
 		})
 	}
 
 	t.Run("too many columns in request", func(t *testing.T) {
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.MaxRequestDataColumnSidecars = 4
-		params.OverrideBeaconConfig(cfg)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.MaxRequestDataColumnSidecars = 4
+			params.OverrideBeaconConfig(cfg)
 
-		request := p2ptypes.DataColumnsByRootIdentifiers{
-			{Columns: []uint64{1, 2, 3}},
-			{Columns: []uint64{4, 5, 6}},
-		}
+			request := p2ptypes.DataColumnsByRootIdentifiers{
+				{Columns: []uint64{1, 2, 3}},
+				{Columns: []uint64{4, 5, 6}},
+			}
 
-		_, err := SendDataColumnSidecarsByRootRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", request)
-		require.ErrorContains(t, errMaxRequestDataColumnSidecarsExceeded.Error(), err)
+			_, err := SendDataColumnSidecarsByRootRequest(DataColumnSidecarsParams{Ctx: t.Context()}, "", request)
+			require.ErrorContains(t, errMaxRequestDataColumnSidecarsExceeded.Error(), err)
+		})
 	})
 
 	type slotIndex struct {
@@ -1359,69 +1369,71 @@ func TestSendDataColumnSidecarsByRootRequest(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
-			clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
+				clock := startup.NewClock(time.Now(), [fieldparams.RootLength]byte{})
 
-			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-			p1.Connect(p2)
+				p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+				p1.Connect(p2)
 
-			expected := make([]blocks.RODataColumn, 0, len(tc.slotIndices))
-			for _, slotIndex := range tc.slotIndices {
-				roSidecar := createSidecar(slotIndex)
-				expected = append(expected, roSidecar)
-			}
-
-			blockRoot1, blockRoot2 := expected[0].BlockRoot(), expected[3].BlockRoot()
-
-			sentRequest := p2ptypes.DataColumnsByRootIdentifiers{
-				{BlockRoot: blockRoot1[:], Columns: []uint64{1, 2, 3}},
-				{BlockRoot: blockRoot2[:], Columns: []uint64{1, 2, 3}},
-			}
-
-			var wg sync.WaitGroup
-			wg.Add(1)
-
-			p2.SetStreamHandler(protocol, func(stream network.Stream) {
-				wg.Done()
-
-				requestReceived := new(p2ptypes.DataColumnsByRootIdentifiers)
-				err := p2.Encoding().DecodeWithMaxLength(stream, requestReceived)
-				assert.NoError(t, err)
-
-				require.Equal(t, len(sentRequest), len(*requestReceived))
-				for i := range sentRequest {
-					require.DeepSSZEqual(t, (sentRequest)[i], (*requestReceived)[i])
+				expected := make([]blocks.RODataColumn, 0, len(tc.slotIndices))
+				for _, slotIndex := range tc.slotIndices {
+					roSidecar := createSidecar(slotIndex)
+					expected = append(expected, roSidecar)
 				}
 
-				for _, sidecar := range expected {
-					err := WriteDataColumnSidecarChunk(stream, clock, p2.Encoding(), sidecar)
+				blockRoot1, blockRoot2 := expected[0].BlockRoot(), expected[3].BlockRoot()
+
+				sentRequest := p2ptypes.DataColumnsByRootIdentifiers{
+					{BlockRoot: blockRoot1[:], Columns: []uint64{1, 2, 3}},
+					{BlockRoot: blockRoot2[:], Columns: []uint64{1, 2, 3}},
+				}
+
+				var wg sync.WaitGroup
+				wg.Add(1)
+
+				p2.SetStreamHandler(protocol, func(stream network.Stream) {
+					wg.Done()
+
+					requestReceived := new(p2ptypes.DataColumnsByRootIdentifiers)
+					err := p2.Encoding().DecodeWithMaxLength(stream, requestReceived)
 					assert.NoError(t, err)
+
+					require.Equal(t, len(sentRequest), len(*requestReceived))
+					for i := range sentRequest {
+						require.DeepSSZEqual(t, (sentRequest)[i], (*requestReceived)[i])
+					}
+
+					for _, sidecar := range expected {
+						err := WriteDataColumnSidecarChunk(stream, clock, p2.Encoding(), sidecar)
+						assert.NoError(t, err)
+					}
+
+					err = stream.CloseWrite()
+					assert.NoError(t, err)
+				})
+
+				parameters := DataColumnSidecarsParams{
+					Ctx:    t.Context(),
+					Tor:    clock,
+					P2P:    p1,
+					CtxMap: ctxMap,
+				}
+				actual, err := SendDataColumnSidecarsByRootRequest(parameters, p2.PeerID(), sentRequest)
+				if tc.expectedError != nil {
+					require.ErrorContains(t, tc.expectedError.Error(), err)
+					if util.WaitTimeout(&wg, time.Second) {
+						t.Fatal("Did not receive stream within 1 sec")
+					}
+
+					return
 				}
 
-				err = stream.CloseWrite()
-				assert.NoError(t, err)
+				require.Equal(t, len(expected), len(actual))
+				for i := range expected {
+					require.DeepSSZEqual(t, expected[i].DataColumnSidecar(), actual[i].DataColumnSidecar())
+				}
 			})
-
-			parameters := DataColumnSidecarsParams{
-				Ctx:    t.Context(),
-				Tor:    clock,
-				P2P:    p1,
-				CtxMap: ctxMap,
-			}
-			actual, err := SendDataColumnSidecarsByRootRequest(parameters, p2.PeerID(), sentRequest)
-			if tc.expectedError != nil {
-				require.ErrorContains(t, tc.expectedError.Error(), err)
-				if util.WaitTimeout(&wg, time.Second) {
-					t.Fatal("Did not receive stream within 1 sec")
-				}
-
-				return
-			}
-
-			require.Equal(t, len(expected), len(actual))
-			for i := range expected {
-				require.DeepSSZEqual(t, expected[i].DataColumnSidecar(), actual[i].DataColumnSidecar())
-			}
 		})
 	}
 }
@@ -1497,244 +1509,256 @@ func TestIsSidecarIndexRootRequested(t *testing.T) {
 
 func TestReadChunkedDataColumnSidecar(t *testing.T) {
 	t.Run("non nil status code", func(t *testing.T) {
-		const reason = "a dummy reason"
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			const reason = "a dummy reason"
 
-		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
+				defer wg.Done()
 
-			_, err := readChunkedDataColumnSidecar(stream, p2, nil)
-			require.ErrorContains(t, reason, err)
+				_, err := readChunkedDataColumnSidecar(stream, p2, nil)
+				require.ErrorContains(t, reason, err)
+			})
+
+			p1.Connect(p2)
+
+			stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
+			require.NoError(t, err)
+
+			writeErrorResponseToStream(responseCodeInvalidRequest, reason, stream, p1)
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		p1.Connect(p2)
-
-		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
-		require.NoError(t, err)
-
-		writeErrorResponseToStream(responseCodeInvalidRequest, reason, stream, p1)
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("unrecognized fork digest", func(t *testing.T) {
-		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
+				defer wg.Done()
 
-			_, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{})
-			require.ErrorContains(t, "unrecognized fork digest", err)
+				_, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{})
+				require.ErrorContains(t, "unrecognized fork digest", err)
+			})
+
+			p1.Connect(p2)
+
+			stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
+			require.NoError(t, err)
+
+			_, err = stream.Write([]byte{responseCodeSuccess})
+			require.NoError(t, err)
+
+			err = writeContextToStream([]byte{42, 42, 42, 42}, stream)
+			require.NoError(t, err)
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		p1.Connect(p2)
-
-		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
-		require.NoError(t, err)
-
-		_, err = stream.Write([]byte{responseCodeSuccess})
-		require.NoError(t, err)
-
-		err = writeContextToStream([]byte{42, 42, 42, 42}, stream)
-		require.NoError(t, err)
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("before fulu", func(t *testing.T) {
-		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
+				defer wg.Done()
 
-			_, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Phase0})
-			require.ErrorContains(t, "unexpected context bytes", err)
+				_, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Phase0})
+				require.ErrorContains(t, "unexpected context bytes", err)
+			})
+
+			p1.Connect(p2)
+
+			stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
+			require.NoError(t, err)
+
+			_, err = stream.Write([]byte{responseCodeSuccess})
+			require.NoError(t, err)
+
+			err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
+			require.NoError(t, err)
+
+			if util.WaitTimeout(&wg, time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		p1.Connect(p2)
-
-		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
-		require.NoError(t, err)
-
-		_, err = stream.Write([]byte{responseCodeSuccess})
-		require.NoError(t, err)
-
-		err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
-		require.NoError(t, err)
-
-		if util.WaitTimeout(&wg, time.Second) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("one validation failed", func(t *testing.T) {
-		const reason = "a dummy reason"
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			const reason = "a dummy reason"
 
-		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
+				defer wg.Done()
 
-			validationOne := func(column blocks.RODataColumn) error {
-				return nil
+				validationOne := func(column blocks.RODataColumn) error {
+					return nil
+				}
+
+				validationTwo := func(column blocks.RODataColumn) error {
+					return errors.New(reason)
+				}
+
+				_, err := readChunkedDataColumnSidecar(
+					stream,
+					p2,
+					ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Fulu},
+					validationOne, // OK
+					validationTwo, // Fail
+				)
+
+				require.ErrorContains(t, reason, err)
+			})
+
+			p1.Connect(p2)
+
+			stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
+			require.NoError(t, err)
+
+			const count = 4
+			kzgCommitmentsInclusionProof := make([][]byte, 0, count)
+			for range count {
+				kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
 			}
 
-			validationTwo := func(column blocks.RODataColumn) error {
-				return errors.New(reason)
-			}
+			// Success response code.
+			_, err = stream.Write([]byte{responseCodeSuccess})
+			require.NoError(t, err)
 
-			_, err := readChunkedDataColumnSidecar(
-				stream,
-				p2,
-				ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Fulu},
-				validationOne, // OK
-				validationTwo, // Fail
-			)
+			// Fork digest.
+			err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
+			require.NoError(t, err)
 
-			require.ErrorContains(t, reason, err)
-		})
-
-		p1.Connect(p2)
-
-		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
-		require.NoError(t, err)
-
-		const count = 4
-		kzgCommitmentsInclusionProof := make([][]byte, 0, count)
-		for range count {
-			kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
-		}
-
-		// Success response code.
-		_, err = stream.Write([]byte{responseCodeSuccess})
-		require.NoError(t, err)
-
-		// Fork digest.
-		err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
-		require.NoError(t, err)
-
-		// Sidecar.
-		_, err = p1.Encoding().EncodeWithMaxLength(stream, &ethpb.DataColumnSidecar{
-			SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
-				Header: &ethpb.BeaconBlockHeader{
-					ParentRoot: make([]byte, fieldparams.RootLength),
-					StateRoot:  make([]byte, fieldparams.RootLength),
-					BodyRoot:   make([]byte, fieldparams.RootLength),
+			// Sidecar.
+			_, err = p1.Encoding().EncodeWithMaxLength(stream, &ethpb.DataColumnSidecar{
+				SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
+					Header: &ethpb.BeaconBlockHeader{
+						ParentRoot: make([]byte, fieldparams.RootLength),
+						StateRoot:  make([]byte, fieldparams.RootLength),
+						BodyRoot:   make([]byte, fieldparams.RootLength),
+					},
+					Signature: make([]byte, fieldparams.BLSSignatureLength),
 				},
-				Signature: make([]byte, fieldparams.BLSSignatureLength),
-			},
-			KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
-		})
-		require.NoError(t, err)
+				KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
+			})
+			require.NoError(t, err)
 
-		if util.WaitTimeout(&wg, time.Minute) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
+			if util.WaitTimeout(&wg, time.Minute) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
+		})
 	})
 
 	t.Run("nominal", func(t *testing.T) {
-		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
 
-		const count = 4
-		kzgCommitmentsInclusionProof := make([][]byte, 0, count)
-		for range count {
-			kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
-		}
+			const count = 4
+			kzgCommitmentsInclusionProof := make([][]byte, 0, count)
+			for range count {
+				kzgCommitmentsInclusionProof = append(kzgCommitmentsInclusionProof, make([]byte, 32))
+			}
 
-		expected := &ethpb.DataColumnSidecar{
-			SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
-				Header: &ethpb.BeaconBlockHeader{
-					ParentRoot: make([]byte, fieldparams.RootLength),
-					StateRoot:  make([]byte, fieldparams.RootLength),
-					BodyRoot:   make([]byte, fieldparams.RootLength),
+			expected := &ethpb.DataColumnSidecar{
+				SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
+					Header: &ethpb.BeaconBlockHeader{
+						ParentRoot: make([]byte, fieldparams.RootLength),
+						StateRoot:  make([]byte, fieldparams.RootLength),
+						BodyRoot:   make([]byte, fieldparams.RootLength),
+					},
+					Signature: make([]byte, fieldparams.BLSSignatureLength),
 				},
-				Signature: make([]byte, fieldparams.BLSSignatureLength),
-			},
-			KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
-		}
+				KzgCommitmentsInclusionProof: kzgCommitmentsInclusionProof,
+			}
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
+				defer wg.Done()
 
-			actual, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Fulu})
+				actual, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Fulu})
+				require.NoError(t, err)
+				require.DeepSSZEqual(t, expected, actual.DataColumnSidecar())
+			})
+
+			p1.Connect(p2)
+
+			stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
 			require.NoError(t, err)
-			require.DeepSSZEqual(t, expected, actual.DataColumnSidecar())
+
+			// Success response code.
+			_, err = stream.Write([]byte{responseCodeSuccess})
+			require.NoError(t, err)
+
+			// Fork digest.
+			err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
+			require.NoError(t, err)
+
+			// Sidecar.
+			_, err = p1.Encoding().EncodeWithMaxLength(stream, expected)
+			require.NoError(t, err)
+
+			if util.WaitTimeout(&wg, time.Minute) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		p1.Connect(p2)
-
-		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
-		require.NoError(t, err)
-
-		// Success response code.
-		_, err = stream.Write([]byte{responseCodeSuccess})
-		require.NoError(t, err)
-
-		// Fork digest.
-		err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
-		require.NoError(t, err)
-
-		// Sidecar.
-		_, err = p1.Encoding().EncodeWithMaxLength(stream, expected)
-		require.NoError(t, err)
-
-		if util.WaitTimeout(&wg, time.Minute) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 
 	t.Run("nominal gloas", func(t *testing.T) {
-		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
 
-		expected := &ethpb.DataColumnSidecarGloas{
-			Index:           7,
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-			BeaconBlockRoot: make([]byte, fieldparams.RootLength),
-		}
+			expected := &ethpb.DataColumnSidecarGloas{
+				Index:           7,
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+				BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+			}
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
-			defer wg.Done()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
+				defer wg.Done()
 
-			actual, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Gloas})
+				actual, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Gloas})
+				require.NoError(t, err)
+				require.Equal(t, true, actual.IsGloas())
+				require.Equal(t, uint64(7), actual.Index())
+			})
+
+			p1.Connect(p2)
+
+			stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
 			require.NoError(t, err)
-			require.Equal(t, true, actual.IsGloas())
-			require.Equal(t, uint64(7), actual.Index())
+
+			_, err = stream.Write([]byte{responseCodeSuccess})
+			require.NoError(t, err)
+
+			err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
+			require.NoError(t, err)
+
+			_, err = p1.Encoding().EncodeWithMaxLength(stream, expected)
+			require.NoError(t, err)
+
+			if util.WaitTimeout(&wg, time.Minute) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
 		})
-
-		p1.Connect(p2)
-
-		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
-		require.NoError(t, err)
-
-		_, err = stream.Write([]byte{responseCodeSuccess})
-		require.NoError(t, err)
-
-		err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
-		require.NoError(t, err)
-
-		_, err = p1.Encoding().EncodeWithMaxLength(stream, expected)
-		require.NoError(t, err)
-
-		if util.WaitTimeout(&wg, time.Minute) {
-			t.Fatal("Did not receive stream within 1 sec")
-		}
 	})
 }

--- a/beacon-chain/sync/rpc_send_request_test.go
+++ b/beacon-chain/sync/rpc_send_request_test.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -32,19 +31,20 @@ import (
 )
 
 func TestSendRequest_SendBeaconBlocksByRangeRequest(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 	pcl := fmt.Sprintf("%s/ssz_snappy", p2p.RPCBlocksByRangeTopicV1)
 
 	t.Run("stream error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		// Bogus peer doesn't support a given protocol, so stream error is expected.
-		bogusPeer := p2ptest.NewTestP2P(t)
-		p1.Connect(bogusPeer)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			// Bogus peer doesn't support a given protocol, so stream error is expected.
+			bogusPeer := p2ptest.NewTestP2P(t)
+			p1.Connect(bogusPeer)
 
-		req := &ethpb.BeaconBlocksByRangeRequest{}
-		_, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, bogusPeer.PeerID(), req, nil)
-		assert.ErrorContains(t, "protocols not supported", err)
+			req := &ethpb.BeaconBlocksByRangeRequest{}
+			_, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, bogusPeer.PeerID(), req, nil)
+			assert.ErrorContains(t, "protocols not supported", err)
+		})
 	})
 
 	knownBlocks := make([]*ethpb.SignedBeaconBlock, 0)
@@ -101,211 +101,230 @@ func TestSendRequest_SendBeaconBlocksByRangeRequest(t *testing.T) {
 	}
 
 	t.Run("no block processor", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 20,
-			Count:     128,
-			Step:      1,
-		}
-		blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, 128, len(blocks))
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 20,
+				Count:     128,
+				Step:      1,
+			}
+			blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, 128, len(blocks))
+		})
 	})
 
 	t.Run("has block processor - no errors", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		// No error from block processor.
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 20,
-			Count:     128,
-			Step:      1,
-		}
-		blocksFromProcessor := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
-		blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			blocksFromProcessor = append(blocksFromProcessor, block)
-			return nil
+			// No error from block processor.
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 20,
+				Count:     128,
+				Step:      1,
+			}
+			blocksFromProcessor := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
+			blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				blocksFromProcessor = append(blocksFromProcessor, block)
+				return nil
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, 128, len(blocks))
+			assert.DeepEqual(t, blocks, blocksFromProcessor)
 		})
-		assert.NoError(t, err)
-		assert.Equal(t, 128, len(blocks))
-		assert.DeepEqual(t, blocks, blocksFromProcessor)
 	})
 
 	t.Run("has block processor - throw error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		// Send error from block processor.
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 20,
-			Count:     128,
-			Step:      1,
-		}
-		errFromProcessor := errors.New("processor error")
-		_, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			return errFromProcessor
+			// Send error from block processor.
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 20,
+				Count:     128,
+				Step:      1,
+			}
+			errFromProcessor := errors.New("processor error")
+			_, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				return errFromProcessor
+			})
+			assert.ErrorContains(t, errFromProcessor.Error(), err)
 		})
-		assert.ErrorContains(t, errFromProcessor.Error(), err)
 	})
 
 	t.Run("max request blocks", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		// No cap on max roots.
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 20,
-			Count:     128,
-			Step:      1,
-		}
-		blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, 128, len(blocks))
+			// No cap on max roots.
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 20,
+				Count:     128,
+				Step:      1,
+			}
+			blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, 128, len(blocks))
 
-		// Cap max returned roots.
-		cfg := params.BeaconConfig().Copy()
-		maxRequestBlocks := cfg.MaxRequestBlocks
-		defer func() {
-			cfg.MaxRequestBlocks = maxRequestBlocks
-			params.OverrideBeaconConfig(cfg)
-		}()
-		blocks, err = SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			// Since ssz checks the boundaries, and doesn't normally allow to send requests bigger than
-			// the max request size, we are updating max request size dynamically. Even when updated dynamically,
-			// no more than max request size of blocks is expected on return.
-			cfg.MaxRequestBlocks = 3
-			params.OverrideBeaconConfig(cfg)
-			return nil
+			// Cap max returned roots.
+			cfg := params.BeaconConfig().Copy()
+			maxRequestBlocks := cfg.MaxRequestBlocks
+			defer func() {
+				cfg.MaxRequestBlocks = maxRequestBlocks
+				params.OverrideBeaconConfig(cfg)
+			}()
+			blocks, err = SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				// Since ssz checks the boundaries, and doesn't normally allow to send requests bigger than
+				// the max request size, we are updating max request size dynamically. Even when updated dynamically,
+				// no more than max request size of blocks is expected on return.
+				cfg.MaxRequestBlocks = 3
+				params.OverrideBeaconConfig(cfg)
+				return nil
+			})
+			assert.ErrorContains(t, ErrInvalidFetchedData.Error(), err)
+			assert.Equal(t, 0, len(blocks))
 		})
-		assert.ErrorContains(t, ErrInvalidFetchedData.Error(), err)
-		assert.Equal(t, 0, len(blocks))
 	})
 
 	t.Run("process custom error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		blocksProcessed := 0
-		expectedErr := errors.New("some error")
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			if blocksProcessed > 2 {
-				return expectedErr
-			}
-			blocksProcessed++
-			return nil
-		}))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			blocksProcessed := 0
+			expectedErr := errors.New("some error")
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				if blocksProcessed > 2 {
+					return expectedErr
+				}
+				blocksProcessed++
+				return nil
+			}))
 
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 20,
-			Count:     128,
-			Step:      1,
-		}
-		blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.ErrorContains(t, expectedErr.Error(), err)
-		assert.Equal(t, 0, len(blocks))
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 20,
+				Count:     128,
+				Step:      1,
+			}
+			blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.ErrorContains(t, expectedErr.Error(), err)
+			assert.Equal(t, 0, len(blocks))
+		})
 	})
 
 	t.Run("blocks out of order: step 1", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-		// Switch known blocks, so that slots are out of order.
-		knownBlocks[30], knownBlocks[31] = knownBlocks[31], knownBlocks[30]
-		defer func() {
-			knownBlocks[31], knownBlocks[30] = knownBlocks[30], knownBlocks[31]
-		}()
-
-		p2.SetStreamHandler(pcl, func(stream network.Stream) {
+			// Switch known blocks, so that slots are out of order.
+			knownBlocks[30], knownBlocks[31] = knownBlocks[31], knownBlocks[30]
 			defer func() {
-				assert.NoError(t, stream.Close())
+				knownBlocks[31], knownBlocks[30] = knownBlocks[30], knownBlocks[31]
 			}()
 
-			req := &ethpb.BeaconBlocksByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+			p2.SetStreamHandler(pcl, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
 
-			for i := req.StartSlot; i < req.StartSlot.Add(req.Count*req.Step); i += primitives.Slot(req.Step) {
-				if uint64(i) >= uint64(len(knownBlocks)) {
-					break
-				}
-				wsb, err := blocks.NewSignedBeaconBlock(knownBlocks[i])
-				require.NoError(t, err)
-				err = WriteBlockChunk(stream, startup.NewClock(time.Now(), [32]byte{}), p2.Encoding(), wsb)
-				if err != nil && err.Error() != network.ErrReset.Error() {
+				req := &ethpb.BeaconBlocksByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+
+				for i := req.StartSlot; i < req.StartSlot.Add(req.Count*req.Step); i += primitives.Slot(req.Step) {
+					if uint64(i) >= uint64(len(knownBlocks)) {
+						break
+					}
+					wsb, err := blocks.NewSignedBeaconBlock(knownBlocks[i])
 					require.NoError(t, err)
+					err = WriteBlockChunk(stream, startup.NewClock(time.Now(), [32]byte{}), p2.Encoding(), wsb)
+					if err != nil && err.Error() != network.ErrReset.Error() {
+						require.NoError(t, err)
+					}
 				}
+			})
+
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 20,
+				Count:     128,
+				Step:      1,
 			}
+			blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.ErrorContains(t, ErrInvalidFetchedData.Error(), err)
+			assert.Equal(t, 0, len(blocks))
+
 		})
-
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 20,
-			Count:     128,
-			Step:      1,
-		}
-		blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.ErrorContains(t, ErrInvalidFetchedData.Error(), err)
-		assert.Equal(t, 0, len(blocks))
-
 	})
 
 	t.Run("blocks out of order: step 10", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-		// Switch known blocks, so that slots are out of order.
-		knownBlocks[30], knownBlocks[31] = knownBlocks[31], knownBlocks[30]
-		defer func() {
-			knownBlocks[31], knownBlocks[30] = knownBlocks[30], knownBlocks[31]
-		}()
-
-		p2.SetStreamHandler(pcl, func(stream network.Stream) {
+			// Switch known blocks, so that slots are out of order.
+			knownBlocks[30], knownBlocks[31] = knownBlocks[31], knownBlocks[30]
 			defer func() {
-				assert.NoError(t, stream.Close())
+				knownBlocks[31], knownBlocks[30] = knownBlocks[30], knownBlocks[31]
 			}()
 
-			req := &ethpb.BeaconBlocksByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+			p2.SetStreamHandler(pcl, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
 
-			for i := req.StartSlot; i < req.StartSlot.Add(req.Count*req.Step); i += primitives.Slot(req.Step) {
-				if uint64(i) >= uint64(len(knownBlocks)) {
-					break
-				}
-				wsb, err := blocks.NewSignedBeaconBlock(knownBlocks[i])
-				require.NoError(t, err)
-				err = WriteBlockChunk(stream, startup.NewClock(time.Now(), [32]byte{}), p2.Encoding(), wsb)
-				if err != nil && err.Error() != network.ErrReset.Error() {
+				req := &ethpb.BeaconBlocksByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+
+				for i := req.StartSlot; i < req.StartSlot.Add(req.Count*req.Step); i += primitives.Slot(req.Step) {
+					if uint64(i) >= uint64(len(knownBlocks)) {
+						break
+					}
+					wsb, err := blocks.NewSignedBeaconBlock(knownBlocks[i])
 					require.NoError(t, err)
+					err = WriteBlockChunk(stream, startup.NewClock(time.Now(), [32]byte{}), p2.Encoding(), wsb)
+					if err != nil && err.Error() != network.ErrReset.Error() {
+						require.NoError(t, err)
+					}
 				}
+			})
+
+			req := &ethpb.BeaconBlocksByRangeRequest{
+				StartSlot: 20,
+				Count:     128,
+				Step:      10,
 			}
+			blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.ErrorContains(t, ErrInvalidFetchedData.Error(), err)
+			assert.Equal(t, 0, len(blocks))
+
 		})
-
-		req := &ethpb.BeaconBlocksByRangeRequest{
-			StartSlot: 20,
-			Count:     128,
-			Step:      10,
-		}
-		blocks, err := SendBeaconBlocksByRangeRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.ErrorContains(t, ErrInvalidFetchedData.Error(), err)
-		assert.Equal(t, 0, len(blocks))
-
 	})
 }
 
 func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 	pcl := fmt.Sprintf("%s/ssz_snappy", p2p.RPCBlocksByRootTopicV1)
 
 	knownBlocks := make(map[[32]byte]*ethpb.SignedBeaconBlock)
@@ -319,14 +338,17 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 	}
 
 	t.Run("stream error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		// Bogus peer doesn't support a given protocol, so stream error is expected.
-		bogusPeer := p2ptest.NewTestP2P(t)
-		p1.Connect(bogusPeer)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			// Bogus peer doesn't support a given protocol, so stream error is expected.
+			bogusPeer := p2ptest.NewTestP2P(t)
+			p1.Connect(bogusPeer)
 
-		req := &p2pTypes.BeaconBlockByRootsReq{}
-		_, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, bogusPeer.PeerID(), req, nil)
-		assert.ErrorContains(t, "protocols not supported", err)
+			req := &p2pTypes.BeaconBlockByRootsReq{}
+			_, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, bogusPeer.PeerID(), req, nil)
+			assert.ErrorContains(t, "protocols not supported", err)
+		})
 	})
 
 	knownBlocksProvider := func(p2pProvider p2p.P2P, processor BeaconBlockProcessor) func(stream network.Stream) {
@@ -368,120 +390,138 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 	}
 
 	t.Run("no block processor", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
-		blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(blocks))
+			req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
+			blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(blocks))
+		})
 	})
 
 	t.Run("has block processor - no errors", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		// No error from block processor.
-		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
-		blocksFromProcessor := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
-		blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			blocksFromProcessor = append(blocksFromProcessor, block)
-			return nil
+			// No error from block processor.
+			req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
+			blocksFromProcessor := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
+			blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				blocksFromProcessor = append(blocksFromProcessor, block)
+				return nil
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(blocks))
+			assert.DeepEqual(t, blocks, blocksFromProcessor)
 		})
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(blocks))
-		assert.DeepEqual(t, blocks, blocksFromProcessor)
 	})
 
 	t.Run("has block processor - throw error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		// Send error from block processor.
-		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
-		errFromProcessor := errors.New("processor error")
-		_, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			return errFromProcessor
+			// Send error from block processor.
+			req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
+			errFromProcessor := errors.New("processor error")
+			_, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				return errFromProcessor
+			})
+			assert.ErrorContains(t, errFromProcessor.Error(), err)
 		})
-		assert.ErrorContains(t, errFromProcessor.Error(), err)
 	})
 
 	t.Run("max request blocks", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, nil))
 
-		// No cap on max roots.
-		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1], knownRoots[2], knownRoots[3]}
-		clock := startup.NewClock(time.Now(), [32]byte{})
-		blocks, err := SendBeaconBlocksByRootRequest(ctx, clock, p1, p2.PeerID(), req, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, 4, len(blocks))
+			// No cap on max roots.
+			req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1], knownRoots[2], knownRoots[3]}
+			clock := startup.NewClock(time.Now(), [32]byte{})
+			blocks, err := SendBeaconBlocksByRootRequest(ctx, clock, p1, p2.PeerID(), req, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, 4, len(blocks))
 
-		// Cap max returned roots.
-		cfg := params.BeaconConfig().Copy()
-		maxRequestBlocks := cfg.MaxRequestBlocks
-		defer func() {
-			cfg.MaxRequestBlocks = maxRequestBlocks
-			params.OverrideBeaconConfig(cfg)
-		}()
-		blocks, err = SendBeaconBlocksByRootRequest(ctx, clock, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			// Since ssz checks the boundaries, and doesn't normally allow to send requests bigger than
-			// the max request size, we are updating max request size dynamically. Even when updated dynamically,
-			// no more than max request size of blocks is expected on return.
-			cfg.MaxRequestBlocks = 3
-			params.OverrideBeaconConfig(cfg)
-			return nil
+			// Cap max returned roots.
+			cfg := params.BeaconConfig().Copy()
+			maxRequestBlocks := cfg.MaxRequestBlocks
+			defer func() {
+				cfg.MaxRequestBlocks = maxRequestBlocks
+				params.OverrideBeaconConfig(cfg)
+			}()
+			blocks, err = SendBeaconBlocksByRootRequest(ctx, clock, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				// Since ssz checks the boundaries, and doesn't normally allow to send requests bigger than
+				// the max request size, we are updating max request size dynamically. Even when updated dynamically,
+				// no more than max request size of blocks is expected on return.
+				cfg.MaxRequestBlocks = 3
+				params.OverrideBeaconConfig(cfg)
+				return nil
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, 3, len(blocks))
 		})
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(blocks))
 	})
 
 	t.Run("process custom error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		blocksProcessed := 0
-		expectedErr := errors.New("some error")
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			if blocksProcessed > 2 {
-				return expectedErr
-			}
-			blocksProcessed++
-			return nil
-		}))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			blocksProcessed := 0
+			expectedErr := errors.New("some error")
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				if blocksProcessed > 2 {
+					return expectedErr
+				}
+				blocksProcessed++
+				return nil
+			}))
 
-		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1], knownRoots[2], knownRoots[3]}
-		blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.ErrorContains(t, expectedErr.Error(), err)
-		assert.Equal(t, 0, len(blocks))
+			req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1], knownRoots[2], knownRoots[3]}
+			blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.ErrorContains(t, expectedErr.Error(), err)
+			assert.Equal(t, 0, len(blocks))
+		})
 	})
 
 	t.Run("process io.EOF error", func(t *testing.T) {
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		blocksProcessed := 0
-		expectedErr := io.EOF
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
-			if blocksProcessed > 2 {
-				return expectedErr
-			}
-			blocksProcessed++
-			return nil
-		}))
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			blocksProcessed := 0
+			expectedErr := io.EOF
+			p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
+				if blocksProcessed > 2 {
+					return expectedErr
+				}
+				blocksProcessed++
+				return nil
+			}))
 
-		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1], knownRoots[2], knownRoots[3]}
-		blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(blocks))
+			req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1], knownRoots[2], knownRoots[3]}
+			blocks, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), req, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, 3, len(blocks))
+		})
 	})
 }
 
@@ -701,186 +741,194 @@ func TestSeqBlobValid(t *testing.T) {
 
 func TestSendBlobsByRangeRequest(t *testing.T) {
 	topic := fmt.Sprintf("%s/ssz_snappy", p2p.RPCBlobSidecarsByRangeTopicV1)
-	ctx := t.Context()
 
 	t.Run("single blob - Deneb", func(t *testing.T) {
-		// Setup genesis such that we are currently in deneb.
-		s := uint64(util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)) * params.BeaconConfig().SecondsPerSlot
-		clock := startup.NewClock(time.Now().Add(-time.Second*time.Duration(s)), [32]byte{})
-		ctxByte, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
-		require.NoError(t, err)
-		// Setup peers
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		// Set current slot to a deneb slot.
-		slot := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch+1)
-		// Create a simple handler that will return a valid response.
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
-			defer func() {
-				assert.NoError(t, stream.Close())
-			}()
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			// Setup genesis such that we are currently in deneb.
+			s := uint64(util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)) * params.BeaconConfig().SecondsPerSlot
+			clock := startup.NewClock(time.Now().Add(-time.Second*time.Duration(s)), [32]byte{})
+			ctxByte, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
+			require.NoError(t, err)
+			// Setup peers
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			// Set current slot to a deneb slot.
+			slot := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch+1)
+			// Create a simple handler that will return a valid response.
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
 
-			req := &ethpb.BlobSidecarsByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
-			assert.Equal(t, slot, req.StartSlot)
-			assert.Equal(t, uint64(1), req.Count)
+				req := &ethpb.BlobSidecarsByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+				assert.Equal(t, slot, req.StartSlot)
+				assert.Equal(t, uint64(1), req.Count)
 
-			// Create a sequential set of blobs with the appropriate header information.
-			var prevRoot [32]byte
-			for i := req.StartSlot; i < req.StartSlot+primitives.Slot(req.Count); i++ {
-				b := util.HydrateBlobSidecar(&ethpb.BlobSidecar{})
-				b.SignedBlockHeader.Header.Slot = i
-				b.SignedBlockHeader.Header.ParentRoot = prevRoot[:]
-				ro, err := blocks.NewROBlob(b)
-				require.NoError(t, err)
-				vro := blocks.NewVerifiedROBlob(ro)
-				prevRoot = vro.BlockRoot()
-				assert.NoError(t, WriteBlobSidecarChunk(stream, clock, p2.Encoding(), vro))
+				// Create a sequential set of blobs with the appropriate header information.
+				var prevRoot [32]byte
+				for i := req.StartSlot; i < req.StartSlot+primitives.Slot(req.Count); i++ {
+					b := util.HydrateBlobSidecar(&ethpb.BlobSidecar{})
+					b.SignedBlockHeader.Header.Slot = i
+					b.SignedBlockHeader.Header.ParentRoot = prevRoot[:]
+					ro, err := blocks.NewROBlob(b)
+					require.NoError(t, err)
+					vro := blocks.NewVerifiedROBlob(ro)
+					prevRoot = vro.BlockRoot()
+					assert.NoError(t, WriteBlobSidecarChunk(stream, clock, p2.Encoding(), vro))
+				}
+			})
+			req := &ethpb.BlobSidecarsByRangeRequest{
+				StartSlot: slot,
+				Count:     1,
 			}
-		})
-		req := &ethpb.BlobSidecarsByRangeRequest{
-			StartSlot: slot,
-			Count:     1,
-		}
 
-		blobs, err := SendBlobsByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxByte, req)
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(blobs))
+			blobs, err := SendBlobsByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxByte, req)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(blobs))
+		})
 	})
 
 	t.Run("Deneb - Electra epoch boundary crossing", func(t *testing.T) {
-		cfg := params.BeaconConfig()
-		cfg.ElectraForkEpoch = cfg.DenebForkEpoch + 1
-		undo, err := params.SetActiveWithUndo(cfg)
-		require.NoError(t, err)
-		defer func() {
-			require.NoError(t, undo())
-		}()
-		// Setup genesis such that we are currently in deneb.
-		s := uint64(util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)) * params.BeaconConfig().SecondsPerSlot
-		clock := startup.NewClock(time.Now().Add(-time.Second*time.Duration(s)), [32]byte{})
-		ctxByte, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
-		require.NoError(t, err)
-		// Setup peers
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-		// Set current slot to the first slot of the last deneb epoch.
-		slot := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)
-		// Create a simple handler that will return a valid response.
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			cfg := params.BeaconConfig()
+			cfg.ElectraForkEpoch = cfg.DenebForkEpoch + 1
+			undo, err := params.SetActiveWithUndo(cfg)
+			require.NoError(t, err)
 			defer func() {
-				assert.NoError(t, stream.Close())
+				require.NoError(t, undo())
 			}()
+			// Setup genesis such that we are currently in deneb.
+			s := uint64(util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)) * params.BeaconConfig().SecondsPerSlot
+			clock := startup.NewClock(time.Now().Add(-time.Second*time.Duration(s)), [32]byte{})
+			ctxByte, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
+			require.NoError(t, err)
+			// Setup peers
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+			// Set current slot to the first slot of the last deneb epoch.
+			slot := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)
+			// Create a simple handler that will return a valid response.
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
 
-			req := &ethpb.BlobSidecarsByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
-			assert.Equal(t, slot, req.StartSlot)
-			assert.Equal(t, uint64(params.BeaconConfig().SlotsPerEpoch)*3, req.Count)
+				req := &ethpb.BlobSidecarsByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+				assert.Equal(t, slot, req.StartSlot)
+				assert.Equal(t, uint64(params.BeaconConfig().SlotsPerEpoch)*3, req.Count)
 
-			// Create a sequential set of blobs with the appropriate header information.
-			var prevRoot [32]byte
-			for i := req.StartSlot; i < req.StartSlot+primitives.Slot(req.Count); i++ {
-				maxBlobsForSlot := cfg.MaxBlobsPerBlock(i)
-				parentRoot := prevRoot
-				header := util.HydrateSignedBeaconHeader(&ethpb.SignedBeaconBlockHeader{})
-				header.Header.Slot = i
-				header.Header.ParentRoot = parentRoot[:]
-				bRoot, err := header.Header.HashTreeRoot()
-				require.NoError(t, err)
-				prevRoot = bRoot
-				// Send the maximum possible blobs per slot.
-				for j := range maxBlobsForSlot {
-					b := util.HydrateBlobSidecar(&ethpb.BlobSidecar{})
-					b.SignedBlockHeader = header
-					b.Index = uint64(j)
-					ro, err := blocks.NewROBlob(b)
+				// Create a sequential set of blobs with the appropriate header information.
+				var prevRoot [32]byte
+				for i := req.StartSlot; i < req.StartSlot+primitives.Slot(req.Count); i++ {
+					maxBlobsForSlot := cfg.MaxBlobsPerBlock(i)
+					parentRoot := prevRoot
+					header := util.HydrateSignedBeaconHeader(&ethpb.SignedBeaconBlockHeader{})
+					header.Header.Slot = i
+					header.Header.ParentRoot = parentRoot[:]
+					bRoot, err := header.Header.HashTreeRoot()
 					require.NoError(t, err)
-					vro := blocks.NewVerifiedROBlob(ro)
-					assert.NoError(t, WriteBlobSidecarChunk(stream, clock, p2.Encoding(), vro))
+					prevRoot = bRoot
+					// Send the maximum possible blobs per slot.
+					for j := range maxBlobsForSlot {
+						b := util.HydrateBlobSidecar(&ethpb.BlobSidecar{})
+						b.SignedBlockHeader = header
+						b.Index = uint64(j)
+						ro, err := blocks.NewROBlob(b)
+						require.NoError(t, err)
+						vro := blocks.NewVerifiedROBlob(ro)
+						assert.NoError(t, WriteBlobSidecarChunk(stream, clock, p2.Encoding(), vro))
+					}
 				}
+			})
+			req := &ethpb.BlobSidecarsByRangeRequest{
+				StartSlot: slot,
+				Count:     uint64(params.BeaconConfig().SlotsPerEpoch) * 3,
 			}
-		})
-		req := &ethpb.BlobSidecarsByRangeRequest{
-			StartSlot: slot,
-			Count:     uint64(params.BeaconConfig().SlotsPerEpoch) * 3,
-		}
-		maxDenebBlobs := cfg.MaxBlobsPerBlockAtEpoch(cfg.DenebForkEpoch)
-		maxElectraBlobs := cfg.MaxBlobsPerBlockAtEpoch(cfg.ElectraForkEpoch)
-		totalDenebBlobs := primitives.Slot(maxDenebBlobs) * params.BeaconConfig().SlotsPerEpoch
-		totalElectraBlobs := primitives.Slot(maxElectraBlobs) * 2 * params.BeaconConfig().SlotsPerEpoch
-		totalExpectedBlobs := totalDenebBlobs + totalElectraBlobs
+			maxDenebBlobs := cfg.MaxBlobsPerBlockAtEpoch(cfg.DenebForkEpoch)
+			maxElectraBlobs := cfg.MaxBlobsPerBlockAtEpoch(cfg.ElectraForkEpoch)
+			totalDenebBlobs := primitives.Slot(maxDenebBlobs) * params.BeaconConfig().SlotsPerEpoch
+			totalElectraBlobs := primitives.Slot(maxElectraBlobs) * 2 * params.BeaconConfig().SlotsPerEpoch
+			totalExpectedBlobs := totalDenebBlobs + totalElectraBlobs
 
-		blobs, err := SendBlobsByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxByte, req)
-		assert.NoError(t, err)
-		assert.Equal(t, int(totalExpectedBlobs), len(blobs))
+			blobs, err := SendBlobsByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxByte, req)
+			assert.NoError(t, err)
+			assert.Equal(t, int(totalExpectedBlobs), len(blobs))
+		})
 	})
 
 	t.Run("Starting from Electra", func(t *testing.T) {
-		cfg := params.BeaconConfig()
-		cfg.ElectraForkEpoch = cfg.DenebForkEpoch + 1
-		undo, err := params.SetActiveWithUndo(cfg)
-		require.NoError(t, err)
-		defer func() {
-			require.NoError(t, undo())
-		}()
-
-		s := uint64(util.SlotAtEpoch(t, params.BeaconConfig().ElectraForkEpoch)) * params.BeaconConfig().SecondsPerSlot
-		clock := startup.NewClock(time.Now().Add(-time.Second*time.Duration(s)), [32]byte{})
-		ctxByte, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
-		require.NoError(t, err)
-		// Setup peers
-		p1 := p2ptest.NewTestP2P(t)
-		p2 := p2ptest.NewTestP2P(t)
-		p1.Connect(p2)
-
-		slot := util.SlotAtEpoch(t, params.BeaconConfig().ElectraForkEpoch)
-		// Create a simple handler that will return a valid response.
-		p2.SetStreamHandler(topic, func(stream network.Stream) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			ctx := t.Context()
+			cfg := params.BeaconConfig()
+			cfg.ElectraForkEpoch = cfg.DenebForkEpoch + 1
+			undo, err := params.SetActiveWithUndo(cfg)
+			require.NoError(t, err)
 			defer func() {
-				assert.NoError(t, stream.Close())
+				require.NoError(t, undo())
 			}()
 
-			req := &ethpb.BlobSidecarsByRangeRequest{}
-			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
-			assert.Equal(t, slot, req.StartSlot)
-			assert.Equal(t, uint64(params.BeaconConfig().SlotsPerEpoch)*3, req.Count)
+			s := uint64(util.SlotAtEpoch(t, params.BeaconConfig().ElectraForkEpoch)) * params.BeaconConfig().SecondsPerSlot
+			clock := startup.NewClock(time.Now().Add(-time.Second*time.Duration(s)), [32]byte{})
+			ctxByte, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
+			require.NoError(t, err)
+			// Setup peers
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
 
-			// Create a sequential set of blobs with the appropriate header information.
-			var prevRoot [32]byte
-			for i := req.StartSlot; i < req.StartSlot+primitives.Slot(req.Count); i++ {
-				maxBlobsForSlot := cfg.MaxBlobsPerBlock(i)
-				parentRoot := prevRoot
-				header := util.HydrateSignedBeaconHeader(&ethpb.SignedBeaconBlockHeader{})
-				header.Header.Slot = i
-				header.Header.ParentRoot = parentRoot[:]
-				bRoot, err := header.Header.HashTreeRoot()
-				require.NoError(t, err)
-				prevRoot = bRoot
-				// Send the maximum possible blobs per slot.
-				for j := range maxBlobsForSlot {
-					b := util.HydrateBlobSidecar(&ethpb.BlobSidecar{})
-					b.SignedBlockHeader = header
-					b.Index = uint64(j)
-					ro, err := blocks.NewROBlob(b)
+			slot := util.SlotAtEpoch(t, params.BeaconConfig().ElectraForkEpoch)
+			// Create a simple handler that will return a valid response.
+			p2.SetStreamHandler(topic, func(stream network.Stream) {
+				defer func() {
+					assert.NoError(t, stream.Close())
+				}()
+
+				req := &ethpb.BlobSidecarsByRangeRequest{}
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+				assert.Equal(t, slot, req.StartSlot)
+				assert.Equal(t, uint64(params.BeaconConfig().SlotsPerEpoch)*3, req.Count)
+
+				// Create a sequential set of blobs with the appropriate header information.
+				var prevRoot [32]byte
+				for i := req.StartSlot; i < req.StartSlot+primitives.Slot(req.Count); i++ {
+					maxBlobsForSlot := cfg.MaxBlobsPerBlock(i)
+					parentRoot := prevRoot
+					header := util.HydrateSignedBeaconHeader(&ethpb.SignedBeaconBlockHeader{})
+					header.Header.Slot = i
+					header.Header.ParentRoot = parentRoot[:]
+					bRoot, err := header.Header.HashTreeRoot()
 					require.NoError(t, err)
-					vro := blocks.NewVerifiedROBlob(ro)
-					assert.NoError(t, WriteBlobSidecarChunk(stream, clock, p2.Encoding(), vro))
+					prevRoot = bRoot
+					// Send the maximum possible blobs per slot.
+					for j := range maxBlobsForSlot {
+						b := util.HydrateBlobSidecar(&ethpb.BlobSidecar{})
+						b.SignedBlockHeader = header
+						b.Index = uint64(j)
+						ro, err := blocks.NewROBlob(b)
+						require.NoError(t, err)
+						vro := blocks.NewVerifiedROBlob(ro)
+						assert.NoError(t, WriteBlobSidecarChunk(stream, clock, p2.Encoding(), vro))
+					}
 				}
+			})
+			req := &ethpb.BlobSidecarsByRangeRequest{
+				StartSlot: slot,
+				Count:     uint64(params.BeaconConfig().SlotsPerEpoch) * 3,
 			}
+
+			maxElectraBlobs := cfg.MaxBlobsPerBlockAtEpoch(cfg.ElectraForkEpoch)
+			totalElectraBlobs := primitives.Slot(maxElectraBlobs) * 3 * params.BeaconConfig().SlotsPerEpoch
+
+			blobs, err := SendBlobsByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxByte, req)
+			assert.NoError(t, err)
+			assert.Equal(t, int(totalElectraBlobs), len(blobs))
 		})
-		req := &ethpb.BlobSidecarsByRangeRequest{
-			StartSlot: slot,
-			Count:     uint64(params.BeaconConfig().SlotsPerEpoch) * 3,
-		}
-
-		maxElectraBlobs := cfg.MaxBlobsPerBlockAtEpoch(cfg.ElectraForkEpoch)
-		totalElectraBlobs := primitives.Slot(maxElectraBlobs) * 3 * params.BeaconConfig().SlotsPerEpoch
-
-		blobs, err := SendBlobsByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxByte, req)
-		assert.NoError(t, err)
-		assert.Equal(t, int(totalElectraBlobs), len(blobs))
 	})
 }
 

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -454,19 +454,18 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 	)
 
 	cfg := params.BeaconConfig()
-	ctx := t.Context()
 
 	testCases := []struct {
 		name          string
 		fuluForkEpoch primitives.Epoch
 		topic         string
-		streamHandler func(service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte)
+		streamHandler func(ctx context.Context, service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte)
 	}{
 		{
 			name:          "before fulu",
 			fuluForkEpoch: cfg.FarFutureEpoch,
 			topic:         "/eth2/beacon_chain/req/status/1/ssz_snappy",
-			streamHandler: func(service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
+			streamHandler: func(ctx context.Context, service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
 				out := &ethpb.Status{}
 				require.NoError(t, service.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
 
@@ -492,7 +491,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 			name:          "after fulu",
 			fuluForkEpoch: 0,
 			topic:         "/eth2/beacon_chain/req/status/2/ssz_snappy",
-			streamHandler: func(service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
+			streamHandler: func(ctx context.Context, service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
 				out := &ethpb.StatusV2{}
 				assert.NoError(t, service.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
 
@@ -519,84 +518,87 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			params.SetupTestConfigCleanup(t)
-			cfg := params.BeaconConfig().Copy()
-			cfg.FuluForkEpoch = tc.fuluForkEpoch
-			cfg.ForkVersionSchedule[bytesutil.ToBytes4(cfg.FuluForkVersion)] = cfg.FuluForkEpoch
-			params.OverrideBeaconConfig(cfg)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				ctx := t.Context()
+				params.SetupTestConfigCleanup(t)
+				cfg := params.BeaconConfig().Copy()
+				cfg.FuluForkEpoch = tc.fuluForkEpoch
+				cfg.ForkVersionSchedule[bytesutil.ToBytes4(cfg.FuluForkVersion)] = cfg.FuluForkEpoch
+				params.OverrideBeaconConfig(cfg)
 
-			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-			p1.Connect(p2)
+				p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+				p1.Connect(p2)
 
-			updatedEas, updatedCgc, err := p1.UpdateCustodyInfo(earliestAvailableSlot, custodyGroupCount)
-			require.NoError(t, err)
-			require.Equal(t, earliestAvailableSlot, updatedEas)
-			require.Equal(t, custodyGroupCount, updatedCgc)
+				updatedEas, updatedCgc, err := p1.UpdateCustodyInfo(earliestAvailableSlot, custodyGroupCount)
+				require.NoError(t, err)
+				require.Equal(t, earliestAvailableSlot, updatedEas)
+				require.Equal(t, custodyGroupCount, updatedCgc)
 
-			// Set up a head state with data we expect.
-			head := util.NewBeaconBlock()
-			head.Block.Slot = 111
-			headRoot, err := head.Block.HashTreeRoot()
-			require.NoError(t, err)
+				// Set up a head state with data we expect.
+				head := util.NewBeaconBlock()
+				head.Block.Slot = 111
+				headRoot, err := head.Block.HashTreeRoot()
+				require.NoError(t, err)
 
-			finalized := util.NewBeaconBlock()
-			finalized.Block.Slot = 40
-			finalizedRoot, err := finalized.Block.HashTreeRoot()
-			require.NoError(t, err)
+				finalized := util.NewBeaconBlock()
+				finalized.Block.Slot = 40
+				finalizedRoot, err := finalized.Block.HashTreeRoot()
+				require.NoError(t, err)
 
-			genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
-			require.NoError(t, err)
+				genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
+				require.NoError(t, err)
 
-			require.NoError(t, genesisState.SetSlot(111))
-			require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+				require.NoError(t, genesisState.SetSlot(111))
+				require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
 
-			finalizedCheckpt := &ethpb.Checkpoint{
-				Epoch: 5,
-				Root:  finalizedRoot[:],
-			}
+				finalizedCheckpt := &ethpb.Checkpoint{
+					Epoch: 5,
+					Root:  finalizedRoot[:],
+				}
 
-			chain := &mock.ChainService{
-				State:               genesisState,
-				FinalizedCheckPoint: finalizedCheckpt,
-				Root:                headRoot[:],
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-				},
-				Genesis:        time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot)*150, 0),
-				ValidatorsRoot: [32]byte{'A'},
-			}
+				chain := &mock.ChainService{
+					State:               genesisState,
+					FinalizedCheckPoint: finalizedCheckpt,
+					Root:                headRoot[:],
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					Genesis:        time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot)*150, 0),
+					ValidatorsRoot: [32]byte{'A'},
+				}
 
-			r := &Service{
-				cfg: &config{
-					p2p:   p1,
-					chain: chain,
-					clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-				},
-				ctx:         ctx,
-				rateLimiter: newRateLimiter(p1),
-			}
+				r := &Service{
+					cfg: &config{
+						p2p:   p1,
+						chain: chain,
+						clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+					},
+					ctx:         ctx,
+					rateLimiter: newRateLimiter(p1),
+				}
 
-			// Setup streams
-			pcl := protocol.ID(tc.topic)
+				// Setup streams
+				pcl := protocol.ID(tc.topic)
 
-			r.rateLimiter.limiterMap[tc.topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+				r.rateLimiter.limiterMap[tc.topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-			var wg sync.WaitGroup
-			wg.Add(1)
-			p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-				defer wg.Done()
-				tc.streamHandler(r, stream, genesisState, chain.Root, headRoot[:], finalizedRoot[:])
+				var wg sync.WaitGroup
+				wg.Add(1)
+				p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+					defer wg.Done()
+					tc.streamHandler(ctx, r, stream, genesisState, chain.Root, headRoot[:], finalizedRoot[:])
+				})
+
+				err = r.sendRPCStatusRequest(ctx, p2.BHost.ID())
+				require.ErrorIs(t, err, p2ptypes.ErrInvalidEpoch)
+
+				if util.WaitTimeout(&wg, 1*time.Hour) {
+					t.Fatal("Did not receive stream within 1 sec")
+				}
+
+				assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
 			})
-
-			err = r.sendRPCStatusRequest(ctx, p2.BHost.ID())
-			require.ErrorIs(t, err, p2ptypes.ErrInvalidEpoch)
-
-			if util.WaitTimeout(&wg, 1*time.Hour) {
-				t.Fatal("Did not receive stream within 1 sec")
-			}
-
-			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
 		})
 	}
 }

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -42,401 +42,409 @@ import (
 )
 
 func TestStatusRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	root := [32]byte{'C'}
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		root := [32]byte{'C'}
 
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := &Service{
-		cfg: &config{
-			p2p: p1,
-			chain: &mock.ChainService{
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := &Service{
+			cfg: &config{
+				p2p: p1,
+				chain: &mock.ChainService{
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  root[:],
+					},
+					Genesis:        gt,
+					ValidatorsRoot: vr,
+					Root:           make([]byte, 32),
 				},
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  root[:],
-				},
-				Genesis:        gt,
-				ValidatorsRoot: vr,
-				Root:           make([]byte, 32),
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	pcl := protocol.ID(p2p.RPCStatusTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+			rateLimiter: newRateLimiter(p1),
+		}
+		pcl := protocol.ID(p2p.RPCStatusTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.DeepEqual(t, root[:], out.FinalizedRoot)
-		assert.NoError(t, stream.Close())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.DeepEqual(t, root[:], out.FinalizedRoot)
+			assert.NoError(t, stream.Close())
+		})
+
+		pcl2 := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic = string(pcl2)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg2 sync.WaitGroup
+		wg2.Add(1)
+		p2.BHost.SetStreamHandler(pcl2, func(stream network.Stream) {
+			defer wg2.Done()
+			msg := new(primitives.SSZUint64)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg))
+			assert.Equal(t, p2ptypes.GoodbyeCodeWrongNetwork, *msg)
+			assert.NoError(t, stream.Close())
+		})
+
+		stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		assert.NoError(t, r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: bytesutil.PadTo([]byte("f"), 4), HeadRoot: make([]byte, 32), FinalizedRoot: make([]byte, 32)}, stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+		if util.WaitTimeout(&wg2, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		assert.Equal(t, 0, len(p1.BHost.Network().Peers()), "handler did not disconnect peer")
 	})
-
-	pcl2 := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic = string(pcl2)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg2 sync.WaitGroup
-	wg2.Add(1)
-	p2.BHost.SetStreamHandler(pcl2, func(stream network.Stream) {
-		defer wg2.Done()
-		msg := new(primitives.SSZUint64)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg))
-		assert.Equal(t, p2ptypes.GoodbyeCodeWrongNetwork, *msg)
-		assert.NoError(t, stream.Close())
-	})
-
-	stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	assert.NoError(t, r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: bytesutil.PadTo([]byte("f"), 4), HeadRoot: make([]byte, 32), FinalizedRoot: make([]byte, 32)}, stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-	if util.WaitTimeout(&wg2, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	assert.Equal(t, 0, len(p1.BHost.Network().Peers()), "handler did not disconnect peer")
 }
 
 func TestStatusRPCHandler_ConnectsOnGenesis(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	var root [32]byte
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		var root [32]byte
 
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := &Service{
-		cfg: &config{
-			p2p: p1,
-			chain: &mock.ChainService{
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := &Service{
+			cfg: &config{
+				p2p: p1,
+				chain: &mock.ChainService{
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  params.BeaconConfig().ZeroHash[:],
+					},
+					Genesis:        gt,
+					ValidatorsRoot: vr,
+					Root:           make([]byte, 32),
 				},
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  params.BeaconConfig().ZeroHash[:],
-				},
-				Genesis:        gt,
-				ValidatorsRoot: vr,
-				Root:           make([]byte, 32),
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	pcl := protocol.ID(p2p.RPCStatusTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+			rateLimiter: newRateLimiter(p1),
+		}
+		pcl := protocol.ID(p2p.RPCStatusTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.DeepEqual(t, root[:], out.FinalizedRoot)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.DeepEqual(t, root[:], out.FinalizedRoot)
+		})
+
+		stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		digest := r.currentForkDigest()
+
+		err = r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: digest[:], FinalizedRoot: params.BeaconConfig().ZeroHash[:]}, stream1)
+		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Handler disconnected with peer")
 	})
-
-	stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	digest := r.currentForkDigest()
-
-	err = r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: digest[:], FinalizedRoot: params.BeaconConfig().ZeroHash[:]}, stream1)
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Handler disconnected with peer")
 }
 
 func TestStatusRPCHandler_ReturnsHelloMessage(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	db := testingDB.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		db := testingDB.SetupDB(t)
 
-	// Set up a head state with data we expect.
-	head := util.NewBeaconBlock()
-	head.Block.Slot = 111
-	headRoot, err := head.Block.HashTreeRoot()
-	require.NoError(t, err)
-	blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
-	finalized := util.NewBeaconBlock()
-	finalized.Block.Slot = blkSlot
-	finalizedRoot, err := finalized.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
-	require.NoError(t, err)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
-	util.SaveBlock(t, ctx, db, finalized)
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 3,
-		Root:  finalizedRoot[:],
-	}
-	totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
-	genTime := time.Now().Unix() - totalSec
-
-	gt := time.Unix(genTime, 0)
-	vr := [32]byte{'A'}
-	r := &Service{
-		cfg: &config{
-			p2p: p1,
-			chain: &mock.ChainService{
-				State:               genesisState,
-				FinalizedCheckPoint: finalizedCheckpt,
-				Root:                headRoot[:],
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-				},
-				ValidatorsRoot: vr,
-				Genesis:        gt,
-				FinalizedRoots: map[[32]byte]bool{
-					finalizedRoot: true,
-				},
-			},
-			clock:    startup.NewClock(gt, vr),
-			beaconDB: db,
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	digest := r.currentForkDigest()
-
-	// Setup streams
-	pcl := protocol.ID(p2p.RPCStatusTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		expected := &ethpb.Status{
-			ForkDigest:     digest[:],
-			HeadSlot:       genesisState.Slot(),
-			HeadRoot:       headRoot[:],
-			FinalizedEpoch: 3,
-			FinalizedRoot:  finalizedRoot[:],
+		// Set up a head state with data we expect.
+		head := util.NewBeaconBlock()
+		head.Block.Slot = 111
+		headRoot, err := head.Block.HashTreeRoot()
+		require.NoError(t, err)
+		blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
+		finalized := util.NewBeaconBlock()
+		finalized.Block.Slot = blkSlot
+		finalizedRoot, err := finalized.Block.HashTreeRoot()
+		require.NoError(t, err)
+		genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
+		require.NoError(t, err)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+		util.SaveBlock(t, ctx, db, finalized)
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
+		finalizedCheckpt := &ethpb.Checkpoint{
+			Epoch: 3,
+			Root:  finalizedRoot[:],
 		}
-		if !proto.Equal(out, expected) {
-			t.Errorf("Did not receive expected message. Got %+v wanted %+v", out, expected)
+		totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
+		genTime := time.Now().Unix() - totalSec
+
+		gt := time.Unix(genTime, 0)
+		vr := [32]byte{'A'}
+		r := &Service{
+			cfg: &config{
+				p2p: p1,
+				chain: &mock.ChainService{
+					State:               genesisState,
+					FinalizedCheckPoint: finalizedCheckpt,
+					Root:                headRoot[:],
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+					FinalizedRoots: map[[32]byte]bool{
+						finalizedRoot: true,
+					},
+				},
+				clock:    startup.NewClock(gt, vr),
+				beaconDB: db,
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
+		digest := r.currentForkDigest()
+
+		// Setup streams
+		pcl := protocol.ID(p2p.RPCStatusTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			expected := &ethpb.Status{
+				ForkDigest:     digest[:],
+				HeadSlot:       genesisState.Slot(),
+				HeadRoot:       headRoot[:],
+				FinalizedEpoch: 3,
+				FinalizedRoot:  finalizedRoot[:],
+			}
+			if !proto.Equal(out, expected) {
+				t.Errorf("Did not receive expected message. Got %+v wanted %+v", out, expected)
+			}
+		})
+		stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+
+		err = r.statusRPCHandler(ctx, &ethpb.Status{
+			ForkDigest:     digest[:],
+			FinalizedRoot:  finalizedRoot[:],
+			FinalizedEpoch: 3,
+		}, stream1)
+		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
 		}
 	})
-	stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-
-	err = r.statusRPCHandler(ctx, &ethpb.Status{
-		ForkDigest:     digest[:],
-		FinalizedRoot:  finalizedRoot[:],
-		FinalizedEpoch: 3,
-	}, stream1)
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestHandshakeHandlers_Roundtrip(t *testing.T) {
-	ctx := t.Context()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
-	// Scenario is that p1 and p2 connect, exchange handshakes.
-	// p2 disconnects and p1 should forget the handshake status.
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	db := testingDB.SetupDB(t)
+		// Scenario is that p1 and p2 connect, exchange handshakes.
+		// p2 disconnects and p1 should forget the handshake status.
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		db := testingDB.SetupDB(t)
 
-	p1.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   bytesutil.PadTo([]byte{'A', 'B'}, 8),
-	})
+		p1.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   bytesutil.PadTo([]byte{'A', 'B'}, 8),
+		})
 
-	p2.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   bytesutil.PadTo([]byte{'C', 'D'}, 8),
-	})
+		p2.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   bytesutil.PadTo([]byte{'C', 'D'}, 8),
+		})
 
-	st, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
-		Slot: 5,
-	})
-	require.NoError(t, err)
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = 0
-	util.SaveBlock(t, ctx, db, blk)
-	finalizedRoot, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
-	chain := &mock.ChainService{
-		State:               st,
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-		Root:           make([]byte, 32),
-		FinalizedRoots: map[[32]byte]bool{
-			finalizedRoot: true,
-		},
-	}
-	cw := startup.NewClockSynchronizer()
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:           p1,
-			chain:         chain,
-			clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			beaconDB:      db,
-			stateNotifier: chain.StateNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-		rateLimiter:                     newRateLimiter(p1),
-		clockWaiter:                     cw,
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	markInitSyncComplete(t, r)
-	clock := startup.NewClockSynchronizer()
-	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
-	r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
-	p1.Digest = r.currentForkDigest()
-
-	chain2 := &mock.ChainService{
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
-	}
-	r2 := &Service{
-		ctx: ctx,
-		cfg: &config{
-			chain:         chain2,
-			clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
-			p2p:           p2,
-			stateNotifier: chain.StateNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-		rateLimiter: newRateLimiter(p2),
-		subHandler:  newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, r2)
-	clock = startup.NewClockSynchronizer()
-	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
-	r2.verifierWaiter = verification.NewInitializerWaiter(clock, chain2.ForkChoiceStore, r2.cfg.stateGen, chain2)
-
-	p2.Digest = r.currentForkDigest()
-
-	go r.Start()
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		log.WithField("status", out).Warn("received status")
-		resp := &ethpb.Status{HeadSlot: 0, HeadRoot: make([]byte, 32), ForkDigest: p2.Digest[:],
-			FinalizedRoot: finalizedRoot[:], FinalizedEpoch: 0}
-		_, err := stream.Write([]byte{responseCodeSuccess})
-		assert.NoError(t, err)
-		_, err = r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, resp)
-		assert.NoError(t, err)
-		log.WithField("status", out).Warn("sending status")
-		if err := stream.Close(); err != nil {
-			t.Log(err)
+		st, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
+			Slot: 5,
+		})
+		require.NoError(t, err)
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = 0
+		util.SaveBlock(t, ctx, db, blk)
+		finalizedRoot, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
+		chain := &mock.ChainService{
+			State:               st,
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
+			Fork: &ethpb.Fork{
+				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+			},
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+			Root:           make([]byte, 32),
+			FinalizedRoots: map[[32]byte]bool{
+				finalizedRoot: true,
+			},
 		}
+		cw := startup.NewClockSynchronizer()
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:           p1,
+				chain:         chain,
+				clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				beaconDB:      db,
+				stateNotifier: chain.StateNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+			rateLimiter:                     newRateLimiter(p1),
+			clockWaiter:                     cw,
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		markInitSyncComplete(t, r)
+		clock := startup.NewClockSynchronizer()
+		require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
+		r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
+		p1.Digest = r.currentForkDigest()
+
+		chain2 := &mock.ChainService{
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
+		}
+		r2 := &Service{
+			ctx: ctx,
+			cfg: &config{
+				chain:         chain2,
+				clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
+				p2p:           p2,
+				stateNotifier: chain.StateNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+			rateLimiter: newRateLimiter(p2),
+			subHandler:  newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, r2)
+		clock = startup.NewClockSynchronizer()
+		require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
+		r2.verifierWaiter = verification.NewInitializerWaiter(clock, chain2.ForkChoiceStore, r2.cfg.stateGen, chain2)
+
+		p2.Digest = r.currentForkDigest()
+
+		go r.Start()
+
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			log.WithField("status", out).Warn("received status")
+			resp := &ethpb.Status{HeadSlot: 0, HeadRoot: make([]byte, 32), ForkDigest: p2.Digest[:],
+				FinalizedRoot: finalizedRoot[:], FinalizedEpoch: 0}
+			_, err := stream.Write([]byte{responseCodeSuccess})
+			assert.NoError(t, err)
+			_, err = r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, resp)
+			assert.NoError(t, err)
+			log.WithField("status", out).Warn("sending status")
+			if err := stream.Close(); err != nil {
+				t.Log(err)
+			}
+		})
+
+		pcl = "/eth2/beacon_chain/req/ping/1/ssz_snappy"
+		topic = string(pcl)
+		r2.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg2 sync.WaitGroup
+		wg2.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg2.Done()
+			out := new(primitives.SSZUint64)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.Equal(t, uint64(2), uint64(*out))
+			assert.NoError(t, r2.pingHandler(ctx, out, stream))
+			assert.NoError(t, stream.Close())
+		})
+
+		numInactive1 := len(p1.Peers().Inactive())
+		numActive1 := len(p1.Peers().Active())
+
+		require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
+		p1.Connect(p2)
+
+		p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
+		p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
+
+		p2.Peers().Add(new(enr.Record), p1.BHost.ID(), p1.BHost.Addrs()[0], network.DirUnknown)
+		p2.Peers().SetMetadata(p1.BHost.ID(), p1.LocalMetadata)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		if util.WaitTimeout(&wg2, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		// Wait for stream buffer to be read.
+		time.Sleep(200 * time.Millisecond)
+
+		numInactive2 := len(p1.Peers().Inactive())
+		numActive2 := len(p1.Peers().Active())
+
+		assert.Equal(t, numInactive1, numInactive1, "Number of inactive peers changed unexpectedly")
+		assert.Equal(t, numActive1+1, numActive2, "Number of active peers unexpected")
+
+		require.NoError(t, p2.Disconnect(p1.PeerID()))
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Disconnected)
+
+		// Wait for disconnect event to trigger.
+		time.Sleep(200 * time.Millisecond)
+
+		numInactive3 := len(p1.Peers().Inactive())
+		numActive3 := len(p1.Peers().Active())
+		assert.Equal(t, numInactive2+1, numInactive3, "Number of inactive peers unexpected")
+		assert.Equal(t, numActive2-1, numActive3, "Number of active peers unexpected")
 	})
-
-	pcl = "/eth2/beacon_chain/req/ping/1/ssz_snappy"
-	topic = string(pcl)
-	r2.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg2 sync.WaitGroup
-	wg2.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg2.Done()
-		out := new(primitives.SSZUint64)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.Equal(t, uint64(2), uint64(*out))
-		assert.NoError(t, r2.pingHandler(ctx, out, stream))
-		assert.NoError(t, stream.Close())
-	})
-
-	numInactive1 := len(p1.Peers().Inactive())
-	numActive1 := len(p1.Peers().Active())
-
-	require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
-	p1.Connect(p2)
-
-	p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
-	p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
-
-	p2.Peers().Add(new(enr.Record), p1.BHost.ID(), p1.BHost.Addrs()[0], network.DirUnknown)
-	p2.Peers().SetMetadata(p1.BHost.ID(), p1.LocalMetadata)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	if util.WaitTimeout(&wg2, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	// Wait for stream buffer to be read.
-	time.Sleep(200 * time.Millisecond)
-
-	numInactive2 := len(p1.Peers().Inactive())
-	numActive2 := len(p1.Peers().Active())
-
-	assert.Equal(t, numInactive1, numInactive1, "Number of inactive peers changed unexpectedly")
-	assert.Equal(t, numActive1+1, numActive2, "Number of active peers unexpected")
-
-	require.NoError(t, p2.Disconnect(p1.PeerID()))
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Disconnected)
-
-	// Wait for disconnect event to trigger.
-	time.Sleep(200 * time.Millisecond)
-
-	numInactive3 := len(p1.Peers().Inactive())
-	numActive3 := len(p1.Peers().Active())
-	assert.Equal(t, numInactive2+1, numInactive3, "Number of inactive peers unexpected")
-	assert.Equal(t, numActive2-1, numActive3, "Number of active peers unexpected")
 }
 
 func TestStatusRPCRequest_RequestSent(t *testing.T) {
@@ -594,238 +602,49 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 }
 
 func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	db := testingDB.SetupDB(t)
-
-	// Set up a head state with data we expect.
-	head := util.NewBeaconBlock()
-	head.Block.Slot = 111
-	headRoot, err := head.Block.HashTreeRoot()
-	require.NoError(t, err)
-	blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
-	finalized := util.NewBeaconBlock()
-	finalized.Block.Slot = blkSlot
-	finalizedRoot, err := finalized.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
-	require.NoError(t, err)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = blkSlot
-	util.SaveBlock(t, ctx, db, blk)
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 3,
-		Root:  finalizedRoot[:],
-	}
-	totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
-	genTime := time.Now().Unix() - totalSec
-	chain := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                headRoot[:],
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Unix(genTime, 0),
-		ValidatorsRoot: [32]byte{'A'},
-		FinalizedRoots: map[[32]byte]bool{
-			finalizedRoot: true,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:           p1,
-			chain:         chain,
-			clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			stateNotifier: chain.StateNotifier(),
-		},
-		ctx:         ctx,
-		rateLimiter: newRateLimiter(p1),
-	}
-	chain2 := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                headRoot[:],
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Unix(genTime, 0),
-		ValidatorsRoot: [32]byte{'A'},
-		FinalizedRoots: map[[32]byte]bool{
-			finalizedRoot: true,
-		},
-	}
-	r2 := &Service{
-		cfg: &config{
-			p2p:           p1,
-			chain:         chain2,
-			clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
-			beaconDB:      db,
-			stateNotifier: chain.StateNotifier(),
-		},
-		ctx:         ctx,
-		rateLimiter: newRateLimiter(p1),
-	}
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.NoError(t, r2.validateStatusMessage(ctx, out))
-	})
-
-	p1.AddConnectionHandler(r.sendRPCStatusRequest, nil)
-	p1.Connect(p2)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
-}
-
-func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
-	ctx := t.Context()
-
-	db, err := kv.NewKVStore(ctx, t.TempDir())
-	require.NoError(t, err)
-	bState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
-	require.NoError(t, err)
-
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = 0
-	genRoot, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-
-	wsb, err := consensusblocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	require.NoError(t, db.SaveBlock(ctx, wsb))
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, genRoot))
-	blocksTillHead := makeBlocks(t, 1, 1000, genRoot)
-	require.NoError(t, db.SaveBlocks(ctx, blocksTillHead))
-
-	stateSummaries := make([]*ethpb.StateSummary, len(blocksTillHead))
-	for i, b := range blocksTillHead {
-		bRoot, err := b.Block().HashTreeRoot()
-		require.NoError(t, err)
-		stateSummaries[i] = &ethpb.StateSummary{
-			Slot: b.Block().Slot(),
-			Root: bRoot[:],
-		}
-	}
-	require.NoError(t, db.SaveStateSummaries(ctx, stateSummaries))
-
-	rootFetcher := func(slot primitives.Slot) [32]byte {
-		rt, err := blocksTillHead[slot-1].Block().HashTreeRoot()
-		require.NoError(t, err)
-		return rt
-	}
-	tests := []struct {
-		name                   string
-		expectedFinalizedEpoch primitives.Epoch
-		expectedFinalizedRoot  [32]byte
-		headSlot               primitives.Slot
-		remoteFinalizedEpoch   primitives.Epoch
-		remoteFinalizedRoot    [32]byte
-		remoteHeadSlot         primitives.Slot
-		expectError            bool
-	}{
-		{
-			name:                   "valid finalized epoch",
-			expectedFinalizedEpoch: 3,
-			expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			headSlot:               111,
-			remoteFinalizedEpoch:   3,
-			remoteFinalizedRoot:    rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			remoteHeadSlot:         100,
-			expectError:            false,
-		},
-		{
-			name:                   "invalid finalized epoch",
-			expectedFinalizedEpoch: 3,
-			expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			headSlot:               111,
-			remoteFinalizedEpoch:   3,
-			// give an incorrect root relative to the finalized epoch.
-			remoteFinalizedRoot: rootFetcher(2 * params.BeaconConfig().SlotsPerEpoch),
-			remoteHeadSlot:      120,
-			expectError:         true,
-		},
-		{
-			name:                   "invalid finalized root",
-			expectedFinalizedEpoch: 3,
-			expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			headSlot:               111,
-			remoteFinalizedEpoch:   3,
-			// give a bad finalized root, and the beacon node verifies that
-			// it is indeed incorrect.
-			remoteFinalizedRoot: [32]byte{'a', 'b', 'c'},
-			remoteHeadSlot:      120,
-			expectError:         true,
-		},
-	}
-
-	for _, tt := range tests {
 		p1 := p2ptest.NewTestP2P(t)
 		p2 := p2ptest.NewTestP2P(t)
+		db := testingDB.SetupDB(t)
 
-		expectedFinalizedEpoch := tt.expectedFinalizedEpoch
-		headSlot := tt.headSlot
-
-		nState := bState.Copy()
 		// Set up a head state with data we expect.
-		head := blocksTillHead[len(blocksTillHead)-1]
-		headRoot, err := head.Block().HashTreeRoot()
+		head := util.NewBeaconBlock()
+		head.Block.Slot = 111
+		headRoot, err := head.Block.HashTreeRoot()
 		require.NoError(t, err)
-
-		rHead := blocksTillHead[tt.remoteHeadSlot-1]
-		rHeadRoot, err := rHead.Block().HashTreeRoot()
+		blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
+		finalized := util.NewBeaconBlock()
+		finalized.Block.Slot = blkSlot
+		finalizedRoot, err := finalized.Block.HashTreeRoot()
 		require.NoError(t, err)
-
-		require.NoError(t, nState.SetSlot(headSlot))
-		require.NoError(t, nState.UpdateBlockRootAtIndex(uint64(headSlot.ModSlot(params.BeaconConfig().SlotsPerHistoricalRoot)), headRoot))
-
+		genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
+		require.NoError(t, err)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = blkSlot
+		util.SaveBlock(t, ctx, db, blk)
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
 		finalizedCheckpt := &ethpb.Checkpoint{
-			Epoch: expectedFinalizedEpoch,
-			Root:  tt.expectedFinalizedRoot[:],
+			Epoch: 3,
+			Root:  finalizedRoot[:],
 		}
-
-		remoteFinalizedChkpt := &ethpb.Checkpoint{
-			Epoch: tt.remoteFinalizedEpoch,
-			Root:  tt.remoteFinalizedRoot[:],
-		}
-		require.NoError(t, db.SaveFinalizedCheckpoint(ctx, finalizedCheckpt))
-
-		epoch := expectedFinalizedEpoch.Add(2)
-		totalSec := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch) * params.BeaconConfig().SecondsPerSlot))
-		gt := time.Unix(time.Now().Unix()-int64(totalSec), 0)
-		vr := [32]byte{'A'}
+		totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
+		genTime := time.Now().Unix() - totalSec
 		chain := &mock.ChainService{
-			State:               nState,
-			FinalizedCheckPoint: remoteFinalizedChkpt,
-			Root:                rHeadRoot[:],
+			State:               genesisState,
+			FinalizedCheckPoint: finalizedCheckpt,
+			Root:                headRoot[:],
 			Fork: &ethpb.Fork{
 				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
 				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 			},
-			Genesis:        gt,
-			ValidatorsRoot: vr,
+			Genesis:        time.Unix(genTime, 0),
+			ValidatorsRoot: [32]byte{'A'},
 			FinalizedRoots: map[[32]byte]bool{
-				tt.expectedFinalizedRoot: true,
-				tt.remoteFinalizedRoot:   true,
+				finalizedRoot: true,
 			},
 		}
 		r := &Service{
@@ -839,29 +658,27 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 			rateLimiter: newRateLimiter(p1),
 		}
 		chain2 := &mock.ChainService{
-			State:               nState,
+			State:               genesisState,
 			FinalizedCheckPoint: finalizedCheckpt,
 			Root:                headRoot[:],
 			Fork: &ethpb.Fork{
 				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
 				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 			},
-			Genesis:        gt,
-			ValidatorsRoot: vr,
+			Genesis:        time.Unix(genTime, 0),
+			ValidatorsRoot: [32]byte{'A'},
 			FinalizedRoots: map[[32]byte]bool{
-				tt.expectedFinalizedRoot: true,
-				tt.remoteFinalizedRoot:   true,
+				finalizedRoot: true,
 			},
 		}
 		r2 := &Service{
 			cfg: &config{
-				p2p:           p2,
+				p2p:           p1,
 				chain:         chain2,
 				clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
 				beaconDB:      db,
 				stateNotifier: chain.StateNotifier(),
 			},
-
 			ctx:         ctx,
 			rateLimiter: newRateLimiter(p1),
 		}
@@ -879,7 +696,7 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 			defer done.Do(wg.Done)
 			out := &ethpb.Status{}
 			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-			assert.Equal(t, tt.expectError, r2.validateStatusMessage(ctx, out) != nil)
+			assert.NoError(t, r2.validateStatusMessage(ctx, out))
 		})
 
 		p1.AddConnectionHandler(r.sendRPCStatusRequest, nil)
@@ -890,9 +707,204 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 		}
 
 		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
-		assert.NoError(t, p1.Disconnect(p2.PeerID()))
-	}
-	assert.NoError(t, db.Close())
+	})
+}
+
+func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		db, err := kv.NewKVStore(ctx, t.TempDir())
+		require.NoError(t, err)
+		bState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
+		require.NoError(t, err)
+
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = 0
+		genRoot, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+
+		wsb, err := consensusblocks.NewSignedBeaconBlock(blk)
+		require.NoError(t, err)
+		require.NoError(t, db.SaveBlock(ctx, wsb))
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, genRoot))
+		blocksTillHead := makeBlocks(t, 1, 1000, genRoot)
+		require.NoError(t, db.SaveBlocks(ctx, blocksTillHead))
+
+		stateSummaries := make([]*ethpb.StateSummary, len(blocksTillHead))
+		for i, b := range blocksTillHead {
+			bRoot, err := b.Block().HashTreeRoot()
+			require.NoError(t, err)
+			stateSummaries[i] = &ethpb.StateSummary{
+				Slot: b.Block().Slot(),
+				Root: bRoot[:],
+			}
+		}
+		require.NoError(t, db.SaveStateSummaries(ctx, stateSummaries))
+
+		rootFetcher := func(slot primitives.Slot) [32]byte {
+			rt, err := blocksTillHead[slot-1].Block().HashTreeRoot()
+			require.NoError(t, err)
+			return rt
+		}
+		tests := []struct {
+			name                   string
+			expectedFinalizedEpoch primitives.Epoch
+			expectedFinalizedRoot  [32]byte
+			headSlot               primitives.Slot
+			remoteFinalizedEpoch   primitives.Epoch
+			remoteFinalizedRoot    [32]byte
+			remoteHeadSlot         primitives.Slot
+			expectError            bool
+		}{
+			{
+				name:                   "valid finalized epoch",
+				expectedFinalizedEpoch: 3,
+				expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				headSlot:               111,
+				remoteFinalizedEpoch:   3,
+				remoteFinalizedRoot:    rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				remoteHeadSlot:         100,
+				expectError:            false,
+			},
+			{
+				name:                   "invalid finalized epoch",
+				expectedFinalizedEpoch: 3,
+				expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				headSlot:               111,
+				remoteFinalizedEpoch:   3,
+				// give an incorrect root relative to the finalized epoch.
+				remoteFinalizedRoot: rootFetcher(2 * params.BeaconConfig().SlotsPerEpoch),
+				remoteHeadSlot:      120,
+				expectError:         true,
+			},
+			{
+				name:                   "invalid finalized root",
+				expectedFinalizedEpoch: 3,
+				expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				headSlot:               111,
+				remoteFinalizedEpoch:   3,
+				// give a bad finalized root, and the beacon node verifies that
+				// it is indeed incorrect.
+				remoteFinalizedRoot: [32]byte{'a', 'b', 'c'},
+				remoteHeadSlot:      120,
+				expectError:         true,
+			},
+		}
+
+		for _, tt := range tests {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+
+			expectedFinalizedEpoch := tt.expectedFinalizedEpoch
+			headSlot := tt.headSlot
+
+			nState := bState.Copy()
+			// Set up a head state with data we expect.
+			head := blocksTillHead[len(blocksTillHead)-1]
+			headRoot, err := head.Block().HashTreeRoot()
+			require.NoError(t, err)
+
+			rHead := blocksTillHead[tt.remoteHeadSlot-1]
+			rHeadRoot, err := rHead.Block().HashTreeRoot()
+			require.NoError(t, err)
+
+			require.NoError(t, nState.SetSlot(headSlot))
+			require.NoError(t, nState.UpdateBlockRootAtIndex(uint64(headSlot.ModSlot(params.BeaconConfig().SlotsPerHistoricalRoot)), headRoot))
+
+			finalizedCheckpt := &ethpb.Checkpoint{
+				Epoch: expectedFinalizedEpoch,
+				Root:  tt.expectedFinalizedRoot[:],
+			}
+
+			remoteFinalizedChkpt := &ethpb.Checkpoint{
+				Epoch: tt.remoteFinalizedEpoch,
+				Root:  tt.remoteFinalizedRoot[:],
+			}
+			require.NoError(t, db.SaveFinalizedCheckpoint(ctx, finalizedCheckpt))
+
+			epoch := expectedFinalizedEpoch.Add(2)
+			totalSec := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch) * params.BeaconConfig().SecondsPerSlot))
+			gt := time.Unix(time.Now().Unix()-int64(totalSec), 0)
+			vr := [32]byte{'A'}
+			chain := &mock.ChainService{
+				State:               nState,
+				FinalizedCheckPoint: remoteFinalizedChkpt,
+				Root:                rHeadRoot[:],
+				Fork: &ethpb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        gt,
+				ValidatorsRoot: vr,
+				FinalizedRoots: map[[32]byte]bool{
+					tt.expectedFinalizedRoot: true,
+					tt.remoteFinalizedRoot:   true,
+				},
+			}
+			r := &Service{
+				cfg: &config{
+					p2p:           p1,
+					chain:         chain,
+					clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+					stateNotifier: chain.StateNotifier(),
+				},
+				ctx:         ctx,
+				rateLimiter: newRateLimiter(p1),
+			}
+			chain2 := &mock.ChainService{
+				State:               nState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &ethpb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        gt,
+				ValidatorsRoot: vr,
+				FinalizedRoots: map[[32]byte]bool{
+					tt.expectedFinalizedRoot: true,
+					tt.remoteFinalizedRoot:   true,
+				},
+			}
+			r2 := &Service{
+				cfg: &config{
+					p2p:           p2,
+					chain:         chain2,
+					clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
+					beaconDB:      db,
+					stateNotifier: chain.StateNotifier(),
+				},
+
+				ctx:         ctx,
+				rateLimiter: newRateLimiter(p1),
+			}
+
+			// Setup streams
+			pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
+			topic := string(pcl)
+			r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+				defer wg.Done()
+				out := &ethpb.Status{}
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+				assert.Equal(t, tt.expectError, r2.validateStatusMessage(ctx, out) != nil)
+			})
+
+			p1.AddConnectionHandler(r.sendRPCStatusRequest, nil)
+			p1.Connect(p2)
+
+			if util.WaitTimeout(&wg, 1*time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
+
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
+			assert.NoError(t, p1.Disconnect(p2.PeerID()))
+		}
+		assert.NoError(t, db.Close())
+	})
 }
 
 func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -910,105 +910,109 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 }
 
 func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {
-	ctx := t.Context()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
 
-	// Set up a head state with data we expect.
-	head := util.NewBeaconBlock()
-	head.Block.Slot = 111
-	headRoot, err := head.Block.HashTreeRoot()
-	require.NoError(t, err)
-	finalized := util.NewBeaconBlock()
-	finalizedRoot, err := finalized.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
-	require.NoError(t, err)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 5,
-		Root:  finalizedRoot[:],
-	}
-	chain := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                headRoot[:],
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	cw := startup.NewClockSynchronizer()
-
-	r := &Service{
-		cfg: &config{
-			p2p:           p1,
-			beaconDB:      dbTest.SetupDB(t),
-			chain:         chain,
-			stateNotifier: chain.StateNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-
-		ctx:                             ctx,
-		rateLimiter:                     newRateLimiter(p1),
-		clockWaiter:                     cw,
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	markInitSyncComplete(t, r)
-	clock := startup.NewClockSynchronizer()
-	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
-	r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
-
-	go r.Start()
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		expected := &ethpb.Status{
-			ForkDigest:     []byte{1, 1, 1, 1},
-			HeadSlot:       genesisState.Slot(),
-			HeadRoot:       headRoot[:],
-			FinalizedEpoch: 5,
-			FinalizedRoot:  finalizedRoot[:],
+		// Set up a head state with data we expect.
+		head := util.NewBeaconBlock()
+		head.Block.Slot = 111
+		headRoot, err := head.Block.HashTreeRoot()
+		require.NoError(t, err)
+		finalized := util.NewBeaconBlock()
+		finalizedRoot, err := finalized.Block.HashTreeRoot()
+		require.NoError(t, err)
+		genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
+		require.NoError(t, err)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+		finalizedCheckpt := &ethpb.Checkpoint{
+			Epoch: 5,
+			Root:  finalizedRoot[:],
 		}
-		if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
-			log.WithError(err).Debug("Could not write to stream")
+		chain := &mock.ChainService{
+			State:               genesisState,
+			FinalizedCheckPoint: finalizedCheckpt,
+			Root:                headRoot[:],
+			Fork: &ethpb.Fork{
+				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+			},
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
 		}
-		_, err := r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, expected)
-		assert.NoError(t, err)
+		cw := startup.NewClockSynchronizer()
+
+		r := &Service{
+			cfg: &config{
+				p2p:           p1,
+				beaconDB:      dbTest.SetupDB(t),
+				chain:         chain,
+				stateNotifier: chain.StateNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+
+			ctx:                             ctx,
+			rateLimiter:                     newRateLimiter(p1),
+			clockWaiter:                     cw,
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		markInitSyncComplete(t, r)
+		clock := startup.NewClockSynchronizer()
+		require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
+		r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
+
+		go r.Start()
+
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		var once sync.Once
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer once.Do(wg.Done)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			expected := &ethpb.Status{
+				ForkDigest:     []byte{1, 1, 1, 1},
+				HeadSlot:       genesisState.Slot(),
+				HeadRoot:       headRoot[:],
+				FinalizedEpoch: 5,
+				FinalizedRoot:  finalizedRoot[:],
+			}
+			if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
+				log.WithError(err).Debug("Could not write to stream")
+			}
+			_, err := r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, expected)
+			assert.NoError(t, err)
+		})
+
+		require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
+
+		assert.NoError(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is marked as bad")
+		p1.Connect(p2)
+
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+		time.Sleep(100 * time.Millisecond)
+
+		connectionState, err := p1.Peers().ConnectionState(p2.PeerID())
+		require.NoError(t, err, "Could not obtain peer connection state")
+		assert.Equal(t, peers.Disconnected, connectionState, "Expected peer to be disconnected")
+
+		assert.NotNil(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is not marked as bad")
 	})
-
-	require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
-
-	assert.NoError(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is marked as bad")
-	p1.Connect(p2)
-
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-	time.Sleep(100 * time.Millisecond)
-
-	connectionState, err := p1.Peers().ConnectionState(p2.PeerID())
-	require.NoError(t, err, "Could not obtain peer connection state")
-	assert.Equal(t, peers.Disconnected, connectionState, "Expected peer to be disconnected")
-
-	assert.NotNil(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is not marked as bad")
 }
 
 func TestStatusRPC_ValidGenesisMessage(t *testing.T) {

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -42,405 +42,413 @@ import (
 )
 
 func TestStatusRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	root := [32]byte{'C'}
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		root := [32]byte{'C'}
 
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := &Service{
-		cfg: &config{
-			p2p: p1,
-			chain: &mock.ChainService{
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := &Service{
+			cfg: &config{
+				p2p: p1,
+				chain: &mock.ChainService{
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  root[:],
+					},
+					Genesis:        gt,
+					ValidatorsRoot: vr,
+					Root:           make([]byte, 32),
 				},
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  root[:],
-				},
-				Genesis:        gt,
-				ValidatorsRoot: vr,
-				Root:           make([]byte, 32),
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	pcl := protocol.ID(p2p.RPCStatusTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+			rateLimiter: newRateLimiter(p1),
+		}
+		pcl := protocol.ID(p2p.RPCStatusTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.DeepEqual(t, root[:], out.FinalizedRoot)
-		assert.NoError(t, stream.Close())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.DeepEqual(t, root[:], out.FinalizedRoot)
+			assert.NoError(t, stream.Close())
+		})
+
+		pcl2 := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic = string(pcl2)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg2 sync.WaitGroup
+		wg2.Add(1)
+		p2.BHost.SetStreamHandler(pcl2, func(stream network.Stream) {
+			defer wg2.Done()
+			msg := new(primitives.SSZUint64)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg))
+			assert.Equal(t, p2ptypes.GoodbyeCodeWrongNetwork, *msg)
+			assert.NoError(t, stream.Close())
+		})
+
+		stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		assert.NoError(t, r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: bytesutil.PadTo([]byte("f"), 4), HeadRoot: make([]byte, 32), FinalizedRoot: make([]byte, 32)}, stream1))
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+		if util.WaitTimeout(&wg2, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		assert.Equal(t, 0, len(p1.BHost.Network().Peers()), "handler did not disconnect peer")
 	})
-
-	pcl2 := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic = string(pcl2)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg2 sync.WaitGroup
-	wg2.Add(1)
-	p2.BHost.SetStreamHandler(pcl2, func(stream network.Stream) {
-		defer wg2.Done()
-		msg := new(primitives.SSZUint64)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg))
-		assert.Equal(t, p2ptypes.GoodbyeCodeWrongNetwork, *msg)
-		assert.NoError(t, stream.Close())
-	})
-
-	stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	assert.NoError(t, r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: bytesutil.PadTo([]byte("f"), 4), HeadRoot: make([]byte, 32), FinalizedRoot: make([]byte, 32)}, stream1))
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-	if util.WaitTimeout(&wg2, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	assert.Equal(t, 0, len(p1.BHost.Network().Peers()), "handler did not disconnect peer")
 }
 
 func TestStatusRPCHandler_ConnectsOnGenesis(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	var root [32]byte
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		var root [32]byte
 
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := &Service{
-		cfg: &config{
-			p2p: p1,
-			chain: &mock.ChainService{
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := &Service{
+			cfg: &config{
+				p2p: p1,
+				chain: &mock.ChainService{
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  params.BeaconConfig().ZeroHash[:],
+					},
+					Genesis:        gt,
+					ValidatorsRoot: vr,
+					Root:           make([]byte, 32),
 				},
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  params.BeaconConfig().ZeroHash[:],
-				},
-				Genesis:        gt,
-				ValidatorsRoot: vr,
-				Root:           make([]byte, 32),
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	pcl := protocol.ID(p2p.RPCStatusTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+			rateLimiter: newRateLimiter(p1),
+		}
+		pcl := protocol.ID(p2p.RPCStatusTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.DeepEqual(t, root[:], out.FinalizedRoot)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.DeepEqual(t, root[:], out.FinalizedRoot)
+		})
+
+		stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+		digest, err := r.currentForkDigest()
+		require.NoError(t, err)
+
+		err = r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: digest[:], FinalizedRoot: params.BeaconConfig().ZeroHash[:]}, stream1)
+		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Handler disconnected with peer")
 	})
-
-	stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
-
-	err = r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: digest[:], FinalizedRoot: params.BeaconConfig().ZeroHash[:]}, stream1)
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Handler disconnected with peer")
 }
 
 func TestStatusRPCHandler_ReturnsHelloMessage(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	db := testingDB.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		db := testingDB.SetupDB(t)
 
-	// Set up a head state with data we expect.
-	head := util.NewBeaconBlock()
-	head.Block.Slot = 111
-	headRoot, err := head.Block.HashTreeRoot()
-	require.NoError(t, err)
-	blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
-	finalized := util.NewBeaconBlock()
-	finalized.Block.Slot = blkSlot
-	finalizedRoot, err := finalized.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
-	require.NoError(t, err)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
-	util.SaveBlock(t, ctx, db, finalized)
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 3,
-		Root:  finalizedRoot[:],
-	}
-	totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
-	genTime := time.Now().Unix() - totalSec
-
-	gt := time.Unix(genTime, 0)
-	vr := [32]byte{'A'}
-	r := &Service{
-		cfg: &config{
-			p2p: p1,
-			chain: &mock.ChainService{
-				State:               genesisState,
-				FinalizedCheckPoint: finalizedCheckpt,
-				Root:                headRoot[:],
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-				},
-				ValidatorsRoot: vr,
-				Genesis:        gt,
-				FinalizedRoots: map[[32]byte]bool{
-					finalizedRoot: true,
-				},
-			},
-			clock:    startup.NewClock(gt, vr),
-			beaconDB: db,
-		},
-		rateLimiter: newRateLimiter(p1),
-	}
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
-
-	// Setup streams
-	pcl := protocol.ID(p2p.RPCStatusTopicV1)
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		expectSuccess(t, stream)
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		expected := &ethpb.Status{
-			ForkDigest:     digest[:],
-			HeadSlot:       genesisState.Slot(),
-			HeadRoot:       headRoot[:],
-			FinalizedEpoch: 3,
-			FinalizedRoot:  finalizedRoot[:],
+		// Set up a head state with data we expect.
+		head := util.NewBeaconBlock()
+		head.Block.Slot = 111
+		headRoot, err := head.Block.HashTreeRoot()
+		require.NoError(t, err)
+		blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
+		finalized := util.NewBeaconBlock()
+		finalized.Block.Slot = blkSlot
+		finalizedRoot, err := finalized.Block.HashTreeRoot()
+		require.NoError(t, err)
+		genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
+		require.NoError(t, err)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+		util.SaveBlock(t, ctx, db, finalized)
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
+		finalizedCheckpt := &ethpb.Checkpoint{
+			Epoch: 3,
+			Root:  finalizedRoot[:],
 		}
-		if !proto.Equal(out, expected) {
-			t.Errorf("Did not receive expected message. Got %+v wanted %+v", out, expected)
+		totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
+		genTime := time.Now().Unix() - totalSec
+
+		gt := time.Unix(genTime, 0)
+		vr := [32]byte{'A'}
+		r := &Service{
+			cfg: &config{
+				p2p: p1,
+				chain: &mock.ChainService{
+					State:               genesisState,
+					FinalizedCheckPoint: finalizedCheckpt,
+					Root:                headRoot[:],
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+					FinalizedRoots: map[[32]byte]bool{
+						finalizedRoot: true,
+					},
+				},
+				clock:    startup.NewClock(gt, vr),
+				beaconDB: db,
+			},
+			rateLimiter: newRateLimiter(p1),
+		}
+		digest, err := r.currentForkDigest()
+		require.NoError(t, err)
+
+		// Setup streams
+		pcl := protocol.ID(p2p.RPCStatusTopicV1)
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			expectSuccess(t, stream)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			expected := &ethpb.Status{
+				ForkDigest:     digest[:],
+				HeadSlot:       genesisState.Slot(),
+				HeadRoot:       headRoot[:],
+				FinalizedEpoch: 3,
+				FinalizedRoot:  finalizedRoot[:],
+			}
+			if !proto.Equal(out, expected) {
+				t.Errorf("Did not receive expected message. Got %+v wanted %+v", out, expected)
+			}
+		})
+		stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
+		require.NoError(t, err)
+
+		err = r.statusRPCHandler(ctx, &ethpb.Status{
+			ForkDigest:     digest[:],
+			FinalizedRoot:  finalizedRoot[:],
+			FinalizedEpoch: 3,
+		}, stream1)
+		assert.NoError(t, err)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
 		}
 	})
-	stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
-	require.NoError(t, err)
-
-	err = r.statusRPCHandler(ctx, &ethpb.Status{
-		ForkDigest:     digest[:],
-		FinalizedRoot:  finalizedRoot[:],
-		FinalizedEpoch: 3,
-	}, stream1)
-	assert.NoError(t, err)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
 }
 
 func TestHandshakeHandlers_Roundtrip(t *testing.T) {
-	ctx := t.Context()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
-	// Scenario is that p1 and p2 connect, exchange handshakes.
-	// p2 disconnects and p1 should forget the handshake status.
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	db := testingDB.SetupDB(t)
+		// Scenario is that p1 and p2 connect, exchange handshakes.
+		// p2 disconnects and p1 should forget the handshake status.
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		db := testingDB.SetupDB(t)
 
-	p1.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   bytesutil.PadTo([]byte{'A', 'B'}, 8),
-	})
+		p1.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   bytesutil.PadTo([]byte{'A', 'B'}, 8),
+		})
 
-	p2.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
-		SeqNumber: 2,
-		Attnets:   bytesutil.PadTo([]byte{'C', 'D'}, 8),
-	})
+		p2.LocalMetadata = wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{
+			SeqNumber: 2,
+			Attnets:   bytesutil.PadTo([]byte{'C', 'D'}, 8),
+		})
 
-	st, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
-		Slot: 5,
-	})
-	require.NoError(t, err)
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = 0
-	util.SaveBlock(t, ctx, db, blk)
-	finalizedRoot, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
-	chain := &mock.ChainService{
-		State:               st,
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-		Root:           make([]byte, 32),
-		FinalizedRoots: map[[32]byte]bool{
-			finalizedRoot: true,
-		},
-	}
-	cw := startup.NewClockSynchronizer()
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:           p1,
-			chain:         chain,
-			clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			beaconDB:      db,
-			stateNotifier: chain.StateNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-		rateLimiter:                     newRateLimiter(p1),
-		clockWaiter:                     cw,
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	markInitSyncComplete(t, r)
-	clock := startup.NewClockSynchronizer()
-	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
-	r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
-	p1.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
-
-	chain2 := &mock.ChainService{
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
-	}
-	r2 := &Service{
-		ctx: ctx,
-		cfg: &config{
-			chain:         chain2,
-			clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
-			p2p:           p2,
-			stateNotifier: chain.StateNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-		rateLimiter: newRateLimiter(p2),
-		subHandler:  newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, r2)
-	clock = startup.NewClockSynchronizer()
-	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
-	r2.verifierWaiter = verification.NewInitializerWaiter(clock, chain2.ForkChoiceStore, r2.cfg.stateGen, chain2)
-
-	p2.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
-
-	go r.Start()
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		log.WithField("status", out).Warn("received status")
-		resp := &ethpb.Status{HeadSlot: 0, HeadRoot: make([]byte, 32), ForkDigest: p2.Digest[:],
-			FinalizedRoot: finalizedRoot[:], FinalizedEpoch: 0}
-		_, err := stream.Write([]byte{responseCodeSuccess})
-		assert.NoError(t, err)
-		_, err = r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, resp)
-		assert.NoError(t, err)
-		log.WithField("status", out).Warn("sending status")
-		if err := stream.Close(); err != nil {
-			t.Log(err)
+		st, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
+			Slot: 5,
+		})
+		require.NoError(t, err)
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = 0
+		util.SaveBlock(t, ctx, db, blk)
+		finalizedRoot, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
+		chain := &mock.ChainService{
+			State:               st,
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
+			Fork: &ethpb.Fork{
+				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+			},
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+			Root:           make([]byte, 32),
+			FinalizedRoots: map[[32]byte]bool{
+				finalizedRoot: true,
+			},
 		}
+		cw := startup.NewClockSynchronizer()
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:           p1,
+				chain:         chain,
+				clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				beaconDB:      db,
+				stateNotifier: chain.StateNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+			rateLimiter:                     newRateLimiter(p1),
+			clockWaiter:                     cw,
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		markInitSyncComplete(t, r)
+		clock := startup.NewClockSynchronizer()
+		require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
+		r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
+		p1.Digest, err = r.currentForkDigest()
+		require.NoError(t, err)
+
+		chain2 := &mock.ChainService{
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
+		}
+		r2 := &Service{
+			ctx: ctx,
+			cfg: &config{
+				chain:         chain2,
+				clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
+				p2p:           p2,
+				stateNotifier: chain.StateNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+			rateLimiter: newRateLimiter(p2),
+			subHandler:  newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, r2)
+		clock = startup.NewClockSynchronizer()
+		require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
+		r2.verifierWaiter = verification.NewInitializerWaiter(clock, chain2.ForkChoiceStore, r2.cfg.stateGen, chain2)
+
+		p2.Digest, err = r.currentForkDigest()
+		require.NoError(t, err)
+
+		go r.Start()
+
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			log.WithField("status", out).Warn("received status")
+			resp := &ethpb.Status{HeadSlot: 0, HeadRoot: make([]byte, 32), ForkDigest: p2.Digest[:],
+				FinalizedRoot: finalizedRoot[:], FinalizedEpoch: 0}
+			_, err := stream.Write([]byte{responseCodeSuccess})
+			assert.NoError(t, err)
+			_, err = r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, resp)
+			assert.NoError(t, err)
+			log.WithField("status", out).Warn("sending status")
+			if err := stream.Close(); err != nil {
+				t.Log(err)
+			}
+		})
+
+		pcl = "/eth2/beacon_chain/req/ping/1/ssz_snappy"
+		topic = string(pcl)
+		r2.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg2 sync.WaitGroup
+		wg2.Add(1)
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg2.Done()
+			out := new(primitives.SSZUint64)
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.Equal(t, uint64(2), uint64(*out))
+			assert.NoError(t, r2.pingHandler(ctx, out, stream))
+			assert.NoError(t, stream.Close())
+		})
+
+		numInactive1 := len(p1.Peers().Inactive())
+		numActive1 := len(p1.Peers().Active())
+
+		require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
+		p1.Connect(p2)
+
+		p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
+		p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
+
+		p2.Peers().Add(new(enr.Record), p1.BHost.ID(), p1.BHost.Addrs()[0], network.DirUnknown)
+		p2.Peers().SetMetadata(p1.BHost.ID(), p1.LocalMetadata)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		if util.WaitTimeout(&wg2, 1*time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+
+		// Wait for stream buffer to be read.
+		time.Sleep(200 * time.Millisecond)
+
+		numInactive2 := len(p1.Peers().Inactive())
+		numActive2 := len(p1.Peers().Active())
+
+		assert.Equal(t, numInactive1, numInactive1, "Number of inactive peers changed unexpectedly")
+		assert.Equal(t, numActive1+1, numActive2, "Number of active peers unexpected")
+
+		require.NoError(t, p2.Disconnect(p1.PeerID()))
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Disconnected)
+
+		// Wait for disconnect event to trigger.
+		time.Sleep(200 * time.Millisecond)
+
+		numInactive3 := len(p1.Peers().Inactive())
+		numActive3 := len(p1.Peers().Active())
+		assert.Equal(t, numInactive2+1, numInactive3, "Number of inactive peers unexpected")
+		assert.Equal(t, numActive2-1, numActive3, "Number of active peers unexpected")
 	})
-
-	pcl = "/eth2/beacon_chain/req/ping/1/ssz_snappy"
-	topic = string(pcl)
-	r2.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg2 sync.WaitGroup
-	wg2.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg2.Done()
-		out := new(primitives.SSZUint64)
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.Equal(t, uint64(2), uint64(*out))
-		assert.NoError(t, r2.pingHandler(ctx, out, stream))
-		assert.NoError(t, stream.Close())
-	})
-
-	numInactive1 := len(p1.Peers().Inactive())
-	numActive1 := len(p1.Peers().Active())
-
-	require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
-	p1.Connect(p2)
-
-	p1.Peers().Add(new(enr.Record), p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirUnknown)
-	p1.Peers().SetMetadata(p2.BHost.ID(), p2.LocalMetadata)
-
-	p2.Peers().Add(new(enr.Record), p1.BHost.ID(), p1.BHost.Addrs()[0], network.DirUnknown)
-	p2.Peers().SetMetadata(p1.BHost.ID(), p1.LocalMetadata)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	if util.WaitTimeout(&wg2, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	// Wait for stream buffer to be read.
-	time.Sleep(200 * time.Millisecond)
-
-	numInactive2 := len(p1.Peers().Inactive())
-	numActive2 := len(p1.Peers().Active())
-
-	assert.Equal(t, numInactive1, numInactive1, "Number of inactive peers changed unexpectedly")
-	assert.Equal(t, numActive1+1, numActive2, "Number of active peers unexpected")
-
-	require.NoError(t, p2.Disconnect(p1.PeerID()))
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Disconnected)
-
-	// Wait for disconnect event to trigger.
-	time.Sleep(200 * time.Millisecond)
-
-	numInactive3 := len(p1.Peers().Inactive())
-	numActive3 := len(p1.Peers().Active())
-	assert.Equal(t, numInactive2+1, numInactive3, "Number of inactive peers unexpected")
-	assert.Equal(t, numActive2-1, numActive3, "Number of active peers unexpected")
 }
 
 func TestStatusRPCRequest_RequestSent(t *testing.T) {
@@ -600,238 +608,49 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 }
 
 func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	db := testingDB.SetupDB(t)
-
-	// Set up a head state with data we expect.
-	head := util.NewBeaconBlock()
-	head.Block.Slot = 111
-	headRoot, err := head.Block.HashTreeRoot()
-	require.NoError(t, err)
-	blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
-	finalized := util.NewBeaconBlock()
-	finalized.Block.Slot = blkSlot
-	finalizedRoot, err := finalized.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
-	require.NoError(t, err)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = blkSlot
-	util.SaveBlock(t, ctx, db, blk)
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 3,
-		Root:  finalizedRoot[:],
-	}
-	totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
-	genTime := time.Now().Unix() - totalSec
-	chain := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                headRoot[:],
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Unix(genTime, 0),
-		ValidatorsRoot: [32]byte{'A'},
-		FinalizedRoots: map[[32]byte]bool{
-			finalizedRoot: true,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:           p1,
-			chain:         chain,
-			clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			stateNotifier: chain.StateNotifier(),
-		},
-		ctx:         ctx,
-		rateLimiter: newRateLimiter(p1),
-	}
-	chain2 := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                headRoot[:],
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Unix(genTime, 0),
-		ValidatorsRoot: [32]byte{'A'},
-		FinalizedRoots: map[[32]byte]bool{
-			finalizedRoot: true,
-		},
-	}
-	r2 := &Service{
-		cfg: &config{
-			p2p:           p1,
-			chain:         chain2,
-			clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
-			beaconDB:      db,
-			stateNotifier: chain.StateNotifier(),
-		},
-		ctx:         ctx,
-		rateLimiter: newRateLimiter(p1),
-	}
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		assert.NoError(t, r2.validateStatusMessage(ctx, out))
-	})
-
-	p1.AddConnectionHandler(r.sendRPCStatusRequest, nil)
-	p1.Connect(p2)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
-}
-
-func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
-	ctx := t.Context()
-
-	db, err := kv.NewKVStore(ctx, t.TempDir())
-	require.NoError(t, err)
-	bState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
-	require.NoError(t, err)
-
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = 0
-	genRoot, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-
-	wsb, err := consensusblocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	require.NoError(t, db.SaveBlock(ctx, wsb))
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, genRoot))
-	blocksTillHead := makeBlocks(t, 1, 1000, genRoot)
-	require.NoError(t, db.SaveBlocks(ctx, blocksTillHead))
-
-	stateSummaries := make([]*ethpb.StateSummary, len(blocksTillHead))
-	for i, b := range blocksTillHead {
-		bRoot, err := b.Block().HashTreeRoot()
-		require.NoError(t, err)
-		stateSummaries[i] = &ethpb.StateSummary{
-			Slot: b.Block().Slot(),
-			Root: bRoot[:],
-		}
-	}
-	require.NoError(t, db.SaveStateSummaries(ctx, stateSummaries))
-
-	rootFetcher := func(slot primitives.Slot) [32]byte {
-		rt, err := blocksTillHead[slot-1].Block().HashTreeRoot()
-		require.NoError(t, err)
-		return rt
-	}
-	tests := []struct {
-		name                   string
-		expectedFinalizedEpoch primitives.Epoch
-		expectedFinalizedRoot  [32]byte
-		headSlot               primitives.Slot
-		remoteFinalizedEpoch   primitives.Epoch
-		remoteFinalizedRoot    [32]byte
-		remoteHeadSlot         primitives.Slot
-		expectError            bool
-	}{
-		{
-			name:                   "valid finalized epoch",
-			expectedFinalizedEpoch: 3,
-			expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			headSlot:               111,
-			remoteFinalizedEpoch:   3,
-			remoteFinalizedRoot:    rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			remoteHeadSlot:         100,
-			expectError:            false,
-		},
-		{
-			name:                   "invalid finalized epoch",
-			expectedFinalizedEpoch: 3,
-			expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			headSlot:               111,
-			remoteFinalizedEpoch:   3,
-			// give an incorrect root relative to the finalized epoch.
-			remoteFinalizedRoot: rootFetcher(2 * params.BeaconConfig().SlotsPerEpoch),
-			remoteHeadSlot:      120,
-			expectError:         true,
-		},
-		{
-			name:                   "invalid finalized root",
-			expectedFinalizedEpoch: 3,
-			expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
-			headSlot:               111,
-			remoteFinalizedEpoch:   3,
-			// give a bad finalized root, and the beacon node verifies that
-			// it is indeed incorrect.
-			remoteFinalizedRoot: [32]byte{'a', 'b', 'c'},
-			remoteHeadSlot:      120,
-			expectError:         true,
-		},
-	}
-
-	for _, tt := range tests {
 		p1 := p2ptest.NewTestP2P(t)
 		p2 := p2ptest.NewTestP2P(t)
+		db := testingDB.SetupDB(t)
 
-		expectedFinalizedEpoch := tt.expectedFinalizedEpoch
-		headSlot := tt.headSlot
-
-		nState := bState.Copy()
 		// Set up a head state with data we expect.
-		head := blocksTillHead[len(blocksTillHead)-1]
-		headRoot, err := head.Block().HashTreeRoot()
+		head := util.NewBeaconBlock()
+		head.Block.Slot = 111
+		headRoot, err := head.Block.HashTreeRoot()
 		require.NoError(t, err)
-
-		rHead := blocksTillHead[tt.remoteHeadSlot-1]
-		rHeadRoot, err := rHead.Block().HashTreeRoot()
+		blkSlot := 3 * params.BeaconConfig().SlotsPerEpoch
+		finalized := util.NewBeaconBlock()
+		finalized.Block.Slot = blkSlot
+		finalizedRoot, err := finalized.Block.HashTreeRoot()
 		require.NoError(t, err)
-
-		require.NoError(t, nState.SetSlot(headSlot))
-		require.NoError(t, nState.UpdateBlockRootAtIndex(uint64(headSlot.ModSlot(params.BeaconConfig().SlotsPerHistoricalRoot)), headRoot))
-
+		genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
+		require.NoError(t, err)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = blkSlot
+		util.SaveBlock(t, ctx, db, blk)
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, finalizedRoot))
 		finalizedCheckpt := &ethpb.Checkpoint{
-			Epoch: expectedFinalizedEpoch,
-			Root:  tt.expectedFinalizedRoot[:],
+			Epoch: 3,
+			Root:  finalizedRoot[:],
 		}
-
-		remoteFinalizedChkpt := &ethpb.Checkpoint{
-			Epoch: tt.remoteFinalizedEpoch,
-			Root:  tt.remoteFinalizedRoot[:],
-		}
-		require.NoError(t, db.SaveFinalizedCheckpoint(ctx, finalizedCheckpt))
-
-		epoch := expectedFinalizedEpoch.Add(2)
-		totalSec := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch) * params.BeaconConfig().SecondsPerSlot))
-		gt := time.Unix(time.Now().Unix()-int64(totalSec), 0)
-		vr := [32]byte{'A'}
+		totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
+		genTime := time.Now().Unix() - totalSec
 		chain := &mock.ChainService{
-			State:               nState,
-			FinalizedCheckPoint: remoteFinalizedChkpt,
-			Root:                rHeadRoot[:],
+			State:               genesisState,
+			FinalizedCheckPoint: finalizedCheckpt,
+			Root:                headRoot[:],
 			Fork: &ethpb.Fork{
 				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
 				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 			},
-			Genesis:        gt,
-			ValidatorsRoot: vr,
+			Genesis:        time.Unix(genTime, 0),
+			ValidatorsRoot: [32]byte{'A'},
 			FinalizedRoots: map[[32]byte]bool{
-				tt.expectedFinalizedRoot: true,
-				tt.remoteFinalizedRoot:   true,
+				finalizedRoot: true,
 			},
 		}
 		r := &Service{
@@ -845,29 +664,27 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 			rateLimiter: newRateLimiter(p1),
 		}
 		chain2 := &mock.ChainService{
-			State:               nState,
+			State:               genesisState,
 			FinalizedCheckPoint: finalizedCheckpt,
 			Root:                headRoot[:],
 			Fork: &ethpb.Fork{
 				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
 				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 			},
-			Genesis:        gt,
-			ValidatorsRoot: vr,
+			Genesis:        time.Unix(genTime, 0),
+			ValidatorsRoot: [32]byte{'A'},
 			FinalizedRoots: map[[32]byte]bool{
-				tt.expectedFinalizedRoot: true,
-				tt.remoteFinalizedRoot:   true,
+				finalizedRoot: true,
 			},
 		}
 		r2 := &Service{
 			cfg: &config{
-				p2p:           p2,
+				p2p:           p1,
 				chain:         chain2,
 				clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
 				beaconDB:      db,
 				stateNotifier: chain.StateNotifier(),
 			},
-
 			ctx:         ctx,
 			rateLimiter: newRateLimiter(p1),
 		}
@@ -885,7 +702,7 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 			defer done.Do(wg.Done)
 			out := &ethpb.Status{}
 			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-			assert.Equal(t, tt.expectError, r2.validateStatusMessage(ctx, out) != nil)
+			assert.NoError(t, r2.validateStatusMessage(ctx, out))
 		})
 
 		p1.AddConnectionHandler(r.sendRPCStatusRequest, nil)
@@ -896,9 +713,204 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 		}
 
 		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
-		assert.NoError(t, p1.Disconnect(p2.PeerID()))
-	}
-	assert.NoError(t, db.Close())
+	})
+}
+
+func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		db, err := kv.NewKVStore(ctx, t.TempDir())
+		require.NoError(t, err)
+		bState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)})
+		require.NoError(t, err)
+
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = 0
+		genRoot, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+
+		wsb, err := consensusblocks.NewSignedBeaconBlock(blk)
+		require.NoError(t, err)
+		require.NoError(t, db.SaveBlock(ctx, wsb))
+		require.NoError(t, db.SaveGenesisBlockRoot(ctx, genRoot))
+		blocksTillHead := makeBlocks(t, 1, 1000, genRoot)
+		require.NoError(t, db.SaveBlocks(ctx, blocksTillHead))
+
+		stateSummaries := make([]*ethpb.StateSummary, len(blocksTillHead))
+		for i, b := range blocksTillHead {
+			bRoot, err := b.Block().HashTreeRoot()
+			require.NoError(t, err)
+			stateSummaries[i] = &ethpb.StateSummary{
+				Slot: b.Block().Slot(),
+				Root: bRoot[:],
+			}
+		}
+		require.NoError(t, db.SaveStateSummaries(ctx, stateSummaries))
+
+		rootFetcher := func(slot primitives.Slot) [32]byte {
+			rt, err := blocksTillHead[slot-1].Block().HashTreeRoot()
+			require.NoError(t, err)
+			return rt
+		}
+		tests := []struct {
+			name                   string
+			expectedFinalizedEpoch primitives.Epoch
+			expectedFinalizedRoot  [32]byte
+			headSlot               primitives.Slot
+			remoteFinalizedEpoch   primitives.Epoch
+			remoteFinalizedRoot    [32]byte
+			remoteHeadSlot         primitives.Slot
+			expectError            bool
+		}{
+			{
+				name:                   "valid finalized epoch",
+				expectedFinalizedEpoch: 3,
+				expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				headSlot:               111,
+				remoteFinalizedEpoch:   3,
+				remoteFinalizedRoot:    rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				remoteHeadSlot:         100,
+				expectError:            false,
+			},
+			{
+				name:                   "invalid finalized epoch",
+				expectedFinalizedEpoch: 3,
+				expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				headSlot:               111,
+				remoteFinalizedEpoch:   3,
+				// give an incorrect root relative to the finalized epoch.
+				remoteFinalizedRoot: rootFetcher(2 * params.BeaconConfig().SlotsPerEpoch),
+				remoteHeadSlot:      120,
+				expectError:         true,
+			},
+			{
+				name:                   "invalid finalized root",
+				expectedFinalizedEpoch: 3,
+				expectedFinalizedRoot:  rootFetcher(3 * params.BeaconConfig().SlotsPerEpoch),
+				headSlot:               111,
+				remoteFinalizedEpoch:   3,
+				// give a bad finalized root, and the beacon node verifies that
+				// it is indeed incorrect.
+				remoteFinalizedRoot: [32]byte{'a', 'b', 'c'},
+				remoteHeadSlot:      120,
+				expectError:         true,
+			},
+		}
+
+		for _, tt := range tests {
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+
+			expectedFinalizedEpoch := tt.expectedFinalizedEpoch
+			headSlot := tt.headSlot
+
+			nState := bState.Copy()
+			// Set up a head state with data we expect.
+			head := blocksTillHead[len(blocksTillHead)-1]
+			headRoot, err := head.Block().HashTreeRoot()
+			require.NoError(t, err)
+
+			rHead := blocksTillHead[tt.remoteHeadSlot-1]
+			rHeadRoot, err := rHead.Block().HashTreeRoot()
+			require.NoError(t, err)
+
+			require.NoError(t, nState.SetSlot(headSlot))
+			require.NoError(t, nState.UpdateBlockRootAtIndex(uint64(headSlot.ModSlot(params.BeaconConfig().SlotsPerHistoricalRoot)), headRoot))
+
+			finalizedCheckpt := &ethpb.Checkpoint{
+				Epoch: expectedFinalizedEpoch,
+				Root:  tt.expectedFinalizedRoot[:],
+			}
+
+			remoteFinalizedChkpt := &ethpb.Checkpoint{
+				Epoch: tt.remoteFinalizedEpoch,
+				Root:  tt.remoteFinalizedRoot[:],
+			}
+			require.NoError(t, db.SaveFinalizedCheckpoint(ctx, finalizedCheckpt))
+
+			epoch := expectedFinalizedEpoch.Add(2)
+			totalSec := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch) * params.BeaconConfig().SecondsPerSlot))
+			gt := time.Unix(time.Now().Unix()-int64(totalSec), 0)
+			vr := [32]byte{'A'}
+			chain := &mock.ChainService{
+				State:               nState,
+				FinalizedCheckPoint: remoteFinalizedChkpt,
+				Root:                rHeadRoot[:],
+				Fork: &ethpb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        gt,
+				ValidatorsRoot: vr,
+				FinalizedRoots: map[[32]byte]bool{
+					tt.expectedFinalizedRoot: true,
+					tt.remoteFinalizedRoot:   true,
+				},
+			}
+			r := &Service{
+				cfg: &config{
+					p2p:           p1,
+					chain:         chain,
+					clock:         startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+					stateNotifier: chain.StateNotifier(),
+				},
+				ctx:         ctx,
+				rateLimiter: newRateLimiter(p1),
+			}
+			chain2 := &mock.ChainService{
+				State:               nState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &ethpb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        gt,
+				ValidatorsRoot: vr,
+				FinalizedRoots: map[[32]byte]bool{
+					tt.expectedFinalizedRoot: true,
+					tt.remoteFinalizedRoot:   true,
+				},
+			}
+			r2 := &Service{
+				cfg: &config{
+					p2p:           p2,
+					chain:         chain2,
+					clock:         startup.NewClock(chain2.Genesis, chain2.ValidatorsRoot),
+					beaconDB:      db,
+					stateNotifier: chain.StateNotifier(),
+				},
+
+				ctx:         ctx,
+				rateLimiter: newRateLimiter(p1),
+			}
+
+			// Setup streams
+			pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
+			topic := string(pcl)
+			r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+				defer wg.Done()
+				out := &ethpb.Status{}
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+				assert.Equal(t, tt.expectError, r2.validateStatusMessage(ctx, out) != nil)
+			})
+
+			p1.AddConnectionHandler(r.sendRPCStatusRequest, nil)
+			p1.Connect(p2)
+
+			if util.WaitTimeout(&wg, 1*time.Second) {
+				t.Fatal("Did not receive stream within 1 sec")
+			}
+
+			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
+			assert.NoError(t, p1.Disconnect(p2.PeerID()))
+		}
+		assert.NoError(t, db.Close())
+	})
 }
 
 func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -916,105 +916,109 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 }
 
 func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {
-	ctx := t.Context()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
 
-	// Set up a head state with data we expect.
-	head := util.NewBeaconBlock()
-	head.Block.Slot = 111
-	headRoot, err := head.Block.HashTreeRoot()
-	require.NoError(t, err)
-	finalized := util.NewBeaconBlock()
-	finalizedRoot, err := finalized.Block.HashTreeRoot()
-	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
-	require.NoError(t, err)
-	require.NoError(t, genesisState.SetSlot(111))
-	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
-	finalizedCheckpt := &ethpb.Checkpoint{
-		Epoch: 5,
-		Root:  finalizedRoot[:],
-	}
-	chain := &mock.ChainService{
-		State:               genesisState,
-		FinalizedCheckPoint: finalizedCheckpt,
-		Root:                headRoot[:],
-		Fork: &ethpb.Fork{
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-		},
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	cw := startup.NewClockSynchronizer()
-
-	r := &Service{
-		cfg: &config{
-			p2p:           p1,
-			beaconDB:      dbTest.SetupDB(t),
-			chain:         chain,
-			stateNotifier: chain.StateNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-
-		ctx:                             ctx,
-		rateLimiter:                     newRateLimiter(p1),
-		clockWaiter:                     cw,
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	markInitSyncComplete(t, r)
-	clock := startup.NewClockSynchronizer()
-	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
-	r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
-
-	go r.Start()
-
-	// Setup streams
-	pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := &ethpb.Status{}
-		assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		expected := &ethpb.Status{
-			ForkDigest:     []byte{1, 1, 1, 1},
-			HeadSlot:       genesisState.Slot(),
-			HeadRoot:       headRoot[:],
-			FinalizedEpoch: 5,
-			FinalizedRoot:  finalizedRoot[:],
+		// Set up a head state with data we expect.
+		head := util.NewBeaconBlock()
+		head.Block.Slot = 111
+		headRoot, err := head.Block.HashTreeRoot()
+		require.NoError(t, err)
+		finalized := util.NewBeaconBlock()
+		finalizedRoot, err := finalized.Block.HashTreeRoot()
+		require.NoError(t, err)
+		genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
+		require.NoError(t, err)
+		require.NoError(t, genesisState.SetSlot(111))
+		require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+		finalizedCheckpt := &ethpb.Checkpoint{
+			Epoch: 5,
+			Root:  finalizedRoot[:],
 		}
-		if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
-			log.WithError(err).Debug("Could not write to stream")
+		chain := &mock.ChainService{
+			State:               genesisState,
+			FinalizedCheckPoint: finalizedCheckpt,
+			Root:                headRoot[:],
+			Fork: &ethpb.Fork{
+				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+			},
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
 		}
-		_, err := r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, expected)
-		assert.NoError(t, err)
+		cw := startup.NewClockSynchronizer()
+
+		r := &Service{
+			cfg: &config{
+				p2p:           p1,
+				beaconDB:      dbTest.SetupDB(t),
+				chain:         chain,
+				stateNotifier: chain.StateNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+
+			ctx:                             ctx,
+			rateLimiter:                     newRateLimiter(p1),
+			clockWaiter:                     cw,
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		markInitSyncComplete(t, r)
+		clock := startup.NewClockSynchronizer()
+		require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
+		r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
+
+		go r.Start()
+
+		// Setup streams
+		pcl := protocol.ID("/eth2/beacon_chain/req/status/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		var once sync.Once
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer once.Do(wg.Done)
+			out := &ethpb.Status{}
+			assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			expected := &ethpb.Status{
+				ForkDigest:     []byte{1, 1, 1, 1},
+				HeadSlot:       genesisState.Slot(),
+				HeadRoot:       headRoot[:],
+				FinalizedEpoch: 5,
+				FinalizedRoot:  finalizedRoot[:],
+			}
+			if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
+				log.WithError(err).Debug("Could not write to stream")
+			}
+			_, err := r.cfg.p2p.Encoding().EncodeWithMaxLength(stream, expected)
+			assert.NoError(t, err)
+		})
+
+		require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
+
+		assert.NoError(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is marked as bad")
+		p1.Connect(p2)
+
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+		time.Sleep(100 * time.Millisecond)
+
+		connectionState, err := p1.Peers().ConnectionState(p2.PeerID())
+		require.NoError(t, err, "Could not obtain peer connection state")
+		assert.Equal(t, peers.Disconnected, connectionState, "Expected peer to be disconnected")
+
+		assert.NotNil(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is not marked as bad")
 	})
-
-	require.NoError(t, cw.SetClock(startup.NewClock(chain.Genesis, chain.ValidatorsRoot)))
-
-	assert.NoError(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is marked as bad")
-	p1.Connect(p2)
-
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive stream within 1 sec")
-	}
-	time.Sleep(100 * time.Millisecond)
-
-	connectionState, err := p1.Peers().ConnectionState(p2.PeerID())
-	require.NoError(t, err, "Could not obtain peer connection state")
-	assert.Equal(t, peers.Disconnected, connectionState, "Expected peer to be disconnected")
-
-	assert.NotNil(t, p1.Peers().Scorers().IsBadPeer(p2.PeerID()), "Peer is not marked as bad")
 }
 
 func TestStatusRPC_ValidGenesisMessage(t *testing.T) {

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -458,19 +458,18 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 	)
 
 	cfg := params.BeaconConfig()
-	ctx := t.Context()
 
 	testCases := []struct {
 		name          string
 		fuluForkEpoch primitives.Epoch
 		topic         string
-		streamHandler func(service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte)
+		streamHandler func(ctx context.Context, service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte)
 	}{
 		{
 			name:          "before fulu",
 			fuluForkEpoch: cfg.FarFutureEpoch,
 			topic:         "/eth2/beacon_chain/req/status/1/ssz_snappy",
-			streamHandler: func(service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
+			streamHandler: func(ctx context.Context, service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
 				out := &ethpb.Status{}
 				require.NoError(t, service.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
 
@@ -497,7 +496,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 			name:          "after fulu",
 			fuluForkEpoch: 0,
 			topic:         "/eth2/beacon_chain/req/status/2/ssz_snappy",
-			streamHandler: func(service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
+			streamHandler: func(ctx context.Context, service *Service, stream network.Stream, genesisState beaconState.BeaconState, beaconRoot, headRoot, finalizedRoot []byte) {
 				out := &ethpb.StatusV2{}
 				assert.NoError(t, service.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
 
@@ -525,84 +524,87 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			params.SetupTestConfigCleanup(t)
-			cfg := params.BeaconConfig().Copy()
-			cfg.FuluForkEpoch = tc.fuluForkEpoch
-			cfg.ForkVersionSchedule[bytesutil.ToBytes4(cfg.FuluForkVersion)] = cfg.FuluForkEpoch
-			params.OverrideBeaconConfig(cfg)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				ctx := t.Context()
+				params.SetupTestConfigCleanup(t)
+				cfg := params.BeaconConfig().Copy()
+				cfg.FuluForkEpoch = tc.fuluForkEpoch
+				cfg.ForkVersionSchedule[bytesutil.ToBytes4(cfg.FuluForkVersion)] = cfg.FuluForkEpoch
+				params.OverrideBeaconConfig(cfg)
 
-			p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
-			p1.Connect(p2)
+				p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+				p1.Connect(p2)
 
-			updatedEas, updatedCgc, err := p1.UpdateCustodyInfo(earliestAvailableSlot, custodyGroupCount)
-			require.NoError(t, err)
-			require.Equal(t, earliestAvailableSlot, updatedEas)
-			require.Equal(t, custodyGroupCount, updatedCgc)
+				updatedEas, updatedCgc, err := p1.UpdateCustodyInfo(earliestAvailableSlot, custodyGroupCount)
+				require.NoError(t, err)
+				require.Equal(t, earliestAvailableSlot, updatedEas)
+				require.Equal(t, custodyGroupCount, updatedCgc)
 
-			// Set up a head state with data we expect.
-			head := util.NewBeaconBlock()
-			head.Block.Slot = 111
-			headRoot, err := head.Block.HashTreeRoot()
-			require.NoError(t, err)
+				// Set up a head state with data we expect.
+				head := util.NewBeaconBlock()
+				head.Block.Slot = 111
+				headRoot, err := head.Block.HashTreeRoot()
+				require.NoError(t, err)
 
-			finalized := util.NewBeaconBlock()
-			finalized.Block.Slot = 40
-			finalizedRoot, err := finalized.Block.HashTreeRoot()
-			require.NoError(t, err)
+				finalized := util.NewBeaconBlock()
+				finalized.Block.Slot = 40
+				finalizedRoot, err := finalized.Block.HashTreeRoot()
+				require.NoError(t, err)
 
-			genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
-			require.NoError(t, err)
+				genesisState, err := transition.GenesisBeaconState(ctx, nil, 0, &ethpb.Eth1Data{})
+				require.NoError(t, err)
 
-			require.NoError(t, genesisState.SetSlot(111))
-			require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
+				require.NoError(t, genesisState.SetSlot(111))
+				require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), headRoot))
 
-			finalizedCheckpt := &ethpb.Checkpoint{
-				Epoch: 5,
-				Root:  finalizedRoot[:],
-			}
+				finalizedCheckpt := &ethpb.Checkpoint{
+					Epoch: 5,
+					Root:  finalizedRoot[:],
+				}
 
-			chain := &mock.ChainService{
-				State:               genesisState,
-				FinalizedCheckPoint: finalizedCheckpt,
-				Root:                headRoot[:],
-				Fork: &ethpb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-				},
-				Genesis:        time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot)*150, 0),
-				ValidatorsRoot: [32]byte{'A'},
-			}
+				chain := &mock.ChainService{
+					State:               genesisState,
+					FinalizedCheckPoint: finalizedCheckpt,
+					Root:                headRoot[:],
+					Fork: &ethpb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					Genesis:        time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot)*150, 0),
+					ValidatorsRoot: [32]byte{'A'},
+				}
 
-			r := &Service{
-				cfg: &config{
-					p2p:   p1,
-					chain: chain,
-					clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-				},
-				ctx:         ctx,
-				rateLimiter: newRateLimiter(p1),
-			}
+				r := &Service{
+					cfg: &config{
+						p2p:   p1,
+						chain: chain,
+						clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+					},
+					ctx:         ctx,
+					rateLimiter: newRateLimiter(p1),
+				}
 
-			// Setup streams
-			pcl := protocol.ID(tc.topic)
+				// Setup streams
+				pcl := protocol.ID(tc.topic)
 
-			r.rateLimiter.limiterMap[tc.topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+				r.rateLimiter.limiterMap[tc.topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-			var wg sync.WaitGroup
-			wg.Add(1)
-			p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-				defer wg.Done()
-				tc.streamHandler(r, stream, genesisState, chain.Root, headRoot[:], finalizedRoot[:])
+				var wg sync.WaitGroup
+				wg.Add(1)
+				p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+					defer wg.Done()
+					tc.streamHandler(ctx, r, stream, genesisState, chain.Root, headRoot[:], finalizedRoot[:])
+				})
+
+				err = r.sendRPCStatusRequest(ctx, p2.BHost.ID())
+				require.ErrorIs(t, err, p2ptypes.ErrInvalidEpoch)
+
+				if util.WaitTimeout(&wg, 1*time.Hour) {
+					t.Fatal("Did not receive stream within 1 sec")
+				}
+
+				assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
 			})
-
-			err = r.sendRPCStatusRequest(ctx, p2.BHost.ID())
-			require.ErrorIs(t, err, p2ptypes.ErrInvalidEpoch)
-
-			if util.WaitTimeout(&wg, 1*time.Hour) {
-				t.Fatal("Did not receive stream within 1 sec")
-			}
-
-			assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to continue being connected")
 		})
 	}
 }

--- a/beacon-chain/sync/rpc_test.go
+++ b/beacon-chain/sync/rpc_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -43,9 +44,15 @@ func expectFailure(t *testing.T, expectedCode uint8, expectedErrorMsg string, st
 
 // expectResetStream status code from a stream in regular sync.
 func expectResetStream(t *testing.T, stream network.Stream) {
-	expectedErr := "stream reset"
 	_, _, err := ReadStatusCode(stream, &encoder.SszNetworkEncoder{})
-	require.ErrorContains(t, expectedErr, err)
+	require.NotNil(t, err, "expected stream error")
+
+	// TCP muxers surface a stream reset; QUIC surfaces a connection close.
+	tcpErr := "stream reset"
+	quicErr := "connection closed"
+
+	isExpectedErr := strings.Contains(err.Error(), tcpErr) || strings.Contains(err.Error(), quicErr)
+	require.Equal(t, true, isExpectedErr, "expected stream reset or connection closed error, got: %v", err)
 }
 
 func TestRegisterRPC_ReceivesValidMessage(t *testing.T) {

--- a/beacon-chain/sync/rpc_test.go
+++ b/beacon-chain/sync/rpc_test.go
@@ -49,79 +49,83 @@ func expectResetStream(t *testing.T, stream network.Stream) {
 }
 
 func TestRegisterRPC_ReceivesValidMessage(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	r := &Service{
-		ctx:         t.Context(),
-		cfg:         &config{p2p: p2p},
-		rateLimiter: newRateLimiter(p2p),
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	topic := "/testing/foobar/1"
-	handler := func(ctx context.Context, msg any, stream libp2pcore.Stream) error {
-		m, ok := msg.(*ethpb.Fork)
-		if !ok {
-			t.Error("Object is not of type *pb.TestSimpleMessage")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		r := &Service{
+			ctx:         t.Context(),
+			cfg:         &config{p2p: p2p},
+			rateLimiter: newRateLimiter(p2p),
 		}
-		assert.DeepEqual(t, []byte("fooo"), m.CurrentVersion, "Unexpected incoming message")
-		wg.Done()
 
-		return nil
-	}
-	prysmP2P.RPCTopicMappings[topic] = new(ethpb.Fork)
-	// Cleanup Topic mappings
-	defer func() {
-		delete(prysmP2P.RPCTopicMappings, topic)
-	}()
-	r.registerRPC(topic, handler)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		topic := "/testing/foobar/1"
+		handler := func(ctx context.Context, msg any, stream libp2pcore.Stream) error {
+			m, ok := msg.(*ethpb.Fork)
+			if !ok {
+				t.Error("Object is not of type *pb.TestSimpleMessage")
+			}
+			assert.DeepEqual(t, []byte("fooo"), m.CurrentVersion, "Unexpected incoming message")
+			wg.Done()
 
-	p2p.ReceiveRPC(topic, &ethpb.Fork{CurrentVersion: []byte("fooo"), PreviousVersion: []byte("barr")})
+			return nil
+		}
+		prysmP2P.RPCTopicMappings[topic] = new(ethpb.Fork)
+		// Cleanup Topic mappings
+		defer func() {
+			delete(prysmP2P.RPCTopicMappings, topic)
+		}()
+		r.registerRPC(topic, handler)
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive RPC in 1 second")
-	}
+		p2p.ReceiveRPC(topic, &ethpb.Fork{CurrentVersion: []byte("fooo"), PreviousVersion: []byte("barr")})
+
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive RPC in 1 second")
+		}
+	})
 }
 
 func TestRPC_ReceivesInvalidMessage(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	remotePeer := p2ptest.NewTestP2P(t)
-	remotePeer.Connect(p2p)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		remotePeer := p2ptest.NewTestP2P(t)
+		remotePeer.Connect(p2p)
 
-	r := &Service{
-		ctx:         t.Context(),
-		cfg:         &config{p2p: p2p},
-		rateLimiter: newRateLimiter(p2p),
-	}
-
-	topic := "/testing/foobar/1"
-	handler := func(ctx context.Context, msg any, stream libp2pcore.Stream) error {
-		m, ok := msg.(*ethpb.Fork)
-		if !ok {
-			t.Error("Object is not of type *pb.Fork")
+		r := &Service{
+			ctx:         t.Context(),
+			cfg:         &config{p2p: p2p},
+			rateLimiter: newRateLimiter(p2p),
 		}
-		if !bytes.Equal(m.CurrentVersion, []byte("fooo")) {
-			t.Errorf("Unexpected incoming message: %+v", m)
+
+		topic := "/testing/foobar/1"
+		handler := func(ctx context.Context, msg any, stream libp2pcore.Stream) error {
+			m, ok := msg.(*ethpb.Fork)
+			if !ok {
+				t.Error("Object is not of type *pb.Fork")
+			}
+			if !bytes.Equal(m.CurrentVersion, []byte("fooo")) {
+				t.Errorf("Unexpected incoming message: %+v", m)
+			}
+			return nil
 		}
-		return nil
-	}
-	prysmP2P.RPCTopicMappings[topic] = new(ethpb.Fork)
-	// Cleanup Topic mappings
-	defer func() {
-		delete(prysmP2P.RPCTopicMappings, topic)
-	}()
-	r.registerRPC(topic, handler)
+		prysmP2P.RPCTopicMappings[topic] = new(ethpb.Fork)
+		// Cleanup Topic mappings
+		defer func() {
+			delete(prysmP2P.RPCTopicMappings, topic)
+		}()
+		r.registerRPC(topic, handler)
 
-	stream, err := remotePeer.Host().NewStream(t.Context(), p2p.BHost.ID(), protocol.ID(topic+p2p.Encoding().ProtocolSuffix()))
-	require.NoError(t, err)
-	// Write invalid SSZ object to peer.
-	_, err = stream.Write([]byte("JUNK MESSAGE"))
-	require.NoError(t, err)
+		stream, err := remotePeer.Host().NewStream(t.Context(), p2p.BHost.ID(), protocol.ID(topic+p2p.Encoding().ProtocolSuffix()))
+		require.NoError(t, err)
+		// Write invalid SSZ object to peer.
+		_, err = stream.Write([]byte("JUNK MESSAGE"))
+		require.NoError(t, err)
 
-	time.Sleep(1 * time.Second)
-	faultCount, err := p2p.Peers().Scorers().BadResponsesScorer().Count(remotePeer.BHost.ID())
-	require.NoError(t, err)
+		time.Sleep(1 * time.Second)
+		faultCount, err := p2p.Peers().Scorers().BadResponsesScorer().Count(remotePeer.BHost.ID())
+		require.NoError(t, err)
 
-	assert.Equal(t, 1, faultCount, "peer was not penalised for sending bad message")
+		assert.Equal(t, 1, faultCount, "peer was not penalised for sending bad message")
 
+	})
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -344,7 +344,6 @@ func (s *Service) Start() {
 	// Prune data column cache periodically on finalization.
 	async.RunEvery(s.ctx, 30*time.Second, s.pruneDataColumnCache)
 
-	go s.prunePendingGloasColumns()
 	go s.processPendingGloasColumnsRoutine()
 
 	if !params.FuluEnabled() {

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -34,418 +34,434 @@ import (
 )
 
 func TestService_StatusZeroEpoch(t *testing.T) {
-	bState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: 0})
-	require.NoError(t, err)
-	chain := &mockChain.ChainService{
-		Genesis: time.Now(),
-		State:   bState,
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:         p2ptest.NewTestP2P(t),
-			initialSync: new(mockSync.Sync),
-			chain:       chain,
-			clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		chainStarted: &atomic.Bool{},
-	}
-	r.chainStarted.Store(true)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		bState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: 0})
+		require.NoError(t, err)
+		chain := &mockChain.ChainService{
+			Genesis: time.Now(),
+			State:   bState,
+		}
+		r := &Service{
+			cfg: &config{
+				p2p:         p2ptest.NewTestP2P(t),
+				initialSync: new(mockSync.Sync),
+				chain:       chain,
+				clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			chainStarted: &atomic.Bool{},
+		}
+		r.chainStarted.Store(true)
 
-	assert.NoError(t, r.Status(), "Wanted non failing status")
+		assert.NoError(t, r.Status(), "Wanted non failing status")
+	})
 }
 
 func TestSyncHandlers_WaitToSync(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2p,
-			chain:       chainService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		clockWaiter:                     gs,
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2p,
+				chain:       chainService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			clockWaiter:                     gs,
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
 
-	topic := "/eth2/%x/beacon_block"
-	go r.startDiscoveryAndSubscriptions()
+		topic := "/eth2/%x/beacon_block"
+		go r.startDiscoveryAndSubscriptions()
 
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
-	p2p.ReceivePubSub(topic, msg)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
+		p2p.ReceivePubSub(topic, msg)
 
-	// Wait for chainstart event to be processed
-	require.Eventually(t, func() bool {
-		return r.chainStarted.Load()
-	}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event.")
+		// Wait for chainstart event to be processed
+		require.Eventually(t, func() bool {
+			return r.chainStarted.Load()
+		}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event.")
+	})
 }
 
 func TestSyncHandlers_WaitForChainStart(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2p,
-			chain:       chainService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:        &atomic.Bool{},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		clockWaiter:         gs,
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2p,
+				chain:       chainService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:        &atomic.Bool{},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			clockWaiter:         gs,
+		}
 
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	r.waitForChainStart()
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		r.waitForChainStart()
 
-	require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
+		require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
+	})
 }
 
 func TestSyncHandlers_WaitTillSynced(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:           p2p,
-			beaconDB:      dbTest.SetupDB(t),
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		clockWaiter:                     gs,
-		initialSyncComplete:             make(chan struct{}),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	r.initCaches()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:           p2p,
+				beaconDB:      dbTest.SetupDB(t),
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			clockWaiter:                     gs,
+			initialSyncComplete:             make(chan struct{}),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		r.initCaches()
 
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	r.waitForChainStart()
-	require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		r.waitForChainStart()
+		require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
 
-	p2p.Digest = r.currentForkDigest()
+		p2p.Digest = r.currentForkDigest()
 
-	syncCompleteCh := make(chan bool)
-	go func() {
-		r.startDiscoveryAndSubscriptions()
-		syncCompleteCh <- true
-	}()
+		syncCompleteCh := make(chan bool)
+		go func() {
+			r.startDiscoveryAndSubscriptions()
+			syncCompleteCh <- true
+		}()
 
-	blockChan := make(chan *feed.Event, 1)
-	sub := r.cfg.blockNotifier.BlockFeed().Subscribe(blockChan)
-	defer sub.Unsubscribe()
+		blockChan := make(chan *feed.Event, 1)
+		sub := r.cfg.blockNotifier.BlockFeed().Subscribe(blockChan)
+		defer sub.Unsubscribe()
 
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
 
-	// Save block into DB so that validateBeaconBlockPubSub() process gets short cut.
-	util.SaveBlock(t, ctx, r.cfg.beaconDB, msg)
+		// Save block into DB so that validateBeaconBlockPubSub() process gets short cut.
+		util.SaveBlock(t, ctx, r.cfg.beaconDB, msg)
 
-	topic := "/eth2/%x/beacon_block"
-	p2p.ReceivePubSub(topic, msg)
-	assert.Equal(t, 0, len(blockChan), "block was received by sync service despite not being fully synced")
+		topic := "/eth2/%x/beacon_block"
+		p2p.ReceivePubSub(topic, msg)
+		assert.Equal(t, 0, len(blockChan), "block was received by sync service despite not being fully synced")
 
-	close(r.initialSyncComplete)
-	<-syncCompleteCh
+		close(r.initialSyncComplete)
+		<-syncCompleteCh
 
-	p2p.ReceivePubSub(topic, msg)
+		p2p.ReceivePubSub(topic, msg)
 
-	select {
-	case <-blockChan:
-	case <-ctx.Done():
-	}
-	assert.NoError(t, ctx.Err())
+		select {
+		case <-blockChan:
+		case <-ctx.Done():
+		}
+		assert.NoError(t, ctx.Err())
+	})
 }
 
 func TestSyncService_StopCleanly(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	ctx, cancel := context.WithCancel(t.Context())
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx:    ctx,
-		cancel: cancel,
-		cfg: &config{
-			p2p:         p2p,
-			chain:       chainService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		clockWaiter:                     gs,
-		initialSyncComplete:             make(chan struct{}),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	markInitSyncComplete(t, &r)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx:    ctx,
+			cancel: cancel,
+			cfg: &config{
+				p2p:         p2p,
+				chain:       chainService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			clockWaiter:                     gs,
+			initialSyncComplete:             make(chan struct{}),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		markInitSyncComplete(t, &r)
 
-	go r.startDiscoveryAndSubscriptions()
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	r.waitForChainStart()
+		go r.startDiscoveryAndSubscriptions()
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		r.waitForChainStart()
 
-	p2p.Digest = r.currentForkDigest()
+		p2p.Digest = r.currentForkDigest()
 
-	// Wait for chainstart and topics to be registered
-	require.Eventually(t, func() bool {
-		return r.chainStarted.Load() && len(r.cfg.p2p.PubSub().GetTopics()) > 0 && len(r.cfg.p2p.Host().Mux().Protocols()) > 0
-	}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event or topics not registered.")
+		// Wait for chainstart and topics to be registered
+		require.Eventually(t, func() bool {
+			return r.chainStarted.Load() && len(r.cfg.p2p.PubSub().GetTopics()) > 0 && len(r.cfg.p2p.Host().Mux().Protocols()) > 0
+		}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event or topics not registered.")
 
-	// Both pubsub and rpc topics should be unsubscribed.
-	require.NoError(t, r.Stop())
+		// Both pubsub and rpc topics should be unsubscribed.
+		require.NoError(t, r.Stop())
 
-	// Wait for pubsub topics to be deregistered.
-	require.Eventually(t, func() bool {
-		return len(r.cfg.p2p.PubSub().GetTopics()) == 0 && len(r.cfg.p2p.Host().Mux().Protocols()) == 0
-	}, 5*time.Second, 50*time.Millisecond, "Pubsub topics were not deregistered")
+		// Wait for pubsub topics to be deregistered.
+		require.Eventually(t, func() bool {
+			return len(r.cfg.p2p.PubSub().GetTopics()) == 0 && len(r.cfg.p2p.Host().Mux().Protocols()) == 0
+		}, 5*time.Second, 50*time.Millisecond, "Pubsub topics were not deregistered")
+	})
 }
 
 func TestService_Stop_SendsGoodbyeMessages(t *testing.T) {
-	// Create test peers
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p3 := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		// Create test peers
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p3 := p2ptest.NewTestP2P(t)
 
-	// Connect peers
-	p1.Connect(p2)
-	p1.Connect(p3)
+		// Connect peers
+		p1.Connect(p2)
+		p1.Connect(p3)
 
-	// Register peers in the peer status
-	p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
-	p1.Peers().Add(nil, p3.BHost.ID(), p3.BHost.Addrs()[0], network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
-	p1.Peers().SetConnectionState(p3.BHost.ID(), peers.Connected)
+		// Register peers in the peer status
+		p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
+		p1.Peers().Add(nil, p3.BHost.ID(), p3.BHost.Addrs()[0], network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
+		p1.Peers().SetConnectionState(p3.BHost.ID(), peers.Connected)
 
-	// Create service with connected peers
-	d := dbTest.SetupDB(t)
-	chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-	ctx, cancel := context.WithCancel(context.Background())
+		// Create service with connected peers
+		d := dbTest.SetupDB(t)
+		chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+		ctx, cancel := context.WithCancel(context.Background())
 
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		ctx:         ctx,
-		cancel:      cancel,
-		rateLimiter: newRateLimiter(p1),
-	}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			ctx:         ctx,
+			cancel:      cancel,
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Initialize context map for RPC
-	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
-	require.NoError(t, err)
-	r.ctxMap = ctxMap
+		// Initialize context map for RPC
+		ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
+		require.NoError(t, err)
+		r.ctxMap = ctxMap
 
-	// Setup rate limiter for goodbye topic
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		// Setup rate limiter for goodbye topic
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	// Track goodbye messages received
-	var goodbyeMessages sync.Map
-	var wg sync.WaitGroup
+		// Track goodbye messages received
+		var goodbyeMessages sync.Map
+		var wg sync.WaitGroup
 
-	wg.Add(2)
+		wg.Add(2)
 
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(primitives.SSZUint64)
-		require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		goodbyeMessages.Store(p2.BHost.ID().String(), *out)
-		require.NoError(t, stream.Close())
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(primitives.SSZUint64)
+			require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			goodbyeMessages.Store(p2.BHost.ID().String(), *out)
+			require.NoError(t, stream.Close())
+		})
+
+		p3.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(primitives.SSZUint64)
+			require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			goodbyeMessages.Store(p3.BHost.ID().String(), *out)
+			require.NoError(t, stream.Close())
+		})
+
+		connectedPeers := r.cfg.p2p.Peers().Connected()
+		t.Logf("Connected peers before Stop: %d", len(connectedPeers))
+		assert.Equal(t, 2, len(connectedPeers), "Expected 2 connected peers")
+
+		err = r.Stop()
+		assert.NoError(t, err)
+
+		// Wait for goodbye messages
+		if util.WaitTimeout(&wg, 15*time.Second) {
+			t.Fatal("Did not receive goodbye messages within timeout")
+		}
+
+		// Verify correct goodbye codes were sent
+		msg2, ok := goodbyeMessages.Load(p2.BHost.ID().String())
+		assert.Equal(t, true, ok, "Expected goodbye message to peer 2")
+		assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg2)
+
+		msg3, ok := goodbyeMessages.Load(p3.BHost.ID().String())
+		assert.Equal(t, true, ok, "Expected goodbye message to peer 3")
+		assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg3)
 	})
-
-	p3.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(primitives.SSZUint64)
-		require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		goodbyeMessages.Store(p3.BHost.ID().String(), *out)
-		require.NoError(t, stream.Close())
-	})
-
-	connectedPeers := r.cfg.p2p.Peers().Connected()
-	t.Logf("Connected peers before Stop: %d", len(connectedPeers))
-	assert.Equal(t, 2, len(connectedPeers), "Expected 2 connected peers")
-
-	err = r.Stop()
-	assert.NoError(t, err)
-
-	// Wait for goodbye messages
-	if util.WaitTimeout(&wg, 15*time.Second) {
-		t.Fatal("Did not receive goodbye messages within timeout")
-	}
-
-	// Verify correct goodbye codes were sent
-	msg2, ok := goodbyeMessages.Load(p2.BHost.ID().String())
-	assert.Equal(t, true, ok, "Expected goodbye message to peer 2")
-	assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg2)
-
-	msg3, ok := goodbyeMessages.Load(p3.BHost.ID().String())
-	assert.Equal(t, true, ok, "Expected goodbye message to peer 3")
-	assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg3)
 }
 
 func TestService_Stop_TimeoutHandling(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
 
-	p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
+		p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
 
-	d := dbTest.SetupDB(t)
-	chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-	ctx, cancel := context.WithCancel(context.Background())
+		d := dbTest.SetupDB(t)
+		chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+		ctx, cancel := context.WithCancel(context.Background())
 
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		ctx:         ctx,
-		cancel:      cancel,
-		rateLimiter: newRateLimiter(p1),
-	}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			ctx:         ctx,
+			cancel:      cancel,
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Initialize context map for RPC
-	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
-	require.NoError(t, err)
-	r.ctxMap = ctxMap
+		// Initialize context map for RPC
+		ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
+		require.NoError(t, err)
+		r.ctxMap = ctxMap
 
-	// Setup rate limiter for goodbye topic
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		// Setup rate limiter for goodbye topic
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	// Don't set up stream handler on p2 to simulate unresponsive peer
+		// Don't set up stream handler on p2 to simulate unresponsive peer
 
-	// Verify peers are connected before stopping
-	connectedPeers := r.cfg.p2p.Peers().Connected()
-	t.Logf("Connected peers before Stop: %d", len(connectedPeers))
+		// Verify peers are connected before stopping
+		connectedPeers := r.cfg.p2p.Peers().Connected()
+		t.Logf("Connected peers before Stop: %d", len(connectedPeers))
 
-	start := time.Now()
-	err = r.Stop()
-	duration := time.Since(start)
+		start := time.Now()
+		err = r.Stop()
+		duration := time.Since(start)
 
-	t.Logf("Stop completed in %v", duration)
+		t.Logf("Stop completed in %v", duration)
 
-	// Stop should complete successfully even when peers don't respond
-	assert.NoError(t, err)
-	// Should not hang - completes quickly when goodbye fails
-	assert.Equal(t, true, duration < 5*time.Second, "Stop() should not hang when peer is unresponsive")
-	// Test passes - the timeout behavior is working correctly, goodbye attempts fail quickly
+		// Stop should complete successfully even when peers don't respond
+		assert.NoError(t, err)
+		// Should not hang - completes quickly when goodbye fails
+		assert.Equal(t, true, duration < 5*time.Second, "Stop() should not hang when peer is unresponsive")
+		// Test passes - the timeout behavior is working correctly, goodbye attempts fail quickly
+	})
 }
 
 func TestService_Stop_ConcurrentGoodbyeMessages(t *testing.T) {
-	// Test that goodbye messages are sent concurrently, not sequentially
-	const numPeers = 10
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		// Test that goodbye messages are sent concurrently, not sequentially
+		const numPeers = 10
 
-	p1 := p2ptest.NewTestP2P(t)
-	testPeers := make([]*p2ptest.TestP2P, numPeers)
+		p1 := p2ptest.NewTestP2P(t)
+		testPeers := make([]*p2ptest.TestP2P, numPeers)
 
-	// Create and connect multiple peers
-	for i := range numPeers {
-		testPeers[i] = p2ptest.NewTestP2P(t)
-		p1.Connect(testPeers[i])
-		// Register peer in the peer status
-		p1.Peers().Add(nil, testPeers[i].BHost.ID(), testPeers[i].BHost.Addrs()[0], network.DirOutbound)
-		p1.Peers().SetConnectionState(testPeers[i].BHost.ID(), peers.Connected)
-	}
+		// Create and connect multiple peers
+		for i := range numPeers {
+			testPeers[i] = p2ptest.NewTestP2P(t)
+			p1.Connect(testPeers[i])
+			// Register peer in the peer status
+			p1.Peers().Add(nil, testPeers[i].BHost.ID(), testPeers[i].BHost.Addrs()[0], network.DirOutbound)
+			p1.Peers().SetConnectionState(testPeers[i].BHost.ID(), peers.Connected)
+		}
 
-	d := dbTest.SetupDB(t)
-	chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-	ctx, cancel := context.WithCancel(context.Background())
+		d := dbTest.SetupDB(t)
+		chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+		ctx, cancel := context.WithCancel(context.Background())
 
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		ctx:         ctx,
-		cancel:      cancel,
-		rateLimiter: newRateLimiter(p1),
-	}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			ctx:         ctx,
+			cancel:      cancel,
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Initialize context map for RPC
-	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
-	require.NoError(t, err)
-	r.ctxMap = ctxMap
+		// Initialize context map for RPC
+		ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
+		require.NoError(t, err)
+		r.ctxMap = ctxMap
 
-	// Setup rate limiter for goodbye topic
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		// Setup rate limiter for goodbye topic
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	// Each peer will have artificial delay in processing goodbye
-	var wg sync.WaitGroup
-	wg.Add(numPeers)
+		// Each peer will have artificial delay in processing goodbye
+		var wg sync.WaitGroup
+		wg.Add(numPeers)
 
-	for i := range numPeers {
-		idx := i // capture loop variable
-		testPeers[idx].BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-			defer wg.Done()
-			time.Sleep(100 * time.Millisecond) // Artificial delay
-			out := new(primitives.SSZUint64)
-			require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-			require.NoError(t, stream.Close())
-		})
-	}
+		for i := range numPeers {
+			idx := i // capture loop variable
+			testPeers[idx].BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+				defer wg.Done()
+				time.Sleep(100 * time.Millisecond) // Artificial delay
+				out := new(primitives.SSZUint64)
+				require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+				require.NoError(t, stream.Close())
+			})
+		}
 
-	start := time.Now()
-	err = r.Stop()
-	duration := time.Since(start)
+		start := time.Now()
+		err = r.Stop()
+		duration := time.Since(start)
 
-	// If messages were sent sequentially, it would take numPeers * 100ms = 1 second
-	// If concurrent, should be ~100ms
-	assert.NoError(t, err)
-	assert.Equal(t, true, duration < 500*time.Millisecond, "Goodbye messages should be sent concurrently")
+		// If messages were sent sequentially, it would take numPeers * 100ms = 1 second
+		// If concurrent, should be ~100ms
+		assert.NoError(t, err)
+		assert.Equal(t, true, duration < 500*time.Millisecond, "Goodbye messages should be sent concurrently")
 
-	require.Equal(t, false, util.WaitTimeout(&wg, 2*time.Second))
+		require.Equal(t, false, util.WaitTimeout(&wg, 2*time.Second))
+	})
 }
 
 func TestUpdateCustodyInfoInDB(t *testing.T) {

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -34,422 +34,438 @@ import (
 )
 
 func TestService_StatusZeroEpoch(t *testing.T) {
-	bState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: 0})
-	require.NoError(t, err)
-	chain := &mockChain.ChainService{
-		Genesis: time.Now(),
-		State:   bState,
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:         p2ptest.NewTestP2P(t),
-			initialSync: new(mockSync.Sync),
-			chain:       chain,
-			clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		chainStarted: &atomic.Bool{},
-	}
-	r.chainStarted.Store(true)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		bState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: 0})
+		require.NoError(t, err)
+		chain := &mockChain.ChainService{
+			Genesis: time.Now(),
+			State:   bState,
+		}
+		r := &Service{
+			cfg: &config{
+				p2p:         p2ptest.NewTestP2P(t),
+				initialSync: new(mockSync.Sync),
+				chain:       chain,
+				clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			chainStarted: &atomic.Bool{},
+		}
+		r.chainStarted.Store(true)
 
-	assert.NoError(t, r.Status(), "Wanted non failing status")
+		assert.NoError(t, r.Status(), "Wanted non failing status")
+	})
 }
 
 func TestSyncHandlers_WaitToSync(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2p,
-			chain:       chainService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		clockWaiter:                     gs,
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2p,
+				chain:       chainService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			clockWaiter:                     gs,
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
 
-	topic := "/eth2/%x/beacon_block"
-	go r.startDiscoveryAndSubscriptions()
+		topic := "/eth2/%x/beacon_block"
+		go r.startDiscoveryAndSubscriptions()
 
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
-	p2p.ReceivePubSub(topic, msg)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
+		p2p.ReceivePubSub(topic, msg)
 
-	// Wait for chainstart event to be processed
-	require.Eventually(t, func() bool {
-		return r.chainStarted.Load()
-	}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event.")
+		// Wait for chainstart event to be processed
+		require.Eventually(t, func() bool {
+			return r.chainStarted.Load()
+		}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event.")
+	})
 }
 
 func TestSyncHandlers_WaitForChainStart(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2p,
-			chain:       chainService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:        &atomic.Bool{},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		clockWaiter:         gs,
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2p,
+				chain:       chainService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:        &atomic.Bool{},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			clockWaiter:         gs,
+		}
 
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	r.waitForChainStart()
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		r.waitForChainStart()
 
-	require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
+		require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
+	})
 }
 
 func TestSyncHandlers_WaitTillSynced(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:           p2p,
-			beaconDB:      dbTest.SetupDB(t),
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		clockWaiter:                     gs,
-		initialSyncComplete:             make(chan struct{}),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	r.initCaches()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:           p2p,
+				beaconDB:      dbTest.SetupDB(t),
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			clockWaiter:                     gs,
+			initialSyncComplete:             make(chan struct{}),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		r.initCaches()
 
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	r.waitForChainStart()
-	require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		r.waitForChainStart()
+		require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
 
-	var err error
-	p2p.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
+		var err error
+		p2p.Digest, err = r.currentForkDigest()
+		require.NoError(t, err)
 
-	syncCompleteCh := make(chan bool)
-	go func() {
-		r.startDiscoveryAndSubscriptions()
-		syncCompleteCh <- true
-	}()
+		syncCompleteCh := make(chan bool)
+		go func() {
+			r.startDiscoveryAndSubscriptions()
+			syncCompleteCh <- true
+		}()
 
-	blockChan := make(chan *feed.Event, 1)
-	sub := r.cfg.blockNotifier.BlockFeed().Subscribe(blockChan)
-	defer sub.Unsubscribe()
+		blockChan := make(chan *feed.Event, 1)
+		sub := r.cfg.blockNotifier.BlockFeed().Subscribe(blockChan)
+		defer sub.Unsubscribe()
 
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
 
-	// Save block into DB so that validateBeaconBlockPubSub() process gets short cut.
-	util.SaveBlock(t, ctx, r.cfg.beaconDB, msg)
+		// Save block into DB so that validateBeaconBlockPubSub() process gets short cut.
+		util.SaveBlock(t, ctx, r.cfg.beaconDB, msg)
 
-	topic := "/eth2/%x/beacon_block"
-	p2p.ReceivePubSub(topic, msg)
-	assert.Equal(t, 0, len(blockChan), "block was received by sync service despite not being fully synced")
+		topic := "/eth2/%x/beacon_block"
+		p2p.ReceivePubSub(topic, msg)
+		assert.Equal(t, 0, len(blockChan), "block was received by sync service despite not being fully synced")
 
-	close(r.initialSyncComplete)
-	<-syncCompleteCh
+		close(r.initialSyncComplete)
+		<-syncCompleteCh
 
-	p2p.ReceivePubSub(topic, msg)
+		p2p.ReceivePubSub(topic, msg)
 
-	select {
-	case <-blockChan:
-	case <-ctx.Done():
-	}
-	assert.NoError(t, ctx.Err())
+		select {
+		case <-blockChan:
+		case <-ctx.Done():
+		}
+		assert.NoError(t, ctx.Err())
+	})
 }
 
 func TestSyncService_StopCleanly(t *testing.T) {
-	p2p := p2ptest.NewTestP2P(t)
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	ctx, cancel := context.WithCancel(t.Context())
-	gs := startup.NewClockSynchronizer()
-	r := Service{
-		ctx:    ctx,
-		cancel: cancel,
-		cfg: &config{
-			p2p:         p2p,
-			chain:       chainService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		chainStarted:                    &atomic.Bool{},
-		subHandler:                      newSubTopicHandler(),
-		clockWaiter:                     gs,
-		initialSyncComplete:             make(chan struct{}),
-		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	markInitSyncComplete(t, &r)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2p := p2ptest.NewTestP2P(t)
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		gs := startup.NewClockSynchronizer()
+		r := Service{
+			ctx:    ctx,
+			cancel: cancel,
+			cfg: &config{
+				p2p:         p2p,
+				chain:       chainService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			chainStarted:                    &atomic.Bool{},
+			subHandler:                      newSubTopicHandler(),
+			clockWaiter:                     gs,
+			initialSyncComplete:             make(chan struct{}),
+			proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		markInitSyncComplete(t, &r)
 
-	go r.startDiscoveryAndSubscriptions()
-	var vr [32]byte
-	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
-	r.waitForChainStart()
+		go r.startDiscoveryAndSubscriptions()
+		var vr [32]byte
+		require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
+		r.waitForChainStart()
 
-	var err error
-	p2p.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
+		var err error
+		p2p.Digest, err = r.currentForkDigest()
+		require.NoError(t, err)
 
-	// Wait for chainstart and topics to be registered
-	require.Eventually(t, func() bool {
-		return r.chainStarted.Load() && len(r.cfg.p2p.PubSub().GetTopics()) > 0 && len(r.cfg.p2p.Host().Mux().Protocols()) > 0
-	}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event or topics not registered.")
+		// Wait for chainstart and topics to be registered
+		require.Eventually(t, func() bool {
+			return r.chainStarted.Load() && len(r.cfg.p2p.PubSub().GetTopics()) > 0 && len(r.cfg.p2p.Host().Mux().Protocols()) > 0
+		}, 5*time.Second, 50*time.Millisecond, "Did not receive chain start event or topics not registered.")
 
-	// Both pubsub and rpc topics should be unsubscribed.
-	require.NoError(t, r.Stop())
+		// Both pubsub and rpc topics should be unsubscribed.
+		require.NoError(t, r.Stop())
 
-	// Wait for pubsub topics to be deregistered.
-	require.Eventually(t, func() bool {
-		return len(r.cfg.p2p.PubSub().GetTopics()) == 0 && len(r.cfg.p2p.Host().Mux().Protocols()) == 0
-	}, 5*time.Second, 50*time.Millisecond, "Pubsub topics were not deregistered")
+		// Wait for pubsub topics to be deregistered.
+		require.Eventually(t, func() bool {
+			return len(r.cfg.p2p.PubSub().GetTopics()) == 0 && len(r.cfg.p2p.Host().Mux().Protocols()) == 0
+		}, 5*time.Second, 50*time.Millisecond, "Pubsub topics were not deregistered")
+	})
 }
 
 func TestService_Stop_SendsGoodbyeMessages(t *testing.T) {
-	// Create test peers
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p3 := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		// Create test peers
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p3 := p2ptest.NewTestP2P(t)
 
-	// Connect peers
-	p1.Connect(p2)
-	p1.Connect(p3)
+		// Connect peers
+		p1.Connect(p2)
+		p1.Connect(p3)
 
-	// Register peers in the peer status
-	p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
-	p1.Peers().Add(nil, p3.BHost.ID(), p3.BHost.Addrs()[0], network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
-	p1.Peers().SetConnectionState(p3.BHost.ID(), peers.Connected)
+		// Register peers in the peer status
+		p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
+		p1.Peers().Add(nil, p3.BHost.ID(), p3.BHost.Addrs()[0], network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
+		p1.Peers().SetConnectionState(p3.BHost.ID(), peers.Connected)
 
-	// Create service with connected peers
-	d := dbTest.SetupDB(t)
-	chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-	ctx, cancel := context.WithCancel(context.Background())
+		// Create service with connected peers
+		d := dbTest.SetupDB(t)
+		chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+		ctx, cancel := context.WithCancel(context.Background())
 
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		ctx:         ctx,
-		cancel:      cancel,
-		rateLimiter: newRateLimiter(p1),
-	}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			ctx:         ctx,
+			cancel:      cancel,
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Initialize context map for RPC
-	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
-	require.NoError(t, err)
-	r.ctxMap = ctxMap
+		// Initialize context map for RPC
+		ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
+		require.NoError(t, err)
+		r.ctxMap = ctxMap
 
-	// Setup rate limiter for goodbye topic
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		// Setup rate limiter for goodbye topic
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	// Track goodbye messages received
-	var goodbyeMessages sync.Map
-	var wg sync.WaitGroup
+		// Track goodbye messages received
+		var goodbyeMessages sync.Map
+		var wg sync.WaitGroup
 
-	wg.Add(2)
+		wg.Add(2)
 
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(primitives.SSZUint64)
-		require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		goodbyeMessages.Store(p2.BHost.ID().String(), *out)
-		require.NoError(t, stream.Close())
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(primitives.SSZUint64)
+			require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			goodbyeMessages.Store(p2.BHost.ID().String(), *out)
+			require.NoError(t, stream.Close())
+		})
+
+		p3.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer wg.Done()
+			out := new(primitives.SSZUint64)
+			require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			goodbyeMessages.Store(p3.BHost.ID().String(), *out)
+			require.NoError(t, stream.Close())
+		})
+
+		connectedPeers := r.cfg.p2p.Peers().Connected()
+		t.Logf("Connected peers before Stop: %d", len(connectedPeers))
+		assert.Equal(t, 2, len(connectedPeers), "Expected 2 connected peers")
+
+		err = r.Stop()
+		assert.NoError(t, err)
+
+		// Wait for goodbye messages
+		if util.WaitTimeout(&wg, 15*time.Second) {
+			t.Fatal("Did not receive goodbye messages within timeout")
+		}
+
+		// Verify correct goodbye codes were sent
+		msg2, ok := goodbyeMessages.Load(p2.BHost.ID().String())
+		assert.Equal(t, true, ok, "Expected goodbye message to peer 2")
+		assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg2)
+
+		msg3, ok := goodbyeMessages.Load(p3.BHost.ID().String())
+		assert.Equal(t, true, ok, "Expected goodbye message to peer 3")
+		assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg3)
 	})
-
-	p3.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer wg.Done()
-		out := new(primitives.SSZUint64)
-		require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		goodbyeMessages.Store(p3.BHost.ID().String(), *out)
-		require.NoError(t, stream.Close())
-	})
-
-	connectedPeers := r.cfg.p2p.Peers().Connected()
-	t.Logf("Connected peers before Stop: %d", len(connectedPeers))
-	assert.Equal(t, 2, len(connectedPeers), "Expected 2 connected peers")
-
-	err = r.Stop()
-	assert.NoError(t, err)
-
-	// Wait for goodbye messages
-	if util.WaitTimeout(&wg, 15*time.Second) {
-		t.Fatal("Did not receive goodbye messages within timeout")
-	}
-
-	// Verify correct goodbye codes were sent
-	msg2, ok := goodbyeMessages.Load(p2.BHost.ID().String())
-	assert.Equal(t, true, ok, "Expected goodbye message to peer 2")
-	assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg2)
-
-	msg3, ok := goodbyeMessages.Load(p3.BHost.ID().String())
-	assert.Equal(t, true, ok, "Expected goodbye message to peer 3")
-	assert.Equal(t, p2ptypes.GoodbyeCodeClientShutdown, msg3)
 }
 
 func TestService_Stop_TimeoutHandling(t *testing.T) {
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
 
-	p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
+		p1.Peers().Add(nil, p2.BHost.ID(), p2.BHost.Addrs()[0], network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.BHost.ID(), peers.Connected)
 
-	d := dbTest.SetupDB(t)
-	chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-	ctx, cancel := context.WithCancel(context.Background())
+		d := dbTest.SetupDB(t)
+		chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+		ctx, cancel := context.WithCancel(context.Background())
 
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		ctx:         ctx,
-		cancel:      cancel,
-		rateLimiter: newRateLimiter(p1),
-	}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			ctx:         ctx,
+			cancel:      cancel,
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Initialize context map for RPC
-	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
-	require.NoError(t, err)
-	r.ctxMap = ctxMap
+		// Initialize context map for RPC
+		ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
+		require.NoError(t, err)
+		r.ctxMap = ctxMap
 
-	// Setup rate limiter for goodbye topic
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		// Setup rate limiter for goodbye topic
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	// Don't set up stream handler on p2 to simulate unresponsive peer
+		// Don't set up stream handler on p2 to simulate unresponsive peer
 
-	// Verify peers are connected before stopping
-	connectedPeers := r.cfg.p2p.Peers().Connected()
-	t.Logf("Connected peers before Stop: %d", len(connectedPeers))
+		// Verify peers are connected before stopping
+		connectedPeers := r.cfg.p2p.Peers().Connected()
+		t.Logf("Connected peers before Stop: %d", len(connectedPeers))
 
-	start := time.Now()
-	err = r.Stop()
-	duration := time.Since(start)
+		start := time.Now()
+		err = r.Stop()
+		duration := time.Since(start)
 
-	t.Logf("Stop completed in %v", duration)
+		t.Logf("Stop completed in %v", duration)
 
-	// Stop should complete successfully even when peers don't respond
-	assert.NoError(t, err)
-	// Should not hang - completes quickly when goodbye fails
-	assert.Equal(t, true, duration < 5*time.Second, "Stop() should not hang when peer is unresponsive")
-	// Test passes - the timeout behavior is working correctly, goodbye attempts fail quickly
+		// Stop should complete successfully even when peers don't respond
+		assert.NoError(t, err)
+		// Should not hang - completes quickly when goodbye fails
+		assert.Equal(t, true, duration < 5*time.Second, "Stop() should not hang when peer is unresponsive")
+		// Test passes - the timeout behavior is working correctly, goodbye attempts fail quickly
+	})
 }
 
 func TestService_Stop_ConcurrentGoodbyeMessages(t *testing.T) {
-	// Test that goodbye messages are sent concurrently, not sequentially
-	const numPeers = 10
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		// Test that goodbye messages are sent concurrently, not sequentially
+		const numPeers = 10
 
-	p1 := p2ptest.NewTestP2P(t)
-	testPeers := make([]*p2ptest.TestP2P, numPeers)
+		p1 := p2ptest.NewTestP2P(t)
+		testPeers := make([]*p2ptest.TestP2P, numPeers)
 
-	// Create and connect multiple peers
-	for i := range numPeers {
-		testPeers[i] = p2ptest.NewTestP2P(t)
-		p1.Connect(testPeers[i])
-		// Register peer in the peer status
-		p1.Peers().Add(nil, testPeers[i].BHost.ID(), testPeers[i].BHost.Addrs()[0], network.DirOutbound)
-		p1.Peers().SetConnectionState(testPeers[i].BHost.ID(), peers.Connected)
-	}
+		// Create and connect multiple peers
+		for i := range numPeers {
+			testPeers[i] = p2ptest.NewTestP2P(t)
+			p1.Connect(testPeers[i])
+			// Register peer in the peer status
+			p1.Peers().Add(nil, testPeers[i].BHost.ID(), testPeers[i].BHost.Addrs()[0], network.DirOutbound)
+			p1.Peers().SetConnectionState(testPeers[i].BHost.ID(), peers.Connected)
+		}
 
-	d := dbTest.SetupDB(t)
-	chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-	ctx, cancel := context.WithCancel(context.Background())
+		d := dbTest.SetupDB(t)
+		chain := &mockChain.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
+		ctx, cancel := context.WithCancel(context.Background())
 
-	r := &Service{
-		cfg: &config{
-			beaconDB: d,
-			p2p:      p1,
-			chain:    chain,
-			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		ctx:         ctx,
-		cancel:      cancel,
-		rateLimiter: newRateLimiter(p1),
-	}
+		r := &Service{
+			cfg: &config{
+				beaconDB: d,
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			ctx:         ctx,
+			cancel:      cancel,
+			rateLimiter: newRateLimiter(p1),
+		}
 
-	// Initialize context map for RPC
-	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
-	require.NoError(t, err)
-	r.ctxMap = ctxMap
+		// Initialize context map for RPC
+		ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
+		require.NoError(t, err)
+		r.ctxMap = ctxMap
 
-	// Setup rate limiter for goodbye topic
-	pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
-	topic := string(pcl)
-	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
+		// Setup rate limiter for goodbye topic
+		pcl := protocol.ID("/eth2/beacon_chain/req/goodbye/1/ssz_snappy")
+		topic := string(pcl)
+		r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, time.Second, false)
 
-	// Each peer will have artificial delay in processing goodbye
-	var wg sync.WaitGroup
-	wg.Add(numPeers)
+		// Each peer will have artificial delay in processing goodbye
+		var wg sync.WaitGroup
+		wg.Add(numPeers)
 
-	for i := range numPeers {
-		idx := i // capture loop variable
-		testPeers[idx].BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-			defer wg.Done()
-			time.Sleep(100 * time.Millisecond) // Artificial delay
-			out := new(primitives.SSZUint64)
-			require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
-			require.NoError(t, stream.Close())
-		})
-	}
+		for i := range numPeers {
+			idx := i // capture loop variable
+			testPeers[idx].BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+				defer wg.Done()
+				time.Sleep(100 * time.Millisecond) // Artificial delay
+				out := new(primitives.SSZUint64)
+				require.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
+				require.NoError(t, stream.Close())
+			})
+		}
 
-	start := time.Now()
-	err = r.Stop()
-	duration := time.Since(start)
+		start := time.Now()
+		err = r.Stop()
+		duration := time.Since(start)
 
-	// If messages were sent sequentially, it would take numPeers * 100ms = 1 second
-	// If concurrent, should be ~100ms
-	assert.NoError(t, err)
-	assert.Equal(t, true, duration < 500*time.Millisecond, "Goodbye messages should be sent concurrently")
+		// If messages were sent sequentially, it would take numPeers * 100ms = 1 second
+		// If concurrent, should be ~100ms
+		assert.NoError(t, err)
+		assert.Equal(t, true, duration < 500*time.Millisecond, "Goodbye messages should be sent concurrently")
 
-	require.Equal(t, false, util.WaitTimeout(&wg, 2*time.Second))
+		require.Equal(t, false, util.WaitTimeout(&wg, 2*time.Second))
+	})
 }
 
 func TestUpdateCustodyInfoInDB(t *testing.T) {

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -471,44 +471,46 @@ func TestHaveAllSidecarsBeenSeen(t *testing.T) {
 // TestBroadcastAndReceiveUnseenDataColumnSidecars_GloasUsesRootKey verifies the unseen filter keys
 // Gloas sidecars by (block root, index): a column already seen under that key is skipped, the rest pass.
 func TestBroadcastAndReceiveUnseenDataColumnSidecars_GloasUsesRootKey(t *testing.T) {
-	chainService := &chainMock.ChainService{}
-	s := Service{
-		cfg: &config{
-			p2p:               mockp2p.NewTestP2P(t),
-			chain:             chainService,
-			clock:             startup.NewClock(time.Now(), [32]byte{}),
-			dataColumnStorage: filesystem.NewEphemeralDataColumnStorage(t),
-			operationNotifier: &chainMock.MockOperationNotifier{},
-		},
-		seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-	}
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		chainService := &chainMock.ChainService{}
+		s := Service{
+			cfg: &config{
+				p2p:               mockp2p.NewTestP2P(t),
+				chain:             chainService,
+				clock:             startup.NewClock(time.Now(), [32]byte{}),
+				dataColumnStorage: filesystem.NewEphemeralDataColumnStorage(t),
+				operationNotifier: &chainMock.MockOperationNotifier{},
+			},
+			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+		}
 
-	slot := primitives.Slot(7)
-	root := [fieldparams.RootLength]byte{0xab}
-	needed := map[uint64]bool{0: true, 1: true, 2: true}
+		slot := primitives.Slot(7)
+		root := [fieldparams.RootLength]byte{0xab}
+		needed := map[uint64]bool{0: true, 1: true, 2: true}
 
-	sidecars := make([]blocks.VerifiedRODataColumn, 0, 3)
-	for i := range uint64(3) {
-		gdc, err := blocks.NewRODataColumnGloasWithRoot(&ethpb.DataColumnSidecarGloas{
-			Index:           i,
-			Slot:            slot,
-			BeaconBlockRoot: root[:],
-		}, root)
+		sidecars := make([]blocks.VerifiedRODataColumn, 0, 3)
+		for i := range uint64(3) {
+			gdc, err := blocks.NewRODataColumnGloasWithRoot(&ethpb.DataColumnSidecarGloas{
+				Index:           i,
+				Slot:            slot,
+				BeaconBlockRoot: root[:],
+			}, root)
+			require.NoError(t, err)
+			sidecars = append(sidecars, blocks.VerifiedRODataColumn{RODataColumn: gdc})
+		}
+
+		// Mark index 1 already seen via the Gloas (root, index) key.
+		s.setSeenDataColumnRootIndex(root, 1, slot)
+
+		unseen, err := s.broadcastAndReceiveUnseenDataColumnSidecars(t.Context(), slot, 0, needed, sidecars, false)
 		require.NoError(t, err)
-		sidecars = append(sidecars, blocks.VerifiedRODataColumn{RODataColumn: gdc})
-	}
 
-	// Mark index 1 already seen via the Gloas (root, index) key.
-	s.setSeenDataColumnRootIndex(root, 1, slot)
-
-	unseen, err := s.broadcastAndReceiveUnseenDataColumnSidecars(t.Context(), slot, 0, needed, sidecars, false)
-	require.NoError(t, err)
-
-	require.Equal(t, 2, len(unseen))
-	require.Equal(t, true, unseen[0])
-	_, seen1 := unseen[1]
-	require.Equal(t, false, seen1)
-	require.Equal(t, true, unseen[2])
+		require.Equal(t, 2, len(unseen))
+		require.Equal(t, true, unseen[0])
+		_, seen1 := unseen[1]
+		require.Equal(t, false, seen1)
+		require.Equal(t, true, unseen[2])
+	})
 }
 
 // TestProcessDataColumnSidecarsFromExecution_GloasEarlyExitWhenAllSeen verifies that when every
@@ -516,65 +518,67 @@ func TestBroadcastAndReceiveUnseenDataColumnSidecars_GloasUsesRootKey(t *testing
 // path exits early instead of reconstructing and re-broadcasting. Gloas columns are tracked under
 // the (block root, index) key, so the early-exit must consult that key, not the Fulu one.
 func TestProcessDataColumnSidecarsFromExecution_GloasEarlyExitWhenAllSeen(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.CapellaForkEpoch = 0
-	cfg.DenebForkEpoch = 0
-	cfg.ElectraForkEpoch = 0
-	cfg.FuluForkEpoch = 0
-	cfg.GloasForkEpoch = 0
-	params.OverrideBeaconConfig(cfg)
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.CapellaForkEpoch = 0
+		cfg.DenebForkEpoch = 0
+		cfg.ElectraForkEpoch = 0
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
 
-	chainService := &chainMock.ChainService{Genesis: time.Now()}
+		chainService := &chainMock.ChainService{Genesis: time.Now()}
 
-	// The EL would return a full set of columns if it were ever consulted.
-	elColumns := make([]blocks.VerifiedRODataColumn, fieldparams.NumberOfColumns)
-	for i := range elColumns {
-		gdc, err := blocks.NewRODataColumnGloas(&ethpb.DataColumnSidecarGloas{
-			Index:           uint64(i),
-			Slot:            primitives.Slot(1),
-			BeaconBlockRoot: make([]byte, 32),
-		})
-		require.NoError(t, err)
-		elColumns[i] = blocks.VerifiedRODataColumn{RODataColumn: gdc}
-	}
+		// The EL would return a full set of columns if it were ever consulted.
+		elColumns := make([]blocks.VerifiedRODataColumn, fieldparams.NumberOfColumns)
+		for i := range elColumns {
+			gdc, err := blocks.NewRODataColumnGloas(&ethpb.DataColumnSidecarGloas{
+				Index:           uint64(i),
+				Slot:            primitives.Slot(1),
+				BeaconBlockRoot: make([]byte, 32),
+			})
+			require.NoError(t, err)
+			elColumns[i] = blocks.VerifiedRODataColumn{RODataColumn: gdc}
+		}
 
-	s := Service{
-		cfg: &config{
-			p2p:               mockp2p.NewTestP2P(t),
-			chain:             chainService,
-			clock:             startup.NewClock(time.Now(), [32]byte{}),
-			dataColumnStorage: filesystem.NewEphemeralDataColumnStorage(t),
-			executionReconstructor: &mockExecution.EngineClient{
-				DataColumnSidecars: elColumns,
+		s := Service{
+			cfg: &config{
+				p2p:               mockp2p.NewTestP2P(t),
+				chain:             chainService,
+				clock:             startup.NewClock(time.Now(), [32]byte{}),
+				dataColumnStorage: filesystem.NewEphemeralDataColumnStorage(t),
+				executionReconstructor: &mockExecution.EngineClient{
+					DataColumnSidecars: elColumns,
+				},
+				operationNotifier: &chainMock.MockOperationNotifier{},
 			},
-			operationNotifier: &chainMock.MockOperationNotifier{},
-		},
-		seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-	}
+			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+		}
 
-	_, _, err := s.cfg.p2p.UpdateCustodyInfo(0, params.BeaconConfig().CustodyRequirement)
-	require.NoError(t, err)
+		_, _, err := s.cfg.p2p.UpdateCustodyInfo(0, params.BeaconConfig().CustodyRequirement)
+		require.NoError(t, err)
 
-	b := util.NewBeaconBlockGloas()
-	b.Block.Body.SignedExecutionPayloadBid.Message.BlobKzgCommitments = [][]byte{make([]byte, 48)}
-	b.Block.Slot = 1
+		b := util.NewBeaconBlockGloas()
+		b.Block.Body.SignedExecutionPayloadBid.Message.BlobKzgCommitments = [][]byte{make([]byte, 48)}
+		b.Block.Slot = 1
 
-	sb, err := blocks.NewSignedBeaconBlock(b)
-	require.NoError(t, err)
-	roBlock, err := blocks.NewROBlock(sb)
-	require.NoError(t, err)
+		sb, err := blocks.NewSignedBeaconBlock(b)
+		require.NoError(t, err)
+		roBlock, err := blocks.NewROBlock(sb)
+		require.NoError(t, err)
 
-	// Simulate every column already received via gossip: mark seen under the Gloas (root, index) key.
-	root := roBlock.Root()
-	for i := range uint64(fieldparams.NumberOfColumns) {
-		s.setSeenDataColumnRootIndex(root, i, primitives.Slot(1))
-	}
+		// Simulate every column already received via gossip: mark seen under the Gloas (root, index) key.
+		root := roBlock.Root()
+		for i := range uint64(fieldparams.NumberOfColumns) {
+			s.setSeenDataColumnRootIndex(root, i, primitives.Slot(1))
+		}
 
-	require.NoError(t, s.processSidecarsFromExecutionFromBlock(t.Context(), roBlock))
+		require.NoError(t, s.processSidecarsFromExecutionFromBlock(t.Context(), roBlock))
 
-	// Early-exit must skip EL reconstruction entirely, so nothing is reconstructed/received.
-	require.Equal(t, 0, len(chainService.DataColumns))
+		// Early-exit must skip EL reconstruction entirely, so nothing is reconstructed/received.
+		require.Equal(t, 0, len(chainService.DataColumns))
+	})
 }
 
 func TestColumnIndicesToSample(t *testing.T) {
@@ -603,19 +607,21 @@ func TestColumnIndicesToSample(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			p2p := mockp2p.NewTestP2P(t)
-			_, _, err := p2p.UpdateCustodyInfo(earliestAvailableSlot, tc.custodyGroupCount)
-			require.NoError(t, err)
+			mockp2p.SynctestTest(t, func(t *testing.T) {
+				p2p := mockp2p.NewTestP2P(t)
+				_, _, err := p2p.UpdateCustodyInfo(earliestAvailableSlot, tc.custodyGroupCount)
+				require.NoError(t, err)
 
-			service := NewService(t.Context(), WithP2P(p2p))
+				service := NewService(t.Context(), WithP2P(p2p))
 
-			actual, err := service.columnIndicesToSample()
-			require.NoError(t, err)
+				actual, err := service.columnIndicesToSample()
+				require.NoError(t, err)
 
-			require.Equal(t, len(tc.expected), len(actual))
-			for index := range tc.expected {
-				require.Equal(t, true, actual[index])
-			}
+				require.Equal(t, len(tc.expected), len(actual))
+				for index := range tc.expected {
+					require.Equal(t, true, actual[index])
+				}
+			})
 		})
 	}
 }
@@ -646,42 +652,44 @@ func (b *blockingReconstructor) ReconstructBlobSidecars(ctx context.Context, _ i
 // sidecar-reconstruction goroutine survives the pubsub handler returning: its
 // context must not be cancelled when the handler's context is cancelled.
 func TestService_beaconBlockSubscriber_sidecarContextDetached(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	rec := &blockingReconstructor{
-		EngineClient:    &mockExecution.EngineClient{},
-		parentCancelled: make(chan struct{}),
-		ownCtxCancelled: make(chan bool, 1),
-	}
-	s := &Service{
-		ctx: context.Background(),
-		cfg: &config{
-			p2p: mockp2p.NewTestP2P(t),
-			chain: &chainMock.ChainService{
-				DB:      db,
-				Root:    make([]byte, 32),
-				Genesis: time.Now(),
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		rec := &blockingReconstructor{
+			EngineClient:    &mockExecution.EngineClient{},
+			parentCancelled: make(chan struct{}),
+			ownCtxCancelled: make(chan bool, 1),
+		}
+		s := &Service{
+			ctx: context.Background(),
+			cfg: &config{
+				p2p: mockp2p.NewTestP2P(t),
+				chain: &chainMock.ChainService{
+					DB:      db,
+					Root:    make([]byte, 32),
+					Genesis: time.Now(),
+				},
+				clock:                  startup.NewClock(time.Now(), [32]byte{}),
+				attPool:                attestations.NewPool(),
+				blobStorage:            filesystem.NewEphemeralBlobStorage(t),
+				executionReconstructor: rec,
+				operationNotifier:      &chainMock.MockOperationNotifier{},
 			},
-			clock:                  startup.NewClock(time.Now(), [32]byte{}),
-			attPool:                attestations.NewPool(),
-			blobStorage:            filesystem.NewEphemeralBlobStorage(t),
-			executionReconstructor: rec,
-			operationNotifier:      &chainMock.MockOperationNotifier{},
-		},
-		seenBlobCache: lruwrpr.New(1),
-	}
-	s.initCaches()
+			seenBlobCache: lruwrpr.New(1),
+		}
+		s.initCaches()
 
-	b := util.NewBeaconBlockDeneb()
-	b.Block.Body.BlobKzgCommitments = [][]byte{bytesutil.PadTo([]byte{0x01}, 48)}
+		b := util.NewBeaconBlockDeneb()
+		b.Block.Body.BlobKzgCommitments = [][]byte{bytesutil.PadTo([]byte{0x01}, 48)}
 
-	parentCtx, cancel := context.WithCancel(context.Background())
-	// The handler spawns the reconstruction goroutine then returns (ReceiveBlock may
-	// error on the mock's nil state, which is fine: the goroutine is spawned first).
-	_ = s.beaconBlockSubscriber(parentCtx, b)
-	// Cancelling the parent context is the moment that previously aborted the in-flight
-	// reconstruction goroutine. Signal the mock to make its observation afterwards.
-	cancel()
-	close(rec.parentCancelled)
+		parentCtx, cancel := context.WithCancel(context.Background())
+		// The handler spawns the reconstruction goroutine then returns (ReceiveBlock may
+		// error on the mock's nil state, which is fine: the goroutine is spawned first).
+		_ = s.beaconBlockSubscriber(parentCtx, b)
+		// Cancelling the parent context is the moment that previously aborted the in-flight
+		// reconstruction goroutine. Signal the mock to make its observation afterwards.
+		cancel()
+		close(rec.parentCancelled)
 
-	require.Equal(t, false, <-rec.ownCtxCancelled)
+		require.Equal(t, false, <-rec.ownCtxCancelled)
+	})
 }

--- a/beacon-chain/sync/subscriber_data_column_sidecar_test.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar_test.go
@@ -74,31 +74,33 @@ func TestAllDataColumnSubnets(t *testing.T) {
 // Gloas sidecars don't expose a proposer index, so reconstruction must not call ProposerIndex().
 // With no stored columns, reconstruction is unnecessary and the call returns nil instead of erroring.
 func TestProcessDataColumnSidecarsFromReconstruction_GloasSkipsProposerIndex(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.FuluForkEpoch = 0
-	cfg.GloasForkEpoch = 0
-	params.OverrideBeaconConfig(cfg)
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
 
-	s := &Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:               mockp2p.NewTestP2P(t),
-			clock:             startup.NewClock(time.Now(), [32]byte{}),
-			dataColumnStorage: filesystem.NewEphemeralDataColumnStorage(t),
-		},
-		seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-	}
+		s := &Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:               mockp2p.NewTestP2P(t),
+				clock:             startup.NewClock(time.Now(), [32]byte{}),
+				dataColumnStorage: filesystem.NewEphemeralDataColumnStorage(t),
+			},
+			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+		}
 
-	var root [fieldparams.RootLength]byte
-	root[0] = 0xEE
-	gdc, err := blocks.NewRODataColumnGloasWithRoot(&ethpb.DataColumnSidecarGloas{
-		Index:           0,
-		Slot:            1,
-		BeaconBlockRoot: root[:],
-	}, root)
-	require.NoError(t, err)
-	v := blocks.NewVerifiedRODataColumn(gdc)
+		var root [fieldparams.RootLength]byte
+		root[0] = 0xEE
+		gdc, err := blocks.NewRODataColumnGloasWithRoot(&ethpb.DataColumnSidecarGloas{
+			Index:           0,
+			Slot:            1,
+			BeaconBlockRoot: root[:],
+		}, root)
+		require.NoError(t, err)
+		v := blocks.NewVerifiedRODataColumn(gdc)
 
-	require.NoError(t, s.processDataColumnSidecarsFromReconstruction(t.Context(), v))
+		require.NoError(t, s.processDataColumnSidecarsFromReconstruction(t.Context(), v))
+	})
 }

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -37,93 +37,97 @@ import (
 )
 
 func TestSubscribe_ReceivesValidMessage(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2pService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mockChain.ChainService{
-				ValidatorsRoot: vr,
-				Genesis:        gt,
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2pService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mockChain.ChainService{
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+				},
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		subHandler:   newSubTopicHandler(),
-		chainStarted: &atomic.Bool{},
-	}
-	markInitSyncComplete(t, &r)
-	var err error
-	require.NoError(t, err)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	topic := "/eth2/%x/voluntary_exit"
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
-		m, ok := msg.(*pb.SignedVoluntaryExit)
-		assert.Equal(t, true, ok, "Object is not of type *pb.SignedVoluntaryExit")
-		if m.Exit == nil || m.Exit.Epoch != 55 {
-			t.Errorf("Unexpected incoming message: %+v", m)
+			subHandler:   newSubTopicHandler(),
+			chainStarted: &atomic.Bool{},
 		}
-		wg.Done()
-		return nil
-	}, nse)
-	r.markForChainStart()
+		markInitSyncComplete(t, &r)
+		var err error
+		require.NoError(t, err)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		topic := "/eth2/%x/voluntary_exit"
+		var wg sync.WaitGroup
+		wg.Add(1)
 
-	p2pService.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+		r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
+			m, ok := msg.(*pb.SignedVoluntaryExit)
+			assert.Equal(t, true, ok, "Object is not of type *pb.SignedVoluntaryExit")
+			if m.Exit == nil || m.Exit.Epoch != 55 {
+				t.Errorf("Unexpected incoming message: %+v", m)
+			}
+			wg.Done()
+			return nil
+		}, nse)
+		r.markForChainStart()
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
+		p2pService.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+	})
 }
 
 // TestSubscribe_DoesNotWaitForInitialSyncToRegisterTopic verifies regular-sync topics are registered before initial sync completes.
 func TestSubscribe_DoesNotWaitForInitialSyncToRegisterTopic(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:         p2pService,
-			initialSync: &mockSync.Sync{IsSyncing: true},
-			chain: &mockChain.ChainService{
-				ValidatorsRoot: vr,
-				Genesis:        gt,
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:         p2pService,
+				initialSync: &mockSync.Sync{IsSyncing: true},
+				chain: &mockChain.ChainService{
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+				},
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		subHandler:          newSubTopicHandler(),
-		chainStarted:        &atomic.Bool{},
-		initialSyncComplete: make(chan struct{}),
-	}
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	topic := "/eth2/%x/voluntary_exit"
+			subHandler:          newSubTopicHandler(),
+			chainStarted:        &atomic.Bool{},
+			initialSyncComplete: make(chan struct{}),
+		}
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		topic := "/eth2/%x/voluntary_exit"
 
-	done := make(chan struct{})
-	go func() {
-		r.subscribe(topic, r.noopValidator, func(_ context.Context, _ proto.Message) error {
-			return nil
-		}, nse)
-		close(done)
-	}()
+		done := make(chan struct{})
+		go func() {
+			r.subscribe(topic, r.noopValidator, func(_ context.Context, _ proto.Message) error {
+				return nil
+			}, nse)
+			close(done)
+		}()
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("the node reported sync complete before it was ready to follow new gossip blocks")
-	}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("the node reported sync complete before it was ready to follow new gossip blocks")
+		}
 
-	fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
-	r.unSubscribeFromTopic(fullTopic)
+		fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
+		r.unSubscribeFromTopic(fullTopic)
+	})
 }
 
 func markInitSyncComplete(_ *testing.T, s *Service) {
@@ -132,242 +136,252 @@ func markInitSyncComplete(_ *testing.T, s *Service) {
 }
 
 func TestSubscribe_UnsubscribeTopic(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2pService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mockChain.ChainService{
-				ValidatorsRoot: vr,
-				Genesis:        gt,
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2pService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mockChain.ChainService{
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+				},
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	topic := "/eth2/%x/voluntary_exit"
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		topic := "/eth2/%x/voluntary_exit"
 
-	r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
-		return nil
-	}, nse)
-	r.markForChainStart()
+		r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
+			return nil
+		}, nse)
+		r.markForChainStart()
 
-	fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
-	topics := p2pService.PubSub().GetTopics()
-	assert.Equal(t, fullTopic, topics[0])
+		fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
+		topics := p2pService.PubSub().GetTopics()
+		assert.Equal(t, fullTopic, topics[0])
 
-	r.unSubscribeFromTopic(fullTopic)
+		r.unSubscribeFromTopic(fullTopic)
 
-	assert.Equal(t, false, r.subHandler.topicExists(fullTopic))
-	assert.Equal(t, 0, len(p2pService.PubSub().GetTopics()))
+		assert.Equal(t, false, r.subHandler.topicExists(fullTopic))
+		assert.Equal(t, 0, len(p2pService.PubSub().GetTopics()))
 
+	})
 }
 
 func TestSubscribe_ReceivesAttesterSlashing(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig()
-	cfg.SlotDurationMilliseconds = 1000
-	params.OverrideBeaconConfig(cfg)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.MainnetConfig()
+		cfg.SlotDurationMilliseconds = 1000
+		params.OverrideBeaconConfig(cfg)
 
-	p2pService := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	d := db.SetupDB(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	chainService := &mockChain.ChainService{
-		Genesis:        gt,
-		ValidatorsRoot: vr,
-	}
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:          p2pService,
-			initialSync:  &mockSync.Sync{IsSyncing: false},
-			slashingPool: slashings.NewPool(),
-			chain:        chainService,
-			clock:        startup.NewClock(gt, vr),
-			beaconDB:     d,
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		chainStarted:              &atomic.Bool{},
-		subHandler:                newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	topic := "/eth2/%x/attester_slashing"
-	var wg sync.WaitGroup
-	wg.Add(1)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
-		require.NoError(t, r.attesterSlashingSubscriber(ctx, msg))
-		wg.Done()
-		return nil
-	}, nse)
-	beaconState, privKeys := util.DeterministicGenesisState(t, 64)
-	chainService.State = beaconState
-	r.markForChainStart()
-	attesterSlashing, err := util.GenerateAttesterSlashingForValidator(
-		beaconState,
-		privKeys[1],
-		1, /* validator index */
-	)
-	require.NoError(t, err, "Error generating attester slashing")
-	err = r.cfg.beaconDB.SaveState(ctx, beaconState, bytesutil.ToBytes32(attesterSlashing.FirstAttestation().GetData().BeaconBlockRoot))
-	require.NoError(t, err)
-	p2pService.ReceivePubSub(topic, attesterSlashing)
+		p2pService := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		d := db.SetupDB(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		chainService := &mockChain.ChainService{
+			Genesis:        gt,
+			ValidatorsRoot: vr,
+		}
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:          p2pService,
+				initialSync:  &mockSync.Sync{IsSyncing: false},
+				slashingPool: slashings.NewPool(),
+				chain:        chainService,
+				clock:        startup.NewClock(gt, vr),
+				beaconDB:     d,
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			chainStarted:              &atomic.Bool{},
+			subHandler:                newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		topic := "/eth2/%x/attester_slashing"
+		var wg sync.WaitGroup
+		wg.Add(1)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
+			require.NoError(t, r.attesterSlashingSubscriber(ctx, msg))
+			wg.Done()
+			return nil
+		}, nse)
+		beaconState, privKeys := util.DeterministicGenesisState(t, 64)
+		chainService.State = beaconState
+		r.markForChainStart()
+		attesterSlashing, err := util.GenerateAttesterSlashingForValidator(
+			beaconState,
+			privKeys[1],
+			1, /* validator index */
+		)
+		require.NoError(t, err, "Error generating attester slashing")
+		err = r.cfg.beaconDB.SaveState(ctx, beaconState, bytesutil.ToBytes32(attesterSlashing.FirstAttestation().GetData().BeaconBlockRoot))
+		require.NoError(t, err)
+		p2pService.ReceivePubSub(topic, attesterSlashing)
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
-	as := r.cfg.slashingPool.PendingAttesterSlashings(ctx, beaconState, false /*noLimit*/)
-	assert.Equal(t, 1, len(as), "Expected attester slashing")
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+		as := r.cfg.slashingPool.PendingAttesterSlashings(ctx, beaconState, false /*noLimit*/)
+		assert.Equal(t, 1, len(as), "Expected attester slashing")
+	})
 }
 
 func TestSubscribe_ReceivesProposerSlashing(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	chainService := &mockChain.ChainService{
-		ValidatorsRoot: [32]byte{'A'},
-		Genesis:        time.Now(),
-	}
-	d := db.SetupDB(t)
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:          p2pService,
-			initialSync:  &mockSync.Sync{IsSyncing: false},
-			slashingPool: slashings.NewPool(),
-			chain:        chainService,
-			beaconDB:     d,
-			clock:        startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-		chainStarted:              &atomic.Bool{},
-		subHandler:                newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	topic := "/eth2/%x/proposer_slashing"
-	var wg sync.WaitGroup
-	wg.Add(1)
-	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig())
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
-		require.NoError(t, r.proposerSlashingSubscriber(ctx, msg))
-		wg.Done()
-		return nil
-	}, nse)
-	beaconState, privKeys := util.DeterministicGenesisState(t, 64)
-	chainService.State = beaconState
-	r.markForChainStart()
-	proposerSlashing, err := util.GenerateProposerSlashingForValidator(
-		beaconState,
-		privKeys[1],
-		1, /* validator index */
-	)
-	require.NoError(t, err, "Error generating proposer slashing")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		chainService := &mockChain.ChainService{
+			ValidatorsRoot: [32]byte{'A'},
+			Genesis:        time.Now(),
+		}
+		d := db.SetupDB(t)
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:          p2pService,
+				initialSync:  &mockSync.Sync{IsSyncing: false},
+				slashingPool: slashings.NewPool(),
+				chain:        chainService,
+				beaconDB:     d,
+				clock:        startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+			chainStarted:              &atomic.Bool{},
+			subHandler:                newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		topic := "/eth2/%x/proposer_slashing"
+		var wg sync.WaitGroup
+		wg.Add(1)
+		params.SetupTestConfigCleanup(t)
+		params.OverrideBeaconConfig(params.MainnetConfig())
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
+			require.NoError(t, r.proposerSlashingSubscriber(ctx, msg))
+			wg.Done()
+			return nil
+		}, nse)
+		beaconState, privKeys := util.DeterministicGenesisState(t, 64)
+		chainService.State = beaconState
+		r.markForChainStart()
+		proposerSlashing, err := util.GenerateProposerSlashingForValidator(
+			beaconState,
+			privKeys[1],
+			1, /* validator index */
+		)
+		require.NoError(t, err, "Error generating proposer slashing")
 
-	p2pService.ReceivePubSub(topic, proposerSlashing)
+		p2pService.ReceivePubSub(topic, proposerSlashing)
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
-	ps := r.cfg.slashingPool.PendingProposerSlashings(ctx, beaconState, false /*noLimit*/)
-	assert.Equal(t, 1, len(ps), "Expected proposer slashing")
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+		ps := r.cfg.slashingPool.PendingProposerSlashings(ctx, beaconState, false /*noLimit*/)
+		assert.Equal(t, 1, len(ps), "Expected proposer slashing")
+	})
 }
 
 func TestSubscribe_HandlesPanic(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	chain := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			chain: chain,
-			clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			p2p:   p,
-		},
-		subHandler:   newSubTopicHandler(),
-		chainStarted: &atomic.Bool{},
-	}
-	markInitSyncComplete(t, &r)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		chain := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				chain: chain,
+				clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				p2p:   p,
+			},
+			subHandler:   newSubTopicHandler(),
+			chainStarted: &atomic.Bool{},
+		}
+		markInitSyncComplete(t, &r)
 
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p.Digest = nse.ForkDigest
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p.Digest = nse.ForkDigest
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*pb.SignedVoluntaryExit]()]
-	var wg sync.WaitGroup
-	wg.Add(1)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*pb.SignedVoluntaryExit]()]
+		var wg sync.WaitGroup
+		wg.Add(1)
 
-	r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
-		defer wg.Done()
-		panic("bad")
-	}, nse)
-	r.markForChainStart()
-	p.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+		r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
+			defer wg.Done()
+			panic("bad")
+		}, nse)
+		r.markForChainStart()
+		p.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+	})
 }
 
 func TestRevalidateSubscription_CorrectlyFormatsTopic(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	hook := logTest.NewGlobal()
-	chain := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			chain: chain,
-			clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			p2p:   p,
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		hook := logTest.NewGlobal()
+		chain := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				chain: chain,
+				clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				p2p:   p,
+			},
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
 
-	params := subscribeParameters{
-		topicFormat: "/eth2/testing/%#x/committee%d",
-		nse:         nse,
-	}
-	tracker := newSubnetTracker(params)
+		params := subscribeParameters{
+			topicFormat: "/eth2/testing/%#x/committee%d",
+			nse:         nse,
+		}
+		tracker := newSubnetTracker(params)
 
-	// committee index 1
-	c1 := uint64(1)
-	fullTopic := params.fullTopic(c1, r.cfg.p2p.Encoding().ProtocolSuffix())
-	_, topVal := r.wrapAndReportValidation(fullTopic, r.noopValidator)
-	require.NoError(t, r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal))
-	sub1, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
-	require.NoError(t, err)
-	tracker.track(c1, sub1)
+		// committee index 1
+		c1 := uint64(1)
+		fullTopic := params.fullTopic(c1, r.cfg.p2p.Encoding().ProtocolSuffix())
+		_, topVal := r.wrapAndReportValidation(fullTopic, r.noopValidator)
+		require.NoError(t, r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal))
+		sub1, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
+		require.NoError(t, err)
+		tracker.track(c1, sub1)
 
-	// committee index 2
-	c2 := uint64(2)
-	fullTopic = params.fullTopic(c2, r.cfg.p2p.Encoding().ProtocolSuffix())
-	_, topVal = r.wrapAndReportValidation(fullTopic, r.noopValidator)
-	err = r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal)
-	require.NoError(t, err)
-	sub2, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
-	require.NoError(t, err)
-	tracker.track(c2, sub2)
+		// committee index 2
+		c2 := uint64(2)
+		fullTopic = params.fullTopic(c2, r.cfg.p2p.Encoding().ProtocolSuffix())
+		_, topVal = r.wrapAndReportValidation(fullTopic, r.noopValidator)
+		err = r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal)
+		require.NoError(t, err)
+		sub2, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
+		require.NoError(t, err)
+		tracker.track(c2, sub2)
 
-	r.pruneNotWanted(tracker, map[uint64]bool{c2: true})
-	require.LogsDoNotContain(t, hook, "Could not unregister topic validator")
+		r.pruneNotWanted(tracker, map[uint64]bool{c2: true})
+		require.LogsDoNotContain(t, hook, "Could not unregister topic validator")
+	})
 }
 
 func Test_wrapAndReportValidation(t *testing.T) {
@@ -563,205 +577,211 @@ func Test_wrapAndReportValidation_NextEpochDigest(t *testing.T) {
 }
 
 func TestFilterSubnetPeers(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig()
-	cfg.SlotDurationMilliseconds = 1000
-	params.OverrideBeaconConfig(cfg)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.MainnetConfig()
+		cfg.SlotDurationMilliseconds = 1000
+		params.OverrideBeaconConfig(cfg)
 
-	gFlags := new(flags.GlobalFlags)
-	gFlags.MinimumPeersPerSubnet = 4
-	flags.Init(gFlags)
-	// Reset config.
-	defer flags.Init(new(flags.GlobalFlags))
+		gFlags := new(flags.GlobalFlags)
+		gFlags.MinimumPeersPerSubnet = 4
+		flags.Init(gFlags)
+		// Reset config.
+		defer flags.Init(new(flags.GlobalFlags))
 
-	tracer := p2ptest.NewGossipTracer()
-	p := p2ptest.NewTestP2PWithPubsubOptions(t, []pubsub.Option{pubsub.WithRawTracer(tracer)})
+		tracer := p2ptest.NewGossipTracer()
+		p := p2ptest.NewTestP2PWithPubsubOptions(t, []pubsub.Option{pubsub.WithRawTracer(tracer)})
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	currSlot := primitives.Slot(100)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		currSlot := primitives.Slot(100)
 
-	gt := time.Now()
-	slotDuration := params.BeaconConfig().SlotDuration()
-	genPlus100 := func() time.Time {
-		return gt.Add(time.Duration(uint64(currSlot)) * slotDuration)
-	}
-	chain := &mockChain.ChainService{
-		Genesis:        gt,
-		ValidatorsRoot: [32]byte{'A'},
-		FinalizedRoots: map[[32]byte]bool{
-			{}: true,
-		},
-	}
-	clock := startup.NewClock(chain.Genesis, chain.ValidatorsRoot, startup.WithNower(genPlus100))
-	require.Equal(t, currSlot, clock.CurrentSlot())
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			chain: chain,
-			clock: clock,
-			p2p:   p,
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	// Empty cache at the end of the test.
-	defer cache.SubnetIDs.EmptyAllCaches()
-	digest := r.currentForkDigest()
-	defaultTopic := "/eth2/%x/beacon_attestation_%d" + r.cfg.p2p.Encoding().ProtocolSuffix()
-	subnet10 := r.addDigestAndIndexToTopic(defaultTopic, digest, 10)
-	cache.SubnetIDs.AddAggregatorSubnetID(currSlot, 10)
+		gt := time.Now()
+		slotDuration := params.BeaconConfig().SlotDuration()
+		genPlus100 := func() time.Time {
+			return gt.Add(time.Duration(uint64(currSlot)) * slotDuration)
+		}
+		chain := &mockChain.ChainService{
+			Genesis:        gt,
+			ValidatorsRoot: [32]byte{'A'},
+			FinalizedRoots: map[[32]byte]bool{
+				{}: true,
+			},
+		}
+		clock := startup.NewClock(chain.Genesis, chain.ValidatorsRoot, startup.WithNower(genPlus100))
+		require.Equal(t, currSlot, clock.CurrentSlot())
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				chain: chain,
+				clock: clock,
+				p2p:   p,
+			},
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		// Empty cache at the end of the test.
+		defer cache.SubnetIDs.EmptyAllCaches()
+		digest := r.currentForkDigest()
+		defaultTopic := "/eth2/%x/beacon_attestation_%d" + r.cfg.p2p.Encoding().ProtocolSuffix()
+		subnet10 := r.addDigestAndIndexToTopic(defaultTopic, digest, 10)
+		cache.SubnetIDs.AddAggregatorSubnetID(currSlot, 10)
 
-	subnet20 := r.addDigestAndIndexToTopic(defaultTopic, digest, 20)
-	cache.SubnetIDs.AddAttesterSubnetID(currSlot, 20)
+		subnet20 := r.addDigestAndIndexToTopic(defaultTopic, digest, 20)
+		cache.SubnetIDs.AddAttesterSubnetID(currSlot, 20)
 
-	_, err := tracer.JoinAndWatchTopic(t.Context(), subnet10, p)
-	require.NoError(t, err)
-	_, err = tracer.JoinAndWatchTopic(t.Context(), subnet20, p)
-	require.NoError(t, err)
+		_, err := tracer.JoinAndWatchTopic(t.Context(), subnet10, p)
+		require.NoError(t, err)
+		_, err = tracer.JoinAndWatchTopic(t.Context(), subnet20, p)
+		require.NoError(t, err)
 
-	p1 := createPeer(t, subnet10)
-	p2 := createPeer(t, subnet10, subnet20)
-	p3 := createPeer(t)
+		p1 := createPeer(t, subnet10)
+		p2 := createPeer(t, subnet10, subnet20)
+		p3 := createPeer(t)
 
-	p.Connect(p1)
-	p.Connect(p2)
-	p.Connect(p3)
+		p.Connect(p1)
+		p.Connect(p2)
+		p.Connect(p3)
 
-	require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p1.PeerID()))
-	require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p2.PeerID()))
-	require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, p2.PeerID()))
+		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p1.PeerID()))
+		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p2.PeerID()))
+		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, p2.PeerID()))
 
-	wantedPeers := []peer.ID{p1.PeerID(), p2.PeerID(), p3.PeerID()}
-	// Expect Peer 3 to be marked as suitable.
-	recPeers := r.filterNeededPeers(wantedPeers)
-	assert.DeepEqual(t, []peer.ID{p3.PeerID()}, recPeers)
+		wantedPeers := []peer.ID{p1.PeerID(), p2.PeerID(), p3.PeerID()}
+		// Expect Peer 3 to be marked as suitable.
+		recPeers := r.filterNeededPeers(wantedPeers)
+		assert.DeepEqual(t, []peer.ID{p3.PeerID()}, recPeers)
 
-	// Try with only peers from subnet 20.
-	wantedPeers = []peer.ID{p2.BHost.ID()}
-	// Connect an excess amount of peers in the particular subnet.
-	for i := 1; i <= flags.Get().MinimumPeersPerSubnet; i++ {
-		nPeer := createPeer(t, subnet20)
-		p.Connect(nPeer)
-		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, nPeer.PeerID()))
+		// Try with only peers from subnet 20.
+		wantedPeers = []peer.ID{p2.BHost.ID()}
+		// Connect an excess amount of peers in the particular subnet.
+		for i := 1; i <= flags.Get().MinimumPeersPerSubnet; i++ {
+			nPeer := createPeer(t, subnet20)
+			p.Connect(nPeer)
+			require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, nPeer.PeerID()))
 
-		wantedPeers = append(wantedPeers, nPeer.BHost.ID())
-	}
+			wantedPeers = append(wantedPeers, nPeer.BHost.ID())
+		}
 
-	recPeers = r.filterNeededPeers(wantedPeers)
-	assert.Equal(t, 1, len(recPeers), "expected at least 1 suitable peer to prune")
+		recPeers = r.filterNeededPeers(wantedPeers)
+		assert.Equal(t, 1, len(recPeers), "expected at least 1 suitable peer to prune")
+	})
 }
 
 func TestSubscribeWithSyncSubnets_DynamicOK(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig()
-	cfg.SlotDurationMilliseconds = 1000
-	params.OverrideBeaconConfig(cfg)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.MainnetConfig()
+		cfg.SlotDurationMilliseconds = 1000
+		params.OverrideBeaconConfig(cfg)
 
-	p := p2ptest.NewTestP2P(t)
-	ctx, cancel := context.WithCancel(t.Context())
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			chain: &mockChain.ChainService{
-				Genesis:        gt,
-				ValidatorsRoot: vr,
+		p := p2ptest.NewTestP2P(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				chain: &mockChain.ChainService{
+					Genesis:        gt,
+					ValidatorsRoot: vr,
+				},
+				p2p:   p,
+				clock: startup.NewClock(gt, vr),
 			},
-			p2p:   p,
-			clock: startup.NewClock(gt, vr),
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	// Empty cache at the end of the test.
-	defer cache.SyncSubnetIDs.EmptyAllCaches()
-	slot := r.cfg.clock.CurrentSlot()
-	currEpoch := slots.ToEpoch(slot)
-	cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), currEpoch, []uint64{0, 1}, 10*time.Second)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	go r.subscribeWithParameters(subscribeParameters{
-		topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
-		nse:              nse,
-		getSubnetsToJoin: r.activeSyncSubnetIndices,
-	})
-	time.Sleep(2 * time.Second)
-	assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
-	topicMap := map[string]bool{}
-	for _, t := range r.cfg.p2p.PubSub().GetTopics() {
-		topicMap[t] = true
-	}
-	firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[firstSub])
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		// Empty cache at the end of the test.
+		defer cache.SyncSubnetIDs.EmptyAllCaches()
+		slot := r.cfg.clock.CurrentSlot()
+		currEpoch := slots.ToEpoch(slot)
+		cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), currEpoch, []uint64{0, 1}, 10*time.Second)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		go r.subscribeWithParameters(subscribeParameters{
+			topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
+			nse:              nse,
+			getSubnetsToJoin: r.activeSyncSubnetIndices,
+		})
+		time.Sleep(2 * time.Second)
+		assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
+		topicMap := map[string]bool{}
+		for _, t := range r.cfg.p2p.PubSub().GetTopics() {
+			topicMap[t] = true
+		}
+		firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[firstSub])
 
-	secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[secondSub])
-	cancel()
+		secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[secondSub])
+		cancel()
+	})
 }
 
 func TestSubscribeWithSyncSubnets_DynamicSwitchFork(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	p := p2ptest.NewTestP2P(t)
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	vr := params.BeaconConfig().GenesisValidatorsRoot
-	mockNow := &startup.MockNower{}
-	clock := startup.NewClock(time.Now(), vr, startup.WithNower(mockNow.Now))
-	denebSlot, err := slots.EpochStart(params.BeaconConfig().DenebForkEpoch)
-	require.NoError(t, err)
-	mockNow.SetSlot(t, clock, denebSlot)
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			chain: &mockChain.ChainService{},
-			clock: clock,
-			p2p:   p,
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	// Empty cache at the end of the test.
-	defer cache.SyncSubnetIDs.EmptyAllCaches()
-	cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), 0, []uint64{0, 1}, 10*time.Second)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	require.Equal(t, [4]byte(params.BeaconConfig().DenebForkVersion), nse.ForkVersion)
-	require.Equal(t, params.BeaconConfig().DenebForkEpoch, nse.Epoch)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		p := p2ptest.NewTestP2P(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		vr := params.BeaconConfig().GenesisValidatorsRoot
+		mockNow := &startup.MockNower{}
+		clock := startup.NewClock(time.Now(), vr, startup.WithNower(mockNow.Now))
+		denebSlot, err := slots.EpochStart(params.BeaconConfig().DenebForkEpoch)
+		require.NoError(t, err)
+		mockNow.SetSlot(t, clock, denebSlot)
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				chain: &mockChain.ChainService{},
+				clock: clock,
+				p2p:   p,
+			},
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		// Empty cache at the end of the test.
+		defer cache.SyncSubnetIDs.EmptyAllCaches()
+		cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), 0, []uint64{0, 1}, 10*time.Second)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		require.Equal(t, [4]byte(params.BeaconConfig().DenebForkVersion), nse.ForkVersion)
+		require.Equal(t, params.BeaconConfig().DenebForkEpoch, nse.Epoch)
 
-	sp := newSubnetTracker(subscribeParameters{
-		topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
-		nse:              nse,
-		getSubnetsToJoin: r.activeSyncSubnetIndices,
+		sp := newSubnetTracker(subscribeParameters{
+			topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
+			nse:              nse,
+			getSubnetsToJoin: r.activeSyncSubnetIndices,
+		})
+		r.trySubscribeSubnets(t.Context(), sp)
+		assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
+		topicMap := map[string]bool{}
+		for _, t := range r.cfg.p2p.PubSub().GetTopics() {
+			topicMap[t] = true
+		}
+		firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[firstSub])
+
+		secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[secondSub])
+
+		electraSlot, err := slots.EpochStart(params.BeaconConfig().ElectraForkEpoch)
+		require.NoError(t, err)
+		mockNow.SetSlot(t, clock, electraSlot)
+		nse = params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		require.Equal(t, [4]byte(params.BeaconConfig().ElectraForkVersion), nse.ForkVersion)
+		require.Equal(t, params.BeaconConfig().ElectraForkEpoch, nse.Epoch)
+
+		sp.nse = nse
+		// clear the cache and re-subscribe to subnets.
+		// this should result in the subscriptions being removed
+		cache.SyncSubnetIDs.EmptyAllCaches()
+		r.trySubscribeSubnets(t.Context(), sp)
+		assert.Equal(t, 0, len(r.cfg.p2p.PubSub().GetTopics()))
 	})
-	r.trySubscribeSubnets(t.Context(), sp)
-	assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
-	topicMap := map[string]bool{}
-	for _, t := range r.cfg.p2p.PubSub().GetTopics() {
-		topicMap[t] = true
-	}
-	firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[firstSub])
-
-	secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[secondSub])
-
-	electraSlot, err := slots.EpochStart(params.BeaconConfig().ElectraForkEpoch)
-	require.NoError(t, err)
-	mockNow.SetSlot(t, clock, electraSlot)
-	nse = params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	require.Equal(t, [4]byte(params.BeaconConfig().ElectraForkVersion), nse.ForkVersion)
-	require.Equal(t, params.BeaconConfig().ElectraForkEpoch, nse.Epoch)
-
-	sp.nse = nse
-	// clear the cache and re-subscribe to subnets.
-	// this should result in the subscriptions being removed
-	cache.SyncSubnetIDs.EmptyAllCaches()
-	r.trySubscribeSubnets(t.Context(), sp)
-	assert.Equal(t, 0, len(r.cfg.p2p.PubSub().GetTopics()))
 }
 
 func TestSamplingSize(t *testing.T) {

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -37,93 +37,97 @@ import (
 )
 
 func TestSubscribe_ReceivesValidMessage(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2pService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mockChain.ChainService{
-				ValidatorsRoot: vr,
-				Genesis:        gt,
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2pService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mockChain.ChainService{
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+				},
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		subHandler:   newSubTopicHandler(),
-		chainStarted: &atomic.Bool{},
-	}
-	markInitSyncComplete(t, &r)
-	var err error
-	require.NoError(t, err)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	topic := "/eth2/%x/voluntary_exit"
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
-		m, ok := msg.(*pb.SignedVoluntaryExit)
-		assert.Equal(t, true, ok, "Object is not of type *pb.SignedVoluntaryExit")
-		if m.Exit == nil || m.Exit.Epoch != 55 {
-			t.Errorf("Unexpected incoming message: %+v", m)
+			subHandler:   newSubTopicHandler(),
+			chainStarted: &atomic.Bool{},
 		}
-		wg.Done()
-		return nil
-	}, nse)
-	r.markForChainStart()
+		markInitSyncComplete(t, &r)
+		var err error
+		require.NoError(t, err)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		topic := "/eth2/%x/voluntary_exit"
+		var wg sync.WaitGroup
+		wg.Add(1)
 
-	p2pService.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+		r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
+			m, ok := msg.(*pb.SignedVoluntaryExit)
+			assert.Equal(t, true, ok, "Object is not of type *pb.SignedVoluntaryExit")
+			if m.Exit == nil || m.Exit.Epoch != 55 {
+				t.Errorf("Unexpected incoming message: %+v", m)
+			}
+			wg.Done()
+			return nil
+		}, nse)
+		r.markForChainStart()
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
+		p2pService.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+	})
 }
 
 // TestSubscribe_DoesNotWaitForInitialSyncToRegisterTopic verifies regular-sync topics are registered before initial sync completes.
 func TestSubscribe_DoesNotWaitForInitialSyncToRegisterTopic(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:         p2pService,
-			initialSync: &mockSync.Sync{IsSyncing: true},
-			chain: &mockChain.ChainService{
-				ValidatorsRoot: vr,
-				Genesis:        gt,
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:         p2pService,
+				initialSync: &mockSync.Sync{IsSyncing: true},
+				chain: &mockChain.ChainService{
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+				},
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		subHandler:          newSubTopicHandler(),
-		chainStarted:        &atomic.Bool{},
-		initialSyncComplete: make(chan struct{}),
-	}
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	topic := "/eth2/%x/voluntary_exit"
+			subHandler:          newSubTopicHandler(),
+			chainStarted:        &atomic.Bool{},
+			initialSyncComplete: make(chan struct{}),
+		}
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		topic := "/eth2/%x/voluntary_exit"
 
-	done := make(chan struct{})
-	go func() {
-		r.subscribe(topic, r.noopValidator, func(_ context.Context, _ proto.Message) error {
-			return nil
-		}, nse)
-		close(done)
-	}()
+		done := make(chan struct{})
+		go func() {
+			r.subscribe(topic, r.noopValidator, func(_ context.Context, _ proto.Message) error {
+				return nil
+			}, nse)
+			close(done)
+		}()
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("the node reported sync complete before it was ready to follow new gossip blocks")
-	}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("the node reported sync complete before it was ready to follow new gossip blocks")
+		}
 
-	fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
-	r.unSubscribeFromTopic(fullTopic)
+		fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
+		r.unSubscribeFromTopic(fullTopic)
+	})
 }
 
 func markInitSyncComplete(_ *testing.T, s *Service) {
@@ -132,242 +136,252 @@ func markInitSyncComplete(_ *testing.T, s *Service) {
 }
 
 func TestSubscribe_UnsubscribeTopic(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			p2p:         p2pService,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mockChain.ChainService{
-				ValidatorsRoot: vr,
-				Genesis:        gt,
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:         p2pService,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mockChain.ChainService{
+					ValidatorsRoot: vr,
+					Genesis:        gt,
+				},
+				clock: startup.NewClock(gt, vr),
 			},
-			clock: startup.NewClock(gt, vr),
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	topic := "/eth2/%x/voluntary_exit"
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		topic := "/eth2/%x/voluntary_exit"
 
-	r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
-		return nil
-	}, nse)
-	r.markForChainStart()
+		r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
+			return nil
+		}, nse)
+		r.markForChainStart()
 
-	fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
-	topics := p2pService.PubSub().GetTopics()
-	assert.Equal(t, fullTopic, topics[0])
+		fullTopic := fmt.Sprintf(topic, p2pService.Digest) + p2pService.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, r.subHandler.topicExists(fullTopic))
+		topics := p2pService.PubSub().GetTopics()
+		assert.Equal(t, fullTopic, topics[0])
 
-	r.unSubscribeFromTopic(fullTopic)
+		r.unSubscribeFromTopic(fullTopic)
 
-	assert.Equal(t, false, r.subHandler.topicExists(fullTopic))
-	assert.Equal(t, 0, len(p2pService.PubSub().GetTopics()))
+		assert.Equal(t, false, r.subHandler.topicExists(fullTopic))
+		assert.Equal(t, 0, len(p2pService.PubSub().GetTopics()))
 
+	})
 }
 
 func TestSubscribe_ReceivesAttesterSlashing(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig()
-	cfg.SlotDurationMilliseconds = 1000
-	params.OverrideBeaconConfig(cfg)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.MainnetConfig()
+		cfg.SlotDurationMilliseconds = 1000
+		params.OverrideBeaconConfig(cfg)
 
-	p2pService := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	d := db.SetupDB(t)
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	chainService := &mockChain.ChainService{
-		Genesis:        gt,
-		ValidatorsRoot: vr,
-	}
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:          p2pService,
-			initialSync:  &mockSync.Sync{IsSyncing: false},
-			slashingPool: slashings.NewPool(),
-			chain:        chainService,
-			clock:        startup.NewClock(gt, vr),
-			beaconDB:     d,
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		chainStarted:              &atomic.Bool{},
-		subHandler:                newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	topic := "/eth2/%x/attester_slashing"
-	var wg sync.WaitGroup
-	wg.Add(1)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
-		require.NoError(t, r.attesterSlashingSubscriber(ctx, msg))
-		wg.Done()
-		return nil
-	}, nse)
-	beaconState, privKeys := util.DeterministicGenesisState(t, 64)
-	chainService.State = beaconState
-	r.markForChainStart()
-	attesterSlashing, err := util.GenerateAttesterSlashingForValidator(
-		beaconState,
-		privKeys[1],
-		1, /* validator index */
-	)
-	require.NoError(t, err, "Error generating attester slashing")
-	err = r.cfg.beaconDB.SaveState(ctx, beaconState, bytesutil.ToBytes32(attesterSlashing.FirstAttestation().GetData().BeaconBlockRoot))
-	require.NoError(t, err)
-	p2pService.ReceivePubSub(topic, attesterSlashing)
+		p2pService := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		d := db.SetupDB(t)
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		chainService := &mockChain.ChainService{
+			Genesis:        gt,
+			ValidatorsRoot: vr,
+		}
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:          p2pService,
+				initialSync:  &mockSync.Sync{IsSyncing: false},
+				slashingPool: slashings.NewPool(),
+				chain:        chainService,
+				clock:        startup.NewClock(gt, vr),
+				beaconDB:     d,
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			chainStarted:              &atomic.Bool{},
+			subHandler:                newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		topic := "/eth2/%x/attester_slashing"
+		var wg sync.WaitGroup
+		wg.Add(1)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
+			require.NoError(t, r.attesterSlashingSubscriber(ctx, msg))
+			wg.Done()
+			return nil
+		}, nse)
+		beaconState, privKeys := util.DeterministicGenesisState(t, 64)
+		chainService.State = beaconState
+		r.markForChainStart()
+		attesterSlashing, err := util.GenerateAttesterSlashingForValidator(
+			beaconState,
+			privKeys[1],
+			1, /* validator index */
+		)
+		require.NoError(t, err, "Error generating attester slashing")
+		err = r.cfg.beaconDB.SaveState(ctx, beaconState, bytesutil.ToBytes32(attesterSlashing.FirstAttestation().GetData().BeaconBlockRoot))
+		require.NoError(t, err)
+		p2pService.ReceivePubSub(topic, attesterSlashing)
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
-	as := r.cfg.slashingPool.PendingAttesterSlashings(ctx, beaconState, false /*noLimit*/)
-	assert.Equal(t, 1, len(as), "Expected attester slashing")
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+		as := r.cfg.slashingPool.PendingAttesterSlashings(ctx, beaconState, false /*noLimit*/)
+		assert.Equal(t, 1, len(as), "Expected attester slashing")
+	})
 }
 
 func TestSubscribe_ReceivesProposerSlashing(t *testing.T) {
-	p2pService := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	chainService := &mockChain.ChainService{
-		ValidatorsRoot: [32]byte{'A'},
-		Genesis:        time.Now(),
-	}
-	d := db.SetupDB(t)
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:          p2pService,
-			initialSync:  &mockSync.Sync{IsSyncing: false},
-			slashingPool: slashings.NewPool(),
-			chain:        chainService,
-			beaconDB:     d,
-			clock:        startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-		chainStarted:              &atomic.Bool{},
-		subHandler:                newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	topic := "/eth2/%x/proposer_slashing"
-	var wg sync.WaitGroup
-	wg.Add(1)
-	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig())
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p2pService.Digest = nse.ForkDigest
-	r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
-		require.NoError(t, r.proposerSlashingSubscriber(ctx, msg))
-		wg.Done()
-		return nil
-	}, nse)
-	beaconState, privKeys := util.DeterministicGenesisState(t, 64)
-	chainService.State = beaconState
-	r.markForChainStart()
-	proposerSlashing, err := util.GenerateProposerSlashingForValidator(
-		beaconState,
-		privKeys[1],
-		1, /* validator index */
-	)
-	require.NoError(t, err, "Error generating proposer slashing")
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p2pService := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		chainService := &mockChain.ChainService{
+			ValidatorsRoot: [32]byte{'A'},
+			Genesis:        time.Now(),
+		}
+		d := db.SetupDB(t)
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:          p2pService,
+				initialSync:  &mockSync.Sync{IsSyncing: false},
+				slashingPool: slashings.NewPool(),
+				chain:        chainService,
+				beaconDB:     d,
+				clock:        startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+			chainStarted:              &atomic.Bool{},
+			subHandler:                newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		topic := "/eth2/%x/proposer_slashing"
+		var wg sync.WaitGroup
+		wg.Add(1)
+		params.SetupTestConfigCleanup(t)
+		params.OverrideBeaconConfig(params.MainnetConfig())
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p2pService.Digest = nse.ForkDigest
+		r.subscribe(topic, r.noopValidator, func(ctx context.Context, msg proto.Message) error {
+			require.NoError(t, r.proposerSlashingSubscriber(ctx, msg))
+			wg.Done()
+			return nil
+		}, nse)
+		beaconState, privKeys := util.DeterministicGenesisState(t, 64)
+		chainService.State = beaconState
+		r.markForChainStart()
+		proposerSlashing, err := util.GenerateProposerSlashingForValidator(
+			beaconState,
+			privKeys[1],
+			1, /* validator index */
+		)
+		require.NoError(t, err, "Error generating proposer slashing")
 
-	p2pService.ReceivePubSub(topic, proposerSlashing)
+		p2pService.ReceivePubSub(topic, proposerSlashing)
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
-	ps := r.cfg.slashingPool.PendingProposerSlashings(ctx, beaconState, false /*noLimit*/)
-	assert.Equal(t, 1, len(ps), "Expected proposer slashing")
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+		ps := r.cfg.slashingPool.PendingProposerSlashings(ctx, beaconState, false /*noLimit*/)
+		assert.Equal(t, 1, len(ps), "Expected proposer slashing")
+	})
 }
 
 func TestSubscribe_HandlesPanic(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	chain := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			chain: chain,
-			clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			p2p:   p,
-		},
-		subHandler:   newSubTopicHandler(),
-		chainStarted: &atomic.Bool{},
-	}
-	markInitSyncComplete(t, &r)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		chain := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				chain: chain,
+				clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				p2p:   p,
+			},
+			subHandler:   newSubTopicHandler(),
+			chainStarted: &atomic.Bool{},
+		}
+		markInitSyncComplete(t, &r)
 
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	p.Digest = nse.ForkDigest
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		p.Digest = nse.ForkDigest
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*pb.SignedVoluntaryExit]()]
-	var wg sync.WaitGroup
-	wg.Add(1)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*pb.SignedVoluntaryExit]()]
+		var wg sync.WaitGroup
+		wg.Add(1)
 
-	r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
-		defer wg.Done()
-		panic("bad")
-	}, nse)
-	r.markForChainStart()
-	p.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+		r.subscribe(topic, r.noopValidator, func(_ context.Context, msg proto.Message) error {
+			defer wg.Done()
+			panic("bad")
+		}, nse)
+		r.markForChainStart()
+		p.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, fieldparams.BLSSignatureLength)})
 
-	if util.WaitTimeout(&wg, time.Second) {
-		t.Fatal("Did not receive PubSub in 1 second")
-	}
+		if util.WaitTimeout(&wg, time.Second) {
+			t.Fatal("Did not receive PubSub in 1 second")
+		}
+	})
 }
 
 func TestRevalidateSubscription_CorrectlyFormatsTopic(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	hook := logTest.NewGlobal()
-	chain := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	r := Service{
-		ctx: t.Context(),
-		cfg: &config{
-			chain: chain,
-			clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			p2p:   p,
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		hook := logTest.NewGlobal()
+		chain := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		r := Service{
+			ctx: t.Context(),
+			cfg: &config{
+				chain: chain,
+				clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				p2p:   p,
+			},
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
 
-	params := subscribeParameters{
-		topicFormat: "/eth2/testing/%#x/committee%d",
-		nse:         nse,
-	}
-	tracker := newSubnetTracker(params)
+		params := subscribeParameters{
+			topicFormat: "/eth2/testing/%#x/committee%d",
+			nse:         nse,
+		}
+		tracker := newSubnetTracker(params)
 
-	// committee index 1
-	c1 := uint64(1)
-	fullTopic := params.fullTopic(c1, r.cfg.p2p.Encoding().ProtocolSuffix())
-	_, topVal := r.wrapAndReportValidation(fullTopic, r.noopValidator)
-	require.NoError(t, r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal))
-	sub1, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
-	require.NoError(t, err)
-	tracker.track(c1, sub1)
+		// committee index 1
+		c1 := uint64(1)
+		fullTopic := params.fullTopic(c1, r.cfg.p2p.Encoding().ProtocolSuffix())
+		_, topVal := r.wrapAndReportValidation(fullTopic, r.noopValidator)
+		require.NoError(t, r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal))
+		sub1, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
+		require.NoError(t, err)
+		tracker.track(c1, sub1)
 
-	// committee index 2
-	c2 := uint64(2)
-	fullTopic = params.fullTopic(c2, r.cfg.p2p.Encoding().ProtocolSuffix())
-	_, topVal = r.wrapAndReportValidation(fullTopic, r.noopValidator)
-	err = r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal)
-	require.NoError(t, err)
-	sub2, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
-	require.NoError(t, err)
-	tracker.track(c2, sub2)
+		// committee index 2
+		c2 := uint64(2)
+		fullTopic = params.fullTopic(c2, r.cfg.p2p.Encoding().ProtocolSuffix())
+		_, topVal = r.wrapAndReportValidation(fullTopic, r.noopValidator)
+		err = r.cfg.p2p.PubSub().RegisterTopicValidator(fullTopic, topVal)
+		require.NoError(t, err)
+		sub2, err := r.cfg.p2p.SubscribeToTopic(fullTopic)
+		require.NoError(t, err)
+		tracker.track(c2, sub2)
 
-	r.pruneNotWanted(tracker, map[uint64]bool{c2: true})
-	require.LogsDoNotContain(t, hook, "Could not unregister topic validator")
+		r.pruneNotWanted(tracker, map[uint64]bool{c2: true})
+		require.LogsDoNotContain(t, hook, "Could not unregister topic validator")
+	})
 }
 
 func Test_wrapAndReportValidation(t *testing.T) {
@@ -563,206 +577,212 @@ func Test_wrapAndReportValidation_NextEpochDigest(t *testing.T) {
 }
 
 func TestFilterSubnetPeers(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig()
-	cfg.SlotDurationMilliseconds = 1000
-	params.OverrideBeaconConfig(cfg)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.MainnetConfig()
+		cfg.SlotDurationMilliseconds = 1000
+		params.OverrideBeaconConfig(cfg)
 
-	gFlags := new(flags.GlobalFlags)
-	gFlags.MinimumPeersPerSubnet = 4
-	flags.Init(gFlags)
-	// Reset config.
-	defer flags.Init(new(flags.GlobalFlags))
+		gFlags := new(flags.GlobalFlags)
+		gFlags.MinimumPeersPerSubnet = 4
+		flags.Init(gFlags)
+		// Reset config.
+		defer flags.Init(new(flags.GlobalFlags))
 
-	tracer := p2ptest.NewGossipTracer()
-	p := p2ptest.NewTestP2PWithPubsubOptions(t, []pubsub.Option{pubsub.WithRawTracer(tracer)})
+		tracer := p2ptest.NewGossipTracer()
+		p := p2ptest.NewTestP2PWithPubsubOptions(t, []pubsub.Option{pubsub.WithRawTracer(tracer)})
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	currSlot := primitives.Slot(100)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		currSlot := primitives.Slot(100)
 
-	gt := time.Now()
-	slotDuration := params.BeaconConfig().SlotDuration()
-	genPlus100 := func() time.Time {
-		return gt.Add(time.Duration(uint64(currSlot)) * slotDuration)
-	}
-	chain := &mockChain.ChainService{
-		Genesis:        gt,
-		ValidatorsRoot: [32]byte{'A'},
-		FinalizedRoots: map[[32]byte]bool{
-			{}: true,
-		},
-	}
-	clock := startup.NewClock(chain.Genesis, chain.ValidatorsRoot, startup.WithNower(genPlus100))
-	require.Equal(t, currSlot, clock.CurrentSlot())
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			chain: chain,
-			clock: clock,
-			p2p:   p,
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	// Empty cache at the end of the test.
-	defer cache.SubnetIDs.EmptyAllCaches()
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	defaultTopic := "/eth2/%x/beacon_attestation_%d" + r.cfg.p2p.Encoding().ProtocolSuffix()
-	subnet10 := r.addDigestAndIndexToTopic(defaultTopic, digest, 10)
-	cache.SubnetIDs.AddAggregatorSubnetID(currSlot, 10)
+		gt := time.Now()
+		slotDuration := params.BeaconConfig().SlotDuration()
+		genPlus100 := func() time.Time {
+			return gt.Add(time.Duration(uint64(currSlot)) * slotDuration)
+		}
+		chain := &mockChain.ChainService{
+			Genesis:        gt,
+			ValidatorsRoot: [32]byte{'A'},
+			FinalizedRoots: map[[32]byte]bool{
+				{}: true,
+			},
+		}
+		clock := startup.NewClock(chain.Genesis, chain.ValidatorsRoot, startup.WithNower(genPlus100))
+		require.Equal(t, currSlot, clock.CurrentSlot())
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				chain: chain,
+				clock: clock,
+				p2p:   p,
+			},
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		// Empty cache at the end of the test.
+		defer cache.SubnetIDs.EmptyAllCaches()
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		defaultTopic := "/eth2/%x/beacon_attestation_%d" + r.cfg.p2p.Encoding().ProtocolSuffix()
+		subnet10 := r.addDigestAndIndexToTopic(defaultTopic, digest, 10)
+		cache.SubnetIDs.AddAggregatorSubnetID(currSlot, 10)
 
-	subnet20 := r.addDigestAndIndexToTopic(defaultTopic, digest, 20)
-	cache.SubnetIDs.AddAttesterSubnetID(currSlot, 20)
+		subnet20 := r.addDigestAndIndexToTopic(defaultTopic, digest, 20)
+		cache.SubnetIDs.AddAttesterSubnetID(currSlot, 20)
 
-	_, err = tracer.JoinAndWatchTopic(t.Context(), subnet10, p)
-	require.NoError(t, err)
-	_, err = tracer.JoinAndWatchTopic(t.Context(), subnet20, p)
-	require.NoError(t, err)
+		_, err = tracer.JoinAndWatchTopic(t.Context(), subnet10, p)
+		require.NoError(t, err)
+		_, err = tracer.JoinAndWatchTopic(t.Context(), subnet20, p)
+		require.NoError(t, err)
 
-	p1 := createPeer(t, subnet10)
-	p2 := createPeer(t, subnet10, subnet20)
-	p3 := createPeer(t)
+		p1 := createPeer(t, subnet10)
+		p2 := createPeer(t, subnet10, subnet20)
+		p3 := createPeer(t)
 
-	p.Connect(p1)
-	p.Connect(p2)
-	p.Connect(p3)
+		p.Connect(p1)
+		p.Connect(p2)
+		p.Connect(p3)
 
-	require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p1.PeerID()))
-	require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p2.PeerID()))
-	require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, p2.PeerID()))
+		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p1.PeerID()))
+		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet10, p2.PeerID()))
+		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, p2.PeerID()))
 
-	wantedPeers := []peer.ID{p1.PeerID(), p2.PeerID(), p3.PeerID()}
-	// Expect Peer 3 to be marked as suitable.
-	recPeers := r.filterNeededPeers(wantedPeers)
-	assert.DeepEqual(t, []peer.ID{p3.PeerID()}, recPeers)
+		wantedPeers := []peer.ID{p1.PeerID(), p2.PeerID(), p3.PeerID()}
+		// Expect Peer 3 to be marked as suitable.
+		recPeers := r.filterNeededPeers(wantedPeers)
+		assert.DeepEqual(t, []peer.ID{p3.PeerID()}, recPeers)
 
-	// Try with only peers from subnet 20.
-	wantedPeers = []peer.ID{p2.BHost.ID()}
-	// Connect an excess amount of peers in the particular subnet.
-	for i := 1; i <= flags.Get().MinimumPeersPerSubnet; i++ {
-		nPeer := createPeer(t, subnet20)
-		p.Connect(nPeer)
-		require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, nPeer.PeerID()))
+		// Try with only peers from subnet 20.
+		wantedPeers = []peer.ID{p2.BHost.ID()}
+		// Connect an excess amount of peers in the particular subnet.
+		for i := 1; i <= flags.Get().MinimumPeersPerSubnet; i++ {
+			nPeer := createPeer(t, subnet20)
+			p.Connect(nPeer)
+			require.NoError(t, tracer.CanPublishToPeer(t.Context(), subnet20, nPeer.PeerID()))
 
-		wantedPeers = append(wantedPeers, nPeer.BHost.ID())
-	}
+			wantedPeers = append(wantedPeers, nPeer.BHost.ID())
+		}
 
-	recPeers = r.filterNeededPeers(wantedPeers)
-	assert.Equal(t, 1, len(recPeers), "expected at least 1 suitable peer to prune")
+		recPeers = r.filterNeededPeers(wantedPeers)
+		assert.Equal(t, 1, len(recPeers), "expected at least 1 suitable peer to prune")
+	})
 }
 
 func TestSubscribeWithSyncSubnets_DynamicOK(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig()
-	cfg.SlotDurationMilliseconds = 1000
-	params.OverrideBeaconConfig(cfg)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.MainnetConfig()
+		cfg.SlotDurationMilliseconds = 1000
+		params.OverrideBeaconConfig(cfg)
 
-	p := p2ptest.NewTestP2P(t)
-	ctx, cancel := context.WithCancel(t.Context())
-	gt := time.Now()
-	vr := [32]byte{'A'}
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			chain: &mockChain.ChainService{
-				Genesis:        gt,
-				ValidatorsRoot: vr,
+		p := p2ptest.NewTestP2P(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		gt := time.Now()
+		vr := [32]byte{'A'}
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				chain: &mockChain.ChainService{
+					Genesis:        gt,
+					ValidatorsRoot: vr,
+				},
+				p2p:   p,
+				clock: startup.NewClock(gt, vr),
 			},
-			p2p:   p,
-			clock: startup.NewClock(gt, vr),
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	// Empty cache at the end of the test.
-	defer cache.SyncSubnetIDs.EmptyAllCaches()
-	slot := r.cfg.clock.CurrentSlot()
-	currEpoch := slots.ToEpoch(slot)
-	cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), currEpoch, []uint64{0, 1}, 10*time.Second)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	go r.subscribeWithParameters(subscribeParameters{
-		topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
-		nse:              nse,
-		getSubnetsToJoin: r.activeSyncSubnetIndices,
-	})
-	time.Sleep(2 * time.Second)
-	assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
-	topicMap := map[string]bool{}
-	for _, t := range r.cfg.p2p.PubSub().GetTopics() {
-		topicMap[t] = true
-	}
-	firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[firstSub])
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		// Empty cache at the end of the test.
+		defer cache.SyncSubnetIDs.EmptyAllCaches()
+		slot := r.cfg.clock.CurrentSlot()
+		currEpoch := slots.ToEpoch(slot)
+		cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), currEpoch, []uint64{0, 1}, 10*time.Second)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		go r.subscribeWithParameters(subscribeParameters{
+			topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
+			nse:              nse,
+			getSubnetsToJoin: r.activeSyncSubnetIndices,
+		})
+		time.Sleep(2 * time.Second)
+		assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
+		topicMap := map[string]bool{}
+		for _, t := range r.cfg.p2p.PubSub().GetTopics() {
+			topicMap[t] = true
+		}
+		firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[firstSub])
 
-	secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[secondSub])
-	cancel()
+		secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[secondSub])
+		cancel()
+	})
 }
 
 func TestSubscribeWithSyncSubnets_DynamicSwitchFork(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	p := p2ptest.NewTestP2P(t)
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	vr := params.BeaconConfig().GenesisValidatorsRoot
-	mockNow := &startup.MockNower{}
-	clock := startup.NewClock(time.Now(), vr, startup.WithNower(mockNow.Now))
-	denebSlot, err := slots.EpochStart(params.BeaconConfig().DenebForkEpoch)
-	require.NoError(t, err)
-	mockNow.SetSlot(t, clock, denebSlot)
-	r := Service{
-		ctx: ctx,
-		cfg: &config{
-			chain: &mockChain.ChainService{},
-			clock: clock,
-			p2p:   p,
-		},
-		chainStarted: &atomic.Bool{},
-		subHandler:   newSubTopicHandler(),
-	}
-	markInitSyncComplete(t, &r)
-	// Empty cache at the end of the test.
-	defer cache.SyncSubnetIDs.EmptyAllCaches()
-	cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), 0, []uint64{0, 1}, 10*time.Second)
-	nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	require.Equal(t, [4]byte(params.BeaconConfig().DenebForkVersion), nse.ForkVersion)
-	require.Equal(t, params.BeaconConfig().DenebForkEpoch, nse.Epoch)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		p := p2ptest.NewTestP2P(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		vr := params.BeaconConfig().GenesisValidatorsRoot
+		mockNow := &startup.MockNower{}
+		clock := startup.NewClock(time.Now(), vr, startup.WithNower(mockNow.Now))
+		denebSlot, err := slots.EpochStart(params.BeaconConfig().DenebForkEpoch)
+		require.NoError(t, err)
+		mockNow.SetSlot(t, clock, denebSlot)
+		r := Service{
+			ctx: ctx,
+			cfg: &config{
+				chain: &mockChain.ChainService{},
+				clock: clock,
+				p2p:   p,
+			},
+			chainStarted: &atomic.Bool{},
+			subHandler:   newSubTopicHandler(),
+		}
+		markInitSyncComplete(t, &r)
+		// Empty cache at the end of the test.
+		defer cache.SyncSubnetIDs.EmptyAllCaches()
+		cache.SyncSubnetIDs.AddSyncCommitteeSubnets([]byte("pubkey"), 0, []uint64{0, 1}, 10*time.Second)
+		nse := params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		require.Equal(t, [4]byte(params.BeaconConfig().DenebForkVersion), nse.ForkVersion)
+		require.Equal(t, params.BeaconConfig().DenebForkEpoch, nse.Epoch)
 
-	sp := newSubnetTracker(subscribeParameters{
-		topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
-		nse:              nse,
-		getSubnetsToJoin: r.activeSyncSubnetIndices,
+		sp := newSubnetTracker(subscribeParameters{
+			topicFormat:      p2p.SyncCommitteeSubnetTopicFormat,
+			nse:              nse,
+			getSubnetsToJoin: r.activeSyncSubnetIndices,
+		})
+		r.trySubscribeSubnets(t.Context(), sp)
+		assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
+		topicMap := map[string]bool{}
+		for _, t := range r.cfg.p2p.PubSub().GetTopics() {
+			topicMap[t] = true
+		}
+		firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[firstSub])
+
+		secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
+		assert.Equal(t, true, topicMap[secondSub])
+
+		electraSlot, err := slots.EpochStart(params.BeaconConfig().ElectraForkEpoch)
+		require.NoError(t, err)
+		mockNow.SetSlot(t, clock, electraSlot)
+		nse = params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
+		require.Equal(t, [4]byte(params.BeaconConfig().ElectraForkVersion), nse.ForkVersion)
+		require.Equal(t, params.BeaconConfig().ElectraForkEpoch, nse.Epoch)
+
+		sp.nse = nse
+		// clear the cache and re-subscribe to subnets.
+		// this should result in the subscriptions being removed
+		cache.SyncSubnetIDs.EmptyAllCaches()
+		r.trySubscribeSubnets(t.Context(), sp)
+		assert.Equal(t, 0, len(r.cfg.p2p.PubSub().GetTopics()))
 	})
-	r.trySubscribeSubnets(t.Context(), sp)
-	assert.Equal(t, 2, len(r.cfg.p2p.PubSub().GetTopics()))
-	topicMap := map[string]bool{}
-	for _, t := range r.cfg.p2p.PubSub().GetTopics() {
-		topicMap[t] = true
-	}
-	firstSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 0) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[firstSub])
-
-	secondSub := fmt.Sprintf(p2p.SyncCommitteeSubnetTopicFormat, nse.ForkDigest, 1) + r.cfg.p2p.Encoding().ProtocolSuffix()
-	assert.Equal(t, true, topicMap[secondSub])
-
-	electraSlot, err := slots.EpochStart(params.BeaconConfig().ElectraForkEpoch)
-	require.NoError(t, err)
-	mockNow.SetSlot(t, clock, electraSlot)
-	nse = params.GetNetworkScheduleEntry(r.cfg.clock.CurrentEpoch())
-	require.Equal(t, [4]byte(params.BeaconConfig().ElectraForkVersion), nse.ForkVersion)
-	require.Equal(t, params.BeaconConfig().ElectraForkEpoch, nse.Epoch)
-
-	sp.nse = nse
-	// clear the cache and re-subscribe to subnets.
-	// this should result in the subscriptions being removed
-	cache.SyncSubnetIDs.EmptyAllCaches()
-	r.trySubscribeSubnets(t.Context(), sp)
-	assert.Equal(t, 0, len(r.cfg.p2p.PubSub().GetTopics()))
 }
 
 func TestSamplingSize(t *testing.T) {

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -195,630 +195,646 @@ func TestVerifySelection_NotAnAggregator(t *testing.T) {
 }
 
 func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	att := util.HydrateAttestation(&ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-		},
+		att := util.HydrateAttestation(&ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Source: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+			},
+		})
+
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  bytesutil.PadTo([]byte{'A'}, fieldparams.BLSSignatureLength),
+			Aggregate:       att,
+			AggregatorIndex: 0,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
+
+		c := lruwrpr.New(10)
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				attPool:     attestations.NewPool(),
+				chain:       &mock.ChainService{},
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			seenAggregatedAttestationCache: c,
+		}
+		r.initCaches()
+
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
+
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
 	})
-
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  bytesutil.PadTo([]byte{'A'}, fieldparams.BLSSignatureLength),
-		Aggregate:       att,
-		AggregatorIndex: 0,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
-
-	c := lruwrpr.New(10)
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			attPool:     attestations.NewPool(),
-			chain:       &mock.ChainService{},
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		seenAggregatedAttestationCache: c,
-	}
-	r.initCaches()
-
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
-
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
 }
 
 func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, _ := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, _ := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(3)
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-		},
-		AggregationBits: aggBits,
-		Signature:       make([]byte, fieldparams.BLSSignatureLength),
-	}
-
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		Aggregate:      att,
-		SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
-
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{
-				Genesis: time.Now(),
-				State:   beaconState,
+		aggBits := bitfield.NewBitlist(3)
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
 			},
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	r.initCaches()
+			AggregationBits: aggBits,
+			Signature:       make([]byte, fieldparams.BLSSignatureLength),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			Aggregate:      att,
+			SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{
+					Genesis: time.Now(),
+					State:   beaconState,
+				},
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		r.initCaches()
 
-	att.Data.Slot = 1<<32 - 1
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	msg = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
+
+		att.Data.Slot = 1<<32 - 1
+
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
+
+		msg = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
+	})
 }
 
 func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, _ := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, _ := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(3)
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-		},
-		AggregationBits: aggBits,
-		Signature:       make([]byte, fieldparams.BLSSignatureLength),
-	}
+		aggBits := bitfield.NewBitlist(3)
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+			},
+			AggregationBits: aggBits,
+			Signature:       make([]byte, fieldparams.BLSSignatureLength),
+		}
 
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		Aggregate:      att,
-		SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			Aggregate:      att,
+			SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	r := &Service{
-		cfg: &config{
-			attPool:     attestations.NewPool(),
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{Genesis: time.Now(),
-				State: beaconState},
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-	}
-	r.initCaches()
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		r := &Service{
+			cfg: &config{
+				attPool:     attestations.NewPool(),
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{Genesis: time.Now(),
+					State: beaconState},
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+		}
+		r.initCaches()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	require.NoError(t, r.cfg.attPool.SaveBlockAttestation(att))
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
+		require.NoError(t, r.cfg.attPool.SaveBlockAttestation(att))
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
+	})
 }
 
 func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	assert.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		assert.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
-		Optimistic:       true,
-		DB:               db,
-		State:            beaconState,
-		ValidAttestation: true,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  att.Data.BeaconBlockRoot,
-		}}
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p,
-			beaconDB:            db,
-			initialSync:         &mockSync.Sync{IsSyncing: false},
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	r.initCaches()
-	go r.verifierRoutine()
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
+			Optimistic:       true,
+			DB:               db,
+			State:            beaconState,
+			ValidAttestation: true,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  att.Data.BeaconBlockRoot,
+			}}
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p,
+				beaconDB:            db,
+				initialSync:         &mockSync.Sync{IsSyncing: false},
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		r.initCaches()
+		go r.verifierRoutine()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NoError(t, err)
-	assert.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
-	assert.NotNil(t, msg.ValidatorData, "Did not set validator data")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NoError(t, err)
+		assert.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
+		assert.NotNil(t, msg.ValidatorData, "Did not set validator data")
+	})
 }
 
 func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	require.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		require.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
-		DB:               db,
-		ValidatorsRoot:   [32]byte{'A'},
-		State:            beaconState,
-		ValidAttestation: true,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  signedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot,
-		}}
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p,
-			beaconDB:            db,
-			initialSync:         &mockSync.Sync{IsSyncing: false},
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	r.initCaches()
-	go r.verifierRoutine()
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
+			DB:               db,
+			ValidatorsRoot:   [32]byte{'A'},
+			State:            beaconState,
+			ValidAttestation: true,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  signedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot,
+			}}
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p,
+				beaconDB:            db,
+				initialSync:         &mockSync.Sync{IsSyncing: false},
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		r.initCaches()
+		go r.verifierRoutine()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
 
-	// Should fail with another attestation in the same epoch.
-	signedAggregateAndProof.Message.Aggregate.Data.Slot++
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
-	msg = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		// Should fail with another attestation in the same epoch.
+		signedAggregateAndProof.Message.Aggregate.Data.Slot++
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
+		msg = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	require.Eventually(t, func() bool {
-		res, _ := r.validateAggregateAndProof(t.Context(), "", msg)
-		return res != pubsub.ValidationAccept
-	}, time.Second, 10*time.Millisecond, "Expected validation to reject duplicate aggregate")
+		require.Eventually(t, func() bool {
+			res, _ := r.validateAggregateAndProof(t.Context(), "", msg)
+			return res != pubsub.ValidationAccept
+		}, time.Second, 10*time.Millisecond, "Expected validation to reject duplicate aggregate")
+	})
 }
 
 func TestValidateAggregateAndProof_BadBlock(t *testing.T) {
+	p2ptest.SynctestTest(t, func(t *testing.T) {
 
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	assert.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		assert.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
 
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{Genesis: time.Now(),
-				State:            beaconState,
-				ValidAttestation: true,
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-				}},
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	r.initCaches()
-	// Set beacon block as bad.
-	r.setBadBlock(t.Context(), root)
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{Genesis: time.Now(),
+					State:            beaconState,
+					ValidAttestation: true,
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+					}},
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		r.initCaches()
+		// Set beacon block as bad.
+		r.setBadBlock(t.Context(), root)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NotNil(t, err)
-	assert.Equal(t, pubsub.ValidationReject, res, "Validated status is true")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NotNil(t, err)
+		assert.Equal(t, pubsub.ValidationReject, res, "Validated status is true")
+	})
 }
 
 func TestValidateAggregateAndProof_RejectWhenAttEpochDoesntEqualTargetEpoch(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 1, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 1, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	assert.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		assert.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{Genesis: time.Now(),
-				State:            beaconState,
-				ValidAttestation: true,
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  att.Data.BeaconBlockRoot,
-				}},
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	r.initCaches()
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{Genesis: time.Now(),
+					State:            beaconState,
+					ValidAttestation: true,
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  att.Data.BeaconBlockRoot,
+					}},
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		r.initCaches()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NotNil(t, err)
-	assert.Equal(t, pubsub.ValidationReject, res)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NotNil(t, err)
+		assert.Equal(t, pubsub.ValidationReject, res)
+	})
 }
 
 func Test_SetAggregatorIndexEpochSeen(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p:      p,
-			beaconDB: db,
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:      p,
+				beaconDB: db,
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
 
-	aggIndex := primitives.ValidatorIndex(42)
-	epoch := primitives.Epoch(7)
+		aggIndex := primitives.ValidatorIndex(42)
+		epoch := primitives.Epoch(7)
 
-	require.Equal(t, false, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
-	first := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
-	require.Equal(t, true, first)
-	require.Equal(t, true, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
+		require.Equal(t, false, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
+		first := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
+		require.Equal(t, true, first)
+		require.Equal(t, true, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
 
-	second := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
-	require.Equal(t, false, second)
+		second := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
+		require.Equal(t, false, second)
+	})
 }

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -195,632 +195,648 @@ func TestVerifySelection_NotAnAggregator(t *testing.T) {
 }
 
 func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	att := util.HydrateAttestation(&ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-		},
+		att := util.HydrateAttestation(&ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Source: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target: &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+			},
+		})
+
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  bytesutil.PadTo([]byte{'A'}, fieldparams.BLSSignatureLength),
+			Aggregate:       att,
+			AggregatorIndex: 0,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
+
+		c := lruwrpr.New(10)
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				attPool:     attestations.NewPool(),
+				chain:       &mock.ChainService{},
+			},
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+			seenAggregatedAttestationCache: c,
+		}
+		r.initCaches()
+
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
+
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
 	})
-
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  bytesutil.PadTo([]byte{'A'}, fieldparams.BLSSignatureLength),
-		Aggregate:       att,
-		AggregatorIndex: 0,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
-
-	c := lruwrpr.New(10)
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			attPool:     attestations.NewPool(),
-			chain:       &mock.ChainService{},
-		},
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-		seenAggregatedAttestationCache: c,
-	}
-	r.initCaches()
-
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
-
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
 }
 
 func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, _ := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, _ := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(3)
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-		},
-		AggregationBits: aggBits,
-		Signature:       make([]byte, fieldparams.BLSSignatureLength),
-	}
-
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		Aggregate:      att,
-		SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
-
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{
-				Genesis: time.Now(),
-				State:   beaconState,
+		aggBits := bitfield.NewBitlist(3)
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
 			},
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	r.initCaches()
+			AggregationBits: aggBits,
+			Signature:       make([]byte, fieldparams.BLSSignatureLength),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			Aggregate:      att,
+			SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{
+					Genesis: time.Now(),
+					State:   beaconState,
+				},
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		r.initCaches()
 
-	att.Data.Slot = 1<<32 - 1
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	msg = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
+
+		att.Data.Slot = 1<<32 - 1
+
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
+
+		msg = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
+	})
 }
 
 func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, _ := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, _ := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	aggBits := bitfield.NewBitlist(3)
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-		},
-		AggregationBits: aggBits,
-		Signature:       make([]byte, fieldparams.BLSSignatureLength),
-	}
+		aggBits := bitfield.NewBitlist(3)
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+			},
+			AggregationBits: aggBits,
+			Signature:       make([]byte, fieldparams.BLSSignatureLength),
+		}
 
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		Aggregate:      att,
-		SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			Aggregate:      att,
+			SelectionProof: make([]byte, fieldparams.BLSSignatureLength),
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, fieldparams.BLSSignatureLength)}
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	r := &Service{
-		cfg: &config{
-			attPool:     attestations.NewPool(),
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{Genesis: time.Now(),
-				State: beaconState},
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		blkRootToPendingAtts:           make(map[[32]byte][]any),
-	}
-	r.initCaches()
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		r := &Service{
+			cfg: &config{
+				attPool:     attestations.NewPool(),
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{Genesis: time.Now(),
+					State: beaconState},
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			blkRootToPendingAtts:           make(map[[32]byte][]any),
+		}
+		r.initCaches()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	require.NoError(t, r.cfg.attPool.SaveBlockAttestation(att))
-	if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
-		_ = err
-		t.Error("Expected validate to fail")
-	}
+		require.NoError(t, r.cfg.attPool.SaveBlockAttestation(att))
+		if res, err := r.validateAggregateAndProof(t.Context(), "", msg); res == pubsub.ValidationAccept {
+			_ = err
+			t.Error("Expected validate to fail")
+		}
+	})
 }
 
 func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	assert.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		assert.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
-		Optimistic:       true,
-		DB:               db,
-		State:            beaconState,
-		ValidAttestation: true,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  att.Data.BeaconBlockRoot,
-		}}
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p,
-			beaconDB:            db,
-			initialSync:         &mockSync.Sync{IsSyncing: false},
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	r.initCaches()
-	go r.verifierRoutine()
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
+			Optimistic:       true,
+			DB:               db,
+			State:            beaconState,
+			ValidAttestation: true,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  att.Data.BeaconBlockRoot,
+			}}
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p,
+				beaconDB:            db,
+				initialSync:         &mockSync.Sync{IsSyncing: false},
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		r.initCaches()
+		go r.verifierRoutine()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NoError(t, err)
-	assert.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
-	assert.NotNil(t, msg.ValidatorData, "Did not set validator data")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NoError(t, err)
+		assert.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
+		assert.NotNil(t, msg.ValidatorData, "Did not set validator data")
+	})
 }
 
 func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			Slot:            1,
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            1,
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	require.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		require.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
-		DB:               db,
-		ValidatorsRoot:   [32]byte{'A'},
-		State:            beaconState,
-		ValidAttestation: true,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  signedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot,
-		}}
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			p2p:                 p,
-			beaconDB:            db,
-			initialSync:         &mockSync.Sync{IsSyncing: false},
-			chain:               chain,
-			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-		signatureChan:                  make(chan *signatureVerifier, verifierLimit),
-	}
-	r.initCaches()
-	go r.verifierRoutine()
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
+			DB:               db,
+			ValidatorsRoot:   [32]byte{'A'},
+			State:            beaconState,
+			ValidAttestation: true,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  signedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot,
+			}}
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				p2p:                 p,
+				beaconDB:            db,
+				initialSync:         &mockSync.Sync{IsSyncing: false},
+				chain:               chain,
+				clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+			signatureChan:                  make(chan *signatureVerifier, verifierLimit),
+		}
+		r.initCaches()
+		go r.verifierRoutine()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, res, "Validated status is false")
 
-	// Should fail with another attestation in the same epoch.
-	signedAggregateAndProof.Message.Aggregate.Data.Slot++
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
-	msg = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		// Should fail with another attestation in the same epoch.
+		signedAggregateAndProof.Message.Aggregate.Data.Slot++
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
+		msg = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	require.Eventually(t, func() bool {
-		res, _ := r.validateAggregateAndProof(t.Context(), "", msg)
-		return res != pubsub.ValidationAccept
-	}, time.Second, 10*time.Millisecond, "Expected validation to reject duplicate aggregate")
+		require.Eventually(t, func() bool {
+			res, _ := r.validateAggregateAndProof(t.Context(), "", msg)
+			return res != pubsub.ValidationAccept
+		}, time.Second, 10*time.Millisecond, "Expected validation to reject duplicate aggregate")
+	})
 }
 
 func TestValidateAggregateAndProof_BadBlock(t *testing.T) {
+	p2ptest.SynctestTest(t, func(t *testing.T) {
 
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 0, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	assert.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		assert.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
 
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{Genesis: time.Now(),
-				State:            beaconState,
-				ValidAttestation: true,
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-				}},
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	r.initCaches()
-	// Set beacon block as bad.
-	r.setBadBlock(t.Context(), root)
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{Genesis: time.Now(),
+					State:            beaconState,
+					ValidAttestation: true,
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+					}},
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		r.initCaches()
+		// Set beacon block as bad.
+		r.setBadBlock(t.Context(), root)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NotNil(t, err)
-	assert.Equal(t, pubsub.ValidationReject, res, "Validated status is true")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NotNil(t, err)
+		assert.Equal(t, pubsub.ValidationReject, res, "Validated status is true")
+	})
 }
 
 func TestValidateAggregateAndProof_RejectWhenAttEpochDoesntEqualTargetEpoch(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	validators := uint64(256)
-	beaconState, privKeys := util.DeterministicGenesisState(t, validators)
+		validators := uint64(256)
+		beaconState, privKeys := util.DeterministicGenesisState(t, validators)
 
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, b)
-	root, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	s, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(t.Context(), s, root))
+		b := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, b)
+		root, err := b.Block.HashTreeRoot()
+		require.NoError(t, err)
+		s, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(t.Context(), s, root))
 
-	aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
-	aggBits.SetBitAt(0, true)
-	att := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: root[:],
-			Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
-			Target:          &ethpb.Checkpoint{Epoch: 1, Root: root[:]},
-		},
-		AggregationBits: aggBits,
-	}
+		aggBits := bitfield.NewBitlist(validators / uint64(params.BeaconConfig().SlotsPerEpoch))
+		aggBits.SetBitAt(0, true)
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				BeaconBlockRoot: root[:],
+				Source:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
+				Target:          &ethpb.Checkpoint{Epoch: 1, Root: root[:]},
+			},
+			AggregationBits: aggBits,
+		}
 
-	committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
-	assert.NoError(t, err)
-	attestingIndices, err := attestation.AttestingIndices(att, committee)
-	require.NoError(t, err)
-	assert.NoError(t, err)
-	attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
-	assert.NoError(t, err)
-	sigs := make([]bls.Signature, len(attestingIndices))
-	for i, indice := range attestingIndices {
-		sig := privKeys[indice].Sign(hashTreeRoot[:])
-		sigs[i] = sig
-	}
-	att.Signature = bls.AggregateSignatures(sigs).Marshal()
-	ai := committee[0]
-	sszUint := primitives.SSZUint64(att.Data.Slot)
-	sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
-	require.NoError(t, err)
-	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  sig,
-		Aggregate:       att,
-		AggregatorIndex: ai,
-	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
-	signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
-	require.NoError(t, err)
+		committee, err := helpers.BeaconCommitteeFromState(t.Context(), beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+		assert.NoError(t, err)
+		attestingIndices, err := attestation.AttestingIndices(att, committee)
+		require.NoError(t, err)
+		assert.NoError(t, err)
+		attesterDomain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		hashTreeRoot, err := signing.ComputeSigningRoot(att.Data, attesterDomain)
+		assert.NoError(t, err)
+		sigs := make([]bls.Signature, len(attestingIndices))
+		for i, indice := range attestingIndices {
+			sig := privKeys[indice].Sign(hashTreeRoot[:])
+			sigs[i] = sig
+		}
+		att.Signature = bls.AggregateSignatures(sigs).Marshal()
+		ai := committee[0]
+		sszUint := primitives.SSZUint64(att.Data.Slot)
+		sig, err := signing.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
+		require.NoError(t, err)
+		aggregateAndProof := &ethpb.AggregateAttestationAndProof{
+			SelectionProof:  sig,
+			Aggregate:       att,
+			AggregatorIndex: ai,
+		}
+		signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}
+		signedAggregateAndProof.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, signedAggregateAndProof.Message, params.BeaconConfig().DomainAggregateAndProof, privKeys[ai])
+		require.NoError(t, err)
 
-	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			beaconDB:    db,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain: &mock.ChainService{Genesis: time.Now(),
-				State:            beaconState,
-				ValidAttestation: true,
-				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Epoch: 0,
-					Root:  att.Data.BeaconBlockRoot,
-				}},
-			attPool:             attestations.NewPool(),
-			attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
-	r.initCaches()
+		require.NoError(t, beaconState.SetGenesisTime(time.Now()))
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				beaconDB:    db,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain: &mock.ChainService{Genesis: time.Now(),
+					State:            beaconState,
+					ValidAttestation: true,
+					FinalizedCheckPoint: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  att.Data.BeaconBlockRoot,
+					}},
+				attPool:             attestations.NewPool(),
+				attestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
+		r.initCaches()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, signedAggregateAndProof)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAggregateAndProof(t.Context(), "", msg)
-	assert.NotNil(t, err)
-	assert.Equal(t, pubsub.ValidationReject, res)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAggregateAndProof(t.Context(), "", msg)
+		assert.NotNil(t, err)
+		assert.Equal(t, pubsub.ValidationReject, res)
+	})
 }
 
 func Test_SetAggregatorIndexEpochSeen(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p:      p,
-			beaconDB: db,
-		},
-		seenAggregatedAttestationCache: lruwrpr.New(10),
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:      p,
+				beaconDB: db,
+			},
+			seenAggregatedAttestationCache: lruwrpr.New(10),
+		}
 
-	aggIndex := primitives.ValidatorIndex(42)
-	epoch := primitives.Epoch(7)
+		aggIndex := primitives.ValidatorIndex(42)
+		epoch := primitives.Epoch(7)
 
-	require.Equal(t, false, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
-	first := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
-	require.Equal(t, true, first)
-	require.Equal(t, true, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
+		require.Equal(t, false, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
+		first := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
+		require.Equal(t, true, first)
+		require.Equal(t, true, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
 
-	second := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
-	require.Equal(t, false, second)
+		second := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
+		require.Equal(t, false, second)
+	})
 }

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -76,276 +76,288 @@ func setupValidAttesterSlashing(t *testing.T) (*ethpb.AttesterSlashing, state.Be
 }
 
 func TestValidateAttesterSlashing_ValidSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
+		slashing, s := setupValidAttesterSlashing(t)
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.NoError(t, err)
-	valid := res == pubsub.ValidationAccept
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.NoError(t, err)
+		valid := res == pubsub.ValidationAccept
 
-	assert.Equal(t, true, valid, "Failed Validation")
-	assert.NotNil(t, msg.ValidatorData, "Decoded message was not set on the message validator data")
+		assert.Equal(t, true, valid, "Failed Validation")
+		assert.NotNil(t, msg.ValidatorData, "Decoded message was not set on the message validator data")
+	})
 }
 
 func TestValidateAttesterSlashing_ValidOldSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
-	vals := s.Validators()
-	for _, v := range vals {
-		v.Slashed = true
-	}
-	require.NoError(t, s.SetValidators(vals))
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		slashing, s := setupValidAttesterSlashing(t)
+		vals := s.Validators()
+		for _, v := range vals {
+			v.Slashed = true
+		}
+		require.NoError(t, s.SetValidators(vals))
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.ErrorContains(t, "validators were previously slashed", err)
-	valid := res == pubsub.ValidationIgnore
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.ErrorContains(t, "validators were previously slashed", err)
+		valid := res == pubsub.ValidationIgnore
 
-	assert.Equal(t, true, valid, "Incorrect Validation")
+		assert.Equal(t, true, valid, "Incorrect Validation")
+	})
 }
 
 func TestValidateAttesterSlashing_InvalidSlashing_WithdrawableEpoch(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
-	// Set only one of the  validators as withdrawn
-	vals := s.Validators()
-	vals[1].WithdrawableEpoch = primitives.Epoch(1)
+		slashing, s := setupValidAttesterSlashing(t)
+		// Set only one of the  validators as withdrawn
+		vals := s.Validators()
+		vals[1].WithdrawableEpoch = primitives.Epoch(1)
 
-	require.NoError(t, s.SetValidators(vals))
+		require.NoError(t, s.SetValidators(vals))
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.NoError(t, err)
-	valid := res == pubsub.ValidationAccept
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.NoError(t, err)
+		valid := res == pubsub.ValidationAccept
 
-	assert.Equal(t, true, valid, "Rejected Validation")
+		assert.Equal(t, true, valid, "Rejected Validation")
 
-	// Set all validators as withdrawn.
-	vals = s.Validators()
-	for _, vv := range vals {
-		vv.WithdrawableEpoch = primitives.Epoch(1)
-	}
+		// Set all validators as withdrawn.
+		vals = s.Validators()
+		for _, vv := range vals {
+			vv.WithdrawableEpoch = primitives.Epoch(1)
+		}
 
-	require.NoError(t, s.SetValidators(vals))
-	res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.ErrorContains(t, "none of the validators are slashable", err)
-	invalid := res == pubsub.ValidationReject
+		require.NoError(t, s.SetValidators(vals))
+		res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.ErrorContains(t, "none of the validators are slashable", err)
+		invalid := res == pubsub.ValidationReject
 
-	assert.Equal(t, true, invalid, "Passed Validation")
+		assert.Equal(t, true, invalid, "Passed Validation")
+	})
 }
 
 func TestValidateAttesterSlashing_CanFilter(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	chain := &mock.ChainService{Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain:       chain,
-			clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		chain := &mock.ChainService{Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain:       chain,
+				clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	r.setAttesterSlashingIndicesSeen([]uint64{1, 2, 3, 4}, []uint64{3, 4, 5, 6})
+		r.setAttesterSlashingIndicesSeen([]uint64{1, 2, 3, 4}, []uint64{3, 4, 5, 6})
 
-	// The below attestations should be filtered hence bad signature is ok.
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
-		Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{3},
-		}),
-		Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{3},
-		}),
+		// The below attestations should be filtered hence bad signature is ok.
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
+			Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{3},
+			}),
+			Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{3},
+			}),
+		})
+		require.NoError(t, err)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		ignored := res == pubsub.ValidationIgnore
+		assert.Equal(t, true, ignored)
+
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
+			Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{4, 3},
+			}),
+			Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{3, 4},
+			}),
+		})
+		require.NoError(t, err)
+		msg = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		ignored = res == pubsub.ValidationIgnore
+		assert.Equal(t, true, ignored)
 	})
-	require.NoError(t, err)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	ignored := res == pubsub.ValidationIgnore
-	assert.Equal(t, true, ignored)
-
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
-		Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{4, 3},
-		}),
-		Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{3, 4},
-		}),
-	})
-	require.NoError(t, err)
-	msg = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	ignored = res == pubsub.ValidationIgnore
-	assert.Equal(t, true, ignored)
 }
 
 func TestValidateAttesterSlashing_ContextTimeout(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
 
-	slashing, s := setupValidAttesterSlashing(t)
-	slashing.Attestation_1.Data.Target.Epoch = 100000000
+		slashing, s := setupValidAttesterSlashing(t)
+		slashing.Attestation_1.Data.Target.Epoch = 100000000
 
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
 
-	chain := &mock.ChainService{State: s}
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       chain,
-			clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-	}
+		chain := &mock.ChainService{State: s}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       chain,
+				clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "slashing from the far distant future should have timed out and returned false")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "slashing from the far distant future should have timed out and returned false")
+	})
 }
 
 func TestValidateAttesterSlashing_Syncing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
+		slashing, s := setupValidAttesterSlashing(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       &mock.ChainService{State: s},
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       &mock.ChainService{State: s},
+				initialSync: &mockSync.Sync{IsSyncing: true},
+			},
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Passed validation")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Passed validation")
+	})
 }
 
 func TestSeenAttesterSlashingIndices(t *testing.T) {

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -76,280 +76,292 @@ func setupValidAttesterSlashing(t *testing.T) (*ethpb.AttesterSlashing, state.Be
 }
 
 func TestValidateAttesterSlashing_ValidSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
+		slashing, s := setupValidAttesterSlashing(t)
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.NoError(t, err)
-	valid := res == pubsub.ValidationAccept
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.NoError(t, err)
+		valid := res == pubsub.ValidationAccept
 
-	assert.Equal(t, true, valid, "Failed Validation")
-	assert.NotNil(t, msg.ValidatorData, "Decoded message was not set on the message validator data")
+		assert.Equal(t, true, valid, "Failed Validation")
+		assert.NotNil(t, msg.ValidatorData, "Decoded message was not set on the message validator data")
+	})
 }
 
 func TestValidateAttesterSlashing_ValidOldSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
-	vals := s.Validators()
-	for _, v := range vals {
-		v.Slashed = true
-	}
-	require.NoError(t, s.SetValidators(vals))
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		slashing, s := setupValidAttesterSlashing(t)
+		vals := s.Validators()
+		for _, v := range vals {
+			v.Slashed = true
+		}
+		require.NoError(t, s.SetValidators(vals))
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.ErrorContains(t, "validators were previously slashed", err)
-	valid := res == pubsub.ValidationIgnore
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.ErrorContains(t, "validators were previously slashed", err)
+		valid := res == pubsub.ValidationIgnore
 
-	assert.Equal(t, true, valid, "Incorrect Validation")
+		assert.Equal(t, true, valid, "Incorrect Validation")
+	})
 }
 
 func TestValidateAttesterSlashing_InvalidSlashing_WithdrawableEpoch(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
-	// Set only one of the  validators as withdrawn
-	vals := s.Validators()
-	vals[1].WithdrawableEpoch = primitives.Epoch(1)
+		slashing, s := setupValidAttesterSlashing(t)
+		// Set only one of the  validators as withdrawn
+		vals := s.Validators()
+		vals[1].WithdrawableEpoch = primitives.Epoch(1)
 
-	require.NoError(t, s.SetValidators(vals))
+		require.NoError(t, s.SetValidators(vals))
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.NoError(t, err)
-	valid := res == pubsub.ValidationAccept
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.NoError(t, err)
+		valid := res == pubsub.ValidationAccept
 
-	assert.Equal(t, true, valid, "Rejected Validation")
+		assert.Equal(t, true, valid, "Rejected Validation")
 
-	// Set all validators as withdrawn.
-	vals = s.Validators()
-	for _, vv := range vals {
-		vv.WithdrawableEpoch = primitives.Epoch(1)
-	}
+		// Set all validators as withdrawn.
+		vals = s.Validators()
+		for _, vv := range vals {
+			vv.WithdrawableEpoch = primitives.Epoch(1)
+		}
 
-	require.NoError(t, s.SetValidators(vals))
-	res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
-	assert.ErrorContains(t, "none of the validators are slashable", err)
-	invalid := res == pubsub.ValidationReject
+		require.NoError(t, s.SetValidators(vals))
+		res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
+		assert.ErrorContains(t, "none of the validators are slashable", err)
+		invalid := res == pubsub.ValidationReject
 
-	assert.Equal(t, true, invalid, "Passed Validation")
+		assert.Equal(t, true, invalid, "Passed Validation")
+	})
 }
 
 func TestValidateAttesterSlashing_CanFilter(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	chain := &mock.ChainService{Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{IsSyncing: false},
-			chain:       chain,
-			clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-		subHandler:                newSubTopicHandler(),
-	}
+		chain := &mock.ChainService{Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				initialSync: &mockSync.Sync{IsSyncing: false},
+				chain:       chain,
+				clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+			subHandler:                newSubTopicHandler(),
+		}
 
-	r.setAttesterSlashingIndicesSeen([]uint64{1, 2, 3, 4}, []uint64{3, 4, 5, 6})
+		r.setAttesterSlashingIndicesSeen([]uint64{1, 2, 3, 4}, []uint64{3, 4, 5, 6})
 
-	// The below attestations should be filtered hence bad signature is ok.
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
-		Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{3},
-		}),
-		Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{3},
-		}),
+		// The below attestations should be filtered hence bad signature is ok.
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
+			Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{3},
+			}),
+			Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{3},
+			}),
+		})
+		require.NoError(t, err)
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		ignored := res == pubsub.ValidationIgnore
+		assert.Equal(t, true, ignored)
+
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
+			Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{4, 3},
+			}),
+			Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{3, 4},
+			}),
+		})
+		require.NoError(t, err)
+		msg = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		ignored = res == pubsub.ValidationIgnore
+		assert.Equal(t, true, ignored)
 	})
-	require.NoError(t, err)
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	ignored := res == pubsub.ValidationIgnore
-	assert.Equal(t, true, ignored)
-
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
-		Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{4, 3},
-		}),
-		Attestation_2: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-			AttestingIndices: []uint64{3, 4},
-		}),
-	})
-	require.NoError(t, err)
-	msg = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err = r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	ignored = res == pubsub.ValidationIgnore
-	assert.Equal(t, true, ignored)
 }
 
 func TestValidateAttesterSlashing_ContextTimeout(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
 
-	slashing, s := setupValidAttesterSlashing(t)
-	slashing.Attestation_1.Data.Target.Epoch = 100000000
+		slashing, s := setupValidAttesterSlashing(t)
+		slashing.Attestation_1.Data.Target.Epoch = 100000000
 
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
 
-	chain := &mock.ChainService{State: s}
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       chain,
-			clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		seenAttesterSlashingCache: make(map[uint64]bool),
-	}
+		chain := &mock.ChainService{State: s}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       chain,
+				clock:       startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			seenAttesterSlashingCache: make(map[uint64]bool),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "slashing from the far distant future should have timed out and returned false")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "slashing from the far distant future should have timed out and returned false")
+	})
 }
 
 func TestValidateAttesterSlashing_Syncing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidAttesterSlashing(t)
+		slashing, s := setupValidAttesterSlashing(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       &mock.ChainService{State: s},
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       &mock.ChainService{State: s},
+				initialSync: &mockSync.Sync{IsSyncing: true},
+			},
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	msg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Passed validation")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
+		msg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateAttesterSlashing(ctx, "foobar", msg)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Passed validation")
+	})
 }
 
 func TestSeenAttesterSlashingIndices(t *testing.T) {

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -754,40 +754,42 @@ func Test_validateGloasCommitteeIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mc := &mockChain.ChainService{
-				BlockSlot:           tt.blockSlot,
-				FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
-			}
-			if tt.hasFullNode {
-				mc.ForkchoiceRoots = map[[32]byte]bool{blockRoot32: true}
-			}
-			s := &Service{
-				ctx: t.Context(),
-				cfg: &config{
-					chain:    mc,
-					p2p:      p2ptest.NewTestP2P(t),
-					beaconDB: dbtest.SetupDB(t),
-				},
-				badPayloadCache: lruwrpr.New(10),
-			}
-			if tt.hasBadPayload {
-				s.badPayloadCache.Add(string(blockRoot32[:]), true)
-			}
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				mc := &mockChain.ChainService{
+					BlockSlot:           tt.blockSlot,
+					FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
+				}
+				if tt.hasFullNode {
+					mc.ForkchoiceRoots = map[[32]byte]bool{blockRoot32: true}
+				}
+				s := &Service{
+					ctx: t.Context(),
+					cfg: &config{
+						chain:    mc,
+						p2p:      p2ptest.NewTestP2P(t),
+						beaconDB: dbtest.SetupDB(t),
+					},
+					badPayloadCache: lruwrpr.New(10),
+				}
+				if tt.hasBadPayload {
+					s.badPayloadCache.Add(string(blockRoot32[:]), true)
+				}
 
-			data := &ethpb.AttestationData{
-				Slot:            tt.attestationSlot,
-				CommitteeIndex:  tt.committeeIndex,
-				BeaconBlockRoot: blockRoot,
-			}
+				data := &ethpb.AttestationData{
+					Slot:            tt.attestationSlot,
+					CommitteeIndex:  tt.committeeIndex,
+					BeaconBlockRoot: blockRoot,
+				}
 
-			result, err := s.validateGloasCommitteeIndex(data)
+				result, err := s.validateGloasCommitteeIndex(data)
 
-			require.Equal(t, tt.wantResult, result)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, tt.wantErr, err)
-			} else {
-				require.NoError(t, err)
-			}
+				require.Equal(t, tt.wantResult, result)
+				if tt.wantErr != "" {
+					require.ErrorContains(t, tt.wantErr, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -756,40 +756,42 @@ func Test_validateGloasCommitteeIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mc := &mockChain.ChainService{
-				BlockSlot:           tt.blockSlot,
-				FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
-			}
-			if tt.hasFullNode {
-				mc.ForkchoiceRoots = map[[32]byte]bool{blockRoot32: true}
-			}
-			s := &Service{
-				ctx: t.Context(),
-				cfg: &config{
-					chain:    mc,
-					p2p:      p2ptest.NewTestP2P(t),
-					beaconDB: dbtest.SetupDB(t),
-				},
-				badPayloadCache: lruwrpr.New(10),
-			}
-			if tt.hasBadPayload {
-				s.badPayloadCache.Add(string(blockRoot32[:]), true)
-			}
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				mc := &mockChain.ChainService{
+					BlockSlot:           tt.blockSlot,
+					FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
+				}
+				if tt.hasFullNode {
+					mc.ForkchoiceRoots = map[[32]byte]bool{blockRoot32: true}
+				}
+				s := &Service{
+					ctx: t.Context(),
+					cfg: &config{
+						chain:    mc,
+						p2p:      p2ptest.NewTestP2P(t),
+						beaconDB: dbtest.SetupDB(t),
+					},
+					badPayloadCache: lruwrpr.New(10),
+				}
+				if tt.hasBadPayload {
+					s.badPayloadCache.Add(string(blockRoot32[:]), true)
+				}
 
-			data := &ethpb.AttestationData{
-				Slot:            tt.attestationSlot,
-				CommitteeIndex:  tt.committeeIndex,
-				BeaconBlockRoot: blockRoot,
-			}
+				data := &ethpb.AttestationData{
+					Slot:            tt.attestationSlot,
+					CommitteeIndex:  tt.committeeIndex,
+					BeaconBlockRoot: blockRoot,
+				}
 
-			result, err := s.validateGloasCommitteeIndex(data)
+				result, err := s.validateGloasCommitteeIndex(data)
 
-			require.Equal(t, tt.wantResult, result)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, tt.wantErr, err)
-			} else {
-				require.NoError(t, err)
-			}
+				require.Equal(t, tt.wantResult, result)
+				if tt.wantErr != "" {
+					require.ErrorContains(t, tt.wantErr, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -325,412 +325,422 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_CanRecoverStateSummary(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB: db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB: db,
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_IsInCache(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(t.Context(), copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(t.Context(), copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		InitSyncBlockRoots: map[[32]byte]bool{bRoot: true},
-		DB:                 db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			InitSyncBlockRoots: map[[32]byte]bool{bRoot: true},
+			DB:                 db,
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB: db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB: db,
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_WithLookahead(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	// The next block is only 1 epoch ahead so as to not induce a new seed.
-	blkSlot := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(coreTime.NextEpoch(copied)))
-	copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
-	require.NoError(t, err)
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = blkSlot
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		// The next block is only 1 epoch ahead so as to not induce a new seed.
+		blkSlot := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(coreTime.NextEpoch(copied)))
+		copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
+		require.NoError(t, err)
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = blkSlot
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-		subHandler:          newSubTopicHandler(),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+			subHandler:          newSubTopicHandler(),
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
-	blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
-	copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
-	require.NoError(t, err)
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = blkSlot
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
+		blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
+		copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
+		require.NoError(t, err)
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = blkSlot
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
@@ -788,61 +798,63 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 10
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 10
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
 
-	chainService := &mock.ChainService{Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			beaconDB:          db,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-		chainStarted:        &atomic.Bool{},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		chainService := &mock.ChainService{Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				beaconDB:          db,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+			chainStarted:        &atomic.Bool{},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block from the future should be ignored")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block from the future should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
@@ -909,98 +921,100 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, beaconState)
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, beaconState)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	// Create a clone of the same block (same signature, not an equivocation)
-	msgClone := util.NewBeaconBlock()
-	msgClone.Block.Slot = 1
-	msgClone.Block.ProposerIndex = proposerIdx
-	msgClone.Block.ParentRoot = bRoot[:]
-	msgClone.Signature = msg.Signature // Use the same signature
+		// Create a clone of the same block (same signature, not an equivocation)
+		msgClone := util.NewBeaconBlock()
+		msgClone.Block.Slot = 1
+		msgClone.Block.ProposerIndex = proposerIdx
+		msgClone.Block.ParentRoot = bRoot[:]
+		msgClone.Signature = msg.Signature // Use the same signature
 
-	signedBlock, err := blocks.NewSignedBeaconBlock(msg)
-	require.NoError(t, err)
+		signedBlock, err := blocks.NewSignedBeaconBlock(msg)
+		require.NoError(t, err)
 
-	slashingPool := &slashingsmock.PoolMock{}
-	chainService := &mock.ChainService{
-		Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State:   beaconState,
-		Block:   signedBlock, // Set the first block as the head block
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			slashingPool:      slashingPool,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		slashingPool := &slashingsmock.PoolMock{}
+		chainService := &mock.ChainService{
+			Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State:   beaconState,
+			Block:   signedBlock, // Set the first block as the head block
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				slashingPool:      slashingPool,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	// Mark the proposer/slot as seen
-	r.setSeenBlockIndexSlot(msg.Block.Slot, msg.Block.ProposerIndex)
+		// Mark the proposer/slot as seen
+		r.setSeenBlockIndexSlot(msg.Block.Slot, msg.Block.ProposerIndex)
 
-	// Prepare and validate the second message (clone)
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msgClone)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		// Prepare and validate the second message (clone)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msgClone)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	// Since this is not an equivocation (same signature), it should be ignored
-	// Wait for the cached value to propagate through buffers
-	require.Eventually(t, func() bool {
-		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-		return err == nil && res == pubsub.ValidationIgnore
-	}, time.Second, 10*time.Millisecond, "block with same signature should be ignored")
+		// Since this is not an equivocation (same signature), it should be ignored
+		// Wait for the cached value to propagate through buffers
+		require.Eventually(t, func() bool {
+			res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+			return err == nil && res == pubsub.ValidationIgnore
+		}, time.Second, 10*time.Millisecond, "block with same signature should be ignored")
 
-	// Verify no slashings were created
-	assert.Equal(t, 0, len(slashingPool.PendingPropSlashings), "Expected no slashings for same signature")
+		// Verify no slashings were created
+		assert.Equal(t, 0, len(slashingPool.PendingPropSlashings), "Expected no slashings for same signature")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
@@ -1086,446 +1100,456 @@ func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{
-		Genesis:      time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		NotFinalized: true,
-		State:        beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		VerifyBlkDescendantErr: errors.New("not part of finalized chain"),
-		DB:                     db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{
+			Genesis:      time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			NotFinalized: true,
+			State:        beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			VerifyBlkDescendantErr: errors.New("not part of finalized chain"),
+			DB:                     db,
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.Equal(t, pubsub.ValidationReject, res, "Wrong validation result returned")
-	require.ErrorContains(t, "not descendant of finalized checkpoint", err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.Equal(t, pubsub.ValidationReject, res, "Wrong validation result returned")
+		require.ErrorContains(t, "not descendant of finalized checkpoint", err)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InvalidParentBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = 1
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = 1
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	// Mutate Signature
-	copy(msg.Signature[:4], []byte{1, 2, 3, 4})
-	currBlockRoot, err := msg.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Mutate Signature
+		copy(msg.Signature[:4], []byte{1, 2, 3, 4})
+		currBlockRoot, err := msg.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "invalid signature", err)
-	assert.Equal(t, res, pubsub.ValidationReject, "block with invalid signature should be rejected")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "invalid signature", err)
+		assert.Equal(t, res, pubsub.ValidationReject, "block with invalid signature should be rejected")
 
-	require.NoError(t, copied.SetSlot(2))
-	proposerIdx, err = helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		require.NoError(t, copied.SetSlot(2))
+		proposerIdx, err = helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg = util.NewBeaconBlock()
-	msg.Block.Slot = 2
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.ParentRoot = currBlockRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg = util.NewBeaconBlock()
+		msg.Block.Slot = 2
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.ParentRoot = currBlockRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	m = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	chainService = &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(2*params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r.cfg.chain = chainService
-	r.cfg.clock = startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		m = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		chainService = &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(2*params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r.cfg.chain = chainService
+		r.cfg.clock = startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
 
-	res, err = r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "unknown parent for block", err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
+		res, err = r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "unknown parent for block", err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InsertValidPendingBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = 1
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = 1
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "unknown parent for block", err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
-	bRoot, err = msg.Block.HashTreeRoot()
-	assert.NoError(t, err)
-	assert.Equal(t, true, r.seenPendingBlocks[bRoot])
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "unknown parent for block", err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
+		bRoot, err = msg.Block.HashTreeRoot()
+		assert.NoError(t, err)
+		assert.Equal(t, true, r.seenPendingBlocks[bRoot])
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_RequestsUnknownParentBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		ctx := t.Context()
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	parentRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, parentRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: parentRoot[:]}))
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		parentRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, parentRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: parentRoot[:]}))
 
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = 1
-	msg.Block.ParentRoot = parentRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = 1
+		msg.Block.ParentRoot = parentRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{
-		Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State:               beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
-	}
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			beaconDB:      db,
-			p2p:           p1,
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			clock:         startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			stateGen:      stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		chainService := &mock.ChainService{
+			Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State:               beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+		}
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				beaconDB:      db,
+				p2p:           p1,
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				clock:         startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				stateGen:      stategen.New(db, doublylinkedtree.New()),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
-	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 2})
+		p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+		p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 2})
 
-	pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
-	var wg sync.WaitGroup
-	wg.Add(1)
-	var once sync.Once
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer once.Do(wg.Done)
-		var out p2ptypes.BeaconBlockByRootsReq
-		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, &out))
-		assert.DeepEqual(t, p2ptypes.BeaconBlockByRootsReq{parentRoot}, out, "Expected a by-root request for the unknown parent")
-		_, err := stream.Write([]byte{responseCodeSuccess})
-		assert.NoError(t, err)
-		_, err = p2.Encoding().EncodeWithMaxLength(stream, parentBlock)
-		assert.NoError(t, err)
-		assert.NoError(t, stream.Close())
+		pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var once sync.Once
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer once.Do(wg.Done)
+			var out p2ptypes.BeaconBlockByRootsReq
+			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, &out))
+			assert.DeepEqual(t, p2ptypes.BeaconBlockByRootsReq{parentRoot}, out, "Expected a by-root request for the unknown parent")
+			_, err := stream.Write([]byte{responseCodeSuccess})
+			assert.NoError(t, err)
+			_, err = p2.Encoding().EncodeWithMaxLength(stream, parentBlock)
+			assert.NoError(t, err)
+			assert.NoError(t, stream.Close())
+		})
+
+		buf := new(bytes.Buffer)
+		_, err = p1.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "unknown parent for block", err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive by-root request for unknown parent within 1 sec")
+		}
 	})
-
-	buf := new(bytes.Buffer)
-	_, err = p1.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "unknown parent for block", err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive by-root request for unknown parent within 1 sec")
-	}
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromBadParent(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	parentBlock.Block.ParentRoot = bytesutil.PadTo([]byte("foo"), 32)
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		parentBlock.Block.ParentRoot = bytesutil.PadTo([]byte("foo"), 32)
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
 
-	copied := beaconState.Copy()
-	// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
-	blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
-	copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
-	require.NoError(t, err)
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		copied := beaconState.Copy()
+		// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
+		blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
+		copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
+		require.NoError(t, err)
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = blkSlot
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = blkSlot
 
-	perSlot := params.BeaconConfig().SecondsPerSlot
-	// current slot time
-	slotsSinceGenesis := primitives.Slot(1000)
-	msg.Block.Slot = slotsSinceGenesis
+		perSlot := params.BeaconConfig().SecondsPerSlot
+		// current slot time
+		slotsSinceGenesis := primitives.Slot(1000)
+		msg.Block.Slot = slotsSinceGenesis
 
-	// valid block
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		// valid block
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	genesisTime := time.Now()
+		genesisTime := time.Now()
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{
-		Genesis: time.Unix(genesisTime.Unix()-int64(slotsSinceGenesis.Mul(perSlot)), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{
+			Genesis: time.Unix(genesisTime.Unix()-int64(slotsSinceGenesis.Mul(perSlot)), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	r.setBadBlock(ctx, bytesutil.ToBytes32(msg.Block.ParentRoot))
+		r.setBadBlock(ctx, bytesutil.ToBytes32(msg.Block.ParentRoot))
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.ErrorContains(t, "invalid parent", err)
-	assert.Equal(t, res, pubsub.ValidationReject)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.ErrorContains(t, "invalid parent", err)
+		assert.Equal(t, res, pubsub.ValidationReject)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestService_setBadBlock_DoesntSetWithContextErr(t *testing.T) {

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -55,265 +55,273 @@ import (
 // tests in this package.
 
 func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	badPrivKeyIdx := proposerIdx + 1 // We generate a valid signature from a wrong private key which fails to verify
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		badPrivKeyIdx := proposerIdx + 1 // We generate a valid signature from a wrong private key which fails to verify
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB:    db,
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB:    db,
+			State: beaconState,
+			Root:  bRoot[:],
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "invalid signature", err)
-	result := res == pubsub.ValidationReject
-	assert.Equal(t, true, result)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "invalid signature", err)
+		result := res == pubsub.ValidationReject
+		assert.Equal(t, true, result)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InvalidSignature_DownscoresPeer(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	attacker := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	badPrivKeyIdx := proposerIdx + 1
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		attacker := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		badPrivKeyIdx := proposerIdx + 1
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB:    db,
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB:    db,
+			State: beaconState,
+			Root:  bRoot[:],
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, attacker.PeerID(), m)
-	require.ErrorContains(t, "invalid signature", err)
-	assert.Equal(t, pubsub.ValidationReject, res)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, attacker.PeerID(), m)
+		require.ErrorContains(t, "invalid signature", err)
+		assert.Equal(t, pubsub.ValidationReject, res)
 
-	count, err := p.Peers().Scorers().BadResponsesScorer().Count(attacker.PeerID())
-	require.NoError(t, err)
-	assert.Equal(t, 1, count, "peer should be downscored on invalid signature")
+		count, err := p.Peers().Scorers().BadResponsesScorer().Count(attacker.PeerID())
+		require.NoError(t, err)
+		assert.Equal(t, 1, count, "peer should be downscored on invalid signature")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_OutOfRangeProposerIndex(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, _ := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, _ := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
 
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = 1 << 40 // out of range for the 100-validator registry
-	blockRoot, err := msg.Block.HashTreeRoot()
-	require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = 1 << 40 // out of range for the 100-validator registry
+		blockRoot, err := msg.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
-		DB:                  db,
-		State:               beaconState,
-		Root:                bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stategen.New(db, doublylinkedtree.New()),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+			DB:                  db,
+			State:               beaconState,
+			Root:                bRoot[:],
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stategen.New(db, doublylinkedtree.New()),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	digest := r.currentForkDigest()
-	topic := r.addDigestToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
-	m := &pubsub.Message{Message: &pubsubpb.Message{Data: buf.Bytes(), Topic: &topic}}
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		digest := r.currentForkDigest()
+		topic := r.addDigestToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
+		m := &pubsub.Message{Message: &pubsubpb.Message{Data: buf.Bytes(), Topic: &topic}}
 
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "invalid proposer index", err)
-	assert.Equal(t, pubsub.ValidationReject, res)
-	// rejected via gossip scoring, not the bad-block cache
-	assert.Equal(t, false, r.hasBadBlock(blockRoot))
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "invalid proposer index", err)
+		assert.Equal(t, pubsub.ValidationReject, res)
+		// rejected via gossip scoring, not the bad-block cache
+		assert.Equal(t, false, r.hasBadBlock(blockRoot))
+	})
 }
 
 func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		ctx := t.Context()
 
-	p := p2ptest.NewTestP2P(t)
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 100
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	util.SaveBlock(t, t.Context(), db, msg)
+		p := p2ptest.NewTestP2P(t)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 100
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		util.SaveBlock(t, t.Context(), db, msg)
 
-	chainService := &mock.ChainService{Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		chainService := &mock.ChainService{Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block present in DB should be ignored")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block present in DB should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_CanRecoverStateSummary(t *testing.T) {
@@ -726,55 +734,57 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
-	chainService := &mock.ChainService{
-		Genesis: time.Now(),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: true},
-			chain:             chainService,
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
+		chainService := &mock.ChainService{
+			Genesis: time.Now(),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: true},
+				chain:             chainService,
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block is ignored until fully synced")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block is ignored until fully synced")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
@@ -836,64 +846,66 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Block.Slot = 10
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Block.Slot = 10
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
 
-	genesisTime := time.Now()
-	chainService := &mock.ChainService{
-		Genesis: time.Unix(genesisTime.Unix()-1000, 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 1,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		genesisTime := time.Now()
+		chainService := &mock.ChainService{
+			Genesis: time.Unix(genesisTime.Unix()-1000, 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 1,
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "greater or equal to block slot", err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block from the past should be ignored")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "greater or equal to block slot", err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block from the past should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
@@ -992,83 +1004,85 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	parent := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, parent)
-	parentRoot, err := parent.Block.HashTreeRoot()
-	require.NoError(t, err)
-	chain := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 1,
-		},
-		ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
-	}
+		parent := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, parent)
+		parentRoot, err := parent.Block.HashTreeRoot()
+		require.NoError(t, err)
+		chain := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 1,
+			},
+			ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
+		}
 
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			blockNotifier:     chain.BlockNotifier(),
-			operationNotifier: chain.OperationNotifier(),
-			attPool:           attestations.NewPool(),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				blockNotifier:     chain.BlockNotifier(),
+				operationNotifier: chain.OperationNotifier(),
+				attPool:           attestations.NewPool(),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	b := util.NewBeaconBlock()
-	b.Block.Slot = 1
-	b.Block.ParentRoot = parentRoot[:]
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, b)
-	require.NoError(t, err)
-	digest, err := signing.ComputeForkDigest(params.BeaconConfig().GenesisForkVersion, params.BeaconConfig().GenesisValidatorsRoot[:])
-	assert.NoError(t, err)
-	topic := fmt.Sprintf(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		b := util.NewBeaconBlock()
+		b.Block.Slot = 1
+		b.Block.ParentRoot = parentRoot[:]
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, b)
+		require.NoError(t, err)
+		digest, err := signing.ComputeForkDigest(params.BeaconConfig().GenesisForkVersion, params.BeaconConfig().GenesisValidatorsRoot[:])
+		assert.NoError(t, err)
+		topic := fmt.Sprintf(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err := r.validateBeaconBlockPubSub(t.Context(), "", m)
-	_ = err
-	assert.Equal(t, pubsub.ValidationIgnore, res)
+		res, err := r.validateBeaconBlockPubSub(t.Context(), "", m)
+		_ = err
+		assert.Equal(t, pubsub.ValidationIgnore, res)
 
-	hook.Reset()
-	b.Block.Slot = params.BeaconConfig().SlotsPerEpoch
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, b)
-	require.NoError(t, err)
-	m = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		hook.Reset()
+		b.Block.Slot = params.BeaconConfig().SlotsPerEpoch
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, b)
+		require.NoError(t, err)
+		m = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err = r.validateBeaconBlockPubSub(t.Context(), "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, pubsub.ValidationIgnore, res)
+		res, err = r.validateBeaconBlockPubSub(t.Context(), "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, pubsub.ValidationIgnore, res)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
@@ -1528,361 +1542,371 @@ func TestService_setBadBlock_DoesntSetWithContextErr(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_ValidExecutionPayload(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	now := time.Now()
-	require.NoError(t, beaconState.SetGenesisTime(now))
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		now := time.Now()
+		require.NoError(t, beaconState.SetGenesisTime(now))
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(now.Unix()) + params.BeaconConfig().SecondsPerSlot
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(now.Unix()) + params.BeaconConfig().SecondsPerSlot
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: now.Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
-		ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
-		DB:             db,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
-	genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
-	BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
-	require.NoError(t, err)
-	topic = r.addDigestToTopic(topic, BellatrixDigest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	require.Equal(t, true, result)
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: now.Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
+			DB:             db,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			State: beaconState,
+			Root:  bRoot[:],
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
+		genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
+		BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
+		require.NoError(t, err)
+		topic = r.addDigestToTopic(topic, BellatrixDigest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		require.Equal(t, true, result)
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InvalidPayloadTimestamp(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	presentTime := time.Now().Unix()
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(presentTime - 600) // add an invalid timestamp
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		presentTime := time.Now().Unix()
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(presentTime - 600) // add an invalid timestamp
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		DB: db,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			DB: db,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
-	genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
-	BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, BellatrixDigest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.NotNil(t, err)
-	result := res == pubsub.ValidationReject
-	assert.Equal(t, true, result)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
+		genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
+		BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, BellatrixDigest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.NotNil(t, err)
+		result := res == pubsub.ValidationReject
+		assert.Equal(t, true, result)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func Test_validateBellatrixBeaconBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	presentTime := time.Now().Unix()
-	chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:      db,
-			p2p:           p,
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			stateGen:      stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		presentTime := time.Now().Unix()
+		chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:      db,
+				p2p:           p,
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				stateGen:      stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
 
-	st, _ := util.DeterministicGenesisStateAltair(t, 1)
-	b := util.NewBeaconBlockBellatrix()
-	blk, err := blocks.NewSignedBeaconBlock(b)
-	require.NoError(t, err)
-	require.ErrorContains(t, "block and state are not the same version", r.validateBellatrixBeaconBlock(ctx, st, blk.Block()))
+		st, _ := util.DeterministicGenesisStateAltair(t, 1)
+		b := util.NewBeaconBlockBellatrix()
+		blk, err := blocks.NewSignedBeaconBlock(b)
+		require.NoError(t, err)
+		require.ErrorContains(t, "block and state are not the same version", r.validateBellatrixBeaconBlock(ctx, st, blk.Block()))
+	})
 }
 
 func Test_validateBellatrixBeaconBlockParentValidation(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	stateGen := stategen.New(db, doublylinkedtree.New())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		stateGen := stategen.New(db, doublylinkedtree.New())
 
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	blk, err := blocks.NewSignedBeaconBlock(msg)
-	require.NoError(t, err)
+		blk, err := blocks.NewSignedBeaconBlock(msg)
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
-		OptimisticRoots: make(map[[32]byte]bool),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		}}
+		chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
+			OptimisticRoots: make(map[[32]byte]bool),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			}}
 
-	chainService.OptimisticRoots[blk.Block().ParentRoot()] = true
-	r := &Service{
-		cfg: &config{
-			beaconDB:      db,
-			p2p:           p,
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			stateGen:      stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	require.ErrorContains(t, "parent of the block is optimistic", r.validateBellatrixBeaconBlock(ctx, beaconState, blk.Block()))
+		chainService.OptimisticRoots[blk.Block().ParentRoot()] = true
+		r := &Service{
+			cfg: &config{
+				beaconDB:      db,
+				p2p:           p,
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				stateGen:      stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		require.ErrorContains(t, "parent of the block is optimistic", r.validateBellatrixBeaconBlock(ctx, beaconState, blk.Block()))
+	})
 }
 
 func Test_validateBeaconBlockProcessingWhenParentIsOptimistic(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	stateGen := stategen.New(db, doublylinkedtree.New())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		stateGen := stategen.New(db, doublylinkedtree.New())
 
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
-		ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
-		DB:             db,
-		Optimistic:     true,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
-	genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
-	BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
-	require.NoError(t, err)
-	topic = r.addDigestToTopic(topic, BellatrixDigest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
+			ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
+			DB:             db,
+			Optimistic:     true,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			State: beaconState,
+			Root:  bRoot[:],
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
+		genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
+		BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
+		require.NoError(t, err)
+		topic = r.addDigestToTopic(topic, BellatrixDigest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func Test_getBlockFields(t *testing.T) {

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -329,417 +329,427 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_CanRecoverStateSummary(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB: db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB: db,
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_IsInCache(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(t.Context(), copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(t.Context(), copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		InitSyncBlockRoots: map[[32]byte]bool{bRoot: true},
-		DB:                 db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			InitSyncBlockRoots: map[[32]byte]bool{bRoot: true},
+			DB:                 db,
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB: db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB: db,
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_WithLookahead(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	// The next block is only 1 epoch ahead so as to not induce a new seed.
-	blkSlot := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(coreTime.NextEpoch(copied)))
-	copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
-	require.NoError(t, err)
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = blkSlot
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		// The next block is only 1 epoch ahead so as to not induce a new seed.
+		blkSlot := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(coreTime.NextEpoch(copied)))
+		copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
+		require.NoError(t, err)
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = blkSlot
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-		subHandler:          newSubTopicHandler(),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+			subHandler:          newSubTopicHandler(),
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
-	blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
-	copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
-	require.NoError(t, err)
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = blkSlot
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
+		blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
+		copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
+		require.NoError(t, err)
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = blkSlot
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
-		DB:    db,
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
+			DB:    db,
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
@@ -797,62 +807,64 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 10
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 10
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
 
-	chainService := &mock.ChainService{Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			beaconDB:          db,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-		chainStarted:        &atomic.Bool{},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		chainService := &mock.ChainService{Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				beaconDB:          db,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+			chainStarted:        &atomic.Bool{},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block from the future should be ignored")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block from the future should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
@@ -920,99 +932,101 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, beaconState)
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, beaconState)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	// Create a clone of the same block (same signature, not an equivocation)
-	msgClone := util.NewBeaconBlock()
-	msgClone.Block.Slot = 1
-	msgClone.Block.ProposerIndex = proposerIdx
-	msgClone.Block.ParentRoot = bRoot[:]
-	msgClone.Signature = msg.Signature // Use the same signature
+		// Create a clone of the same block (same signature, not an equivocation)
+		msgClone := util.NewBeaconBlock()
+		msgClone.Block.Slot = 1
+		msgClone.Block.ProposerIndex = proposerIdx
+		msgClone.Block.ParentRoot = bRoot[:]
+		msgClone.Signature = msg.Signature // Use the same signature
 
-	signedBlock, err := blocks.NewSignedBeaconBlock(msg)
-	require.NoError(t, err)
+		signedBlock, err := blocks.NewSignedBeaconBlock(msg)
+		require.NoError(t, err)
 
-	slashingPool := &slashingsmock.PoolMock{}
-	chainService := &mock.ChainService{
-		Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State:   beaconState,
-		Block:   signedBlock, // Set the first block as the head block
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			slashingPool:      slashingPool,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		slashingPool := &slashingsmock.PoolMock{}
+		chainService := &mock.ChainService{
+			Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State:   beaconState,
+			Block:   signedBlock, // Set the first block as the head block
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				slashingPool:      slashingPool,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	// Mark the proposer/slot as seen
-	r.setSeenBlockIndexSlot(msg.Block.Slot, msg.Block.ProposerIndex)
+		// Mark the proposer/slot as seen
+		r.setSeenBlockIndexSlot(msg.Block.Slot, msg.Block.ProposerIndex)
 
-	// Prepare and validate the second message (clone)
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msgClone)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		// Prepare and validate the second message (clone)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msgClone)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	// Since this is not an equivocation (same signature), it should be ignored
-	// Wait for the cached value to propagate through buffers
-	require.Eventually(t, func() bool {
-		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-		return err == nil && res == pubsub.ValidationIgnore
-	}, time.Second, 10*time.Millisecond, "block with same signature should be ignored")
+		// Since this is not an equivocation (same signature), it should be ignored
+		// Wait for the cached value to propagate through buffers
+		require.Eventually(t, func() bool {
+			res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+			return err == nil && res == pubsub.ValidationIgnore
+		}, time.Second, 10*time.Millisecond, "block with same signature should be ignored")
 
-	// Verify no slashings were created
-	assert.Equal(t, 0, len(slashingPool.PendingPropSlashings), "Expected no slashings for same signature")
+		// Verify no slashings were created
+		assert.Equal(t, 0, len(slashingPool.PendingPropSlashings), "Expected no slashings for same signature")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
@@ -1098,451 +1112,461 @@ func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{
-		Genesis:      time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		NotFinalized: true,
-		State:        beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		VerifyBlkDescendantErr: errors.New("not part of finalized chain"),
-		DB:                     db,
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{
+			Genesis:      time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			NotFinalized: true,
+			State:        beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			VerifyBlkDescendantErr: errors.New("not part of finalized chain"),
+			DB:                     db,
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.Equal(t, pubsub.ValidationReject, res, "Wrong validation result returned")
-	require.ErrorContains(t, "not descendant of finalized checkpoint", err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.Equal(t, pubsub.ValidationReject, res, "Wrong validation result returned")
+		require.ErrorContains(t, "not descendant of finalized checkpoint", err)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InvalidParentBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = 1
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = 1
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	// Mutate Signature
-	copy(msg.Signature[:4], []byte{1, 2, 3, 4})
-	currBlockRoot, err := msg.Block.HashTreeRoot()
-	require.NoError(t, err)
+		// Mutate Signature
+		copy(msg.Signature[:4], []byte{1, 2, 3, 4})
+		currBlockRoot, err := msg.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "invalid signature", err)
-	assert.Equal(t, res, pubsub.ValidationReject, "block with invalid signature should be rejected")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "invalid signature", err)
+		assert.Equal(t, res, pubsub.ValidationReject, "block with invalid signature should be rejected")
 
-	require.NoError(t, copied.SetSlot(2))
-	proposerIdx, err = helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		require.NoError(t, copied.SetSlot(2))
+		proposerIdx, err = helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg = util.NewBeaconBlock()
-	msg.Block.Slot = 2
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.ParentRoot = currBlockRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg = util.NewBeaconBlock()
+		msg.Block.Slot = 2
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.ParentRoot = currBlockRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	m = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	chainService = &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(2*params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r.cfg.chain = chainService
-	r.cfg.clock = startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		m = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		chainService = &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(2*params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r.cfg.chain = chainService
+		r.cfg.clock = startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
 
-	res, err = r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "unknown parent for block", err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
+		res, err = r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "unknown parent for block", err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InsertValidPendingBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = 1
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = 1
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State: beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State: beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "unknown parent for block", err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
-	bRoot, err = msg.Block.HashTreeRoot()
-	assert.NoError(t, err)
-	assert.Equal(t, true, r.seenPendingBlocks[bRoot])
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "unknown parent for block", err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block with unknown parent should be ignored")
+		bRoot, err = msg.Block.HashTreeRoot()
+		assert.NoError(t, err)
+		assert.Equal(t, true, r.seenPendingBlocks[bRoot])
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_RequestsUnknownParentBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+		assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+		ctx := t.Context()
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	parentRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, parentRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: parentRoot[:]}))
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		parentRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, parentRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: parentRoot[:]}))
 
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = 1
-	msg.Block.ParentRoot = parentRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = 1
+		msg.Block.ParentRoot = parentRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{
-		Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		State:               beaconState,
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
-	}
-	r := &Service{
-		ctx: ctx,
-		cfg: &config{
-			beaconDB:      db,
-			p2p:           p1,
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			clock:         startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			stateGen:      stategen.New(db, doublylinkedtree.New()),
-		},
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	r.initCaches()
+		chainService := &mock.ChainService{
+			Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			State:               beaconState,
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+		}
+		r := &Service{
+			ctx: ctx,
+			cfg: &config{
+				beaconDB:      db,
+				p2p:           p1,
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				clock:         startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				stateGen:      stategen.New(db, doublylinkedtree.New()),
+			},
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		r.initCaches()
 
-	p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
-	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
-	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 2})
+		p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
+		p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+		p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{FinalizedEpoch: 2})
 
-	pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
-	var wg sync.WaitGroup
-	wg.Add(1)
-	var once sync.Once
-	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
-		defer once.Do(wg.Done)
-		var out p2ptypes.BeaconBlockByRootsReq
-		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, &out))
-		assert.DeepEqual(t, p2ptypes.BeaconBlockByRootsReq{parentRoot}, out, "Expected a by-root request for the unknown parent")
-		_, err := stream.Write([]byte{responseCodeSuccess})
-		assert.NoError(t, err)
-		_, err = p2.Encoding().EncodeWithMaxLength(stream, parentBlock)
-		assert.NoError(t, err)
-		assert.NoError(t, stream.Close())
+		pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var once sync.Once
+		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+			defer once.Do(wg.Done)
+			var out p2ptypes.BeaconBlockByRootsReq
+			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, &out))
+			assert.DeepEqual(t, p2ptypes.BeaconBlockByRootsReq{parentRoot}, out, "Expected a by-root request for the unknown parent")
+			_, err := stream.Write([]byte{responseCodeSuccess})
+			assert.NoError(t, err)
+			_, err = p2.Encoding().EncodeWithMaxLength(stream, parentBlock)
+			assert.NoError(t, err)
+			assert.NoError(t, stream.Close())
+		})
+
+		buf := new(bytes.Buffer)
+		_, err = p1.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		require.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "unknown parent for block", err)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+
+		if util.WaitTimeout(&wg, 1*time.Second) {
+			t.Fatal("Did not receive by-root request for unknown parent within 1 sec")
+		}
 	})
-
-	buf := new(bytes.Buffer)
-	_, err = p1.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "unknown parent for block", err)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-
-	if util.WaitTimeout(&wg, 1*time.Second) {
-		t.Fatal("Did not receive by-root request for unknown parent within 1 sec")
-	}
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromBadParent(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	parentBlock.Block.ParentRoot = bytesutil.PadTo([]byte("foo"), 32)
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		parentBlock.Block.ParentRoot = bytesutil.PadTo([]byte("foo"), 32)
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
 
-	copied := beaconState.Copy()
-	// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
-	blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
-	copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
-	require.NoError(t, err)
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		copied := beaconState.Copy()
+		// The next block is at least 2 epochs ahead to induce shuffling and a new seed.
+		blkSlot := params.BeaconConfig().SlotsPerEpoch * 2
+		copied, err = transition.ProcessSlots(t.Context(), copied, blkSlot)
+		require.NoError(t, err)
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlock()
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Slot = blkSlot
+		msg := util.NewBeaconBlock()
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Slot = blkSlot
 
-	perSlot := params.BeaconConfig().SecondsPerSlot
-	// current slot time
-	slotsSinceGenesis := primitives.Slot(1000)
-	msg.Block.Slot = slotsSinceGenesis
+		perSlot := params.BeaconConfig().SecondsPerSlot
+		// current slot time
+		slotsSinceGenesis := primitives.Slot(1000)
+		msg.Block.Slot = slotsSinceGenesis
 
-	// valid block
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		// valid block
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	genesisTime := time.Now()
+		genesisTime := time.Now()
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{
-		Genesis: time.Unix(genesisTime.Unix()-int64(slotsSinceGenesis.Mul(perSlot)), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{
+			Genesis: time.Unix(genesisTime.Unix()-int64(slotsSinceGenesis.Mul(perSlot)), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache:      lruwrpr.New(10),
+			badBlockCache:       lruwrpr.New(10),
+			slotToPendingBlocks: gcache.New(time.Second, 0 /* disable janitor */),
+			seenPendingBlocks:   make(map[[32]byte]bool),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	r.setBadBlock(ctx, bytesutil.ToBytes32(msg.Block.ParentRoot))
+		r.setBadBlock(ctx, bytesutil.ToBytes32(msg.Block.ParentRoot))
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.ErrorContains(t, "invalid parent", err)
-	assert.Equal(t, res, pubsub.ValidationReject)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.ErrorContains(t, "invalid parent", err)
+		assert.Equal(t, res, pubsub.ValidationReject)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestService_setBadBlock_DoesntSetWithContextErr(t *testing.T) {

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -55,269 +55,277 @@ import (
 // tests in this package.
 
 func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	badPrivKeyIdx := proposerIdx + 1 // We generate a valid signature from a wrong private key which fails to verify
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		badPrivKeyIdx := proposerIdx + 1 // We generate a valid signature from a wrong private key which fails to verify
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB:    db,
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB:    db,
+			State: beaconState,
+			Root:  bRoot[:],
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "invalid signature", err)
-	result := res == pubsub.ValidationReject
-	assert.Equal(t, true, result)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "invalid signature", err)
+		result := res == pubsub.ValidationReject
+		assert.Equal(t, true, result)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InvalidSignature_DownscoresPeer(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	attacker := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	badPrivKeyIdx := proposerIdx + 1
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		attacker := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		badPrivKeyIdx := proposerIdx + 1
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[badPrivKeyIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		DB:    db,
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			DB:    db,
+			State: beaconState,
+			Root:  bRoot[:],
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, attacker.PeerID(), m)
-	require.ErrorContains(t, "invalid signature", err)
-	assert.Equal(t, pubsub.ValidationReject, res)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, attacker.PeerID(), m)
+		require.ErrorContains(t, "invalid signature", err)
+		assert.Equal(t, pubsub.ValidationReject, res)
 
-	count, err := p.Peers().Scorers().BadResponsesScorer().Count(attacker.PeerID())
-	require.NoError(t, err)
-	assert.Equal(t, 1, count, "peer should be downscored on invalid signature")
+		count, err := p.Peers().Scorers().BadResponsesScorer().Count(attacker.PeerID())
+		require.NoError(t, err)
+		assert.Equal(t, 1, count, "peer should be downscored on invalid signature")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_OutOfRangeProposerIndex(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, _ := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, _ := util.DeterministicGenesisState(t, 100)
+		parentBlock := util.NewBeaconBlock()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
 
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = 1 << 40 // out of range for the 100-validator registry
-	blockRoot, err := msg.Block.HashTreeRoot()
-	require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = 1 << 40 // out of range for the 100-validator registry
+		blockRoot, err := msg.Block.HashTreeRoot()
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
-		DB:                  db,
-		State:               beaconState,
-		Root:                bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stategen.New(db, doublylinkedtree.New()),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+			DB:                  db,
+			State:               beaconState,
+			Root:                bRoot[:],
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stategen.New(db, doublylinkedtree.New()),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
-	topic := r.addDigestToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
-	m := &pubsub.Message{Message: &pubsubpb.Message{Data: buf.Bytes(), Topic: &topic}}
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		digest, err := r.currentForkDigest()
+		require.NoError(t, err)
+		topic := r.addDigestToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
+		m := &pubsub.Message{Message: &pubsubpb.Message{Data: buf.Bytes(), Topic: &topic}}
 
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "invalid proposer index", err)
-	assert.Equal(t, pubsub.ValidationReject, res)
-	// rejected via gossip scoring, not the bad-block cache
-	assert.Equal(t, false, r.hasBadBlock(blockRoot))
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "invalid proposer index", err)
+		assert.Equal(t, pubsub.ValidationReject, res)
+		// rejected via gossip scoring, not the bad-block cache
+		assert.Equal(t, false, r.hasBadBlock(blockRoot))
+	})
 }
 
 func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		ctx := t.Context()
 
-	p := p2ptest.NewTestP2P(t)
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 100
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	util.SaveBlock(t, t.Context(), db, msg)
+		p := p2ptest.NewTestP2P(t)
+		msg := util.NewBeaconBlock()
+		msg.Block.Slot = 100
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		util.SaveBlock(t, t.Context(), db, msg)
 
-	chainService := &mock.ChainService{Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		chainService := &mock.ChainService{Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block present in DB should be ignored")
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block present in DB should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_CanRecoverStateSummary(t *testing.T) {
@@ -735,55 +743,57 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
-	chainService := &mock.ChainService{
-		Genesis: time.Now(),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: true},
-			chain:             chainService,
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
+		chainService := &mock.ChainService{
+			Genesis: time.Now(),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: true},
+				chain:             chainService,
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block is ignored until fully synced")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block is ignored until fully synced")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
@@ -846,65 +856,67 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	b := []byte("sk")
-	b32 := bytesutil.ToBytes32(b)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	sk, err := bls.SecretKeyFromBytes(b32[:])
-	require.NoError(t, err)
-	msg := util.NewBeaconBlock()
-	msg.Block.ParentRoot = util.Random32Bytes(t)
-	msg.Block.Slot = 10
-	msg.Signature = sk.Sign([]byte("data")).Marshal()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		b := []byte("sk")
+		b32 := bytesutil.ToBytes32(b)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		sk, err := bls.SecretKeyFromBytes(b32[:])
+		require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		msg.Block.ParentRoot = util.Random32Bytes(t)
+		msg.Block.Slot = 10
+		msg.Signature = sk.Sign([]byte("data")).Marshal()
 
-	genesisTime := time.Now()
-	chainService := &mock.ChainService{
-		Genesis: time.Unix(genesisTime.Unix()-1000, 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 1,
-		},
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		genesisTime := time.Now()
+		chainService := &mock.ChainService{
+			Genesis: time.Unix(genesisTime.Unix()-1000, 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 1,
+			},
+		}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "greater or equal to block slot", err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "block from the past should be ignored")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
+		digest, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.ErrorContains(t, "greater or equal to block slot", err)
+		assert.Equal(t, res, pubsub.ValidationIgnore, "block from the past should be ignored")
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
@@ -1004,83 +1016,85 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		hook := logTest.NewGlobal()
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
 
-	parent := util.NewBeaconBlock()
-	util.SaveBlock(t, t.Context(), db, parent)
-	parentRoot, err := parent.Block.HashTreeRoot()
-	require.NoError(t, err)
-	chain := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 1,
-		},
-		ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
-	}
+		parent := util.NewBeaconBlock()
+		util.SaveBlock(t, t.Context(), db, parent)
+		parentRoot, err := parent.Block.HashTreeRoot()
+		require.NoError(t, err)
+		chain := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 1,
+			},
+			ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
+		}
 
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			blockNotifier:     chain.BlockNotifier(),
-			operationNotifier: chain.OperationNotifier(),
-			attPool:           attestations.NewPool(),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				blockNotifier:     chain.BlockNotifier(),
+				operationNotifier: chain.OperationNotifier(),
+				attPool:           attestations.NewPool(),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	b := util.NewBeaconBlock()
-	b.Block.Slot = 1
-	b.Block.ParentRoot = parentRoot[:]
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, b)
-	require.NoError(t, err)
-	digest, err := signing.ComputeForkDigest(params.BeaconConfig().GenesisForkVersion, params.BeaconConfig().GenesisValidatorsRoot[:])
-	assert.NoError(t, err)
-	topic := fmt.Sprintf(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		b := util.NewBeaconBlock()
+		b.Block.Slot = 1
+		b.Block.ParentRoot = parentRoot[:]
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, b)
+		require.NoError(t, err)
+		digest, err := signing.ComputeForkDigest(params.BeaconConfig().GenesisForkVersion, params.BeaconConfig().GenesisValidatorsRoot[:])
+		assert.NoError(t, err)
+		topic := fmt.Sprintf(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err := r.validateBeaconBlockPubSub(t.Context(), "", m)
-	_ = err
-	assert.Equal(t, pubsub.ValidationIgnore, res)
+		res, err := r.validateBeaconBlockPubSub(t.Context(), "", m)
+		_ = err
+		assert.Equal(t, pubsub.ValidationIgnore, res)
 
-	hook.Reset()
-	b.Block.Slot = params.BeaconConfig().SlotsPerEpoch
-	buf = new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, b)
-	require.NoError(t, err)
-	m = &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		hook.Reset()
+		b.Block.Slot = params.BeaconConfig().SlotsPerEpoch
+		buf = new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, b)
+		require.NoError(t, err)
+		m = &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err = r.validateBeaconBlockPubSub(t.Context(), "", m)
-	assert.NoError(t, err)
-	assert.Equal(t, pubsub.ValidationIgnore, res)
+		res, err = r.validateBeaconBlockPubSub(t.Context(), "", m)
+		assert.NoError(t, err)
+		assert.Equal(t, pubsub.ValidationIgnore, res)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
@@ -1545,361 +1559,371 @@ func TestService_setBadBlock_DoesntSetWithContextErr(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_ValidExecutionPayload(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	now := time.Now()
-	require.NoError(t, beaconState.SetGenesisTime(now))
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		now := time.Now()
+		require.NoError(t, beaconState.SetGenesisTime(now))
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(now.Unix()) + params.BeaconConfig().SecondsPerSlot
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(now.Unix()) + params.BeaconConfig().SecondsPerSlot
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: now.Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
-		ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
-		DB:             db,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
-	genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
-	BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
-	require.NoError(t, err)
-	topic = r.addDigestToTopic(topic, BellatrixDigest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	require.Equal(t, true, result)
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: now.Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
+			DB:             db,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			State: beaconState,
+			Root:  bRoot[:],
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
+		genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
+		BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
+		require.NoError(t, err)
+		topic = r.addDigestToTopic(topic, BellatrixDigest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		require.Equal(t, true, result)
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func TestValidateBeaconBlockPubSub_InvalidPayloadTimestamp(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	presentTime := time.Now().Unix()
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(presentTime - 600) // add an invalid timestamp
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		presentTime := time.Now().Unix()
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(presentTime - 600) // add an invalid timestamp
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		DB: db,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			DB: db,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
-	genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
-	BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, BellatrixDigest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.NotNil(t, err)
-	result := res == pubsub.ValidationReject
-	assert.Equal(t, true, result)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
+		genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
+		BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, BellatrixDigest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.NotNil(t, err)
+		result := res == pubsub.ValidationReject
+		assert.Equal(t, true, result)
 
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
+		select {
+		case event := <-opChannel:
+			assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+	})
 }
 
 func Test_validateBellatrixBeaconBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	presentTime := time.Now().Unix()
-	chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		}}
-	r := &Service{
-		cfg: &config{
-			beaconDB:      db,
-			p2p:           p,
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			stateGen:      stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		presentTime := time.Now().Unix()
+		chainService := &mock.ChainService{Genesis: time.Unix(presentTime-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			}}
+		r := &Service{
+			cfg: &config{
+				beaconDB:      db,
+				p2p:           p,
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				stateGen:      stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
 
-	st, _ := util.DeterministicGenesisStateAltair(t, 1)
-	b := util.NewBeaconBlockBellatrix()
-	blk, err := blocks.NewSignedBeaconBlock(b)
-	require.NoError(t, err)
-	require.ErrorContains(t, "block and state are not the same version", r.validateBellatrixBeaconBlock(ctx, st, blk.Block()))
+		st, _ := util.DeterministicGenesisStateAltair(t, 1)
+		b := util.NewBeaconBlockBellatrix()
+		blk, err := blocks.NewSignedBeaconBlock(b)
+		require.NoError(t, err)
+		require.ErrorContains(t, "block and state are not the same version", r.validateBellatrixBeaconBlock(ctx, st, blk.Block()))
+	})
 }
 
 func Test_validateBellatrixBeaconBlockParentValidation(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	stateGen := stategen.New(db, doublylinkedtree.New())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		stateGen := stategen.New(db, doublylinkedtree.New())
 
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	blk, err := blocks.NewSignedBeaconBlock(msg)
-	require.NoError(t, err)
+		blk, err := blocks.NewSignedBeaconBlock(msg)
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
-		OptimisticRoots: make(map[[32]byte]bool),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		}}
+		chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
+			OptimisticRoots: make(map[[32]byte]bool),
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			}}
 
-	chainService.OptimisticRoots[blk.Block().ParentRoot()] = true
-	r := &Service{
-		cfg: &config{
-			beaconDB:      db,
-			p2p:           p,
-			initialSync:   &mockSync.Sync{IsSyncing: false},
-			chain:         chainService,
-			blockNotifier: chainService.BlockNotifier(),
-			stateGen:      stateGen,
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	require.ErrorContains(t, "parent of the block is optimistic", r.validateBellatrixBeaconBlock(ctx, beaconState, blk.Block()))
+		chainService.OptimisticRoots[blk.Block().ParentRoot()] = true
+		r := &Service{
+			cfg: &config{
+				beaconDB:      db,
+				p2p:           p,
+				initialSync:   &mockSync.Sync{IsSyncing: false},
+				chain:         chainService,
+				blockNotifier: chainService.BlockNotifier(),
+				stateGen:      stateGen,
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		require.ErrorContains(t, "parent of the block is optimistic", r.validateBellatrixBeaconBlock(ctx, beaconState, blk.Block()))
+	})
 }
 
 func Test_validateBeaconBlockProcessingWhenParentIsOptimistic(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-	stateGen := stategen.New(db, doublylinkedtree.New())
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		db := dbtest.SetupDB(t)
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
+		stateGen := stategen.New(db, doublylinkedtree.New())
 
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	parentBlock := util.NewBeaconBlockBellatrix()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
+		beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
+		parentBlock := util.NewBeaconBlockBellatrix()
+		util.SaveBlock(t, ctx, db, parentBlock)
+		bRoot, err := parentBlock.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+		require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
+		copied := beaconState.Copy()
+		require.NoError(t, copied.SetSlot(1))
+		proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
+		require.NoError(t, err)
 
-	msg := util.NewBeaconBlockBellatrix()
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.Slot = 1
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
-	msg.Block.Body.ExecutionPayload.GasUsed = 10
-	msg.Block.Body.ExecutionPayload.GasLimit = 11
-	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
-	msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
-	msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
+		msg := util.NewBeaconBlockBellatrix()
+		msg.Block.ParentRoot = bRoot[:]
+		msg.Block.Slot = 1
+		msg.Block.ProposerIndex = proposerIdx
+		msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
+		msg.Block.Body.ExecutionPayload.GasUsed = 10
+		msg.Block.Body.ExecutionPayload.GasLimit = 11
+		msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
+		msg.Block.Body.ExecutionPayload.ParentHash = bytesutil.PadTo([]byte("parentHash"), 32)
+		msg.Block.Body.ExecutionPayload.Transactions = append(msg.Block.Body.ExecutionPayload.Transactions, []byte("transaction 1"), []byte("transaction 2"))
+		msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
+		require.NoError(t, err)
 
-	chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
-		ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
-		DB:             db,
-		Optimistic:     true,
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		State: beaconState,
-		Root:  bRoot[:],
-	}
-	r := &Service{
-		cfg: &config{
-			beaconDB:          db,
-			p2p:               p,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-		},
-		seenBlockCache: lruwrpr.New(10),
-		badBlockCache:  lruwrpr.New(10),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
-	genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
-	BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
-	require.NoError(t, err)
-	topic = r.addDigestToTopic(topic, BellatrixDigest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.NoError(t, err)
-	result := res == pubsub.ValidationAccept
-	assert.Equal(t, true, result)
-
-	blockGossipFound := false
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.BlockGossipReceived {
-			blockGossipFound = true
+		chainService := &mock.ChainService{Genesis: beaconState.GenesisTime(),
+			ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
+			DB:             db,
+			Optimistic:     true,
+			FinalizedCheckPoint: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  make([]byte, 32),
+			},
+			State: beaconState,
+			Root:  bRoot[:],
 		}
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-	assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+		r := &Service{
+			cfg: &config{
+				beaconDB:          db,
+				p2p:               p,
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				chain:             chainService,
+				blockNotifier:     chainService.BlockNotifier(),
+				operationNotifier: chainService.OperationNotifier(),
+				stateGen:          stateGen,
+				clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+			},
+			seenBlockCache: lruwrpr.New(10),
+			badBlockCache:  lruwrpr.New(10),
+		}
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlockBellatrix]()]
+		genesisValidatorsRoot := r.cfg.clock.GenesisValidatorsRoot()
+		BellatrixDigest, err := signing.ComputeForkDigest(params.BeaconConfig().BellatrixForkVersion, genesisValidatorsRoot[:])
+		require.NoError(t, err)
+		topic = r.addDigestToTopic(topic, BellatrixDigest)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		res, err := r.validateBeaconBlockPubSub(ctx, "", m)
+		require.NoError(t, err)
+		result := res == pubsub.ValidationAccept
+		assert.Equal(t, true, result)
+
+		blockGossipFound := false
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.BlockGossipReceived {
+				blockGossipFound = true
+			}
+		default:
+			// this case is needed, otherwise the test will never finish
+		}
+		assert.Equal(t, true, blockGossipFound, "BlockGossipReceived event should be sent")
+	})
 }
 
 func Test_getBlockFields(t *testing.T) {

--- a/beacon-chain/sync/validate_blob_test.go
+++ b/beacon-chain/sync/validate_blob_test.go
@@ -27,143 +27,155 @@ import (
 )
 
 func TestValidateBlob_FromSelf(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p}}
-	result, err := s.validateBlob(ctx, s.cfg.p2p.PeerID(), nil)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationAccept)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p}}
+		result, err := s.validateBlob(ctx, s.cfg.p2p.PeerID(), nil)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationAccept)
+	})
 }
 
 func TestValidateBlob_InitSync(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{IsSyncing: true}}}
-	result, err := s.validateBlob(ctx, "", nil)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationIgnore)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{IsSyncing: true}}}
+		result, err := s.validateBlob(ctx, "", nil)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationIgnore)
+	})
 }
 
 func TestValidateBlob_InvalidTopic(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{},
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{},
+		})
+		require.ErrorIs(t, p2p.ErrInvalidTopic, err)
+		require.Equal(t, result, pubsub.ValidationReject)
 	})
-	require.ErrorIs(t, p2p.ErrInvalidTopic, err)
-	require.Equal(t, result, pubsub.ValidationReject)
 }
 
 func TestValidateBlob_InvalidMessageType(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-	s.newBlobVerifier = testNewBlobVerifier()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+		s.newBlobVerifier = testNewBlobVerifier()
 
-	msg := util.NewBeaconBlock()
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.SignedBeaconBlock]()]
-	digest := s.currentForkDigest()
-	topic = s.addDigestToTopic(topic, digest)
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.ErrorIs(t, errWrongMessage, err)
-	require.Equal(t, result, pubsub.ValidationReject)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.SignedBeaconBlock]()]
+		digest := s.currentForkDigest()
+		topic = s.addDigestToTopic(topic, digest)
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.ErrorIs(t, errWrongMessage, err)
+		require.Equal(t, result, pubsub.ValidationReject)
+	})
 }
 
 func TestValidateBlob_AlreadySeenInCache(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Now(), FinalizedCheckPoint: &eth.Checkpoint{}, DB: db}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	s := &Service{
-		seenBlobCache: lruwrpr.New(10),
-		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{},
-			chain:       chainService,
-			stateGen:    stateGen,
-			clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-	s.newBlobVerifier = testNewBlobVerifier()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Now(), FinalizedCheckPoint: &eth.Checkpoint{}, DB: db}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		s := &Service{
+			seenBlobCache: lruwrpr.New(10),
+			cfg: &config{
+				p2p:         p,
+				initialSync: &mockSync.Sync{},
+				chain:       chainService,
+				stateGen:    stateGen,
+				clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+		s.newBlobVerifier = testNewBlobVerifier()
 
-	beaconState, _ := util.DeterministicGenesisState(t, 100)
+		beaconState, _ := util.DeterministicGenesisState(t, 100)
 
-	parent := util.NewBeaconBlock()
-	parentBb, err := blocks.NewSignedBeaconBlock(parent)
-	require.NoError(t, err)
-	parentRoot, err := parentBb.Block().HashTreeRoot()
-	require.NoError(t, err)
+		parent := util.NewBeaconBlock()
+		parentBb, err := blocks.NewSignedBeaconBlock(parent)
+		require.NoError(t, err)
+		parentRoot, err := parentBb.Block().HashTreeRoot()
+		require.NoError(t, err)
 
-	bb := util.NewBeaconBlock()
-	bb.Block.Slot = 1
-	bb.Block.ParentRoot = parentRoot[:]
-	bb.Block.ProposerIndex = 19026
-	signedBb, err := blocks.NewSignedBeaconBlock(bb)
-	require.NoError(t, err)
+		bb := util.NewBeaconBlock()
+		bb.Block.Slot = 1
+		bb.Block.ParentRoot = parentRoot[:]
+		bb.Block.ProposerIndex = 19026
+		signedBb, err := blocks.NewSignedBeaconBlock(bb)
+		require.NoError(t, err)
 
-	require.NoError(t, db.SaveBlock(ctx, parentBb))
-	require.NoError(t, db.SaveBlock(ctx, signedBb))
-	r, err := signedBb.Block().HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, r))
+		require.NoError(t, db.SaveBlock(ctx, parentBb))
+		require.NoError(t, db.SaveBlock(ctx, signedBb))
+		r, err := signedBb.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, r))
 
-	header, err := signedBb.Header()
-	require.NoError(t, err)
-	sc := util.GenerateTestDenebBlobSidecar(t, r, header, 0, make([]byte, 48), make([][]byte, 0))
-	b := sc.BlobSidecar
+		header, err := signedBb.Header()
+		require.NoError(t, err)
+		sc := util.GenerateTestDenebBlobSidecar(t, r, header, 0, make([]byte, 48), make([][]byte, 0))
+		b := sc.BlobSidecar
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, b)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, b)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-	digest := s.currentForkDigest()
-	topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
+		digest := s.currentForkDigest()
+		topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
 
-	s.setSeenBlobIndex(sc.Slot(), sc.SignedBlockHeader.Header.ProposerIndex, 0)
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationIgnore)
+		s.setSeenBlobIndex(sc.Slot(), sc.SignedBlockHeader.Header.ProposerIndex, 0)
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationIgnore)
+	})
 }
 
 func TestValidateBlob_InvalidTopicIndex(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, params.BeaconConfig().GenesisValidatorsRoot)}}
-	s.newBlobVerifier = testNewBlobVerifier()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, params.BeaconConfig().GenesisValidatorsRoot)}}
+		s.newBlobVerifier = testNewBlobVerifier()
 
-	_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
-	msg := scs[0].BlobSidecar
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
+		msg := scs[0].BlobSidecar
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-	digest := s.currentForkDigest()
-	topic = s.addDigestAndIndexToTopic(topic, digest, 1) + p.Encoding().ProtocolSuffix()
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.ErrorContains(t, "blob_sidecar_1", err)
-	require.Equal(t, result, pubsub.ValidationReject)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
+		digest := s.currentForkDigest()
+		topic = s.addDigestAndIndexToTopic(topic, digest, 1) + p.Encoding().ProtocolSuffix()
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.ErrorContains(t, "blob_sidecar_1", err)
+		require.Equal(t, result, pubsub.ValidationReject)
+	})
 }
 
 func TestValidateBlob_ErrorPathsWithMock(t *testing.T) {
@@ -253,31 +265,33 @@ func TestValidateBlob_ErrorPathsWithMock(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.error.Error(), func(t *testing.T) {
-			ctx := t.Context()
-			p := p2ptest.NewTestP2P(t)
-			chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-			s := &Service{
-				seenBlobCache:     lruwrpr.New(10),
-				seenPendingBlocks: make(map[[32]byte]bool),
-				cfg:               &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-			s.newBlobVerifier = tt.verifier
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				ctx := t.Context()
+				p := p2ptest.NewTestP2P(t)
+				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+				s := &Service{
+					seenBlobCache:     lruwrpr.New(10),
+					seenPendingBlocks: make(map[[32]byte]bool),
+					cfg:               &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+				s.newBlobVerifier = tt.verifier
 
-			_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
-			msg := scs[0].BlobSidecar
-			buf := new(bytes.Buffer)
-			_, err := p.Encoding().EncodeGossip(buf, msg)
-			require.NoError(t, err)
+				_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
+				msg := scs[0].BlobSidecar
+				buf := new(bytes.Buffer)
+				_, err := p.Encoding().EncodeGossip(buf, msg)
+				require.NoError(t, err)
 
-			topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-			digest := s.currentForkDigest()
-			topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
-			result, err := s.validateBlob(ctx, "", &pubsub.Message{
-				Message: &pb.Message{
-					Data:  buf.Bytes(),
-					Topic: &topic,
-				}})
-			require.ErrorContains(t, tt.error.Error(), err)
-			require.Equal(t, result, tt.result)
+				topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
+				digest := s.currentForkDigest()
+				topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
+				result, err := s.validateBlob(ctx, "", &pubsub.Message{
+					Message: &pb.Message{
+						Data:  buf.Bytes(),
+						Topic: &topic,
+					}})
+				require.ErrorContains(t, tt.error.Error(), err)
+				require.Equal(t, result, tt.result)
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/validate_blob_test.go
+++ b/beacon-chain/sync/validate_blob_test.go
@@ -27,146 +27,158 @@ import (
 )
 
 func TestValidateBlob_FromSelf(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p}}
-	result, err := s.validateBlob(ctx, s.cfg.p2p.PeerID(), nil)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationAccept)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p}}
+		result, err := s.validateBlob(ctx, s.cfg.p2p.PeerID(), nil)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationAccept)
+	})
 }
 
 func TestValidateBlob_InitSync(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{IsSyncing: true}}}
-	result, err := s.validateBlob(ctx, "", nil)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationIgnore)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{IsSyncing: true}}}
+		result, err := s.validateBlob(ctx, "", nil)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationIgnore)
+	})
 }
 
 func TestValidateBlob_InvalidTopic(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{},
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{},
+		})
+		require.ErrorIs(t, p2p.ErrInvalidTopic, err)
+		require.Equal(t, result, pubsub.ValidationReject)
 	})
-	require.ErrorIs(t, p2p.ErrInvalidTopic, err)
-	require.Equal(t, result, pubsub.ValidationReject)
 }
 
 func TestValidateBlob_InvalidMessageType(t *testing.T) {
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-	s.newBlobVerifier = testNewBlobVerifier()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+		s.newBlobVerifier = testNewBlobVerifier()
 
-	msg := util.NewBeaconBlock()
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		msg := util.NewBeaconBlock()
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.SignedBeaconBlock]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
-	topic = s.addDigestToTopic(topic, digest)
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.ErrorIs(t, errWrongMessage, err)
-	require.Equal(t, result, pubsub.ValidationReject)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.SignedBeaconBlock]()]
+		digest, err := s.currentForkDigest()
+		require.NoError(t, err)
+		topic = s.addDigestToTopic(topic, digest)
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.ErrorIs(t, errWrongMessage, err)
+		require.Equal(t, result, pubsub.ValidationReject)
+	})
 }
 
 func TestValidateBlob_AlreadySeenInCache(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Now(), FinalizedCheckPoint: &eth.Checkpoint{}, DB: db}
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	s := &Service{
-		seenBlobCache: lruwrpr.New(10),
-		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{},
-			chain:       chainService,
-			stateGen:    stateGen,
-			clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-	s.newBlobVerifier = testNewBlobVerifier()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		db := dbtest.SetupDB(t)
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Now(), FinalizedCheckPoint: &eth.Checkpoint{}, DB: db}
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		s := &Service{
+			seenBlobCache: lruwrpr.New(10),
+			cfg: &config{
+				p2p:         p,
+				initialSync: &mockSync.Sync{},
+				chain:       chainService,
+				stateGen:    stateGen,
+				clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+		s.newBlobVerifier = testNewBlobVerifier()
 
-	beaconState, _ := util.DeterministicGenesisState(t, 100)
+		beaconState, _ := util.DeterministicGenesisState(t, 100)
 
-	parent := util.NewBeaconBlock()
-	parentBb, err := blocks.NewSignedBeaconBlock(parent)
-	require.NoError(t, err)
-	parentRoot, err := parentBb.Block().HashTreeRoot()
-	require.NoError(t, err)
+		parent := util.NewBeaconBlock()
+		parentBb, err := blocks.NewSignedBeaconBlock(parent)
+		require.NoError(t, err)
+		parentRoot, err := parentBb.Block().HashTreeRoot()
+		require.NoError(t, err)
 
-	bb := util.NewBeaconBlock()
-	bb.Block.Slot = 1
-	bb.Block.ParentRoot = parentRoot[:]
-	bb.Block.ProposerIndex = 19026
-	signedBb, err := blocks.NewSignedBeaconBlock(bb)
-	require.NoError(t, err)
+		bb := util.NewBeaconBlock()
+		bb.Block.Slot = 1
+		bb.Block.ParentRoot = parentRoot[:]
+		bb.Block.ProposerIndex = 19026
+		signedBb, err := blocks.NewSignedBeaconBlock(bb)
+		require.NoError(t, err)
 
-	require.NoError(t, db.SaveBlock(ctx, parentBb))
-	require.NoError(t, db.SaveBlock(ctx, signedBb))
-	r, err := signedBb.Block().HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, r))
+		require.NoError(t, db.SaveBlock(ctx, parentBb))
+		require.NoError(t, db.SaveBlock(ctx, signedBb))
+		r, err := signedBb.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, db.SaveState(ctx, beaconState, r))
 
-	header, err := signedBb.Header()
-	require.NoError(t, err)
-	sc := util.GenerateTestDenebBlobSidecar(t, r, header, 0, make([]byte, 48), make([][]byte, 0))
-	b := sc.BlobSidecar
+		header, err := signedBb.Header()
+		require.NoError(t, err)
+		sc := util.GenerateTestDenebBlobSidecar(t, r, header, 0, make([]byte, 48), make([][]byte, 0))
+		b := sc.BlobSidecar
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, b)
-	require.NoError(t, err)
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, b)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
-	topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
+		digest, err := s.currentForkDigest()
+		require.NoError(t, err)
+		topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
 
-	s.setSeenBlobIndex(sc.Slot(), sc.SignedBlockHeader.Header.ProposerIndex, 0)
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationIgnore)
+		s.setSeenBlobIndex(sc.Slot(), sc.SignedBlockHeader.Header.ProposerIndex, 0)
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationIgnore)
+	})
 }
 
 func TestValidateBlob_InvalidTopicIndex(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, params.BeaconConfig().GenesisValidatorsRoot)}}
-	s.newBlobVerifier = testNewBlobVerifier()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		params.BeaconConfig().InitializeForkSchedule()
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, params.BeaconConfig().GenesisValidatorsRoot)}}
+		s.newBlobVerifier = testNewBlobVerifier()
 
-	_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
-	msg := scs[0].BlobSidecar
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
+		msg := scs[0].BlobSidecar
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
-	topic = s.addDigestAndIndexToTopic(topic, digest, 1) + p.Encoding().ProtocolSuffix()
-	result, err := s.validateBlob(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.ErrorContains(t, "blob_sidecar_1", err)
-	require.Equal(t, result, pubsub.ValidationReject)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
+		digest, err := s.currentForkDigest()
+		require.NoError(t, err)
+		topic = s.addDigestAndIndexToTopic(topic, digest, 1) + p.Encoding().ProtocolSuffix()
+		result, err := s.validateBlob(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.ErrorContains(t, "blob_sidecar_1", err)
+		require.Equal(t, result, pubsub.ValidationReject)
+	})
 }
 
 func TestValidateBlob_ErrorPathsWithMock(t *testing.T) {
@@ -256,32 +268,34 @@ func TestValidateBlob_ErrorPathsWithMock(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.error.Error(), func(t *testing.T) {
-			ctx := t.Context()
-			p := p2ptest.NewTestP2P(t)
-			chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-			s := &Service{
-				seenBlobCache:     lruwrpr.New(10),
-				seenPendingBlocks: make(map[[32]byte]bool),
-				cfg:               &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-			s.newBlobVerifier = tt.verifier
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				ctx := t.Context()
+				p := p2ptest.NewTestP2P(t)
+				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+				s := &Service{
+					seenBlobCache:     lruwrpr.New(10),
+					seenPendingBlocks: make(map[[32]byte]bool),
+					cfg:               &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+				s.newBlobVerifier = tt.verifier
 
-			_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
-			msg := scs[0].BlobSidecar
-			buf := new(bytes.Buffer)
-			_, err := p.Encoding().EncodeGossip(buf, msg)
-			require.NoError(t, err)
+				_, scs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, chainService.CurrentSlot()+1, 1)
+				msg := scs[0].BlobSidecar
+				buf := new(bytes.Buffer)
+				_, err := p.Encoding().EncodeGossip(buf, msg)
+				require.NoError(t, err)
 
-			topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-			digest, err := s.currentForkDigest()
-			require.NoError(t, err)
-			topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
-			result, err := s.validateBlob(ctx, "", &pubsub.Message{
-				Message: &pb.Message{
-					Data:  buf.Bytes(),
-					Topic: &topic,
-				}})
-			require.ErrorContains(t, tt.error.Error(), err)
-			require.Equal(t, result, tt.result)
+				topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
+				digest, err := s.currentForkDigest()
+				require.NoError(t, err)
+				topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
+				result, err := s.validateBlob(ctx, "", &pubsub.Message{
+					Message: &pb.Message{
+						Data:  buf.Bytes(),
+						Topic: &topic,
+					}})
+				require.ErrorContains(t, tt.error.Error(), err)
+				require.Equal(t, result, tt.result)
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -331,10 +331,14 @@ type dataColumnLogEntry struct {
 
 func (s *Service) processDataColumnLogs() {
 	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
 	slotStats := make(map[[fieldparams.RootLength]byte][]dataColumnLogEntry)
 
 	for {
 		select {
+		case <-s.ctx.Done():
+			return
 		case col := <-s.dataColumnLogCh:
 			cols := slotStats[col.root]
 			cols = append(cols, col)

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -341,25 +341,7 @@ func (s *Service) processPendingGloasColumnsRoutine() {
 	}
 }
 
-// prunePendingGloasColumns removes stale entries every slot.
-func (s *Service) prunePendingGloasColumns() {
-	clock, err := s.clockWaiter.WaitForClock(s.ctx)
-	if err != nil {
-		log.WithError(err).Error("Failed to receive clock for pending Gloas columns pruning routine")
-		return
-	}
-	slotTicker := slots.NewSlotTicker(clock.GenesisTime(), params.BeaconConfig().SlotDuration())
-	defer slotTicker.Done()
-	for {
-		select {
-		case currentSlot := <-slotTicker.C():
-			s.pruneStaleGloasColumns(currentSlot)
-		case <-s.ctx.Done():
-			return
-		}
-	}
-}
-
+// pruneStaleGloasColumns drops entries whose slot has passed.
 func (s *Service) pruneStaleGloasColumns(currentSlot primitives.Slot) {
 	s.pendingGloasColumnsLock.Lock()
 	defer s.pendingGloasColumnsLock.Unlock()

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -297,163 +297,14 @@ func TestPendingGloasColumns(t *testing.T) {
 	clock := startup.NewClock(time.Now(), [32]byte{})
 
 	t.Run("queue and retrieve", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xaa}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           5,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, true, s.hasPendingGloasColumns(root))
-
-		entry := s.pendingGloasColumns[root]
-		require.NotNil(t, entry)
-		require.NotNil(t, entry.columns[5])
-		require.Equal(t, peer.ID("peer1"), entry.columns[5].peer)
-	})
-
-	t.Run("dedup by index", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xbb}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           10,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer2"))
-		require.Equal(t, peer.ID("peer1"), s.pendingGloasColumns[root].columns[10].peer)
-	})
-
-	t.Run("nil block is no-op", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xcc}
-		s.pendingGloasColumns[root] = &pendingGloasEntry{slot: clock.CurrentSlot()}
-
-		s.processPendingGloasColumns(context.Background(), root, nil)
-		// Entry should remain because the block was nil.
-		require.Equal(t, true, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("index out of bounds rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xee}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           fieldparams.NumberOfColumns + 1,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("oversize column rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		// SSZ allows 4096 cells; live max is much smaller. Without admission cap,
-		// this 8 MiB sidecar would sit on the heap until prune.
-		maxCells := params.BeaconConfig().MaxBlobCommitmentsPerBlock
-		cells := make([][]byte, maxCells)
-		proofs := make([][]byte, maxCells)
-		for i := range cells {
-			cells[i] = make([]byte, 2048)
-			proofs[i] = make([]byte, 48)
-		}
-		root := [32]byte{0x77}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          cells,
-			KzgProofs:       proofs,
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("empty column rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0x78}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          nil,
-			KzgProofs:       nil,
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("column proof length mismatch rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0x79}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048), make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("map capped at maxPendingGloasRoots", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		// Fill up to the cap.
-		for i := range maxPendingGloasRoots {
-			root := [32]byte{byte(i)}
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xaa}
 			dc := &ethpb.DataColumnSidecarGloas{
-				Index:           0,
+				Index:           5,
 				Slot:            clock.CurrentSlot(),
 				BeaconBlockRoot: root[:],
 				Column:          [][]byte{make([]byte, 2048)},
@@ -461,260 +312,437 @@ func TestPendingGloasColumns(t *testing.T) {
 			}
 			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
 			require.NoError(t, err)
+
 			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		}
-		require.Equal(t, maxPendingGloasRoots, len(s.pendingGloasColumns))
+			require.Equal(t, true, s.hasPendingGloasColumns(root))
 
-		// One more should be dropped.
-		overflowRoot := [32]byte{0xff}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: overflowRoot[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, overflowRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(overflowRoot))
+			entry := s.pendingGloasColumns[root]
+			require.NotNil(t, entry)
+			require.NotNil(t, entry.columns[5])
+			require.Equal(t, peer.ID("peer1"), entry.columns[5].peer)
+		})
+	})
 
-		// Adding to an existing root should still work.
-		existingRoot := [32]byte{0x00}
-		dc2 := &ethpb.DataColumnSidecarGloas{
-			Index:           1,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: existingRoot[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol2, err := blocks.NewRODataColumnGloasWithRoot(dc2, existingRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol2, "peer1"))
-		require.NotNil(t, s.pendingGloasColumns[existingRoot].columns[1])
+	t.Run("dedup by index", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xbb}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           10,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer2"))
+			require.Equal(t, peer.ID("peer1"), s.pendingGloasColumns[root].columns[10].peer)
+		})
+	})
+
+	t.Run("nil block is no-op", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xcc}
+			s.pendingGloasColumns[root] = &pendingGloasEntry{slot: clock.CurrentSlot()}
+
+			s.processPendingGloasColumns(context.Background(), root, nil)
+			// Entry should remain because the block was nil.
+			require.Equal(t, true, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("index out of bounds rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xee}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           fieldparams.NumberOfColumns + 1,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("oversize column rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			// SSZ allows 4096 cells; live max is much smaller. Without admission cap,
+			// this 8 MiB sidecar would sit on the heap until prune.
+			maxCells := params.BeaconConfig().MaxBlobCommitmentsPerBlock
+			cells := make([][]byte, maxCells)
+			proofs := make([][]byte, maxCells)
+			for i := range cells {
+				cells[i] = make([]byte, 2048)
+				proofs[i] = make([]byte, 48)
+			}
+			root := [32]byte{0x77}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          cells,
+				KzgProofs:       proofs,
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("empty column rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0x78}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          nil,
+				KzgProofs:       nil,
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("column proof length mismatch rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0x79}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          [][]byte{make([]byte, 2048), make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("map capped at maxPendingGloasRoots", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			// Fill up to the cap.
+			for i := range maxPendingGloasRoots {
+				root := [32]byte{byte(i)}
+				dc := &ethpb.DataColumnSidecarGloas{
+					Index:           0,
+					Slot:            clock.CurrentSlot(),
+					BeaconBlockRoot: root[:],
+					Column:          [][]byte{make([]byte, 2048)},
+					KzgProofs:       [][]byte{make([]byte, 48)},
+				}
+				roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+				require.NoError(t, err)
+				require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			}
+			require.Equal(t, maxPendingGloasRoots, len(s.pendingGloasColumns))
+
+			// One more should be dropped.
+			overflowRoot := [32]byte{0xff}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: overflowRoot[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, overflowRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(overflowRoot))
+
+			// Adding to an existing root should still work.
+			existingRoot := [32]byte{0x00}
+			dc2 := &ethpb.DataColumnSidecarGloas{
+				Index:           1,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: existingRoot[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol2, err := blocks.NewRODataColumnGloasWithRoot(dc2, existingRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol2, "peer1"))
+			require.NotNil(t, s.pendingGloasColumns[existingRoot].columns[1])
+		})
 	})
 
 	t.Run("process verifies and saves valid columns", func(t *testing.T) {
-		err := kzg.Start()
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			err := kzg.Start()
+			require.NoError(t, err)
 
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 0
-		cfg.GloasForkEpoch = 0
-		params.OverrideBeaconConfig(cfg)
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 0
+			cfg.GloasForkEpoch = 0
+			params.OverrideBeaconConfig(cfg)
 
-		p := p2ptest.NewTestP2P(t)
-		dcs := filesystem.NewEphemeralDataColumnStorage(t)
+			p := p2ptest.NewTestP2P(t)
+			dcs := filesystem.NewEphemeralDataColumnStorage(t)
 
-		sidecar, signedBlock := gloasFixture(t)
-		blockRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
+			sidecar, signedBlock := gloasFixture(t)
+			blockRoot, err := signedBlock.Block().HashTreeRoot()
+			require.NoError(t, err)
 
-		s := &Service{
-			cfg: &config{
-				p2p:               p,
-				clock:             clock,
-				dataColumnStorage: dcs,
-			},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
+			s := &Service{
+				cfg: &config{
+					p2p:               p,
+					clock:             clock,
+					dataColumnStorage: dcs,
+				},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+			}
 
-		// Queue the sidecar.
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
+			// Queue the sidecar.
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
 
-		// Process with the block.
-		s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
-		require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
+			// Process with the block.
+			s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
+			require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
 
-		// Column should be marked as seen.
-		require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+			// Column should be marked as seen.
+			require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
 
-		// Deferred validation passed, so the column must be re-broadcast.
-		require.Equal(t, true, p.BroadcastCalled.Load())
+			// Deferred validation passed, so the column must be re-broadcast.
+			require.Equal(t, true, p.BroadcastCalled.Load())
+		})
 	})
 
 	t.Run("process downscores bad peer for slot mismatch", func(t *testing.T) {
-		err := kzg.Start()
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			err := kzg.Start()
+			require.NoError(t, err)
 
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 0
-		cfg.GloasForkEpoch = 0
-		params.OverrideBeaconConfig(cfg)
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 0
+			cfg.GloasForkEpoch = 0
+			params.OverrideBeaconConfig(cfg)
 
-		p := p2ptest.NewTestP2P(t)
-		dcs := filesystem.NewEphemeralDataColumnStorage(t)
+			p := p2ptest.NewTestP2P(t)
+			dcs := filesystem.NewEphemeralDataColumnStorage(t)
 
-		sidecar, signedBlock := gloasFixture(t)
-		blockRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
+			sidecar, signedBlock := gloasFixture(t)
+			blockRoot, err := signedBlock.Block().HashTreeRoot()
+			require.NoError(t, err)
 
-		// Mismatch the slot.
-		sidecar.Slot = sidecar.Slot + 10
+			// Mismatch the slot.
+			sidecar.Slot = sidecar.Slot + 10
 
-		s := &Service{
-			cfg: &config{
-				p2p:               p,
-				clock:             clock,
-				dataColumnStorage: dcs,
-			},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
+			s := &Service{
+				cfg: &config{
+					p2p:               p,
+					clock:             clock,
+					dataColumnStorage: dcs,
+				},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+			}
 
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "badpeer"))
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "badpeer"))
 
-		s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
-		require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
-		// Column should NOT be marked as seen (it was invalid).
-		require.Equal(t, false, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
-		// Nothing valid was processed, so nothing is re-broadcast.
-		require.Equal(t, false, p.BroadcastCalled.Load())
+			s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
+			require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
+			// Column should NOT be marked as seen (it was invalid).
+			require.Equal(t, false, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+			// Nothing valid was processed, so nothing is re-broadcast.
+			require.Equal(t, false, p.BroadcastCalled.Load())
+		})
 	})
 
 	t.Run("routine drains pending columns on BlockProcessed", func(t *testing.T) {
-		err := kzg.Start()
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			err := kzg.Start()
+			require.NoError(t, err)
 
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 0
-		cfg.GloasForkEpoch = 0
-		params.OverrideBeaconConfig(cfg)
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 0
+			cfg.GloasForkEpoch = 0
+			params.OverrideBeaconConfig(cfg)
 
-		ctx := t.Context()
+			ctx := t.Context()
 
-		p := p2ptest.NewTestP2P(t)
-		dcs := filesystem.NewEphemeralDataColumnStorage(t)
-		notifier := mock.NewSimpleStateNotifier()
+			p := p2ptest.NewTestP2P(t)
+			dcs := filesystem.NewEphemeralDataColumnStorage(t)
+			notifier := mock.NewSimpleStateNotifier()
 
-		sidecar, signedBlock := gloasFixture(t)
-		blockRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
+			sidecar, signedBlock := gloasFixture(t)
+			blockRoot, err := signedBlock.Block().HashTreeRoot()
+			require.NoError(t, err)
 
-		s := &Service{
-			cfg: &config{
-				p2p:               p,
-				clock:             clock,
-				dataColumnStorage: dcs,
-				stateNotifier:     notifier,
-			},
-			ctx:                 ctx,
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
-
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
-
-		go s.processPendingGloasColumnsRoutine()
-
-		// Resend until the subscription is live and the routine drains the queue.
-		ev := &feed.Event{
-			Type: statefeed.BlockProcessed,
-			Data: &statefeed.BlockProcessedData{
-				Slot:        signedBlock.Block().Slot(),
-				BlockRoot:   blockRoot,
-				SignedBlock: signedBlock,
-			},
-		}
-		drained := false
-		for range 200 {
-			notifier.StateFeed().Send(ev)
-			if !s.hasPendingGloasColumns(blockRoot) {
-				drained = true
-				break
+			s := &Service{
+				cfg: &config{
+					p2p:               p,
+					clock:             clock,
+					dataColumnStorage: dcs,
+					stateNotifier:     notifier,
+				},
+				ctx:                 ctx,
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
 			}
-			time.Sleep(10 * time.Millisecond)
-		}
-		require.Equal(t, true, drained)
-		require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
+
+			go s.processPendingGloasColumnsRoutine()
+
+			// Resend until the subscription is live and the routine drains the queue.
+			ev := &feed.Event{
+				Type: statefeed.BlockProcessed,
+				Data: &statefeed.BlockProcessedData{
+					Slot:        signedBlock.Block().Slot(),
+					BlockRoot:   blockRoot,
+					SignedBlock: signedBlock,
+				},
+			}
+			drained := false
+			for range 200 {
+				notifier.StateFeed().Send(ev)
+				if !s.hasPendingGloasColumns(blockRoot) {
+					drained = true
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			require.Equal(t, true, drained)
+			require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+		})
 	})
 
 	t.Run("no entry is no-op", func(t *testing.T) {
-		p := p2ptest.NewTestP2P(t)
-		s := &Service{
-			cfg: &config{
-				p2p:   p,
-				clock: clock,
-			},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
-		root := [32]byte{0xdd}
-		pb := util.NewBeaconBlockGloas()
-		blk, err := blocks.NewSignedBeaconBlock(pb)
-		require.NoError(t, err)
-		// Should not panic.
-		s.processPendingGloasColumns(context.Background(), root, blk)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p := p2ptest.NewTestP2P(t)
+			s := &Service{
+				cfg: &config{
+					p2p:   p,
+					clock: clock,
+				},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+			}
+			root := [32]byte{0xdd}
+			pb := util.NewBeaconBlockGloas()
+			blk, err := blocks.NewSignedBeaconBlock(pb)
+			require.NoError(t, err)
+			// Should not panic.
+			s.processPendingGloasColumns(context.Background(), root, blk)
+		})
 	})
 
 	t.Run("prune drops stale entries without penalizing peers", func(t *testing.T) {
-		p := p2ptest.NewTestP2P(t)
-		s := &Service{
-			cfg:                 &config{p2p: p, clock: clock},
-			ctx:                 t.Context(),
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p := p2ptest.NewTestP2P(t)
+			s := &Service{
+				cfg:                 &config{p2p: p, clock: clock},
+				ctx:                 t.Context(),
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
 
-		unknownRoot := [32]byte{0x99}
-		e := &pendingGloasEntry{slot: 0}
-		e.columns[0] = &pendingColumnEntry{peer: "peerA"}
-		e.columns[1] = &pendingColumnEntry{peer: "peerA"}
-		e.columns[2] = &pendingColumnEntry{peer: "peerB"}
-		s.pendingGloasColumns[unknownRoot] = e
+			unknownRoot := [32]byte{0x99}
+			e := &pendingGloasEntry{slot: 0}
+			e.columns[0] = &pendingColumnEntry{peer: "peerA"}
+			e.columns[1] = &pendingColumnEntry{peer: "peerA"}
+			e.columns[2] = &pendingColumnEntry{peer: "peerB"}
+			s.pendingGloasColumns[unknownRoot] = e
 
-		s.pruneStaleGloasColumns(5)
+			s.pruneStaleGloasColumns(5)
 
-		require.Equal(t, false, s.hasPendingGloasColumns(unknownRoot))
+			require.Equal(t, false, s.hasPendingGloasColumns(unknownRoot))
 
-		scorer := p.Peers().Scorers().BadResponsesScorer()
-		_, err := scorer.Count("peerA")
-		require.NotNil(t, err)
-		_, err = scorer.Count("peerB")
-		require.NotNil(t, err)
+			scorer := p.Peers().Scorers().BadResponsesScorer()
+			_, err := scorer.Count("peerA")
+			require.NotNil(t, err)
+			_, err = scorer.Count("peerB")
+			require.NotNil(t, err)
+		})
 	})
 
 	t.Run("prune keeps current and next slot", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		currentSlot := clock.CurrentSlot()
-		if currentSlot < 3 {
-			t.Skip("need slot >= 3")
-		}
-
-		staleRoot := [32]byte{0x01}
-		currentRoot := [32]byte{0x02}
-		prevRoot := [32]byte{0x03}
-
-		s.pendingGloasColumns[staleRoot] = &pendingGloasEntry{slot: currentSlot - 3}
-		s.pendingGloasColumns[currentRoot] = &pendingGloasEntry{slot: currentSlot}
-		s.pendingGloasColumns[prevRoot] = &pendingGloasEntry{slot: currentSlot - 1}
-
-		// Simulate what the ticker does.
-		s.pendingGloasColumnsLock.Lock()
-		for r, e := range s.pendingGloasColumns {
-			if e.slot+1 < currentSlot {
-				delete(s.pendingGloasColumns, r)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
 			}
-		}
-		s.pendingGloasColumnsLock.Unlock()
+			currentSlot := clock.CurrentSlot()
+			if currentSlot < 3 {
+				t.Skip("need slot >= 3")
+			}
 
-		// Stale should be pruned, current and prev should remain.
-		require.Equal(t, false, s.hasPendingGloasColumns(staleRoot))
-		require.Equal(t, true, s.hasPendingGloasColumns(currentRoot))
-		require.Equal(t, true, s.hasPendingGloasColumns(prevRoot))
+			staleRoot := [32]byte{0x01}
+			currentRoot := [32]byte{0x02}
+			prevRoot := [32]byte{0x03}
+
+			s.pendingGloasColumns[staleRoot] = &pendingGloasEntry{slot: currentSlot - 3}
+			s.pendingGloasColumns[currentRoot] = &pendingGloasEntry{slot: currentSlot}
+			s.pendingGloasColumns[prevRoot] = &pendingGloasEntry{slot: currentSlot - 1}
+
+			// Simulate what the ticker does.
+			s.pendingGloasColumnsLock.Lock()
+			for r, e := range s.pendingGloasColumns {
+				if e.slot+1 < currentSlot {
+					delete(s.pendingGloasColumns, r)
+				}
+			}
+			s.pendingGloasColumnsLock.Unlock()
+
+			// Stale should be pruned, current and prev should remain.
+			require.Equal(t, false, s.hasPendingGloasColumns(staleRoot))
+			require.Equal(t, true, s.hasPendingGloasColumns(currentRoot))
+			require.Equal(t, true, s.hasPendingGloasColumns(prevRoot))
+		})
 	})
 }

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -300,163 +300,14 @@ func TestPendingGloasColumns(t *testing.T) {
 	clock := startup.NewClock(time.Now(), [32]byte{})
 
 	t.Run("queue and retrieve", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xaa}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           5,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, true, s.hasPendingGloasColumns(root))
-
-		entry := s.pendingGloasColumns[root]
-		require.NotNil(t, entry)
-		require.NotNil(t, entry.columns[5])
-		require.Equal(t, peer.ID("peer1"), entry.columns[5].peer)
-	})
-
-	t.Run("dedup by index", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xbb}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           10,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer2"))
-		require.Equal(t, peer.ID("peer1"), s.pendingGloasColumns[root].columns[10].peer)
-	})
-
-	t.Run("nil block is no-op", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xcc}
-		s.pendingGloasColumns[root] = &pendingGloasEntry{slot: clock.CurrentSlot()}
-
-		s.processPendingGloasColumns(context.Background(), root, nil)
-		// Entry should remain because the block was nil.
-		require.Equal(t, true, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("index out of bounds rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0xee}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           fieldparams.NumberOfColumns + 1,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("oversize column rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		// SSZ allows 4096 cells; live max is much smaller. Without admission cap,
-		// this 8 MiB sidecar would sit on the heap until prune.
-		maxCells := params.BeaconConfig().MaxBlobCommitmentsPerBlock
-		cells := make([][]byte, maxCells)
-		proofs := make([][]byte, maxCells)
-		for i := range cells {
-			cells[i] = make([]byte, 2048)
-			proofs[i] = make([]byte, 48)
-		}
-		root := [32]byte{0x77}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          cells,
-			KzgProofs:       proofs,
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("empty column rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0x78}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          nil,
-			KzgProofs:       nil,
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("column proof length mismatch rejected", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		root := [32]byte{0x79}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: root[:],
-			Column:          [][]byte{make([]byte, 2048), make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
-		require.NoError(t, err)
-
-		require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(root))
-	})
-
-	t.Run("map capped at maxPendingGloasRoots", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		// Fill up to the cap.
-		for i := range maxPendingGloasRoots {
-			root := [32]byte{byte(i)}
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xaa}
 			dc := &ethpb.DataColumnSidecarGloas{
-				Index:           0,
+				Index:           5,
 				Slot:            clock.CurrentSlot(),
 				BeaconBlockRoot: root[:],
 				Column:          [][]byte{make([]byte, 2048)},
@@ -464,260 +315,437 @@ func TestPendingGloasColumns(t *testing.T) {
 			}
 			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
 			require.NoError(t, err)
+
 			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		}
-		require.Equal(t, maxPendingGloasRoots, len(s.pendingGloasColumns))
+			require.Equal(t, true, s.hasPendingGloasColumns(root))
 
-		// One more should be dropped.
-		overflowRoot := [32]byte{0xff}
-		dc := &ethpb.DataColumnSidecarGloas{
-			Index:           0,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: overflowRoot[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, overflowRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, false, s.hasPendingGloasColumns(overflowRoot))
+			entry := s.pendingGloasColumns[root]
+			require.NotNil(t, entry)
+			require.NotNil(t, entry.columns[5])
+			require.Equal(t, peer.ID("peer1"), entry.columns[5].peer)
+		})
+	})
 
-		// Adding to an existing root should still work.
-		existingRoot := [32]byte{0x00}
-		dc2 := &ethpb.DataColumnSidecarGloas{
-			Index:           1,
-			Slot:            clock.CurrentSlot(),
-			BeaconBlockRoot: existingRoot[:],
-			Column:          [][]byte{make([]byte, 2048)},
-			KzgProofs:       [][]byte{make([]byte, 48)},
-		}
-		roCol2, err := blocks.NewRODataColumnGloasWithRoot(dc2, existingRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol2, "peer1"))
-		require.NotNil(t, s.pendingGloasColumns[existingRoot].columns[1])
+	t.Run("dedup by index", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xbb}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           10,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer2"))
+			require.Equal(t, peer.ID("peer1"), s.pendingGloasColumns[root].columns[10].peer)
+		})
+	})
+
+	t.Run("nil block is no-op", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xcc}
+			s.pendingGloasColumns[root] = &pendingGloasEntry{slot: clock.CurrentSlot()}
+
+			s.processPendingGloasColumns(context.Background(), root, nil)
+			// Entry should remain because the block was nil.
+			require.Equal(t, true, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("index out of bounds rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0xee}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           fieldparams.NumberOfColumns + 1,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("oversize column rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			// SSZ allows 4096 cells; live max is much smaller. Without admission cap,
+			// this 8 MiB sidecar would sit on the heap until prune.
+			maxCells := params.BeaconConfig().MaxBlobCommitmentsPerBlock
+			cells := make([][]byte, maxCells)
+			proofs := make([][]byte, maxCells)
+			for i := range cells {
+				cells[i] = make([]byte, 2048)
+				proofs[i] = make([]byte, 48)
+			}
+			root := [32]byte{0x77}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          cells,
+				KzgProofs:       proofs,
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("empty column rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0x78}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          nil,
+				KzgProofs:       nil,
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("column proof length mismatch rejected", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			root := [32]byte{0x79}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          [][]byte{make([]byte, 2048), make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+
+			require.NotNil(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(root))
+		})
+	})
+
+	t.Run("map capped at maxPendingGloasRoots", func(t *testing.T) {
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
+			// Fill up to the cap.
+			for i := range maxPendingGloasRoots {
+				root := [32]byte{byte(i)}
+				dc := &ethpb.DataColumnSidecarGloas{
+					Index:           0,
+					Slot:            clock.CurrentSlot(),
+					BeaconBlockRoot: root[:],
+					Column:          [][]byte{make([]byte, 2048)},
+					KzgProofs:       [][]byte{make([]byte, 48)},
+				}
+				roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+				require.NoError(t, err)
+				require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			}
+			require.Equal(t, maxPendingGloasRoots, len(s.pendingGloasColumns))
+
+			// One more should be dropped.
+			overflowRoot := [32]byte{0xff}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: overflowRoot[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, overflowRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, false, s.hasPendingGloasColumns(overflowRoot))
+
+			// Adding to an existing root should still work.
+			existingRoot := [32]byte{0x00}
+			dc2 := &ethpb.DataColumnSidecarGloas{
+				Index:           1,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: existingRoot[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol2, err := blocks.NewRODataColumnGloasWithRoot(dc2, existingRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol2, "peer1"))
+			require.NotNil(t, s.pendingGloasColumns[existingRoot].columns[1])
+		})
 	})
 
 	t.Run("process verifies and saves valid columns", func(t *testing.T) {
-		err := kzg.Start()
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			err := kzg.Start()
+			require.NoError(t, err)
 
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 0
-		cfg.GloasForkEpoch = 0
-		params.OverrideBeaconConfig(cfg)
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 0
+			cfg.GloasForkEpoch = 0
+			params.OverrideBeaconConfig(cfg)
 
-		p := p2ptest.NewTestP2P(t)
-		dcs := filesystem.NewEphemeralDataColumnStorage(t)
+			p := p2ptest.NewTestP2P(t)
+			dcs := filesystem.NewEphemeralDataColumnStorage(t)
 
-		sidecar, signedBlock := gloasFixture(t)
-		blockRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
+			sidecar, signedBlock := gloasFixture(t)
+			blockRoot, err := signedBlock.Block().HashTreeRoot()
+			require.NoError(t, err)
 
-		s := &Service{
-			cfg: &config{
-				p2p:               p,
-				clock:             clock,
-				dataColumnStorage: dcs,
-			},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
+			s := &Service{
+				cfg: &config{
+					p2p:               p,
+					clock:             clock,
+					dataColumnStorage: dcs,
+				},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+			}
 
-		// Queue the sidecar.
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
+			// Queue the sidecar.
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
 
-		// Process with the block.
-		s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
-		require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
+			// Process with the block.
+			s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
+			require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
 
-		// Column should be marked as seen.
-		require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+			// Column should be marked as seen.
+			require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
 
-		// Deferred validation passed, so the column must be re-broadcast.
-		require.Equal(t, true, p.BroadcastCalled.Load())
+			// Deferred validation passed, so the column must be re-broadcast.
+			require.Equal(t, true, p.BroadcastCalled.Load())
+		})
 	})
 
 	t.Run("process downscores bad peer for slot mismatch", func(t *testing.T) {
-		err := kzg.Start()
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			err := kzg.Start()
+			require.NoError(t, err)
 
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 0
-		cfg.GloasForkEpoch = 0
-		params.OverrideBeaconConfig(cfg)
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 0
+			cfg.GloasForkEpoch = 0
+			params.OverrideBeaconConfig(cfg)
 
-		p := p2ptest.NewTestP2P(t)
-		dcs := filesystem.NewEphemeralDataColumnStorage(t)
+			p := p2ptest.NewTestP2P(t)
+			dcs := filesystem.NewEphemeralDataColumnStorage(t)
 
-		sidecar, signedBlock := gloasFixture(t)
-		blockRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
+			sidecar, signedBlock := gloasFixture(t)
+			blockRoot, err := signedBlock.Block().HashTreeRoot()
+			require.NoError(t, err)
 
-		// Mismatch the slot.
-		sidecar.Slot = sidecar.Slot + 10
+			// Mismatch the slot.
+			sidecar.Slot = sidecar.Slot + 10
 
-		s := &Service{
-			cfg: &config{
-				p2p:               p,
-				clock:             clock,
-				dataColumnStorage: dcs,
-			},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
+			s := &Service{
+				cfg: &config{
+					p2p:               p,
+					clock:             clock,
+					dataColumnStorage: dcs,
+				},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+			}
 
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "badpeer"))
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "badpeer"))
 
-		s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
-		require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
-		// Column should NOT be marked as seen (it was invalid).
-		require.Equal(t, false, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
-		// Nothing valid was processed, so nothing is re-broadcast.
-		require.Equal(t, false, p.BroadcastCalled.Load())
+			s.processPendingGloasColumns(context.Background(), blockRoot, signedBlock)
+			require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
+			// Column should NOT be marked as seen (it was invalid).
+			require.Equal(t, false, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+			// Nothing valid was processed, so nothing is re-broadcast.
+			require.Equal(t, false, p.BroadcastCalled.Load())
+		})
 	})
 
 	t.Run("routine drains pending columns on BlockProcessed", func(t *testing.T) {
-		err := kzg.Start()
-		require.NoError(t, err)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			err := kzg.Start()
+			require.NoError(t, err)
 
-		params.SetupTestConfigCleanup(t)
-		cfg := params.BeaconConfig()
-		cfg.FuluForkEpoch = 0
-		cfg.GloasForkEpoch = 0
-		params.OverrideBeaconConfig(cfg)
+			params.SetupTestConfigCleanup(t)
+			cfg := params.BeaconConfig()
+			cfg.FuluForkEpoch = 0
+			cfg.GloasForkEpoch = 0
+			params.OverrideBeaconConfig(cfg)
 
-		ctx := t.Context()
+			ctx := t.Context()
 
-		p := p2ptest.NewTestP2P(t)
-		dcs := filesystem.NewEphemeralDataColumnStorage(t)
-		notifier := mock.NewSimpleStateNotifier()
+			p := p2ptest.NewTestP2P(t)
+			dcs := filesystem.NewEphemeralDataColumnStorage(t)
+			notifier := mock.NewSimpleStateNotifier()
 
-		sidecar, signedBlock := gloasFixture(t)
-		blockRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
+			sidecar, signedBlock := gloasFixture(t)
+			blockRoot, err := signedBlock.Block().HashTreeRoot()
+			require.NoError(t, err)
 
-		s := &Service{
-			cfg: &config{
-				p2p:               p,
-				clock:             clock,
-				dataColumnStorage: dcs,
-				stateNotifier:     notifier,
-			},
-			ctx:                 ctx,
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
-
-		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
-		require.NoError(t, err)
-		require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
-		require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
-
-		go s.processPendingGloasColumnsRoutine()
-
-		// Resend until the subscription is live and the routine drains the queue.
-		ev := &feed.Event{
-			Type: statefeed.BlockProcessed,
-			Data: &statefeed.BlockProcessedData{
-				Slot:        signedBlock.Block().Slot(),
-				BlockRoot:   blockRoot,
-				SignedBlock: signedBlock,
-			},
-		}
-		drained := false
-		for range 200 {
-			notifier.StateFeed().Send(ev)
-			if !s.hasPendingGloasColumns(blockRoot) {
-				drained = true
-				break
+			s := &Service{
+				cfg: &config{
+					p2p:               p,
+					clock:             clock,
+					dataColumnStorage: dcs,
+					stateNotifier:     notifier,
+				},
+				ctx:                 ctx,
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
 			}
-			time.Sleep(10 * time.Millisecond)
-		}
-		require.Equal(t, true, drained)
-		require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+			require.NoError(t, err)
+			require.NoError(t, s.queuePendingGloasColumn(roCol, "peer1"))
+			require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
+
+			go s.processPendingGloasColumnsRoutine()
+
+			// Resend until the subscription is live and the routine drains the queue.
+			ev := &feed.Event{
+				Type: statefeed.BlockProcessed,
+				Data: &statefeed.BlockProcessedData{
+					Slot:        signedBlock.Block().Slot(),
+					BlockRoot:   blockRoot,
+					SignedBlock: signedBlock,
+				},
+			}
+			drained := false
+			for range 200 {
+				notifier.StateFeed().Send(ev)
+				if !s.hasPendingGloasColumns(blockRoot) {
+					drained = true
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			require.Equal(t, true, drained)
+			require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+		})
 	})
 
 	t.Run("no entry is no-op", func(t *testing.T) {
-		p := p2ptest.NewTestP2P(t)
-		s := &Service{
-			cfg: &config{
-				p2p:   p,
-				clock: clock,
-			},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
-		}
-		root := [32]byte{0xdd}
-		pb := util.NewBeaconBlockGloas()
-		blk, err := blocks.NewSignedBeaconBlock(pb)
-		require.NoError(t, err)
-		// Should not panic.
-		s.processPendingGloasColumns(context.Background(), root, blk)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p := p2ptest.NewTestP2P(t)
+			s := &Service{
+				cfg: &config{
+					p2p:   p,
+					clock: clock,
+				},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+				seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+			}
+			root := [32]byte{0xdd}
+			pb := util.NewBeaconBlockGloas()
+			blk, err := blocks.NewSignedBeaconBlock(pb)
+			require.NoError(t, err)
+			// Should not panic.
+			s.processPendingGloasColumns(context.Background(), root, blk)
+		})
 	})
 
 	t.Run("prune drops stale entries without penalizing peers", func(t *testing.T) {
-		p := p2ptest.NewTestP2P(t)
-		s := &Service{
-			cfg:                 &config{p2p: p, clock: clock},
-			ctx:                 t.Context(),
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			p := p2ptest.NewTestP2P(t)
+			s := &Service{
+				cfg:                 &config{p2p: p, clock: clock},
+				ctx:                 t.Context(),
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			}
 
-		unknownRoot := [32]byte{0x99}
-		e := &pendingGloasEntry{slot: 0}
-		e.columns[0] = &pendingColumnEntry{peer: "peerA"}
-		e.columns[1] = &pendingColumnEntry{peer: "peerA"}
-		e.columns[2] = &pendingColumnEntry{peer: "peerB"}
-		s.pendingGloasColumns[unknownRoot] = e
+			unknownRoot := [32]byte{0x99}
+			e := &pendingGloasEntry{slot: 0}
+			e.columns[0] = &pendingColumnEntry{peer: "peerA"}
+			e.columns[1] = &pendingColumnEntry{peer: "peerA"}
+			e.columns[2] = &pendingColumnEntry{peer: "peerB"}
+			s.pendingGloasColumns[unknownRoot] = e
 
-		s.pruneStaleGloasColumns(5)
+			s.pruneStaleGloasColumns(5)
 
-		require.Equal(t, false, s.hasPendingGloasColumns(unknownRoot))
+			require.Equal(t, false, s.hasPendingGloasColumns(unknownRoot))
 
-		scorer := p.Peers().Scorers().BadResponsesScorer()
-		_, err := scorer.Count("peerA")
-		require.NotNil(t, err)
-		_, err = scorer.Count("peerB")
-		require.NotNil(t, err)
+			scorer := p.Peers().Scorers().BadResponsesScorer()
+			_, err := scorer.Count("peerA")
+			require.NotNil(t, err)
+			_, err = scorer.Count("peerB")
+			require.NotNil(t, err)
+		})
 	})
 
 	t.Run("prune keeps current and next slot", func(t *testing.T) {
-		s := &Service{
-			cfg:                 &config{clock: clock},
-			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
-		}
-		currentSlot := clock.CurrentSlot()
-		if currentSlot < 3 {
-			t.Skip("need slot >= 3")
-		}
-
-		staleRoot := [32]byte{0x01}
-		currentRoot := [32]byte{0x02}
-		prevRoot := [32]byte{0x03}
-
-		s.pendingGloasColumns[staleRoot] = &pendingGloasEntry{slot: currentSlot - 3}
-		s.pendingGloasColumns[currentRoot] = &pendingGloasEntry{slot: currentSlot}
-		s.pendingGloasColumns[prevRoot] = &pendingGloasEntry{slot: currentSlot - 1}
-
-		// Simulate what the ticker does.
-		s.pendingGloasColumnsLock.Lock()
-		for r, e := range s.pendingGloasColumns {
-			if e.slot+1 < currentSlot {
-				delete(s.pendingGloasColumns, r)
+		p2ptest.SynctestTest(t, func(t *testing.T) {
+			s := &Service{
+				cfg:                 &config{clock: clock},
+				pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
 			}
-		}
-		s.pendingGloasColumnsLock.Unlock()
+			currentSlot := clock.CurrentSlot()
+			if currentSlot < 3 {
+				t.Skip("need slot >= 3")
+			}
 
-		// Stale should be pruned, current and prev should remain.
-		require.Equal(t, false, s.hasPendingGloasColumns(staleRoot))
-		require.Equal(t, true, s.hasPendingGloasColumns(currentRoot))
-		require.Equal(t, true, s.hasPendingGloasColumns(prevRoot))
+			staleRoot := [32]byte{0x01}
+			currentRoot := [32]byte{0x02}
+			prevRoot := [32]byte{0x03}
+
+			s.pendingGloasColumns[staleRoot] = &pendingGloasEntry{slot: currentSlot - 3}
+			s.pendingGloasColumns[currentRoot] = &pendingGloasEntry{slot: currentSlot}
+			s.pendingGloasColumns[prevRoot] = &pendingGloasEntry{slot: currentSlot - 1}
+
+			// Simulate what the ticker does.
+			s.pendingGloasColumnsLock.Lock()
+			for r, e := range s.pendingGloasColumns {
+				if e.slot+1 < currentSlot {
+					delete(s.pendingGloasColumns, r)
+				}
+			}
+			s.pendingGloasColumnsLock.Unlock()
+
+			// Stale should be pruned, current and prev should remain.
+			require.Equal(t, false, s.hasPendingGloasColumns(staleRoot))
+			require.Equal(t, true, s.hasPendingGloasColumns(currentRoot))
+			require.Equal(t, true, s.hasPendingGloasColumns(prevRoot))
+		})
 	})
 }

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -34,25 +34,29 @@ import (
 )
 
 func TestValidateExecutionPayloadBidGossip_InvalidTopic(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{Message: &pb.Message{}})
-	require.ErrorIs(t, p2p.ErrInvalidTopic, err)
-	require.Equal(t, pubsub.ValidationReject, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{Message: &pb.Message{}})
+		require.ErrorIs(t, p2p.ErrInvalidTopic, err)
+		require.Equal(t, pubsub.ValidationReject, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_AlreadySeenTuple(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	key := executionPayloadBidTupleKey(mustBid(t, signedBid))
-	s.setSeenExecutionPayloadBid(signedBid.Message.Slot, key)
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		key := executionPayloadBidTupleKey(mustBid(t, signedBid))
+		s.setSeenExecutionPayloadBid(signedBid.Message.Slot, key)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_SameBuilderDifferentParentAccepted(t *testing.T) {
@@ -74,48 +78,54 @@ func TestValidateExecutionPayloadBidGossip_SameBuilderDifferentParentAccepted(t 
 
 // Dedup must short-circuit before every later check; duplicates pay only the cache lookup.
 func TestValidateExecutionPayloadBidGossip_DedupShortCircuitsAllLaterChecks(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	key := executionPayloadBidTupleKey(mustBid(t, signedBid))
-	s.setSeenExecutionPayloadBid(signedBid.Message.Slot, key)
-	// Every subsequent verifier method would Reject/Ignore if it ran; the cache hit must skip them all.
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
-		errCurrentOrNextSlot:    errors.New("slot"),
-		errBuilderActive:        errors.New("builder"),
-		errExecutionPayment:     errors.New("payment"),
-		errFeeRecipientMismatch: errors.New("fee"),
-		errSignature:            errors.New("sig"),
-	})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		key := executionPayloadBidTupleKey(mustBid(t, signedBid))
+		s.setSeenExecutionPayloadBid(signedBid.Message.Slot, key)
+		// Every subsequent verifier method would Reject/Ignore if it ran; the cache hit must skip them all.
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
+			errCurrentOrNextSlot:    errors.New("slot"),
+			errBuilderActive:        errors.New("builder"),
+			errExecutionPayment:     errors.New("payment"),
+			errFeeRecipientMismatch: errors.New("fee"),
+			errSignature:            errors.New("sig"),
+		})
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_ProposerPreferencesUnseen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	s.proposerPreferencesCache.Clear()
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		s.proposerPreferencesCache.Clear()
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_InitialSync(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{
-		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{
+			cfg: &config{
+				p2p:         p,
+				initialSync: &mockSync.Sync{IsSyncing: true},
+			},
+		}
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{})
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{})
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
@@ -208,130 +218,146 @@ func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, msg, _ := setupExecutionPayloadBidService(t)
-			s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(tc.verifier)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				s, msg, _ := setupExecutionPayloadBidService(t)
+				s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(tc.verifier)
 
-			result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-			if tc.wantError {
-				require.NotNil(t, err)
-			}
-			require.Equal(t, tc.result, result)
+				result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+				if tc.wantError {
+					require.NotNil(t, err)
+				}
+				require.Equal(t, tc.result, result)
+			})
 		})
 	}
 }
 
 func TestValidateExecutionPayloadBidGossip_LowerOrEqualBidIgnored(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	s.setHighestExecutionPayloadBid(signedBid)
+		s.setHighestExecutionPayloadBid(signedBid)
 
-	var err error
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
-	require.Equal(t, true, s.hasSeenExecutionPayloadBid(executionPayloadBidTupleKey(mustBid(t, signedBid))))
+		var err error
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.Equal(t, true, s.hasSeenExecutionPayloadBid(executionPayloadBidTupleKey(mustBid(t, signedBid))))
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_LowerBidIgnoredStillMarksTupleSeen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	higherBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
-	higherBid.Message.Value = signedBid.Message.Value + 1
-	s.setHighestExecutionPayloadBid(higherBid)
+		higherBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
+		higherBid.Message.Value = signedBid.Message.Value + 1
+		s.setHighestExecutionPayloadBid(higherBid)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
 
-	// If the lower valid bid did not mark the tuple as seen, the same bid would
-	// be accepted once the highest-bid cache is cleared.
-	s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
-	msg = executionPayloadBidToPubsub(t, s, s.cfg.p2p, signedBid)
+		// If the lower valid bid did not mark the tuple as seen, the same bid would
+		// be accepted once the highest-bid cache is cleared.
+		s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
+		msg = executionPayloadBidToPubsub(t, s, s.cfg.p2p, signedBid)
 
-	result, err = s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err = s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_HigherBidAccepted(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signedBid)
-	require.NoError(t, err)
-	bid, err := wrapped.Bid()
-	require.NoError(t, err)
-	lowerBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
-	lowerBid.Message.Value = bid.Value() - 1
-	s.setHighestExecutionPayloadBid(lowerBid)
+		wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signedBid)
+		require.NoError(t, err)
+		bid, err := wrapped.Bid()
+		require.NoError(t, err)
+		lowerBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
+		lowerBid.Message.Value = bid.Value() - 1
+		s.setHighestExecutionPayloadBid(lowerBid)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_HappyPath(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
 
-	require.Equal(t, true, s.hasSeenExecutionPayloadBid(executionPayloadBidTupleKey(mustBid(t, signedBid))))
-	got, ok := msg.ValidatorData.(*ethpb.SignedExecutionPayloadBid)
-	require.Equal(t, true, ok)
-	require.DeepEqual(t, signedBid, got)
+		require.Equal(t, true, s.hasSeenExecutionPayloadBid(executionPayloadBidTupleKey(mustBid(t, signedBid))))
+		got, ok := msg.ValidatorData.(*ethpb.SignedExecutionPayloadBid)
+		require.Equal(t, true, ok)
+		require.DeepEqual(t, signedBid, got)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_NextSlotStateMissIgnored(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	// errPrevRandao would reject if reached, but a next-slot-cache miss for the bid's parent must ignore first.
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
-		errPrevRandao: errors.New("wrong prev randao"),
-	})
-	// Evict the bid's parent (0x02) from the next-slot cache.
-	other, err := util.NewBeaconStateGloas()
-	require.NoError(t, err)
-	require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x07}, 32), other))
-	require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x08}, 32), other))
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		// errPrevRandao would reject if reached, but a next-slot-cache miss for the bid's parent must ignore first.
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
+			errPrevRandao: errors.New("wrong prev randao"),
+		})
+		// Evict the bid's parent (0x02) from the next-slot cache.
+		other, err := util.NewBeaconStateGloas()
+		require.NoError(t, err)
+		require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x07}, 32), other))
+		require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x08}, 32), other))
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_FeeRecipientMismatch(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
-		mockExecutionPayloadBidVerifier{errFeeRecipientMismatch: verification.ErrBidFeeRecipientMismatch},
-	)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
+			mockExecutionPayloadBidVerifier{errFeeRecipientMismatch: verification.ErrBidFeeRecipientMismatch},
+		)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
-	require.ErrorIs(t, err, verification.ErrBidFeeRecipientMismatch)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NotNil(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.ErrorIs(t, err, verification.ErrBidFeeRecipientMismatch)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_GasLimitIncompatible(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
-		mockExecutionPayloadBidVerifier{errGasLimitIncompatible: verification.ErrBidGasLimitIncompatible},
-	)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
+			mockExecutionPayloadBidVerifier{errGasLimitIncompatible: verification.ErrBidGasLimitIncompatible},
+		)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
-	require.ErrorIs(t, err, verification.ErrBidGasLimitIncompatible)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NotNil(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.ErrorIs(t, err, verification.ErrBidGasLimitIncompatible)
+	})
 }
 
 func TestExecutionPayloadBidSubscriber_WrongMessage(t *testing.T) {
@@ -408,11 +434,13 @@ func TestProposerDependentRoot_UnderflowClampsToZero(t *testing.T) {
 }
 
 func TestExecutionPayloadBidSubscriber_NilMessage(t *testing.T) {
-	s := &Service{
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	err := s.executionPayloadBidSubscriber(context.Background(), &ethpb.SignedExecutionPayloadBid{})
-	require.ErrorIs(t, errNilMessage, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		s := &Service{
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		err := s.executionPayloadBidSubscriber(context.Background(), &ethpb.SignedExecutionPayloadBid{})
+		require.ErrorIs(t, errNilMessage, err)
+	})
 }
 
 type mockExecutionPayloadBidVerifier struct {

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -34,71 +34,81 @@ import (
 )
 
 func TestValidateExecutionPayloadBidGossip_InvalidTopic(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{Message: &pb.Message{}})
-	require.ErrorIs(t, p2p.ErrInvalidTopic, err)
-	require.Equal(t, pubsub.ValidationReject, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{Message: &pb.Message{}})
+		require.ErrorIs(t, p2p.ErrInvalidTopic, err)
+		require.Equal(t, pubsub.ValidationReject, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_AlreadySeenBuilder(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	key := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	s.setSeenExecutionPayloadBidBuilder(signedBid.Message.Slot, key)
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		key := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
+		s.setSeenExecutionPayloadBidBuilder(signedBid.Message.Slot, key)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 // Dedup must short-circuit before every later check; duplicates pay only the cache lookup.
 func TestValidateExecutionPayloadBidGossip_DedupShortCircuitsAllLaterChecks(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	key := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	s.setSeenExecutionPayloadBidBuilder(signedBid.Message.Slot, key)
-	// Every subsequent verifier method would Reject/Ignore if it ran; the cache hit must skip them all.
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
-		errCurrentOrNextSlot:    errors.New("slot"),
-		errBuilderActive:        errors.New("builder"),
-		errExecutionPayment:     errors.New("payment"),
-		errFeeRecipientMismatch: errors.New("fee"),
-		errSignature:            errors.New("sig"),
-	})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		key := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
+		s.setSeenExecutionPayloadBidBuilder(signedBid.Message.Slot, key)
+		// Every subsequent verifier method would Reject/Ignore if it ran; the cache hit must skip them all.
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
+			errCurrentOrNextSlot:    errors.New("slot"),
+			errBuilderActive:        errors.New("builder"),
+			errExecutionPayment:     errors.New("payment"),
+			errFeeRecipientMismatch: errors.New("fee"),
+			errSignature:            errors.New("sig"),
+		})
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_ProposerPreferencesUnseen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	s.proposerPreferencesCache.Clear()
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		s.proposerPreferencesCache.Clear()
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_InitialSync(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{
-		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{
+			cfg: &config{
+				p2p:         p,
+				initialSync: &mockSync.Sync{IsSyncing: true},
+			},
+		}
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{})
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", &pubsub.Message{})
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
@@ -191,132 +201,148 @@ func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, msg, _ := setupExecutionPayloadBidService(t)
-			s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(tc.verifier)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				s, msg, _ := setupExecutionPayloadBidService(t)
+				s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(tc.verifier)
 
-			result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-			if tc.wantError {
-				require.NotNil(t, err)
-			}
-			require.Equal(t, tc.result, result)
+				result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+				if tc.wantError {
+					require.NotNil(t, err)
+				}
+				require.Equal(t, tc.result, result)
+			})
 		})
 	}
 }
 
 func TestValidateExecutionPayloadBidGossip_LowerOrEqualBidIgnored(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	s.setHighestExecutionPayloadBid(signedBid)
+		s.setHighestExecutionPayloadBid(signedBid)
 
-	var err error
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
-	builderKey := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	require.Equal(t, true, s.hasSeenExecutionPayloadBidBuilder(builderKey))
+		var err error
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		builderKey := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
+		require.Equal(t, true, s.hasSeenExecutionPayloadBidBuilder(builderKey))
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_LowerBidIgnoredStillMarksBuilderSeen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	higherBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
-	higherBid.Message.Value = signedBid.Message.Value + 1
-	s.setHighestExecutionPayloadBid(higherBid)
+		higherBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
+		higherBid.Message.Value = signedBid.Message.Value + 1
+		s.setHighestExecutionPayloadBid(higherBid)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
 
-	// If the lower valid bid did not mark the builder as seen, the same bid would
-	// be accepted once the highest-bid cache is cleared.
-	s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
-	msg = executionPayloadBidToPubsub(t, s, s.cfg.p2p, signedBid)
+		// If the lower valid bid did not mark the builder as seen, the same bid would
+		// be accepted once the highest-bid cache is cleared.
+		s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
+		msg = executionPayloadBidToPubsub(t, s, s.cfg.p2p, signedBid)
 
-	result, err = s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err = s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_HigherBidAccepted(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signedBid)
-	require.NoError(t, err)
-	bid, err := wrapped.Bid()
-	require.NoError(t, err)
-	lowerBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
-	lowerBid.Message.Value = bid.Value() - 1
-	s.setHighestExecutionPayloadBid(lowerBid)
+		wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signedBid)
+		require.NoError(t, err)
+		bid, err := wrapped.Bid()
+		require.NoError(t, err)
+		lowerBid := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
+		lowerBid.Message.Value = bid.Value() - 1
+		s.setHighestExecutionPayloadBid(lowerBid)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_HappyPath(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedBid := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
 
-	builderKey := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	require.Equal(t, true, s.hasSeenExecutionPayloadBidBuilder(builderKey))
-	got, ok := msg.ValidatorData.(*ethpb.SignedExecutionPayloadBid)
-	require.Equal(t, true, ok)
-	require.DeepEqual(t, signedBid, got)
+		builderKey := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
+		require.Equal(t, true, s.hasSeenExecutionPayloadBidBuilder(builderKey))
+		got, ok := msg.ValidatorData.(*ethpb.SignedExecutionPayloadBid)
+		require.Equal(t, true, ok)
+		require.DeepEqual(t, signedBid, got)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_NextSlotStateMissIgnored(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	// errPrevRandao would reject if reached, but a next-slot-cache miss for the bid's parent must ignore first.
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
-		errPrevRandao: errors.New("wrong prev randao"),
-	})
-	// Evict the bid's parent (0x02) from the next-slot cache.
-	other, err := util.NewBeaconStateGloas()
-	require.NoError(t, err)
-	require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x07}, 32), other))
-	require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x08}, 32), other))
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		// errPrevRandao would reject if reached, but a next-slot-cache miss for the bid's parent must ignore first.
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
+			errPrevRandao: errors.New("wrong prev randao"),
+		})
+		// Evict the bid's parent (0x02) from the next-slot cache.
+		other, err := util.NewBeaconStateGloas()
+		require.NoError(t, err)
+		require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x07}, 32), other))
+		require.NoError(t, transition.UpdateNextSlotCache(ctx, bytesutil.PadTo([]byte{0x08}, 32), other))
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_FeeRecipientMismatch(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
-		mockExecutionPayloadBidVerifier{errFeeRecipientMismatch: verification.ErrBidFeeRecipientMismatch},
-	)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
+			mockExecutionPayloadBidVerifier{errFeeRecipientMismatch: verification.ErrBidFeeRecipientMismatch},
+		)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
-	require.ErrorIs(t, err, verification.ErrBidFeeRecipientMismatch)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NotNil(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.ErrorIs(t, err, verification.ErrBidFeeRecipientMismatch)
+	})
 }
 
 func TestValidateExecutionPayloadBidGossip_GasLimitIncompatible(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupExecutionPayloadBidService(t)
-	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
-		mockExecutionPayloadBidVerifier{errGasLimitIncompatible: verification.ErrBidGasLimitIncompatible},
-	)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupExecutionPayloadBidService(t)
+		s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(
+			mockExecutionPayloadBidVerifier{errGasLimitIncompatible: verification.ErrBidGasLimitIncompatible},
+		)
 
-	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
-	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
-	require.ErrorIs(t, err, verification.ErrBidGasLimitIncompatible)
+		result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+		require.NotNil(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.ErrorIs(t, err, verification.ErrBidGasLimitIncompatible)
+	})
 }
 
 func TestExecutionPayloadBidSubscriber_WrongMessage(t *testing.T) {
@@ -393,11 +419,13 @@ func TestProposerDependentRoot_UnderflowClampsToZero(t *testing.T) {
 }
 
 func TestExecutionPayloadBidSubscriber_NilMessage(t *testing.T) {
-	s := &Service{
-		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
-	}
-	err := s.executionPayloadBidSubscriber(context.Background(), &ethpb.SignedExecutionPayloadBid{})
-	require.ErrorIs(t, errNilMessage, err)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		s := &Service{
+			highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		}
+		err := s.executionPayloadBidSubscriber(context.Background(), &ethpb.SignedExecutionPayloadBid{})
+		require.ErrorIs(t, errNilMessage, err)
+	})
 }
 
 type mockExecutionPayloadBidVerifier struct {

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -36,26 +36,30 @@ import (
 )
 
 func TestValidateExecutionPayloadEnvelope_InvalidTopic(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
 
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", &pubsub.Message{
-		Message: &pb.Message{},
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", &pubsub.Message{
+			Message: &pb.Message{},
+		})
+		require.ErrorIs(t, p2p.ErrInvalidTopic, err)
+		require.Equal(t, result, pubsub.ValidationReject)
 	})
-	require.ErrorIs(t, p2p.ErrInvalidTopic, err)
-	require.Equal(t, result, pubsub.ValidationReject)
 }
 
 func TestValidateExecutionPayloadEnvelope_AlreadySeen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
-	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
+		s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
 
-	s.setSeenPayloadEnvelope(root, builderIdx)
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationIgnore)
+		s.setSeenPayloadEnvelope(root, builderIdx)
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationIgnore)
+	})
 }
 
 func TestValidateExecutionPayloadEnvelope_ErrorPathsWithMock(t *testing.T) {
@@ -111,28 +115,32 @@ func TestValidateExecutionPayloadEnvelope_ErrorPathsWithMock(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
-			s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(tc.verifier)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
+				s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(tc.verifier)
 
-			result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-			if tc.wantError {
-				require.NotNil(t, err)
-			}
-			require.Equal(t, result, tc.result)
+				result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+				if tc.wantError {
+					require.NotNil(t, err)
+				}
+				require.Equal(t, result, tc.result)
+			})
 		})
 	}
 }
 
 func TestValidateExecutionPayloadEnvelope_HappyPath(t *testing.T) {
-	ctx := context.Background()
-	s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
-	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
+		s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
 
-	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationAccept)
-	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+		require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationAccept)
+		require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+	})
 }
 
 func TestValidateExecutionPayloadEnvelope_BlockSeenButNotInDB_NoPanic(t *testing.T) {
@@ -307,19 +315,21 @@ func (r *recordingEnvelopeVerifier) SatisfyRequirement(req verification.Requirem
 // A successful gossip validation must exercise every requirement in the gossip
 // list — catches a requirement being added without a matching check.
 func TestValidateExecutionPayloadEnvelope_CoversAllGossipRequirements(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
-	rec := &recordingEnvelopeVerifier{recorded: map[verification.Requirement]bool{}}
-	s.newExecutionPayloadEnvelopeVerifier = func(_ interfaces.ROSignedExecutionPayloadEnvelope, _ []verification.Requirement) verification.ExecutionPayloadEnvelopeVerifier {
-		return rec
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
+		rec := &recordingEnvelopeVerifier{recorded: map[verification.Requirement]bool{}}
+		s.newExecutionPayloadEnvelopeVerifier = func(_ interfaces.ROSignedExecutionPayloadEnvelope, _ []verification.Requirement) verification.ExecutionPayloadEnvelopeVerifier {
+			return rec
+		}
 
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, result)
-	for _, req := range verification.ExecutionPayloadEnvelopeGossipRequirements {
-		require.Equal(t, true, rec.recorded[req], "requirement %s is in the gossip list but never checked", req)
-	}
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
+		for _, req := range verification.ExecutionPayloadEnvelopeGossipRequirements {
+			require.Equal(t, true, rec.recorded[req], "requirement %s is in the gossip list but never checked", req)
+		}
+	})
 }
 
 func testNewExecutionPayloadEnvelopeVerifier(m mockExecutionPayloadEnvelopeVerifier) verification.NewExecutionPayloadEnvelopeVerifier {
@@ -424,42 +434,44 @@ func TestQueuePendingPayloadEnvelope_SelfBuildInvalidSignature(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := p2ptest.NewTestP2P(t)
-			chainService := &mock.ChainService{
-				Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-				FinalizedCheckPoint: &ethpb.Checkpoint{},
-			}
-			st, err := util.NewBeaconStateFulu()
-			require.NoError(t, err)
-			chainService.State = st
-
-			s := &Service{
-				seenPayloadEnvelopeCache: lruwrpr.New(10),
-				pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-				cfg: &config{
-					p2p:         p,
-					initialSync: &mockSync.Sync{},
-					chain:       chainService,
-					clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-				},
-			}
-			s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{
-				errBlockRootSeen: errors.New("not seen"),
-				errSignature:     errors.New("bad signature"),
-			})
-
-			root := [32]byte{0x01}
-			blockHash := [32]byte{0x02}
-			env := testSignedExecutionPayloadEnvelope(t, 1, tc.builderIdx, root, blockHash)
-			msg := envelopeToPubsub(t, s, p, env)
-
-			result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-			if tc.wantError {
-				require.NotNil(t, err)
-			} else {
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				p := p2ptest.NewTestP2P(t)
+				chainService := &mock.ChainService{
+					Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+					FinalizedCheckPoint: &ethpb.Checkpoint{},
+				}
+				st, err := util.NewBeaconStateFulu()
 				require.NoError(t, err)
-			}
-			require.Equal(t, tc.result, result)
+				chainService.State = st
+
+				s := &Service{
+					seenPayloadEnvelopeCache: lruwrpr.New(10),
+					pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+					cfg: &config{
+						p2p:         p,
+						initialSync: &mockSync.Sync{},
+						chain:       chainService,
+						clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+					},
+				}
+				s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{
+					errBlockRootSeen: errors.New("not seen"),
+					errSignature:     errors.New("bad signature"),
+				})
+
+				root := [32]byte{0x01}
+				blockHash := [32]byte{0x02}
+				env := testSignedExecutionPayloadEnvelope(t, 1, tc.builderIdx, root, blockHash)
+				msg := envelopeToPubsub(t, s, p, env)
+
+				result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+				if tc.wantError {
+					require.NotNil(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				require.Equal(t, tc.result, result)
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -36,26 +36,30 @@ import (
 )
 
 func TestValidateExecutionPayloadEnvelope_InvalidTopic(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
 
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", &pubsub.Message{
-		Message: &pb.Message{},
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", &pubsub.Message{
+			Message: &pb.Message{},
+		})
+		require.ErrorIs(t, p2p.ErrInvalidTopic, err)
+		require.Equal(t, result, pubsub.ValidationReject)
 	})
-	require.ErrorIs(t, p2p.ErrInvalidTopic, err)
-	require.Equal(t, result, pubsub.ValidationReject)
 }
 
 func TestValidateExecutionPayloadEnvelope_AlreadySeen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
-	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
+		s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
 
-	s.setSeenPayloadEnvelope(root, builderIdx)
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationIgnore)
+		s.setSeenPayloadEnvelope(root, builderIdx)
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationIgnore)
+	})
 }
 
 func TestValidateExecutionPayloadEnvelope_ErrorPathsWithMock(t *testing.T) {
@@ -111,28 +115,32 @@ func TestValidateExecutionPayloadEnvelope_ErrorPathsWithMock(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
-			s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(tc.verifier)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
+				s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(tc.verifier)
 
-			result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-			if tc.wantError {
-				require.NotNil(t, err)
-			}
-			require.Equal(t, result, tc.result)
+				result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+				if tc.wantError {
+					require.NotNil(t, err)
+				}
+				require.Equal(t, result, tc.result)
+			})
 		})
 	}
 }
 
 func TestValidateExecutionPayloadEnvelope_HappyPath(t *testing.T) {
-	ctx := context.Background()
-	s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
-	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
+		s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
 
-	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationAccept)
-	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+		require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationAccept)
+		require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
+	})
 }
 
 func TestValidateExecutionPayloadEnvelope_BlockSeenButNotInDB_NoPanic(t *testing.T) {
@@ -307,19 +315,21 @@ func (r *recordingEnvelopeVerifier) SatisfyRequirement(req verification.Requirem
 // A successful gossip validation must exercise every requirement in the gossip
 // list — catches a requirement being added without a matching check.
 func TestValidateExecutionPayloadEnvelope_CoversAllGossipRequirements(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
-	rec := &recordingEnvelopeVerifier{recorded: map[verification.Requirement]bool{}}
-	s.newExecutionPayloadEnvelopeVerifier = func(_ interfaces.ROSignedExecutionPayloadEnvelope, _ []verification.Requirement) verification.ExecutionPayloadEnvelopeVerifier {
-		return rec
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _, _ := setupExecutionPayloadEnvelopeService(t, 1, 1)
+		rec := &recordingEnvelopeVerifier{recorded: map[verification.Requirement]bool{}}
+		s.newExecutionPayloadEnvelopeVerifier = func(_ interfaces.ROSignedExecutionPayloadEnvelope, _ []verification.Requirement) verification.ExecutionPayloadEnvelopeVerifier {
+			return rec
+		}
 
-	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, result)
-	for _, req := range verification.ExecutionPayloadEnvelopeGossipRequirements {
-		require.Equal(t, true, rec.recorded[req], "requirement %s is in the gossip list but never checked", req)
-	}
+		result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
+		for _, req := range verification.ExecutionPayloadEnvelopeGossipRequirements {
+			require.Equal(t, true, rec.recorded[req], "requirement %s is in the gossip list but never checked", req)
+		}
+	})
 }
 
 func testNewExecutionPayloadEnvelopeVerifier(m mockExecutionPayloadEnvelopeVerifier) verification.NewExecutionPayloadEnvelopeVerifier {
@@ -425,42 +435,44 @@ func TestQueuePendingPayloadEnvelope_SelfBuildInvalidSignature(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := p2ptest.NewTestP2P(t)
-			chainService := &mock.ChainService{
-				Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
-				FinalizedCheckPoint: &ethpb.Checkpoint{},
-			}
-			st, err := util.NewBeaconStateFulu()
-			require.NoError(t, err)
-			chainService.State = st
-
-			s := &Service{
-				seenPayloadEnvelopeCache: lruwrpr.New(10),
-				pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
-				cfg: &config{
-					p2p:         p,
-					initialSync: &mockSync.Sync{},
-					chain:       chainService,
-					clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-				},
-			}
-			s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{
-				errBlockRootSeen: errors.New("not seen"),
-				errSignature:     errors.New("bad signature"),
-			})
-
-			root := [32]byte{0x01}
-			blockHash := [32]byte{0x02}
-			env := testSignedExecutionPayloadEnvelope(t, 1, tc.builderIdx, root, blockHash)
-			msg := envelopeToPubsub(t, s, p, env)
-
-			result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
-			if tc.wantError {
-				require.NotNil(t, err)
-			} else {
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				p := p2ptest.NewTestP2P(t)
+				chainService := &mock.ChainService{
+					Genesis:             time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+					FinalizedCheckPoint: &ethpb.Checkpoint{},
+				}
+				st, err := util.NewBeaconStateFulu()
 				require.NoError(t, err)
-			}
-			require.Equal(t, tc.result, result)
+				chainService.State = st
+
+				s := &Service{
+					seenPayloadEnvelopeCache: lruwrpr.New(10),
+					pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+					cfg: &config{
+						p2p:         p,
+						initialSync: &mockSync.Sync{},
+						chain:       chainService,
+						clock:       startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+					},
+				}
+				s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{
+					errBlockRootSeen: errors.New("not seen"),
+					errSignature:     errors.New("bad signature"),
+				})
+
+				root := [32]byte{0x01}
+				blockHash := [32]byte{0x02}
+				env := testSignedExecutionPayloadEnvelope(t, 1, tc.builderIdx, root, blockHash)
+				msg := envelopeToPubsub(t, s, p, env)
+
+				result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+				if tc.wantError {
+					require.NotNil(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				require.Equal(t, tc.result, result)
+			})
 		})
 	}
 }

--- a/beacon-chain/sync/validate_light_client_test.go
+++ b/beacon-chain/sync/validate_light_client_test.go
@@ -24,26 +24,28 @@ import (
 )
 
 func TestValidateLightClientOptimisticUpdate_NilMessageOrTopic(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
-	mockUpdate, err := util.MockOptimisticUpdate()
-	require.NoError(t, err)
-	s.lcStore.SetLastOptimisticUpdate(mockUpdate, false)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
+		mockUpdate, err := util.MockOptimisticUpdate()
+		require.NoError(t, err)
+		s.lcStore.SetLastOptimisticUpdate(mockUpdate, false)
 
-	_, err = s.validateLightClientOptimisticUpdate(ctx, "", nil)
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientOptimisticUpdate(ctx, "", nil)
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	emptyTopic := ""
-	_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
-		Topic: &emptyTopic,
-	}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		emptyTopic := ""
+		_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
+			Topic: &emptyTopic,
+		}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
+	})
 }
 
 func TestValidateLightClientOptimisticUpdate(t *testing.T) {
@@ -108,72 +110,76 @@ func TestValidateLightClientOptimisticUpdate(t *testing.T) {
 				continue
 			}
 			t.Run(test.name+"_"+version.String(v), func(t *testing.T) {
-				ctx := t.Context()
-				p := p2ptest.NewTestP2P(t)
-				// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
-				genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
-				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
-				lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-				s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
+				p2ptest.SynctestTest(t, func(t *testing.T) {
+					ctx := t.Context()
+					p := p2ptest.NewTestP2P(t)
+					// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
+					genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
+					chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
+					lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+					s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
 
-				var oldUpdate interfaces.LightClientOptimisticUpdate
-				if test.oldUpdateOptions != nil {
-					l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
-					var err error
-					oldUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
+					var oldUpdate interfaces.LightClientOptimisticUpdate
+					if test.oldUpdateOptions != nil {
+						l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
+						var err error
+						oldUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
+						require.NoError(t, err)
+
+						s.lcStore.SetLastOptimisticUpdate(oldUpdate, false)
+					}
+
+					l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
+					newUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
+					require.NoError(t, err)
+					buf := new(bytes.Buffer)
+					_, err = p.Encoding().EncodeGossip(buf, newUpdate)
 					require.NoError(t, err)
 
-					s.lcStore.SetLastOptimisticUpdate(oldUpdate, false)
-				}
+					topic := p2p.LightClientOptimisticUpdateTopicFormat
+					digest := s.currentForkDigest()
+					topic = s.addDigestToTopic(topic, digest)
 
-				l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
-				newUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
-				require.NoError(t, err)
-				buf := new(bytes.Buffer)
-				_, err = p.Encoding().EncodeGossip(buf, newUpdate)
-				require.NoError(t, err)
-
-				topic := p2p.LightClientOptimisticUpdateTopicFormat
-				digest := s.currentForkDigest()
-				topic = s.addDigestToTopic(topic, digest)
-
-				r, err := s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{
-					Message: &pb.Message{
-						Data:  buf.Bytes(),
-						Topic: &topic,
-					}})
-				if test.expectedErr != nil {
-					require.ErrorIs(t, err, test.expectedErr)
-				} else {
-					require.NoError(t, err)
-					require.Equal(t, test.expectedResult, r)
-				}
+					r, err := s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{
+						Message: &pb.Message{
+							Data:  buf.Bytes(),
+							Topic: &topic,
+						}})
+					if test.expectedErr != nil {
+						require.ErrorIs(t, err, test.expectedErr)
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, test.expectedResult, r)
+					}
+				})
 			})
 		}
 	}
 }
 
 func TestValidateLightClientFinalityUpdate_NilMessageOrTopic(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
-	mockUpdate, err := util.MockFinalityUpdate()
-	require.NoError(t, err)
-	s.lcStore.SetLastFinalityUpdate(mockUpdate, false)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
+		mockUpdate, err := util.MockFinalityUpdate()
+		require.NoError(t, err)
+		s.lcStore.SetLastFinalityUpdate(mockUpdate, false)
 
-	_, err = s.validateLightClientFinalityUpdate(ctx, "", nil)
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientFinalityUpdate(ctx, "", nil)
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	emptyTopic := ""
-	_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
-		Topic: &emptyTopic,
-	}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		emptyTopic := ""
+		_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
+			Topic: &emptyTopic,
+		}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
+	})
 }
 
 func TestValidateLightClientFinalityUpdate(t *testing.T) {
@@ -238,46 +244,48 @@ func TestValidateLightClientFinalityUpdate(t *testing.T) {
 				continue
 			}
 			t.Run(test.name+"_"+version.String(v), func(t *testing.T) {
-				ctx := t.Context()
-				p := p2ptest.NewTestP2P(t)
-				// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
-				genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
-				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
-				lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-				s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
+				p2ptest.SynctestTest(t, func(t *testing.T) {
+					ctx := t.Context()
+					p := p2ptest.NewTestP2P(t)
+					// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
+					genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
+					chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
+					lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+					s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
 
-				var oldUpdate interfaces.LightClientFinalityUpdate
-				if test.oldUpdateOptions != nil {
-					l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
-					var err error
-					oldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+					var oldUpdate interfaces.LightClientFinalityUpdate
+					if test.oldUpdateOptions != nil {
+						l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
+						var err error
+						oldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+						require.NoError(t, err)
+
+						s.lcStore.SetLastFinalityUpdate(oldUpdate, false)
+					}
+
+					l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
+					newUpdate, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+					require.NoError(t, err)
+					buf := new(bytes.Buffer)
+					_, err = p.Encoding().EncodeGossip(buf, newUpdate)
 					require.NoError(t, err)
 
-					s.lcStore.SetLastFinalityUpdate(oldUpdate, false)
-				}
+					topic := p2p.LightClientFinalityUpdateTopicFormat
+					digest := s.currentForkDigest()
+					topic = s.addDigestToTopic(topic, digest)
 
-				l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
-				newUpdate, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
-				require.NoError(t, err)
-				buf := new(bytes.Buffer)
-				_, err = p.Encoding().EncodeGossip(buf, newUpdate)
-				require.NoError(t, err)
-
-				topic := p2p.LightClientFinalityUpdateTopicFormat
-				digest := s.currentForkDigest()
-				topic = s.addDigestToTopic(topic, digest)
-
-				r, err := s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{
-					Message: &pb.Message{
-						Data:  buf.Bytes(),
-						Topic: &topic,
-					}})
-				if test.expectedErr != nil {
-					require.ErrorIs(t, err, test.expectedErr)
-				} else {
-					require.NoError(t, err)
-					require.Equal(t, test.expectedResult, r)
-				}
+					r, err := s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{
+						Message: &pb.Message{
+							Data:  buf.Bytes(),
+							Topic: &topic,
+						}})
+					if test.expectedErr != nil {
+						require.ErrorIs(t, err, test.expectedErr)
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, test.expectedResult, r)
+					}
+				})
 			})
 		}
 	}

--- a/beacon-chain/sync/validate_light_client_test.go
+++ b/beacon-chain/sync/validate_light_client_test.go
@@ -24,26 +24,28 @@ import (
 )
 
 func TestValidateLightClientOptimisticUpdate_NilMessageOrTopic(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
-	mockUpdate, err := util.MockOptimisticUpdate()
-	require.NoError(t, err)
-	s.lcStore.SetLastOptimisticUpdate(mockUpdate, false)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
+		mockUpdate, err := util.MockOptimisticUpdate()
+		require.NoError(t, err)
+		s.lcStore.SetLastOptimisticUpdate(mockUpdate, false)
 
-	_, err = s.validateLightClientOptimisticUpdate(ctx, "", nil)
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientOptimisticUpdate(ctx, "", nil)
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	emptyTopic := ""
-	_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
-		Topic: &emptyTopic,
-	}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		emptyTopic := ""
+		_, err = s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
+			Topic: &emptyTopic,
+		}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
+	})
 }
 
 func TestValidateLightClientOptimisticUpdate(t *testing.T) {
@@ -108,73 +110,77 @@ func TestValidateLightClientOptimisticUpdate(t *testing.T) {
 				continue
 			}
 			t.Run(test.name+"_"+version.String(v), func(t *testing.T) {
-				ctx := t.Context()
-				p := p2ptest.NewTestP2P(t)
-				// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
-				genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
-				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
-				lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-				s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
+				p2ptest.SynctestTest(t, func(t *testing.T) {
+					ctx := t.Context()
+					p := p2ptest.NewTestP2P(t)
+					// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
+					genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
+					chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
+					lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+					s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
 
-				var oldUpdate interfaces.LightClientOptimisticUpdate
-				if test.oldUpdateOptions != nil {
-					l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
-					var err error
-					oldUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
+					var oldUpdate interfaces.LightClientOptimisticUpdate
+					if test.oldUpdateOptions != nil {
+						l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
+						var err error
+						oldUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
+						require.NoError(t, err)
+
+						s.lcStore.SetLastOptimisticUpdate(oldUpdate, false)
+					}
+
+					l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
+					newUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
+					require.NoError(t, err)
+					buf := new(bytes.Buffer)
+					_, err = p.Encoding().EncodeGossip(buf, newUpdate)
 					require.NoError(t, err)
 
-					s.lcStore.SetLastOptimisticUpdate(oldUpdate, false)
-				}
-
-				l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
-				newUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
-				require.NoError(t, err)
-				buf := new(bytes.Buffer)
-				_, err = p.Encoding().EncodeGossip(buf, newUpdate)
-				require.NoError(t, err)
-
-				topic := p2p.LightClientOptimisticUpdateTopicFormat
-				digest, err := s.currentForkDigest()
-				require.NoError(t, err)
-				topic = s.addDigestToTopic(topic, digest)
-
-				r, err := s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{
-					Message: &pb.Message{
-						Data:  buf.Bytes(),
-						Topic: &topic,
-					}})
-				if test.expectedErr != nil {
-					require.ErrorIs(t, err, test.expectedErr)
-				} else {
+					topic := p2p.LightClientOptimisticUpdateTopicFormat
+					digest, err := s.currentForkDigest()
 					require.NoError(t, err)
-					require.Equal(t, test.expectedResult, r)
-				}
+					topic = s.addDigestToTopic(topic, digest)
+
+					r, err := s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{
+						Message: &pb.Message{
+							Data:  buf.Bytes(),
+							Topic: &topic,
+						}})
+					if test.expectedErr != nil {
+						require.ErrorIs(t, err, test.expectedErr)
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, test.expectedResult, r)
+					}
+				})
 			})
 		}
 	}
 }
 
 func TestValidateLightClientFinalityUpdate_NilMessageOrTopic(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	ctx := t.Context()
-	p := p2ptest.NewTestP2P(t)
-	lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
-	mockUpdate, err := util.MockFinalityUpdate()
-	require.NoError(t, err)
-	s.lcStore.SetLastFinalityUpdate(mockUpdate, false)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}, lcStore: lcStore}
+		mockUpdate, err := util.MockFinalityUpdate()
+		require.NoError(t, err)
+		s.lcStore.SetLastFinalityUpdate(mockUpdate, false)
 
-	_, err = s.validateLightClientFinalityUpdate(ctx, "", nil)
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientFinalityUpdate(ctx, "", nil)
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
 
-	emptyTopic := ""
-	_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
-		Topic: &emptyTopic,
-	}})
-	require.ErrorIs(t, err, errNilPubsubMessage)
+		emptyTopic := ""
+		_, err = s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{Message: &pb.Message{
+			Topic: &emptyTopic,
+		}})
+		require.ErrorIs(t, err, errNilPubsubMessage)
+	})
 }
 
 func TestValidateLightClientFinalityUpdate(t *testing.T) {
@@ -239,47 +245,49 @@ func TestValidateLightClientFinalityUpdate(t *testing.T) {
 				continue
 			}
 			t.Run(test.name+"_"+version.String(v), func(t *testing.T) {
-				ctx := t.Context()
-				p := p2ptest.NewTestP2P(t)
-				// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
-				genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
-				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
-				lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
-				s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
+				p2ptest.SynctestTest(t, func(t *testing.T) {
+					ctx := t.Context()
+					p := p2ptest.NewTestP2P(t)
+					// drift back appropriate number of epochs based on fork + 2 slots for signature slot + time for gossip propagation + any extra drift
+					genesisDrift := v*slotsPerEpoch*secondsPerSlot + 2*secondsPerSlot + secondsPerSlot/slotIntervals + test.genesisDrift
+					chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(genesisDrift), 0)}
+					lcStore := lightClient.NewLightClientStore(&p2ptest.FakeP2P{}, new(event.Feed), testDB.SetupDB(t))
+					s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}, lcStore: lcStore}
 
-				var oldUpdate interfaces.LightClientFinalityUpdate
-				if test.oldUpdateOptions != nil {
-					l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
-					var err error
-					oldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+					var oldUpdate interfaces.LightClientFinalityUpdate
+					if test.oldUpdateOptions != nil {
+						l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
+						var err error
+						oldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+						require.NoError(t, err)
+
+						s.lcStore.SetLastFinalityUpdate(oldUpdate, false)
+					}
+
+					l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
+					newUpdate, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+					require.NoError(t, err)
+					buf := new(bytes.Buffer)
+					_, err = p.Encoding().EncodeGossip(buf, newUpdate)
 					require.NoError(t, err)
 
-					s.lcStore.SetLastFinalityUpdate(oldUpdate, false)
-				}
-
-				l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
-				newUpdate, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
-				require.NoError(t, err)
-				buf := new(bytes.Buffer)
-				_, err = p.Encoding().EncodeGossip(buf, newUpdate)
-				require.NoError(t, err)
-
-				topic := p2p.LightClientFinalityUpdateTopicFormat
-				digest, err := s.currentForkDigest()
-				require.NoError(t, err)
-				topic = s.addDigestToTopic(topic, digest)
-
-				r, err := s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{
-					Message: &pb.Message{
-						Data:  buf.Bytes(),
-						Topic: &topic,
-					}})
-				if test.expectedErr != nil {
-					require.ErrorIs(t, err, test.expectedErr)
-				} else {
+					topic := p2p.LightClientFinalityUpdateTopicFormat
+					digest, err := s.currentForkDigest()
 					require.NoError(t, err)
-					require.Equal(t, test.expectedResult, r)
-				}
+					topic = s.addDigestToTopic(topic, digest)
+
+					r, err := s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{
+						Message: &pb.Message{
+							Data:  buf.Bytes(),
+							Topic: &topic,
+						}})
+					if test.expectedErr != nil {
+						require.ErrorIs(t, err, test.expectedErr)
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, test.expectedResult, r)
+					}
+				})
 			})
 		}
 	}

--- a/beacon-chain/sync/validate_payload_attestation_test.go
+++ b/beacon-chain/sync/validate_payload_attestation_test.go
@@ -26,29 +26,31 @@ import (
 )
 
 func TestValidatePayloadAttestationMessage_IncorrectTopic(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-	s := &Service{
-		payloadAttestationCache: &cache.PayloadAttestationCache{},
-		cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+		s := &Service{
+			payloadAttestationCache: &cache.PayloadAttestationCache{},
+			cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
 
-	msg := util.HydratePayloadAttestation(&ethpb.PayloadAttestation{}) // Using payload attestation for message should fail.
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		msg := util.HydratePayloadAttestation(&ethpb.PayloadAttestation{}) // Using payload attestation for message should fail.
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestation]()]
-	digest := s.currentForkDigest()
-	topic = s.addDigestToTopic(topic, digest)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestation]()]
+		digest := s.currentForkDigest()
+		topic = s.addDigestToTopic(topic, digest)
 
-	result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.ErrorContains(t, "extraction failed for topic", err)
-	require.Equal(t, result, pubsub.ValidationReject)
+		result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.ErrorContains(t, "extraction failed for topic", err)
+		require.Equal(t, result, pubsub.ValidationReject)
+	})
 }
 
 func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
@@ -95,66 +97,70 @@ func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.error.Error(), func(t *testing.T) {
-			ctx := context.Background()
-			p := p2ptest.NewTestP2P(t)
-			st, err := util.NewBeaconState()
-			require.NoError(t, err)
-			chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
-			s := &Service{
-				payloadAttestationCache: &cache.PayloadAttestationCache{},
-				cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-			s.newPayloadAttestationVerifier = tt.verifier
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				ctx := context.Background()
+				p := p2ptest.NewTestP2P(t)
+				st, err := util.NewBeaconState()
+				require.NoError(t, err)
+				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
+				s := &Service{
+					payloadAttestationCache: &cache.PayloadAttestationCache{},
+					cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+				s.newPayloadAttestationVerifier = tt.verifier
 
-			msg := newPayloadAttestationMessage()
-			buf := new(bytes.Buffer)
-			_, err = p.Encoding().EncodeGossip(buf, msg)
-			require.NoError(t, err)
+				msg := newPayloadAttestationMessage()
+				buf := new(bytes.Buffer)
+				_, err = p.Encoding().EncodeGossip(buf, msg)
+				require.NoError(t, err)
 
-			topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
-			digest := s.currentForkDigest()
-			topic = s.addDigestToTopic(topic, digest)
+				topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
+				digest := s.currentForkDigest()
+				topic = s.addDigestToTopic(topic, digest)
 
-			result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
-				Message: &pb.Message{
-					Data:  buf.Bytes(),
-					Topic: &topic,
-				}})
+				result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
+					Message: &pb.Message{
+						Data:  buf.Bytes(),
+						Topic: &topic,
+					}})
 
-			require.ErrorContains(t, tt.error.Error(), err)
-			require.Equal(t, result, tt.result)
+				require.ErrorContains(t, tt.error.Error(), err)
+				require.Equal(t, result, tt.result)
+			})
 		})
 	}
 }
 
 func TestValidatePayloadAttestationMessage_Accept(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
-	s := &Service{
-		payloadAttestationCache: &cache.PayloadAttestationCache{},
-		cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-	s.newPayloadAttestationVerifier = func(pa payloadattestation.ROMessage, reqs []verification.Requirement) verification.PayloadAttestationMsgVerifier {
-		return &verification.MockPayloadAttestation{}
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
+		s := &Service{
+			payloadAttestationCache: &cache.PayloadAttestationCache{},
+			cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+		s.newPayloadAttestationVerifier = func(pa payloadattestation.ROMessage, reqs []verification.Requirement) verification.PayloadAttestationMsgVerifier {
+			return &verification.MockPayloadAttestation{}
+		}
 
-	msg := newPayloadAttestationMessage()
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		msg := newPayloadAttestationMessage()
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
-	digest := s.currentForkDigest()
-	topic = s.addDigestToTopic(topic, digest)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
+		digest := s.currentForkDigest()
+		topic = s.addDigestToTopic(topic, digest)
 
-	result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationAccept)
+		result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationAccept)
+	})
 }
 
 func newPayloadAttestationMessage() *ethpb.PayloadAttestationMessage {

--- a/beacon-chain/sync/validate_payload_attestation_test.go
+++ b/beacon-chain/sync/validate_payload_attestation_test.go
@@ -26,30 +26,32 @@ import (
 )
 
 func TestValidatePayloadAttestationMessage_IncorrectTopic(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
-	s := &Service{
-		payloadAttestationCache: &cache.PayloadAttestationCache{},
-		cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
+		s := &Service{
+			payloadAttestationCache: &cache.PayloadAttestationCache{},
+			cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
 
-	msg := util.HydratePayloadAttestation(&ethpb.PayloadAttestation{}) // Using payload attestation for message should fail.
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		msg := util.HydratePayloadAttestation(&ethpb.PayloadAttestation{}) // Using payload attestation for message should fail.
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestation]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
-	topic = s.addDigestToTopic(topic, digest)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestation]()]
+		digest, err := s.currentForkDigest()
+		require.NoError(t, err)
+		topic = s.addDigestToTopic(topic, digest)
 
-	result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.ErrorContains(t, "extraction failed for topic", err)
-	require.Equal(t, result, pubsub.ValidationReject)
+		result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.ErrorContains(t, "extraction failed for topic", err)
+		require.Equal(t, result, pubsub.ValidationReject)
+	})
 }
 
 func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
@@ -96,68 +98,72 @@ func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.error.Error(), func(t *testing.T) {
-			ctx := context.Background()
-			p := p2ptest.NewTestP2P(t)
-			st, err := util.NewBeaconState()
-			require.NoError(t, err)
-			chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
-			s := &Service{
-				payloadAttestationCache: &cache.PayloadAttestationCache{},
-				cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-			s.newPayloadAttestationVerifier = tt.verifier
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				ctx := context.Background()
+				p := p2ptest.NewTestP2P(t)
+				st, err := util.NewBeaconState()
+				require.NoError(t, err)
+				chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
+				s := &Service{
+					payloadAttestationCache: &cache.PayloadAttestationCache{},
+					cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+				s.newPayloadAttestationVerifier = tt.verifier
 
-			msg := newPayloadAttestationMessage()
-			buf := new(bytes.Buffer)
-			_, err = p.Encoding().EncodeGossip(buf, msg)
-			require.NoError(t, err)
+				msg := newPayloadAttestationMessage()
+				buf := new(bytes.Buffer)
+				_, err = p.Encoding().EncodeGossip(buf, msg)
+				require.NoError(t, err)
 
-			topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
-			digest, err := s.currentForkDigest()
-			require.NoError(t, err)
-			topic = s.addDigestToTopic(topic, digest)
+				topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
+				digest, err := s.currentForkDigest()
+				require.NoError(t, err)
+				topic = s.addDigestToTopic(topic, digest)
 
-			result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
-				Message: &pb.Message{
-					Data:  buf.Bytes(),
-					Topic: &topic,
-				}})
+				result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
+					Message: &pb.Message{
+						Data:  buf.Bytes(),
+						Topic: &topic,
+					}})
 
-			require.ErrorContains(t, tt.error.Error(), err)
-			require.Equal(t, result, tt.result)
+				require.ErrorContains(t, tt.error.Error(), err)
+				require.Equal(t, result, tt.result)
+			})
 		})
 	}
 }
 
 func TestValidatePayloadAttestationMessage_Accept(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
-	s := &Service{
-		payloadAttestationCache: &cache.PayloadAttestationCache{},
-		cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
-	s.newPayloadAttestationVerifier = func(pa payloadattestation.ROMessage, reqs []verification.Requirement) verification.PayloadAttestationMsgVerifier {
-		return &verification.MockPayloadAttestation{}
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0), State: st}
+		s := &Service{
+			payloadAttestationCache: &cache.PayloadAttestationCache{},
+			cfg:                     &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}
+		s.newPayloadAttestationVerifier = func(pa payloadattestation.ROMessage, reqs []verification.Requirement) verification.PayloadAttestationMsgVerifier {
+			return &verification.MockPayloadAttestation{}
+		}
 
-	msg := newPayloadAttestationMessage()
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
+		msg := newPayloadAttestationMessage()
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, msg)
+		require.NoError(t, err)
 
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
-	topic = s.addDigestToTopic(topic, digest)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
+		digest, err := s.currentForkDigest()
+		require.NoError(t, err)
+		topic = s.addDigestToTopic(topic, digest)
 
-	result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
-		Message: &pb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		}})
-	require.NoError(t, err)
-	require.Equal(t, result, pubsub.ValidationAccept)
+		result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
+			Message: &pb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			}})
+		require.NoError(t, err)
+		require.Equal(t, result, pubsub.ValidationAccept)
+	})
 }
 
 func newPayloadAttestationMessage() *ethpb.PayloadAttestationMessage {

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -109,147 +109,155 @@ func setupValidProposerSlashing(t *testing.T) (*ethpb.ProposerSlashing, state.Be
 }
 
 func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidProposerSlashing(t)
+		slashing, s := setupValidProposerSlashing(t)
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	assert.NoError(t, err)
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, true, valid, "Failed validation")
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		assert.NoError(t, err)
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, true, valid, "Failed validation")
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+	})
 }
 
 func TestValidateProposerSlashing_ValidOldSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidProposerSlashing(t)
-	val, err := s.ValidatorAtIndex(slashing.Header_2.Header.ProposerIndex)
-	require.NoError(t, err)
-	val.Slashed = true
-	assert.NoError(t, s.UpdateValidatorAtIndex(slashing.Header_2.Header.ProposerIndex, val))
+		slashing, s := setupValidProposerSlashing(t)
+		val, err := s.ValidatorAtIndex(slashing.Header_2.Header.ProposerIndex)
+		require.NoError(t, err)
+		val.Slashed = true
+		assert.NoError(t, s.UpdateValidatorAtIndex(slashing.Header_2.Header.ProposerIndex, val))
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	assert.ErrorContains(t, "proposer is already slashed", err)
-	valid := res == pubsub.ValidationIgnore
-	assert.Equal(t, true, valid, "Failed validation")
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		assert.ErrorContains(t, "proposer is already slashed", err)
+		valid := res == pubsub.ValidationIgnore
+		assert.Equal(t, true, valid, "Failed validation")
+	})
 }
 
 func TestValidateProposerSlashing_ContextTimeout(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
 
-	slashing, st := setupValidProposerSlashing(t)
-	slashing.Header_1.Header.Slot = 100000000
-	err := st.SetJustificationBits(bitfield.Bitvector4{0x0F}) // 0b1111
-	require.NoError(t, err)
-	err = st.SetPreviousJustifiedCheckpoint(&ethpb.Checkpoint{Epoch: 0, Root: []byte{}})
-	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+		slashing, st := setupValidProposerSlashing(t)
+		slashing.Header_1.Header.Slot = 100000000
+		err := st.SetJustificationBits(bitfield.Bitvector4{0x0F}) // 0b1111
+		require.NoError(t, err)
+		err = st.SetPreviousJustifiedCheckpoint(&ethpb.Checkpoint{Epoch: 0, Root: []byte{}})
+		require.NoError(t, err)
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
 
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       &mock.ChainService{State: st},
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       &mock.ChainService{State: st},
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	assert.NotNil(t, err)
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Slashing from the far distant future should have timed out and returned false")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		assert.NotNil(t, err)
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Slashing from the far distant future should have timed out and returned false")
+	})
 }
 
 func TestValidateProposerSlashing_Syncing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidProposerSlashing(t)
+		slashing, s := setupValidProposerSlashing(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       &mock.ChainService{State: s},
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       &mock.ChainService{State: s},
+				initialSync: &mockSync.Sync{IsSyncing: true},
+			},
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Did not fail validation")
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Did not fail validation")
+	})
 }

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -109,149 +109,157 @@ func setupValidProposerSlashing(t *testing.T) (*ethpb.ProposerSlashing, state.Be
 }
 
 func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidProposerSlashing(t)
+		slashing, s := setupValidProposerSlashing(t)
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	assert.NoError(t, err)
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, true, valid, "Failed validation")
-	assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		assert.NoError(t, err)
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, true, valid, "Failed validation")
+		assert.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+	})
 }
 
 func TestValidateProposerSlashing_ValidOldSlashing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidProposerSlashing(t)
-	val, err := s.ValidatorAtIndex(slashing.Header_2.Header.ProposerIndex)
-	require.NoError(t, err)
-	val.Slashed = true
-	assert.NoError(t, s.UpdateValidatorAtIndex(slashing.Header_2.Header.ProposerIndex, val))
+		slashing, s := setupValidProposerSlashing(t)
+		val, err := s.ValidatorAtIndex(slashing.Header_2.Header.ProposerIndex)
+		require.NoError(t, err)
+		val.Slashed = true
+		assert.NoError(t, s.UpdateValidatorAtIndex(slashing.Header_2.Header.ProposerIndex, val))
 
-	chain := &mock.ChainService{State: s, Genesis: time.Now()}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             chain,
-			clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: chain.OperationNotifier(),
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-	}
+		chain := &mock.ChainService{State: s, Genesis: time.Now()}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             chain,
+				clock:             startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: chain.OperationNotifier(),
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
 
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	assert.ErrorContains(t, "proposer is already slashed", err)
-	valid := res == pubsub.ValidationIgnore
-	assert.Equal(t, true, valid, "Failed validation")
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		assert.ErrorContains(t, "proposer is already slashed", err)
+		valid := res == pubsub.ValidationIgnore
+		assert.Equal(t, true, valid, "Failed validation")
+	})
 }
 
 func TestValidateProposerSlashing_ContextTimeout(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
 
-	slashing, st := setupValidProposerSlashing(t)
-	slashing.Header_1.Header.Slot = 100000000
-	err := st.SetJustificationBits(bitfield.Bitvector4{0x0F}) // 0b1111
-	require.NoError(t, err)
-	err = st.SetPreviousJustifiedCheckpoint(&ethpb.Checkpoint{Epoch: 0, Root: []byte{}})
-	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+		slashing, st := setupValidProposerSlashing(t)
+		slashing.Header_1.Header.Slot = 100000000
+		err := st.SetJustificationBits(bitfield.Bitvector4{0x0F}) // 0b1111
+		require.NoError(t, err)
+		err = st.SetPreviousJustifiedCheckpoint(&ethpb.Checkpoint{Epoch: 0, Root: []byte{}})
+		require.NoError(t, err)
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
 
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       &mock.ChainService{State: st},
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		seenProposerSlashingCache: lruwrpr.New(10),
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       &mock.ChainService{State: st},
+				initialSync: &mockSync.Sync{IsSyncing: false},
+			},
+			seenProposerSlashingCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	assert.NotNil(t, err)
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Slashing from the far distant future should have timed out and returned false")
+		buf := new(bytes.Buffer)
+		_, err = p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		assert.NotNil(t, err)
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Slashing from the far distant future should have timed out and returned false")
+	})
 }
 
 func TestValidateProposerSlashing_Syncing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	slashing, s := setupValidProposerSlashing(t)
+		slashing, s := setupValidProposerSlashing(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p:         p,
-			chain:       &mock.ChainService{State: s},
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:         p,
+				chain:       &mock.ChainService{State: s},
+				initialSync: &mockSync.Sync{IsSyncing: true},
+			},
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, slashing)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateProposerSlashing(ctx, "", m)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Did not fail validation")
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, slashing)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateProposerSlashing(ctx, "", m)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Did not fail validation")
+	})
 }

--- a/beacon-chain/sync/validate_signed_proposer_preferences_test.go
+++ b/beacon-chain/sync/validate_signed_proposer_preferences_test.go
@@ -30,40 +30,46 @@ import (
 )
 
 func TestValidateSignedProposerPreferencesGossip_InvalidTopic(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{cfg: &config{p2p: p, initialSync: &mockSync.Sync{}}}
 
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", &pubsub.Message{Message: &pb.Message{}})
-	require.ErrorIs(t, p2p.ErrInvalidTopic, err)
-	require.Equal(t, pubsub.ValidationReject, result)
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", &pubsub.Message{Message: &pb.Message{}})
+		require.ErrorIs(t, p2p.ErrInvalidTopic, err)
+		require.Equal(t, pubsub.ValidationReject, result)
+	})
 }
 
 func TestValidateSignedProposerPreferencesGossip_InitialSync(t *testing.T) {
-	ctx := context.Background()
-	p := p2ptest.NewTestP2P(t)
-	s := &Service{
-		cfg: &config{
-			p2p:         p,
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{
+			cfg: &config{
+				p2p:         p,
+				initialSync: &mockSync.Sync{IsSyncing: true},
+			},
+		}
 
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", &pubsub.Message{})
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", &pubsub.Message{})
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateSignedProposerPreferencesGossip_CheckpointBlockNotSeen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, _ := setupSignedProposerPreferencesService(t)
-	s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(
-		mockSignedProposerPreferencesVerifier{errDependentRootSeen: errors.New("dependent_root block not seen")},
-	)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, _ := setupSignedProposerPreferencesService(t)
+		s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(
+			mockSignedProposerPreferencesVerifier{errDependentRootSeen: errors.New("dependent_root block not seen")},
+		)
 
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
-	require.NotNil(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+		require.NotNil(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateSignedProposerPreferencesGossip_ErrorPathsWithMock(t *testing.T) {
@@ -96,33 +102,37 @@ func TestValidateSignedProposerPreferencesGossip_ErrorPathsWithMock(t *testing.T
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, msg, _ := setupSignedProposerPreferencesService(t)
-			s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(tc.verifier)
+			p2ptest.SynctestTest(t, func(t *testing.T) {
+				s, msg, _ := setupSignedProposerPreferencesService(t)
+				s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(tc.verifier)
 
-			result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
-			if tc.wantError {
-				require.NotNil(t, err)
-			}
-			require.Equal(t, tc.result, result)
+				result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+				if tc.wantError {
+					require.NotNil(t, err)
+				}
+				require.Equal(t, tc.result, result)
+			})
 		})
 	}
 }
 
 func TestValidateSignedProposerPreferencesGossip_AlreadySeen(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedPreferences := setupSignedProposerPreferencesService(t)
-	s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedPreferences := setupSignedProposerPreferencesService(t)
+		s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
 
-	dependentRoot := bytesutil.ToBytes32(signedPreferences.Message.DependentRoot)
-	require.Equal(t, true, s.proposerPreferencesCache.Add(cache.ProposerPreference{
-		DependentRoot:  dependentRoot,
-		ValidatorIndex: signedPreferences.Message.ValidatorIndex,
-		FeeRecipient:   primitives.ExecutionAddress{0x01},
-		TargetGasLimit: 10,
-	}, signedPreferences.Message.ProposalSlot))
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		dependentRoot := bytesutil.ToBytes32(signedPreferences.Message.DependentRoot)
+		require.Equal(t, true, s.proposerPreferencesCache.Add(cache.ProposerPreference{
+			DependentRoot:  dependentRoot,
+			ValidatorIndex: signedPreferences.Message.ValidatorIndex,
+			FeeRecipient:   primitives.ExecutionAddress{0x01},
+			TargetGasLimit: 10,
+		}, signedPreferences.Message.ProposalSlot))
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 // TestValidateSignedProposerPreferencesGossip_HeadTooStale exercises the branch
@@ -130,80 +140,88 @@ func TestValidateSignedProposerPreferencesGossip_AlreadySeen(t *testing.T) {
 // (and not the +2 boundary edge case). With head state at epoch 0 and proposal
 // in epoch 3 the validator must ignore — proposer_lookahead cannot cover it.
 func TestValidateSignedProposerPreferencesGossip_HeadTooStale(t *testing.T) {
-	ctx := context.Background()
-	s, _, signedPreferences := setupSignedProposerPreferencesService(t)
-	s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
-	signedPreferences.Message.ProposalSlot = primitives.Slot(96)
-	msg := signedProposerPreferencesToPubsub(t, s, s.cfg.p2p, signedPreferences)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, _, signedPreferences := setupSignedProposerPreferencesService(t)
+		s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
+		signedPreferences.Message.ProposalSlot = primitives.Slot(96)
+		msg := signedProposerPreferencesToPubsub(t, s, s.cfg.p2p, signedPreferences)
 
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
-	require.ErrorContains(t, "cannot verify", err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+		require.ErrorContains(t, "cannot verify", err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateSignedProposerPreferencesGossip_DependentRootMismatchSkipsStateLoad(t *testing.T) {
-	ctx := context.Background()
-	s, _, signedPreferences := setupSignedProposerPreferencesService(t)
-	s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
-	msg := signedProposerPreferencesToPubsub(t, s, s.cfg.p2p, signedPreferences)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, _, signedPreferences := setupSignedProposerPreferencesService(t)
+		s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
+		msg := signedProposerPreferencesToPubsub(t, s, s.cfg.p2p, signedPreferences)
 
-	chainService := s.cfg.chain.(*mock.ChainService)
-	chainService.HeadStateErr = errors.New("head state should not load")
-	chainService.DependentRootCB = func(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
-		require.Equal(t, [32]byte{}, root)
-		require.Equal(t, primitives.Epoch(0), epoch)
-		return [32]byte{0xbb}, nil
-	}
+		chainService := s.cfg.chain.(*mock.ChainService)
+		chainService.HeadStateErr = errors.New("head state should not load")
+		chainService.DependentRootCB = func(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+			require.Equal(t, [32]byte{}, root)
+			require.Equal(t, primitives.Epoch(0), epoch)
+			return [32]byte{0xbb}, nil
+		}
 
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
-	require.ErrorContains(t, "dependent_root", err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+		require.ErrorContains(t, "dependent_root", err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+	})
 }
 
 func TestValidateSignedProposerPreferencesGossip_EpochPlus2DependentRootMismatch(t *testing.T) {
-	ctx := context.Background()
-	s, _, signedPreferences := setupSignedProposerPreferencesService(t)
-	s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
-	signedPreferences.Message.ProposalSlot = primitives.Slot(64)
-	msg := signedProposerPreferencesToPubsub(t, s, s.cfg.p2p, signedPreferences)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, _, signedPreferences := setupSignedProposerPreferencesService(t)
+		s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
+		signedPreferences.Message.ProposalSlot = primitives.Slot(64)
+		msg := signedProposerPreferencesToPubsub(t, s, s.cfg.p2p, signedPreferences)
 
-	var called bool
-	var gotRoot [32]byte
-	var gotEpoch primitives.Epoch
-	expectedRoot := [32]byte{0xaa}
-	s.cfg.chain.(*mock.ChainService).DependentRootCB = func(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
-		called = true
-		gotRoot = root
-		gotEpoch = epoch
-		return expectedRoot, nil
-	}
+		var called bool
+		var gotRoot [32]byte
+		var gotEpoch primitives.Epoch
+		expectedRoot := [32]byte{0xaa}
+		s.cfg.chain.(*mock.ChainService).DependentRootCB = func(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+			called = true
+			gotRoot = root
+			gotEpoch = epoch
+			return expectedRoot, nil
+		}
 
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
-	require.ErrorContains(t, "dependent_root", err)
-	require.Equal(t, pubsub.ValidationIgnore, result)
-	require.Equal(t, true, called)
-	require.Equal(t, [32]byte{}, gotRoot)
-	require.Equal(t, primitives.Epoch(1), gotEpoch)
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+		require.ErrorContains(t, "dependent_root", err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.Equal(t, true, called)
+		require.Equal(t, [32]byte{}, gotRoot)
+		require.Equal(t, primitives.Epoch(1), gotEpoch)
+	})
 }
 
 func TestValidateSignedProposerPreferencesGossip_HappyPath(t *testing.T) {
-	ctx := context.Background()
-	s, msg, signedPreferences := setupSignedProposerPreferencesService(t)
-	s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, msg, signedPreferences := setupSignedProposerPreferencesService(t)
+		s.newSignedProposerPreferencesVerifier = testNewSignedProposerPreferencesVerifier(mockSignedProposerPreferencesVerifier{})
 
-	s.proposerPreferencesCache.Clear()
-	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, result)
+		s.proposerPreferencesCache.Clear()
+		result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, result)
 
-	dependentRoot := bytesutil.ToBytes32(signedPreferences.Message.DependentRoot)
-	got, ok := s.proposerPreferencesCache.Get(dependentRoot, signedPreferences.Message.ProposalSlot)
-	require.Equal(t, true, ok)
-	require.DeepEqual(t, signedPreferences.Message.FeeRecipient, got.FeeRecipient[:])
-	require.Equal(t, signedPreferences.Message.TargetGasLimit, got.TargetGasLimit)
-	validatorData, ok := msg.ValidatorData.(*ethpb.SignedProposerPreferences)
-	require.Equal(t, true, ok)
-	require.DeepEqual(t, signedPreferences, validatorData)
+		dependentRoot := bytesutil.ToBytes32(signedPreferences.Message.DependentRoot)
+		got, ok := s.proposerPreferencesCache.Get(dependentRoot, signedPreferences.Message.ProposalSlot)
+		require.Equal(t, true, ok)
+		require.DeepEqual(t, signedPreferences.Message.FeeRecipient, got.FeeRecipient[:])
+		require.Equal(t, signedPreferences.Message.TargetGasLimit, got.TargetGasLimit)
+		validatorData, ok := msg.ValidatorData.(*ethpb.SignedProposerPreferences)
+		require.Equal(t, true, ok)
+		require.DeepEqual(t, signedPreferences, validatorData)
+	})
 }
 
 type mockSignedProposerPreferencesVerifier struct {

--- a/beacon-chain/sync/validate_sync_contribution_proof_test.go
+++ b/beacon-chain/sync/validate_sync_contribution_proof_test.go
@@ -887,141 +887,143 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 }
 
 func TestValidateSyncContributionAndProof(t *testing.T) {
-	ctx := t.Context()
-	database := testingdb.SetupDB(t)
-	headRoot, keys := fillUpBlocksAndState(ctx, t, database)
-	defaultTopic := p2p.SyncContributionAndProofSubnetTopicFormat
-	defaultTopic = fmt.Sprintf(defaultTopic, []byte{0xAB, 0x00, 0xCC, 0x9E})
-	defaultTopic = defaultTopic + "/" + encoder.ProtocolSuffixSSZSnappy
-	var emptySig [96]byte
-	pid := peer.ID("random")
-	msg := &ethpb.SignedContributionAndProof{
-		Message: &ethpb.ContributionAndProof{
-			AggregatorIndex: 1,
-			Contribution: &ethpb.SyncCommitteeContribution{
-				Slot:              0,
-				SubcommitteeIndex: 1,
-				BlockRoot:         params.BeaconConfig().ZeroHash[:],
-				AggregationBits:   bitfield.NewBitvector128(),
-				Signature:         emptySig[:],
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		ctx := t.Context()
+		database := testingdb.SetupDB(t)
+		headRoot, keys := fillUpBlocksAndState(ctx, t, database)
+		defaultTopic := p2p.SyncContributionAndProofSubnetTopicFormat
+		defaultTopic = fmt.Sprintf(defaultTopic, []byte{0xAB, 0x00, 0xCC, 0x9E})
+		defaultTopic = defaultTopic + "/" + encoder.ProtocolSuffixSSZSnappy
+		var emptySig [96]byte
+		pid := peer.ID("random")
+		msg := &ethpb.SignedContributionAndProof{
+			Message: &ethpb.ContributionAndProof{
+				AggregatorIndex: 1,
+				Contribution: &ethpb.SyncCommitteeContribution{
+					Slot:              0,
+					SubcommitteeIndex: 1,
+					BlockRoot:         params.BeaconConfig().ZeroHash[:],
+					AggregationBits:   bitfield.NewBitvector128(),
+					Signature:         emptySig[:],
+				},
+				SelectionProof: emptySig[:],
 			},
-			SelectionProof: emptySig[:],
-		},
-		Signature: emptySig[:],
-	}
-	chainService := &mockChain.ChainService{
-		Genesis:        time.Now(),
-		ValidatorsRoot: [32]byte{'A'},
-	}
-	s := NewService(t.Context(),
-		WithP2P(mockp2p.NewTestP2P(t)),
-		WithInitialSync(&mockSync.Sync{IsSyncing: false}),
-		WithChainService(chainService),
-		WithOperationNotifier(chainService.OperationNotifier()),
-	)
-	s.cfg.clock = startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
-	go s.verifierRoutine()
-	s.cfg.stateGen = stategen.New(database, doublylinkedtree.New())
-	msg.Message.Contribution.BlockRoot = headRoot[:]
-	s.cfg.beaconDB = database
-	hState, err := database.State(t.Context(), headRoot)
-	assert.NoError(t, err)
-	sc, err := hState.CurrentSyncCommittee()
-	assert.NoError(t, err)
-	cd, err := signing.Domain(hState.Fork(), slots.ToEpoch(slots.PrevSlot(hState.Slot())), params.BeaconConfig().DomainContributionAndProof, hState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	d, err := signing.Domain(hState.Fork(), slots.ToEpoch(hState.Slot()), params.BeaconConfig().DomainSyncCommittee, hState.GenesisValidatorsRoot())
-	assert.NoError(t, err)
-	var pubkeys [][]byte
-	for i := uint64(0); i < params.BeaconConfig().SyncCommitteeSubnetCount; i++ {
-		coms, err := altair.SyncSubCommitteePubkeys(sc, primitives.CommitteeIndex(i))
-		pubkeys = coms
+			Signature: emptySig[:],
+		}
+		chainService := &mockChain.ChainService{
+			Genesis:        time.Now(),
+			ValidatorsRoot: [32]byte{'A'},
+		}
+		s := NewService(t.Context(),
+			WithP2P(mockp2p.NewTestP2P(t)),
+			WithInitialSync(&mockSync.Sync{IsSyncing: false}),
+			WithChainService(chainService),
+			WithOperationNotifier(chainService.OperationNotifier()),
+		)
+		s.cfg.clock = startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
+		go s.verifierRoutine()
+		s.cfg.stateGen = stategen.New(database, doublylinkedtree.New())
+		msg.Message.Contribution.BlockRoot = headRoot[:]
+		s.cfg.beaconDB = database
+		hState, err := database.State(t.Context(), headRoot)
 		assert.NoError(t, err)
-		for _, p := range coms {
-			idx, ok := hState.ValidatorIndexByPubkey(bytesutil.ToBytes48(p))
-			assert.Equal(t, true, ok)
-			rt, err := syncSelectionProofSigningRoot(hState, slots.PrevSlot(hState.Slot()), primitives.CommitteeIndex(i))
+		sc, err := hState.CurrentSyncCommittee()
+		assert.NoError(t, err)
+		cd, err := signing.Domain(hState.Fork(), slots.ToEpoch(slots.PrevSlot(hState.Slot())), params.BeaconConfig().DomainContributionAndProof, hState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		d, err := signing.Domain(hState.Fork(), slots.ToEpoch(hState.Slot()), params.BeaconConfig().DomainSyncCommittee, hState.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		var pubkeys [][]byte
+		for i := uint64(0); i < params.BeaconConfig().SyncCommitteeSubnetCount; i++ {
+			coms, err := altair.SyncSubCommitteePubkeys(sc, primitives.CommitteeIndex(i))
+			pubkeys = coms
 			assert.NoError(t, err)
-			sig := keys[idx].Sign(rt[:])
-			isAggregator, err := altair.IsSyncCommitteeAggregator(sig.Marshal())
-			require.NoError(t, err)
-			if isAggregator {
-				msg.Message.AggregatorIndex = idx
-				msg.Message.SelectionProof = sig.Marshal()
-				msg.Message.Contribution.Slot = slots.PrevSlot(hState.Slot())
-				msg.Message.Contribution.SubcommitteeIndex = i
-				msg.Message.Contribution.BlockRoot = headRoot[:]
-				msg.Message.Contribution.AggregationBits = bitfield.NewBitvector128()
-				// Only Sign for 1 validator.
-				rawBytes := p2ptypes.SSZBytes(headRoot[:])
-				sigRoot, err := signing.ComputeSigningRoot(&rawBytes, d)
-				assert.NoError(t, err)
-				valIdx, ok := hState.ValidatorIndexByPubkey(bytesutil.ToBytes48(coms[0]))
+			for _, p := range coms {
+				idx, ok := hState.ValidatorIndexByPubkey(bytesutil.ToBytes48(p))
 				assert.Equal(t, true, ok)
-				sig = keys[valIdx].Sign(sigRoot[:])
-				msg.Message.Contribution.AggregationBits.SetBitAt(uint64(0), true)
-				msg.Message.Contribution.Signature = sig.Marshal()
-
-				sigRoot, err = signing.ComputeSigningRoot(msg.Message, cd)
+				rt, err := syncSelectionProofSigningRoot(hState, slots.PrevSlot(hState.Slot()), primitives.CommitteeIndex(i))
 				assert.NoError(t, err)
-				contrSig := keys[idx].Sign(sigRoot[:])
-				msg.Signature = contrSig.Marshal()
-				break
+				sig := keys[idx].Sign(rt[:])
+				isAggregator, err := altair.IsSyncCommitteeAggregator(sig.Marshal())
+				require.NoError(t, err)
+				if isAggregator {
+					msg.Message.AggregatorIndex = idx
+					msg.Message.SelectionProof = sig.Marshal()
+					msg.Message.Contribution.Slot = slots.PrevSlot(hState.Slot())
+					msg.Message.Contribution.SubcommitteeIndex = i
+					msg.Message.Contribution.BlockRoot = headRoot[:]
+					msg.Message.Contribution.AggregationBits = bitfield.NewBitvector128()
+					// Only Sign for 1 validator.
+					rawBytes := p2ptypes.SSZBytes(headRoot[:])
+					sigRoot, err := signing.ComputeSigningRoot(&rawBytes, d)
+					assert.NoError(t, err)
+					valIdx, ok := hState.ValidatorIndexByPubkey(bytesutil.ToBytes48(coms[0]))
+					assert.Equal(t, true, ok)
+					sig = keys[valIdx].Sign(sigRoot[:])
+					msg.Message.Contribution.AggregationBits.SetBitAt(uint64(0), true)
+					msg.Message.Contribution.Signature = sig.Marshal()
+
+					sigRoot, err = signing.ComputeSigningRoot(msg.Message, cd)
+					assert.NoError(t, err)
+					contrSig := keys[idx].Sign(sigRoot[:])
+					msg.Signature = contrSig.Marshal()
+					break
+				}
 			}
 		}
-	}
 
-	pd, err := signing.Domain(hState.Fork(), slots.ToEpoch(slots.PrevSlot(hState.Slot())), params.BeaconConfig().DomainSyncCommitteeSelectionProof, hState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	subCommitteeSize := params.BeaconConfig().SyncCommitteeSize / params.BeaconConfig().SyncCommitteeSubnetCount
-	s.cfg.chain = &mockChain.ChainService{
-		ValidatorsRoot:              [32]byte{'A'},
-		Genesis:                     time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot)),
-		SyncCommitteeIndices:        []primitives.CommitteeIndex{primitives.CommitteeIndex(msg.Message.Contribution.SubcommitteeIndex * subCommitteeSize)},
-		PublicKey:                   bytesutil.ToBytes48(keys[msg.Message.AggregatorIndex].PublicKey().Marshal()),
-		SyncSelectionProofDomain:    pd,
-		SyncContributionProofDomain: cd,
-		SyncCommitteeDomain:         d,
-		SyncCommitteePubkeys:        pubkeys,
-	}
-	s.cfg.clock = startup.NewClock(s.cfg.chain.GenesisTime(), s.cfg.chain.GenesisValidatorsRoot())
-	s.initCaches()
-
-	marshalledObj, err := msg.MarshalSSZ()
-	assert.NoError(t, err)
-	marshalledObj = snappy.Encode(nil, marshalledObj)
-	pubsubMsg := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  marshalledObj,
-			Topic: &defaultTopic,
-		},
-		ReceivedFrom:  "",
-		ValidatorData: nil,
-	}
-
-	// Subscribe to operation notifications.
-	opChannel := make(chan *feed.Event, 1)
-	opSub := s.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	_, err = s.validateSyncContributionAndProof(ctx, pid, pubsubMsg)
-	require.NoError(t, err)
-
-	// Ensure the state notification was broadcast.
-	notificationFound := false
-	for !notificationFound {
-		select {
-		case event := <-opChannel:
-			if event.Type == opfeed.SyncCommitteeContributionReceived {
-				notificationFound = true
-				_, ok := event.Data.(*opfeed.SyncCommitteeContributionReceivedData)
-				assert.Equal(t, true, ok, "Entity is not of type *opfeed.SyncCommitteeContributionReceivedData")
-			}
-		case <-opSub.Err():
-			t.Error("Subscription to state notifier failed")
-			return
+		pd, err := signing.Domain(hState.Fork(), slots.ToEpoch(slots.PrevSlot(hState.Slot())), params.BeaconConfig().DomainSyncCommitteeSelectionProof, hState.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		subCommitteeSize := params.BeaconConfig().SyncCommitteeSize / params.BeaconConfig().SyncCommitteeSubnetCount
+		s.cfg.chain = &mockChain.ChainService{
+			ValidatorsRoot:              [32]byte{'A'},
+			Genesis:                     time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot)),
+			SyncCommitteeIndices:        []primitives.CommitteeIndex{primitives.CommitteeIndex(msg.Message.Contribution.SubcommitteeIndex * subCommitteeSize)},
+			PublicKey:                   bytesutil.ToBytes48(keys[msg.Message.AggregatorIndex].PublicKey().Marshal()),
+			SyncSelectionProofDomain:    pd,
+			SyncContributionProofDomain: cd,
+			SyncCommitteeDomain:         d,
+			SyncCommitteePubkeys:        pubkeys,
 		}
-	}
+		s.cfg.clock = startup.NewClock(s.cfg.chain.GenesisTime(), s.cfg.chain.GenesisValidatorsRoot())
+		s.initCaches()
+
+		marshalledObj, err := msg.MarshalSSZ()
+		assert.NoError(t, err)
+		marshalledObj = snappy.Encode(nil, marshalledObj)
+		pubsubMsg := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  marshalledObj,
+				Topic: &defaultTopic,
+			},
+			ReceivedFrom:  "",
+			ValidatorData: nil,
+		}
+
+		// Subscribe to operation notifications.
+		opChannel := make(chan *feed.Event, 1)
+		opSub := s.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		_, err = s.validateSyncContributionAndProof(ctx, pid, pubsubMsg)
+		require.NoError(t, err)
+
+		// Ensure the state notification was broadcast.
+		notificationFound := false
+		for !notificationFound {
+			select {
+			case event := <-opChannel:
+				if event.Type == opfeed.SyncCommitteeContributionReceived {
+					notificationFound = true
+					_, ok := event.Data.(*opfeed.SyncCommitteeContributionReceivedData)
+					assert.Equal(t, true, ok, "Entity is not of type *opfeed.SyncCommitteeContributionReceivedData")
+				}
+			case <-opSub.Err():
+				t.Error("Subscription to state notifier failed")
+				return
+			}
+		}
+	})
 }
 
 func fillUpBlocksAndState(ctx context.Context, t *testing.T, beaconDB db.Database) ([32]byte, []bls.SecretKey) {
@@ -1061,115 +1063,117 @@ func syncSelectionProofSigningRoot(st state.BeaconState, slot primitives.Slot, c
 }
 
 func TestService_setSyncContributionIndexSlotSeen(t *testing.T) {
-	s := NewService(t.Context(), WithP2P(mockp2p.NewTestP2P(t)))
-	s.initCaches()
+	mockp2p.SynctestTest(t, func(t *testing.T) {
+		s := NewService(t.Context(), WithP2P(mockp2p.NewTestP2P(t)))
+		s.initCaches()
 
-	// Empty cache
-	b0 := bitfield.NewBitvector128()
-	b0.SetBitAt(0, true)
-	has, err := s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		AggregationBits: b0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, false, has)
+		// Empty cache
+		b0 := bitfield.NewBitvector128()
+		b0.SetBitAt(0, true)
+		has, err := s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			AggregationBits: b0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, false, has)
 
-	// Cache with entries but same key
-	require.NoError(t, s.setSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		AggregationBits: b0,
-	}))
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		AggregationBits: b0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, true, has)
-	b1 := bitfield.NewBitvector128()
-	b1.SetBitAt(1, true)
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		AggregationBits: b1,
-	})
-	require.NoError(t, err)
-	require.Equal(t, false, has)
-	b2 := bitfield.NewBitvector128()
-	b2.SetBitAt(1, true)
-	b2.SetBitAt(2, true)
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		AggregationBits: b2,
-	})
-	require.NoError(t, err)
-	require.Equal(t, false, has)
-	b2.SetBitAt(0, true)
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		AggregationBits: b2,
-	})
-	require.NoError(t, err)
-	require.Equal(t, true, has)
+		// Cache with entries but same key
+		require.NoError(t, s.setSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			AggregationBits: b0,
+		}))
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			AggregationBits: b0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, true, has)
+		b1 := bitfield.NewBitvector128()
+		b1.SetBitAt(1, true)
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			AggregationBits: b1,
+		})
+		require.NoError(t, err)
+		require.Equal(t, false, has)
+		b2 := bitfield.NewBitvector128()
+		b2.SetBitAt(1, true)
+		b2.SetBitAt(2, true)
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			AggregationBits: b2,
+		})
+		require.NoError(t, err)
+		require.Equal(t, false, has)
+		b2.SetBitAt(0, true)
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			AggregationBits: b2,
+		})
+		require.NoError(t, err)
+		require.Equal(t, true, has)
 
-	// Make sure set doesn't contain existing overlaps
-	require.Equal(t, 1, s.syncContributionBitsOverlapCache.Len())
+		// Make sure set doesn't contain existing overlaps
+		require.Equal(t, 1, s.syncContributionBitsOverlapCache.Len())
 
-	// Cache with entries but different key
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              1,
-		SubcommitteeIndex: 2,
-		BlockRoot:         []byte{'A'},
-		AggregationBits:   b0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, false, has)
-	require.NoError(t, s.setSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              1,
-		SubcommitteeIndex: 2,
-		BlockRoot:         []byte{'A'},
-		AggregationBits:   b2,
-	}))
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              1,
-		SubcommitteeIndex: 2,
-		BlockRoot:         []byte{'A'},
-		AggregationBits:   b0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, true, has)
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              1,
-		SubcommitteeIndex: 2,
-		BlockRoot:         []byte{'A'},
-		AggregationBits:   b1,
-	})
-	require.NoError(t, err)
-	require.Equal(t, true, has)
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              1,
-		SubcommitteeIndex: 2,
-		BlockRoot:         []byte{'A'},
-		AggregationBits:   b2,
-	})
-	require.NoError(t, err)
-	require.Equal(t, true, has)
+		// Cache with entries but different key
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              1,
+			SubcommitteeIndex: 2,
+			BlockRoot:         []byte{'A'},
+			AggregationBits:   b0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, false, has)
+		require.NoError(t, s.setSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              1,
+			SubcommitteeIndex: 2,
+			BlockRoot:         []byte{'A'},
+			AggregationBits:   b2,
+		}))
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              1,
+			SubcommitteeIndex: 2,
+			BlockRoot:         []byte{'A'},
+			AggregationBits:   b0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, true, has)
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              1,
+			SubcommitteeIndex: 2,
+			BlockRoot:         []byte{'A'},
+			AggregationBits:   b1,
+		})
+		require.NoError(t, err)
+		require.Equal(t, true, has)
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              1,
+			SubcommitteeIndex: 2,
+			BlockRoot:         []byte{'A'},
+			AggregationBits:   b2,
+		})
+		require.NoError(t, err)
+		require.Equal(t, true, has)
 
-	// Check invariant with the keys
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              2,
-		SubcommitteeIndex: 2,
-		BlockRoot:         []byte{'A'},
-		AggregationBits:   b0,
+		// Check invariant with the keys
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              2,
+			SubcommitteeIndex: 2,
+			BlockRoot:         []byte{'A'},
+			AggregationBits:   b0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, false, has)
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              1,
+			SubcommitteeIndex: 2,
+			BlockRoot:         []byte{'B'},
+			AggregationBits:   b0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, false, has)
+		has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
+			Slot:              1,
+			SubcommitteeIndex: 3,
+			BlockRoot:         []byte{'A'},
+			AggregationBits:   b0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, false, has)
 	})
-	require.NoError(t, err)
-	require.Equal(t, false, has)
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              1,
-		SubcommitteeIndex: 2,
-		BlockRoot:         []byte{'B'},
-		AggregationBits:   b0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, false, has)
-	has, err = s.hasSeenSyncContributionBits(&ethpb.SyncCommitteeContribution{
-		Slot:              1,
-		SubcommitteeIndex: 3,
-		BlockRoot:         []byte{'A'},
-		AggregationBits:   b0,
-	})
-	require.NoError(t, err)
-	require.Equal(t, false, has)
 }

--- a/beacon-chain/sync/validate_voluntary_exit_test.go
+++ b/beacon-chain/sync/validate_voluntary_exit_test.go
@@ -72,131 +72,137 @@ func setupValidExit(t *testing.T) (*ethpb.SignedVoluntaryExit, state.BeaconState
 }
 
 func TestValidateVoluntaryExit_ValidExit(t *testing.T) {
-	cfg := params.BeaconConfig().Copy()
-	cfg.DenebForkEpoch = math.MaxUint64
-	params.OverrideBeaconConfig(cfg)
-	params.SetupTestConfigCleanup(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.DenebForkEpoch = math.MaxUint64
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
 
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	exit, s := setupValidExit(t)
+		exit, s := setupValidExit(t)
 
-	gt := time.Now()
-	mockChainService := &mock.ChainService{
-		State:   s,
-		Genesis: gt,
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             mockChainService,
-			clock:             startup.NewClock(gt, [32]byte{}),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: mockChainService.OperationNotifier(),
-		},
-		seenExitCache: lruwrpr.New(10),
-	}
-
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, exit)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
-	d := r.currentForkDigest()
-	topic = r.addDigestToTopic(topic, d)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	// Subscribe to operation notifications.
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	res, err := r.validateVoluntaryExit(ctx, "", m)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, res, "Failed validation")
-	require.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.ExitReceived {
-			_, ok := event.Data.(*opfeed.ExitReceivedData)
-			assert.Equal(t, true, ok, "Entity is not of type *opfeed.ExitReceivedData")
-		} else {
-			t.Error("Unexpected event type received")
+		gt := time.Now()
+		mockChainService := &mock.ChainService{
+			State:   s,
+			Genesis: gt,
 		}
-	case <-opSub.Err():
-		t.Error("Subscription to state notifier failed")
-	case <-time.After(10 * time.Second): // Timeout to prevent hanging tests
-		t.Error("Timeout waiting for exit notification")
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             mockChainService,
+				clock:             startup.NewClock(gt, [32]byte{}),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: mockChainService.OperationNotifier(),
+			},
+			seenExitCache: lruwrpr.New(10),
+		}
+
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, exit)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
+		d := r.currentForkDigest()
+		topic = r.addDigestToTopic(topic, d)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		// Subscribe to operation notifications.
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		res, err := r.validateVoluntaryExit(ctx, "", m)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, res, "Failed validation")
+		require.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.ExitReceived {
+				_, ok := event.Data.(*opfeed.ExitReceivedData)
+				assert.Equal(t, true, ok, "Entity is not of type *opfeed.ExitReceivedData")
+			} else {
+				t.Error("Unexpected event type received")
+			}
+		case <-opSub.Err():
+			t.Error("Subscription to state notifier failed")
+		case <-time.After(10 * time.Second): // Timeout to prevent hanging tests
+			t.Error("Timeout waiting for exit notification")
+		}
+	})
 }
 
 func TestValidateVoluntaryExit_InvalidExitSlot(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	exit, s := setupValidExit(t)
-	// Set state slot to 1 to cause exit object fail to verify.
-	require.NoError(t, s.SetSlot(1))
-	r := &Service{
-		cfg: &config{
-			p2p: p,
-			chain: &mock.ChainService{
-				State: s,
+		exit, s := setupValidExit(t)
+		// Set state slot to 1 to cause exit object fail to verify.
+		require.NoError(t, s.SetSlot(1))
+		r := &Service{
+			cfg: &config{
+				p2p: p,
+				chain: &mock.ChainService{
+					State: s,
+				},
+				initialSync: &mockSync.Sync{IsSyncing: false},
 			},
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		seenExitCache: lruwrpr.New(10),
-	}
+			seenExitCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, exit)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateVoluntaryExit(ctx, "", m)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "passed validation")
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, exit)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateVoluntaryExit(ctx, "", m)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "passed validation")
+	})
 }
 
 func TestValidateVoluntaryExit_ValidExit_Syncing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	exit, s := setupValidExit(t)
+		exit, s := setupValidExit(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p: p,
-			chain: &mock.ChainService{
-				State: s,
+		r := &Service{
+			cfg: &config{
+				p2p: p,
+				chain: &mock.ChainService{
+					State: s,
+				},
+				initialSync: &mockSync.Sync{IsSyncing: true},
 			},
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, exit)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateVoluntaryExit(ctx, "", m)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Validation should have failed")
+		}
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, exit)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateVoluntaryExit(ctx, "", m)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Validation should have failed")
+	})
 }

--- a/beacon-chain/sync/validate_voluntary_exit_test.go
+++ b/beacon-chain/sync/validate_voluntary_exit_test.go
@@ -72,132 +72,138 @@ func setupValidExit(t *testing.T) (*ethpb.SignedVoluntaryExit, state.BeaconState
 }
 
 func TestValidateVoluntaryExit_ValidExit(t *testing.T) {
-	cfg := params.BeaconConfig().Copy()
-	cfg.DenebForkEpoch = math.MaxUint64
-	params.OverrideBeaconConfig(cfg)
-	params.SetupTestConfigCleanup(t)
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.DenebForkEpoch = math.MaxUint64
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
 
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	exit, s := setupValidExit(t)
+		exit, s := setupValidExit(t)
 
-	gt := time.Now()
-	mockChainService := &mock.ChainService{
-		State:   s,
-		Genesis: gt,
-	}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			chain:             mockChainService,
-			clock:             startup.NewClock(gt, [32]byte{}),
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			operationNotifier: mockChainService.OperationNotifier(),
-		},
-		seenExitCache: lruwrpr.New(10),
-	}
-
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, exit)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, d)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-
-	// Subscribe to operation notifications.
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	res, err := r.validateVoluntaryExit(ctx, "", m)
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, res, "Failed validation")
-	require.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
-
-	select {
-	case event := <-opChannel:
-		if event.Type == opfeed.ExitReceived {
-			_, ok := event.Data.(*opfeed.ExitReceivedData)
-			assert.Equal(t, true, ok, "Entity is not of type *opfeed.ExitReceivedData")
-		} else {
-			t.Error("Unexpected event type received")
+		gt := time.Now()
+		mockChainService := &mock.ChainService{
+			State:   s,
+			Genesis: gt,
 		}
-	case <-opSub.Err():
-		t.Error("Subscription to state notifier failed")
-	case <-time.After(10 * time.Second): // Timeout to prevent hanging tests
-		t.Error("Timeout waiting for exit notification")
-	}
+		r := &Service{
+			cfg: &config{
+				p2p:               p,
+				chain:             mockChainService,
+				clock:             startup.NewClock(gt, [32]byte{}),
+				initialSync:       &mockSync.Sync{IsSyncing: false},
+				operationNotifier: mockChainService.OperationNotifier(),
+			},
+			seenExitCache: lruwrpr.New(10),
+		}
+
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, exit)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
+		d, err := r.currentForkDigest()
+		assert.NoError(t, err)
+		topic = r.addDigestToTopic(topic, d)
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+
+		// Subscribe to operation notifications.
+		opChannel := make(chan *feed.Event, 1)
+		opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
+		defer opSub.Unsubscribe()
+
+		res, err := r.validateVoluntaryExit(ctx, "", m)
+		require.NoError(t, err)
+		require.Equal(t, pubsub.ValidationAccept, res, "Failed validation")
+		require.NotNil(t, m.ValidatorData, "Decoded message was not set on the message validator data")
+
+		select {
+		case event := <-opChannel:
+			if event.Type == opfeed.ExitReceived {
+				_, ok := event.Data.(*opfeed.ExitReceivedData)
+				assert.Equal(t, true, ok, "Entity is not of type *opfeed.ExitReceivedData")
+			} else {
+				t.Error("Unexpected event type received")
+			}
+		case <-opSub.Err():
+			t.Error("Subscription to state notifier failed")
+		case <-time.After(10 * time.Second): // Timeout to prevent hanging tests
+			t.Error("Timeout waiting for exit notification")
+		}
+	})
 }
 
 func TestValidateVoluntaryExit_InvalidExitSlot(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	exit, s := setupValidExit(t)
-	// Set state slot to 1 to cause exit object fail to verify.
-	require.NoError(t, s.SetSlot(1))
-	r := &Service{
-		cfg: &config{
-			p2p: p,
-			chain: &mock.ChainService{
-				State: s,
+		exit, s := setupValidExit(t)
+		// Set state slot to 1 to cause exit object fail to verify.
+		require.NoError(t, s.SetSlot(1))
+		r := &Service{
+			cfg: &config{
+				p2p: p,
+				chain: &mock.ChainService{
+					State: s,
+				},
+				initialSync: &mockSync.Sync{IsSyncing: false},
 			},
-			initialSync: &mockSync.Sync{IsSyncing: false},
-		},
-		seenExitCache: lruwrpr.New(10),
-	}
+			seenExitCache: lruwrpr.New(10),
+		}
 
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, exit)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateVoluntaryExit(ctx, "", m)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "passed validation")
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, exit)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateVoluntaryExit(ctx, "", m)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "passed validation")
+	})
 }
 
 func TestValidateVoluntaryExit_ValidExit_Syncing(t *testing.T) {
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
+	p2ptest.SynctestTest(t, func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		ctx := t.Context()
 
-	exit, s := setupValidExit(t)
+		exit, s := setupValidExit(t)
 
-	r := &Service{
-		cfg: &config{
-			p2p: p,
-			chain: &mock.ChainService{
-				State: s,
+		r := &Service{
+			cfg: &config{
+				p2p: p,
+				chain: &mock.ChainService{
+					State: s,
+				},
+				initialSync: &mockSync.Sync{IsSyncing: true},
 			},
-			initialSync: &mockSync.Sync{IsSyncing: true},
-		},
-	}
-	buf := new(bytes.Buffer)
-	_, err := p.Encoding().EncodeGossip(buf, exit)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateVoluntaryExit(ctx, "", m)
-	_ = err
-	valid := res == pubsub.ValidationAccept
-	assert.Equal(t, false, valid, "Validation should have failed")
+		}
+		buf := new(bytes.Buffer)
+		_, err := p.Encoding().EncodeGossip(buf, exit)
+		require.NoError(t, err)
+		topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
+		m := &pubsub.Message{
+			Message: &pubsubpb.Message{
+				Data:  buf.Bytes(),
+				Topic: &topic,
+			},
+		}
+		res, err := r.validateVoluntaryExit(ctx, "", m)
+		_ = err
+		valid := res == pubsub.ValidationAccept
+		assert.Equal(t, false, valid, "Validation should have failed")
+	})
 }

--- a/changelog/syjn99_p2p-synctest-tests.md
+++ b/changelog/syjn99_p2p-synctest-tests.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- `SlotTicker` and `SlotIntervalTicker` no longer leak two goroutines when the consumer stops reading `C()` before `Done()`: the tick send now also selects on `done`, and `Done()` closes `done` instead of blocking on an unbuffered send. `Done()` is now idempotent.
+- Sync service background goroutines (`processDataColumnLogs` & the quic-v1 stream-reset delay) now respect service shutdown.
+- Remove `prunePendingGloasColumns` function as it races with genesis clock at startup. Instead include `pruneStaleGloasColumns` in `p2pHandlerControlLoop`.
+- Committee cache (process-wide variable) fill tracking no longer uses a `sync.WaitGroup` that crashes when mixed with `testing/synctest` bubbles.
+- Unstoppable `go-cache` janitor goroutines are disabled, with expired entries reclaimed lazily.
+
+### Ignored
+
+- Migrated `beacon-chain/p2p` and `beacon-chain/sync` p2p tests to `testing/synctest` bubbles with hosts on an in-memory simulated network (`x/simlibp2p`), following libp2p/go-libp2p-pubsub#686. Make tests much faster and deterministic.

--- a/changelog/syjn99_p2p-synctest-tests.md
+++ b/changelog/syjn99_p2p-synctest-tests.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Sync service background goroutines (`processDataColumnLogs` & the quic-v1 stream-reset delay) now respect service shutdown.
+- Remove `prunePendingGloasColumns` function as it races with genesis clock at startup. Instead include `pruneStaleGloasColumns` in `p2pHandlerControlLoop`.
+- Committee cache (process-wide variable) fill tracking no longer uses a `sync.WaitGroup` that crashes when mixed with `testing/synctest` bubbles.
+- Unstoppable `go-cache` janitor goroutines are disabled, with expired entries reclaimed lazily.
+
+### Ignored
+
+- Migrated `beacon-chain/p2p` and `beacon-chain/sync` p2p tests to `testing/synctest` bubbles with hosts on an in-memory simulated network (`x/simlibp2p`), following libp2p/go-libp2p-pubsub#686. Make tests much faster and deterministic.

--- a/time/slots/slotticker.go
+++ b/time/slots/slotticker.go
@@ -2,6 +2,7 @@
 package slots
 
 import (
+	"sync"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -37,15 +38,17 @@ type IntervalTicker interface {
 // multiple of the slot duration.
 // In addition, the channel returns the new slot number.
 type SlotTicker struct {
-	c    chan primitives.Slot
-	done chan struct{}
+	c        chan primitives.Slot
+	done     chan struct{}
+	doneOnce sync.Once
 }
 
 // SlotIntervalTicker is similar to a slot ticker but it returns also
 // the index of the interval that triggered the event
 type SlotIntervalTicker struct {
-	c    chan SlotInterval
-	done chan struct{}
+	c        chan SlotInterval
+	done     chan struct{}
+	doneOnce sync.Once
 }
 
 // C returns the ticker channel. Call Cancel afterwards to ensure
@@ -60,18 +63,24 @@ func (s *SlotIntervalTicker) C() <-chan SlotInterval {
 	return s.c
 }
 
-// Done should be called to clean up the ticker.
+// Done should be called to clean up the ticker. It is safe to call more than once.
 func (s *SlotTicker) Done() {
-	go func() {
-		s.done <- struct{}{}
-	}()
+	s.doneOnce.Do(func() {
+		// A zero-value SlotTicker was never started and has no channel to close.
+		if s.done != nil {
+			close(s.done)
+		}
+	})
 }
 
-// Done should be called to clean up the ticker.
+// Done should be called to clean up the ticker. It is safe to call more than once.
 func (s *SlotIntervalTicker) Done() {
-	go func() {
-		s.done <- struct{}{}
-	}()
+	s.doneOnce.Do(func() {
+		// A zero-value SlotIntervalTicker was never started and has no channel to close.
+		if s.done != nil {
+			close(s.done)
+		}
+	})
 }
 
 // NewSlotTicker starts and returns a new SlotTicker instance.
@@ -140,7 +149,12 @@ func (s *SlotTicker) start(
 			waitTime := until(nextTickTime)
 			select {
 			case <-after(waitTime):
-				s.c <- slot
+				// Also select on done: nothing may be reading C() any more.
+				select {
+				case s.c <- slot:
+				case <-s.done:
+					return
+				}
 				slot++
 				nextTickTime = nextTickTime.Add(d)
 			case <-s.done:
@@ -168,7 +182,12 @@ func (s *SlotIntervalTicker) startWithIntervals(
 			waitTime := until(nextTickTime)
 			select {
 			case <-after(waitTime):
-				s.c <- SlotInterval{Slot: slot, Interval: interval}
+				// Also select on done: nothing may be reading C() any more.
+				select {
+				case s.c <- SlotInterval{Slot: slot, Interval: interval}:
+				case <-s.done:
+					return
+				}
 				interval++
 				if interval == len(intervals) {
 					interval = 0


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix: Found some goroutine leaks while adding synctest.

**What does this PR do? Why is it needed?**

This PR introduces a new harness for testing P2P-related stuffs with [synctest](https://go.dev/blog/synctest). Inspired from https://github.com/libp2p/go-libp2p-pubsub/pull/686, this PR introduces `simlibp2p` and `marcopolo/simnet` to simulate real networking stack ((QUIC, TLS, muxing, gossipsub), upon simulated in-memory wire. This gives us a couple of advantages:

- **Deterministic**: Our P2P tests have been a bit flaky, as it normally "loops back" to the host that these tests are running. By scoping all tests into a dedicated *bubble*, Go test runtime cares all goroutines which are durably blocked. Most of the commits before wrapping the existing unit tests are the effort to make our unit tests avoid leaking goroutines that cannot be stopped inside the bubble.
- **Test duration**: Inside the bubble, there exists a fake clock so we don't have to heuristically *wait* something to happen.

I locally ran unit tests 10 times with this command:

```
bazel test <target> --runs_per_test=10 --local_test_jobs=1 --nocache_test_results --test_summary=detailed
```

and the flakiness and duration have dramatically improved in this branch compared to `develop`.

- `develop`: 9 of 10 runs red so `flaky = True` is triggerred for the most of time. Average testing time: 18.7 second.
- This branch (`test/p2p-synctest`): 10 of 10 runs green - so there's no "re-run" due to inherent flakiness of these tests. Average test time: 15.1 second.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

<img width="266" height="293" alt="image" src="https://github.com/user-attachments/assets/0ad4090b-67d7-49a6-95a6-219108d3dcec" />

> [!NOTE]
> Most of the diff comes from wrapping an existing unit test with `SynctestTest` helper. So I highly recommend to "hide whitespace" to save your brainpower.

> [!IMPORTANT]
> Also, I tried to trim the commit as neat as possible. So please read commit by commit, with commit descriptions. (You can skip changelog commit though)

According to Claude, there are still a lot of unit tests left that are using `NewTestP2P`.

- `beacon-chain/sync/initial-sync`: Deliberately excluded in this PR. Will do in next PRs.
- Few tests in `beacon-chain/p2p`: discovery tests run on real UDP, so this cannot be bubbled at this moment.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
