### PR TITLE
Apply Gloas state-diff pending deposits against pre-upgrade list

### DIFF
--- a/changelog/terence_gloas-state-diff-pending-deposits.md
+++ b/changelog/terence_gloas-state-diff-pending-deposits.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Apply the Gloas cross-fork state-diff pending_deposits against the anchor's pre-upgrade list, fixing a panic and state corruption when builder deposits are onboarded at the Fulu to Gloas fork with `--enable-state-diff`.

--- a/consensus-types/hdiff/BUILD.bazel
+++ b/consensus-types/hdiff/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native:go_default_library",
         "//config/fieldparams:go_default_library",
+        "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//proto/engine/v1:go_default_library",

--- a/consensus-types/hdiff/state_diff.go
+++ b/consensus-types/hdiff/state_diff.go
@@ -1824,6 +1824,14 @@ func applyBalancesDiff(source state.BeaconState, diff []int64) (state.BeaconStat
 // applyStateDiff applies the given diff to the source state in place.
 func applyStateDiff(ctx context.Context, source state.BeaconState, diff *stateDiff) (state.BeaconState, error) {
 	var err error
+	// updateToVersion runs Gloas onboarding which drops builder deposits, so capture the pre-upgrade list the diff indexes.
+	var prevPendingDeposits []*ethpb.PendingDeposit
+	if source.Version() >= version.Electra {
+		prevPendingDeposits, err = source.PendingDeposits()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get pending deposits")
+		}
+	}
 	if source, err = updateToVersion(ctx, source, diff.targetVersion); err != nil {
 		return nil, errors.Wrap(err, "failed to update state to target version")
 	}
@@ -1956,7 +1964,7 @@ func applyStateDiff(ctx context.Context, source state.BeaconState, diff *stateDi
 	if err := source.SetEarliestConsolidationEpoch(diff.earliestConsolidationEpoch); err != nil {
 		return nil, errors.Wrap(err, "failed to set earliest consolidation epoch")
 	}
-	if err := applyPendingDepositsDiff(source, diff); err != nil {
+	if err := applyPendingDepositsDiff(source, diff, prevPendingDeposits); err != nil {
 		return nil, errors.Wrap(err, "failed to apply pending deposits diff")
 	}
 	if err := applyPendingPartialWithdrawalsDiff(source, diff); err != nil {
@@ -1980,13 +1988,12 @@ func applyStateDiff(ctx context.Context, source state.BeaconState, diff *stateDi
 	return source, nil
 }
 
-// applyPendingDepositsDiff applies the pending deposits diff to the source state in place.
-func applyPendingDepositsDiff(source state.BeaconState, diff *stateDiff) error {
-	sPendingDeposits, err := source.PendingDeposits()
-	if err != nil {
-		return errors.Wrap(err, "failed to get pending deposits")
+// prevPendingDeposits is the anchor's pre-upgrade list the diff indexes, not source's post-upgrade list.
+func applyPendingDepositsDiff(source state.BeaconState, diff *stateDiff, prevPendingDeposits []*ethpb.PendingDeposit) error {
+	if int(diff.pendingDepositIndex) > len(prevPendingDeposits) {
+		return errors.Errorf("pending deposit index %d exceeds source length %d", diff.pendingDepositIndex, len(prevPendingDeposits))
 	}
-	sPendingDeposits = sPendingDeposits[int(diff.pendingDepositIndex):]
+	sPendingDeposits := prevPendingDeposits[int(diff.pendingDepositIndex):]
 	for _, t := range diff.pendingDepositDiff {
 		sPendingDeposits = append(sPendingDeposits, &ethpb.PendingDeposit{
 			PublicKey:             slices.Clone(t.PublicKey),

--- a/consensus-types/hdiff/state_diff_gloas_test.go
+++ b/consensus-types/hdiff/state_diff_gloas_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
@@ -252,6 +253,46 @@ func TestGloasCrossForkDiff(t *testing.T) {
 	require.NoError(t, err)
 
 	result, err := ApplyDiff(ctx, fuluSource, hdiffBytes)
+	require.NoError(t, err)
+	requireEqualState(t, gloasTarget, result)
+}
+
+func TestGloasCrossForkDiffOnboardsBuilderDeposit(t *testing.T) {
+	// A 0x03 builder deposit in the Fulu anchor is removed by Gloas onboarding, shortening
+	// pending_deposits. The diff indexes the pre-upgrade list, so applying it must not use the
+	// post-upgrade (shortened) list, which previously panicked with slice bounds out of range.
+	fuluSource, _ := util.DeterministicGenesisStateFulu(t, 64)
+
+	wc := make([]byte, fieldparams.RootLength)
+	wc[0] = params.BeaconConfig().BuilderWithdrawalPrefixByte
+	for i := 12; i < len(wc); i++ {
+		wc[i] = 0xAB
+	}
+	pubkey := make([]byte, fieldparams.BLSPubkeyLength)
+	for i := range pubkey {
+		pubkey[i] = 0xB1
+	}
+	require.NoError(t, fuluSource.SetPendingDeposits([]*ethpb.PendingDeposit{{
+		PublicKey:             pubkey,
+		WithdrawalCredentials: wc,
+		Amount:                params.BeaconConfig().MinActivationBalance,
+		Signature:             make([]byte, fieldparams.BLSSignatureLength),
+		Slot:                  0,
+	}}))
+
+	gloasTarget, err := gloas.UpgradeToGloas(fuluSource.Copy())
+	require.NoError(t, err)
+	require.NoError(t, gloasTarget.SetSlot(fuluSource.Slot()+1))
+
+	tPending, err := gloasTarget.PendingDeposits()
+	require.NoError(t, err)
+	require.Equal(t, 0, len(tPending))
+
+	ctx := t.Context()
+	hdiffBytes, err := Diff(fuluSource, gloasTarget)
+	require.NoError(t, err)
+
+	result, err := ApplyDiff(ctx, fuluSource.Copy(), hdiffBytes)
 	require.NoError(t, err)
 	requireEqualState(t, gloasTarget, result)
 }


### PR DESCRIPTION
Fixes #17147. At the Fulu to Gloas fork, upgrade onboarding removes builder deposits from pending_deposits, but the state-diff index is computed against the raw Fulu anchor while apply time ran the upgrade first and then indexed the now-shortened list, panicking with slice bounds out of range or silently corrupting the queue on nodes running `--enable-state-diff`.

This captures the anchor's pending_deposits before the version upgrade and applies the diff against that list, with a bounds check as a backstop.