### PR TITLE
Bound Gloas data column sidecar slot before queueing

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -249,6 +249,7 @@ go_test(
         "validate_sync_committee_message_test.go",
         "validate_sync_contribution_proof_test.go",
         "validate_voluntary_exit_test.go",
+        "wire_vs_memory_test.go",
     ],
     embed = [":go_default_library"],
     shard_count = 4,

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -47,15 +47,15 @@ func (s *Service) validateDataColumnGloas(
 ) (blocks.VerifiedRODataColumn, error) {
 	// data_column_sidecar_{subnet_id}
 	// [Modified in Gloas:EIP7732]
-
-	if err := s.gloasColumnNotFromFutureSlot(roDataColumn.Slot()); err != nil {
-		return blocks.VerifiedRODataColumn{}, ignoreValidation(err)
-	}
-
+	//
 	// [IGNORE] A valid block for the sidecar's slot has been seen (via gossip or non-gossip sources).
 	// If not yet seen, a client MUST queue the sidecar for deferred validation and possible processing once
 	// the block is received or retrieved.
 	if s.cfg.chain == nil || !s.cfg.chain.HasBlock(ctx, roDataColumn.BlockRoot()) {
+		// The slot is attacker controlled, a far-future slot would make the queued entry unprunable.
+		if err := s.gloasColumnNotFromFutureSlot(roDataColumn.Slot()); err != nil {
+			return blocks.VerifiedRODataColumn{}, ignoreValidation(err)
+		}
 		actualSubnet := peerdas.ComputeSubnetForDataColumnSidecar(roDataColumn.Index())
 		expectedSubTopic := fmt.Sprintf(dataColumnSidecarSubTopic, actualSubnet)
 		if msg.Topic == nil || !strings.Contains(*msg.Topic+"/", expectedSubTopic) {

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -47,7 +47,11 @@ func (s *Service) validateDataColumnGloas(
 ) (blocks.VerifiedRODataColumn, error) {
 	// data_column_sidecar_{subnet_id}
 	// [Modified in Gloas:EIP7732]
-	//
+
+	if err := s.gloasColumnNotFromFutureSlot(roDataColumn.Slot()); err != nil {
+		return blocks.VerifiedRODataColumn{}, ignoreValidation(err)
+	}
+
 	// [IGNORE] A valid block for the sidecar's slot has been seen (via gossip or non-gossip sources).
 	// If not yet seen, a client MUST queue the sidecar for deferred validation and possible processing once
 	// the block is received or retrieved.
@@ -177,6 +181,21 @@ func (s *Service) queuePendingGloasColumn(roCol blocks.RODataColumn, pid peer.ID
 		return nil
 	}
 	entry.columns[idx] = &pendingColumnEntry{sidecar: dc, peer: pid}
+	return nil
+}
+
+func (s *Service) gloasColumnNotFromFutureSlot(slot primitives.Slot) error {
+	if s.cfg.clock.CurrentSlot() == slot {
+		return nil
+	}
+	earliestStart, err := s.cfg.clock.SlotStart(slot)
+	if err != nil {
+		return errors.Wrap(err, "slot start time")
+	}
+	earliestStart = earliestStart.Add(-params.BeaconConfig().MaximumGossipClockDisparityDuration())
+	if s.cfg.clock.Now().Before(earliestStart) {
+		return errors.Errorf("gloas data column slot %d is from a future slot", slot)
+	}
 	return nil
 }
 

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -201,8 +201,7 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		params.OverrideBeaconConfig(cfg)
 
 		sidecar, signedBlock := gloasFixture(t)
-		// Decrement so the mismatch is a past slot, else the future-slot IGNORE fires before the slot-match REJECT.
-		sidecar.Slot--
+		sidecar.Slot++
 
 		service, _ := serviceAndMessage(t, testVerifierReturnsAll(&verification.MockDataColumnsVerifier{}), sidecar, sidecar.Index)
 

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -136,6 +137,26 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		require.Equal(t, peer.ID("aDummyPID"), entry.columns[sidecar.Index].peer)
 	})
 
+	t.Run("ignores future slot without queueing", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.DenebForkEpoch = 0
+		cfg.ElectraForkEpoch = 0
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		// A far-future slot must be dropped before the unseen-block path queues it, otherwise
+		// the entry is never pruned and 8 of them permanently exhaust the pending queue.
+		sidecar, _ := gloasFixture(t)
+		sidecar.Slot = ^primitives.Slot(0) - 1
+		service, message := serviceAndMessage(t, testNewDataColumnSidecarsVerifier(verification.MockDataColumnsVerifier{ErrValidFields: genericError}), sidecar, sidecar.Index)
+		result, err := service.validateDataColumn(ctx, "aDummyPID", message)
+		require.NotNil(t, err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.Equal(t, 0, len(service.pendingGloasColumns))
+	})
+
 	t.Run("validates against bid commitments", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		cfg := params.BeaconConfig()
@@ -180,7 +201,8 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		params.OverrideBeaconConfig(cfg)
 
 		sidecar, signedBlock := gloasFixture(t)
-		sidecar.Slot++
+		// Decrement so the mismatch is a past slot, else the future-slot IGNORE fires before the slot-match REJECT.
+		sidecar.Slot--
 
 		service, _ := serviceAndMessage(t, testVerifierReturnsAll(&verification.MockDataColumnsVerifier{}), sidecar, sidecar.Index)
 

--- a/changelog/terence_gloas-column-future-slot-dos.md
+++ b/changelog/terence_gloas-column-future-slot-dos.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Ignore Gloas data column sidecars from a future slot before queueing, preventing pending entries that are never pruned.


### PR DESCRIPTION
Fixes #17149. Gloas data column sidecars are unsigned, so an attacker controls their slot. The unseen-block path queued them without a slot check, letting a far-future slot create a pending entry that pruning never evicts, permanently exhausting the queue with ~8 messages.

This ignores future-slot sidecars before they reach the pending queue, so every queued entry is prunable within a slot. The gloas spec dropped the future-slot and above-finalized gossip conditions along with the signed header, so this is client-side hardening, not a spec condition.