### PR TITLE
ux improvement on beacon api flags

### DIFF
--- a/changelog/james-prysm_api-flag-ux.md
+++ b/changelog/james-prysm_api-flag-ux.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Setting `--beacon-rest-api-provider` now implicitly enables the beacon REST API, so `--enable-beacon-rest-api` is optional.
+
+### Added
+
+- Added shorter flag aliases: `--beacon-rest`, `--beacon-grpc`, and `--enable-rest`.

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -33,7 +33,8 @@ var (
 	}
 	// BeaconRPCProviderFlag defines a beacon node RPC endpoint.
 	BeaconRPCProviderFlag = &cli.StringFlag{
-		Name: "beacon-rpc-provider",
+		Name:    "beacon-rpc-provider",
+		Aliases: []string{"beacon-grpc"},
 		Usage: `WARNING: The gRPC API will remain the default and fully supported through v8 (expected in 2026) but will be eventually removed in favor of REST API..
 		Beacon node RPC provider endpoint.`,
 		Value: "127.0.0.1:4000",
@@ -41,9 +42,10 @@ var (
 
 	// BeaconRESTApiProviderFlag defines a beacon node REST API endpoint.
 	BeaconRESTApiProviderFlag = &cli.StringFlag{
-		Name:  "beacon-rest-api-provider",
-		Usage: "Beacon node REST API provider endpoint. Use a comma-separated list for ordered failover; the first endpoint is primary, and failover wraps back to the first after the last.",
-		Value: "http://127.0.0.1:3500",
+		Name:    "beacon-rest-api-provider",
+		Aliases: []string{"beacon-rest"},
+		Usage:   "Beacon node REST API provider endpoint. Setting this implicitly enables the beacon REST API (no need for --enable-beacon-rest-api). Use a comma-separated list for ordered failover; the first endpoint is primary, and failover wraps back to the first after the last.",
+		Value:   "http://127.0.0.1:3500",
 	}
 	// BeaconRESTApiHeaders defines a list of headers to send with all HTTP requests to the beacon node.
 	BeaconRESTApiHeaders = &cli.StringFlag{

--- a/config/features/BUILD.bazel
+++ b/config/features/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//cmd:go_default_library",
         "//cmd/beacon-chain/sync/backfill/flags:go_default_library",
+        "//cmd/validator/flags:go_default_library",
         "//config/params:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -30,6 +31,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//cmd/validator/flags:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
+	validatorflags "github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/urfave/cli/v2"
@@ -357,7 +358,7 @@ func ConfigureValidator(ctx *cli.Context) error {
 		logEnabled(enableDoppelGangerProtection)
 		cfg.EnableDoppelGanger = true
 	}
-	if ctx.Bool(EnableBeaconRESTApi.Name) {
+	if ctx.Bool(EnableBeaconRESTApi.Name) || ctx.IsSet(validatorflags.BeaconRESTApiProviderFlag.Name) {
 		logEnabled(EnableBeaconRESTApi)
 		cfg.EnableBeaconRESTApi = true
 	}

--- a/config/features/config_test.go
+++ b/config/features/config_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"testing"
 
+	validatorflags "github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -36,6 +37,27 @@ func TestInitWithReset(t *testing.T) {
 	// Reset must get to previously set configuration (not to default config values).
 	resetCfg()
 	assert.Equal(t, true, Get().EnableDoppelGanger)
+}
+
+func TestConfigureValidator_RESTApiEnabledByEndpoint(t *testing.T) {
+	defer Init(&Flags{})
+	app := cli.App{}
+
+	// Explicitly setting the REST endpoint implies the REST API is enabled,
+	// even without --enable-beacon-rest-api.
+	set := flag.NewFlagSet("test", 0)
+	set.String(validatorflags.BeaconRESTApiProviderFlag.Name, "", "test")
+	require.NoError(t, set.Set(validatorflags.BeaconRESTApiProviderFlag.Name, "http://127.0.0.1:3500"))
+	context := cli.NewContext(&app, set, nil)
+	require.NoError(t, ConfigureValidator(context))
+	assert.Equal(t, true, Get().EnableBeaconRESTApi)
+
+	// Not setting the endpoint or the enable flag leaves REST disabled.
+	set = flag.NewFlagSet("test", 0)
+	set.String(validatorflags.BeaconRESTApiProviderFlag.Name, "http://127.0.0.1:3500", "test")
+	context = cli.NewContext(&app, set, nil)
+	require.NoError(t, ConfigureValidator(context))
+	assert.Equal(t, false, Get().EnableBeaconRESTApi)
 }
 
 func TestConfigureBeaconConfig(t *testing.T) {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -130,8 +130,9 @@ var (
 		Usage: "Saves beacon blocks with full execution payloads instead of execution payload headers in the database.",
 	}
 	EnableBeaconRESTApi = &cli.BoolFlag{
-		Name:  "enable-beacon-rest-api",
-		Usage: "(Experimental): Enables of the beacon REST API when querying a beacon node.",
+		Name:    "enable-beacon-rest-api",
+		Aliases: []string{"enable-rest"},
+		Usage:   "(Experimental): Enables the beacon REST API when querying a beacon node. Optional: also enabled implicitly when --beacon-rest-api-provider is set.",
 	}
 	enableHashtree = &cli.BoolFlag{
 		Name:  "enable-hashtree",


### PR DESCRIPTION

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

### Changed

- Setting `--beacon-rest-api-provider` now implicitly enables the beacon REST API, so `--enable-beacon-rest-api` is optional.

### Added

- Added shorter flag aliases: `--beacon-rest`, `--beacon-grpc`, and `--enable-rest`.


**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
