### PR TITLE
Fix: E2E metrics check comparison logic (Issue #17043)

### DIFF
--- a/testing/endtoend/evaluators/metrics.go
+++ b/testing/endtoend/evaluators/metrics.go
@@ -168,20 +168,15 @@ func metricCheckLessThan(pageContent, topic string, value int) error {
 
 func metricCheckComparison(pageContent, topic1, topic2 string, comparison float64) error {
 	topic2Value, err := valueOfTopic(pageContent, topic2)
-	// If we can't find the first topic (error metrics), then assume the test passes.
-	if topic2Value != -1 {
+	if err != nil || topic2Value == -1 {
 		return nil
 	}
-	if err != nil {
-		return err
-	}
+
 	topic1Value, err := valueOfTopic(pageContent, topic1)
-	if topic1Value != -1 {
+	if err != nil || topic1Value == -1 {
 		return nil
 	}
-	if err != nil {
-		return err
-	}
+
 	topicComparison := float64(topic1Value) / float64(topic2Value)
 	if topicComparison >= comparison {
 		return fmt.Errorf(

--- a/testing/endtoend/evaluators/metrics_test.go
+++ b/testing/endtoend/evaluators/metrics_test.go
@@ -1,0 +1,189 @@
+package evaluators
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetricCheckComparison(t *testing.T) {
+	tests := []struct {
+		name        string
+		pageContent string
+		topic1      string
+		topic2      string
+		comparison  float64
+		wantErr     bool
+	}{
+		{
+			name: "valid metrics with ratio below threshold",
+			pageContent: `# HELP committee_cache_miss Test metric
+# TYPE committee_cache_miss counter
+committee_cache_miss 10
+# HELP committee_cache_hit Test metric
+# TYPE committee_cache_hit counter
+committee_cache_hit 1000
+`,
+			topic1:     "committee_cache_miss",
+			topic2:     "committee_cache_hit",
+			comparison: 0.05,
+			wantErr:    false,
+		},
+		{
+			name: "valid metrics with ratio exceeding threshold",
+			pageContent: `# HELP committee_cache_miss Test metric
+# TYPE committee_cache_miss counter
+committee_cache_miss 40
+# HELP committee_cache_hit Test metric
+# TYPE committee_cache_hit counter
+committee_cache_hit 2946
+`,
+			topic1:     "committee_cache_miss",
+			topic2:     "committee_cache_hit",
+			comparison: 0.01,
+			wantErr:    true,
+		},
+		{
+			name: "topic2 not found should skip test",
+			pageContent: `# HELP committee_cache_miss Test metric
+# TYPE committee_cache_miss counter
+committee_cache_miss 10
+`,
+			topic1:     "committee_cache_miss",
+			topic2:     "missing_cache_hit",
+			comparison: 0.01,
+			wantErr:    false,
+		},
+		{
+			name: "topic1 not found should skip test",
+			pageContent: `# HELP committee_cache_hit Test metric
+# TYPE committee_cache_hit counter
+committee_cache_hit 1000
+`,
+			topic1:     "missing_cache_miss",
+			topic2:     "committee_cache_hit",
+			comparison: 0.01,
+			wantErr:    false,
+		},
+		{
+			name: "both topics missing should skip test",
+			pageContent: `# HELP some_other_metric Test metric
+# TYPE some_other_metric counter
+some_other_metric 100
+`,
+			topic1:     "missing_metric_1",
+			topic2:     "missing_metric_2",
+			comparison: 0.01,
+			wantErr:    false,
+		},
+		{
+			name: "hot state cache miss ratio above threshold",
+			pageContent: `# HELP hot_state_cache_miss Test metric
+# TYPE hot_state_cache_miss counter
+hot_state_cache_miss 1
+# HELP hot_state_cache_hit Test metric
+# TYPE hot_state_cache_hit counter
+hot_state_cache_hit 41
+`,
+			topic1:     "hot_state_cache_miss",
+			topic2:     "hot_state_cache_hit",
+			comparison: 0.01,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := metricCheckComparison(tt.pageContent, tt.topic1, tt.topic2, tt.comparison)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("metricCheckComparison() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValueOfTopic(t *testing.T) {
+	tests := []struct {
+		name        string
+		pageContent string
+		topic       string
+		want        int
+		wantErr     bool
+	}{
+		{
+			name: "finds single metric value",
+			pageContent: `# HELP test_metric Test metric help
+# TYPE test_metric gauge
+test_metric 42
+`,
+			topic:   "test_metric",
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name: "metric not found returns error",
+			pageContent: `# HELP some_metric Some metric help
+# TYPE some_metric gauge
+some_metric 10
+`,
+			topic:   "missing_metric",
+			want:    -1,
+			wantErr: true,
+		},
+		{
+			name: "finds float metric value",
+			pageContent: `# HELP cache_hit_rate Cache hit rate help
+# TYPE cache_hit_rate gauge
+cache_hit_rate 0.95
+`,
+			topic:   "cache_hit_rate",
+			want:    0,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := valueOfTopic(tt.pageContent, tt.topic)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("valueOfTopic() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("valueOfTopic() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetricCheckComparisonFix(t *testing.T) {
+	t.Run("fix verification: comparison actually happens when metrics found", func(t *testing.T) {
+		pageContent := `# HELP committee_cache_miss Test metric
+# TYPE committee_cache_miss counter
+committee_cache_miss 40
+# HELP committee_cache_hit Test metric
+# TYPE committee_cache_hit counter
+committee_cache_hit 2946
+`
+		err := metricCheckComparison(pageContent, "committee_cache_miss", "committee_cache_hit", 0.01)
+		if err == nil {
+			t.Error("Expected error when ratio 40/2946=0.0135 exceeds threshold 0.01, but got nil")
+		}
+		if err != nil && !strings.Contains(err.Error(), "unexpected result") {
+			t.Errorf("Expected error about comparison, got: %v", err)
+		}
+	})
+
+	t.Run("fix verification: test passes when ratio below threshold", func(t *testing.T) {
+		pageContent := `# HELP committee_cache_miss Test metric
+# TYPE committee_cache_miss counter
+committee_cache_miss 5
+# HELP committee_cache_hit Test metric
+# TYPE committee_cache_hit counter
+committee_cache_hit 2946
+`
+		err := metricCheckComparison(pageContent, "committee_cache_miss", "committee_cache_hit", 0.01)
+		if err != nil {
+			t.Errorf("Expected no error when ratio 5/2946=0.0017 is below threshold 0.01, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
- Fix inverted logic in metricCheckComparison function
- Change metric value checks from '!= -1' to '== -1'
- Skip test only when metrics are not found, not when found
- Add comprehensive unit tests for all scenarios
- Tests now correctly fail when metric ratios exceed thresholds

Fixes:
- committee_cache_miss_rate now properly validated
- hot_state_cache_miss_rate now properly validated
- P2P message failure ratios now properly validated

Testing:
- All 11 unit tests pass
- Build successful
- No compilation errors

close #17043
