### PR TITLE
Improve Web3Signer HTTP transport controls: timeout, CA cert, Client auth

### DIFF
--- a/changelog/syjn99_web3signer-transport.md
+++ b/changelog/syjn99_web3signer-transport.md
@@ -1,0 +1,7 @@
+### Added
+
+- Add timeout, custom CA, and mTLS controls for Web3Signer requests.
+
+### Changed
+
+- Categorize Web3Signer request metrics and logs without logging request or response bodies.

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -294,24 +294,28 @@ var (
 	}
 	// Web3SignerTimeoutFlag defines the timeout for Web3Signer HTTP requests.
 	Web3SignerTimeoutFlag = &cli.DurationFlag{
-		Name:  "validators-external-signer-timeout",
-		Usage: "Timeout for requests to the Web3Signer server.",
-		Value: 10 * time.Second,
+		Name:    "validators-external-signer-timeout",
+		Usage:   "Timeout for requests to the Web3Signer server.",
+		Value:   10 * time.Second,
+		Aliases: []string{"remote-signer-timeout"},
 	}
 	// Web3SignerCACertFlag defines a CA certificate for Web3Signer TLS.
 	Web3SignerCACertFlag = &cli.StringFlag{
-		Name:  "validators-external-signer-ca-cert",
-		Usage: "Path to a PEM-encoded CA certificate for the Web3Signer server.",
+		Name:    "validators-external-signer-ca-cert",
+		Usage:   "Path to a PEM-encoded CA certificate for the Web3Signer server.",
+		Aliases: []string{"remote-signer-ca-cert"},
 	}
 	// Web3SignerClientCertFlag defines a client certificate for Web3Signer mTLS.
 	Web3SignerClientCertFlag = &cli.StringFlag{
-		Name:  "validators-external-signer-client-cert",
-		Usage: "Path to a PEM-encoded client certificate for Web3Signer mTLS.",
+		Name:    "validators-external-signer-client-cert",
+		Usage:   "Path to a PEM-encoded client certificate for Web3Signer mTLS.",
+		Aliases: []string{"remote-signer-client-cert"},
 	}
 	// Web3SignerClientKeyFlag defines a client key for Web3Signer mTLS.
 	Web3SignerClientKeyFlag = &cli.StringFlag{
-		Name:  "validators-external-signer-client-key",
-		Usage: "Path to a PEM-encoded client key for Web3Signer mTLS.",
+		Name:    "validators-external-signer-client-key",
+		Usage:   "Path to a PEM-encoded client key for Web3Signer mTLS.",
+		Aliases: []string{"remote-signer-client-key"},
 	}
 	// Web3SignerPublicValidatorKeysFlag defines a comma-separated list of hex string public keys or external url for web3signer to use for validator signing.
 	// example with external url: --validators-external-signer-public-keys= https://web3signer.com/api/v1/eth2/publicKeys

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -292,6 +292,12 @@ var (
 		Value:   "",
 		Aliases: []string{"remote-signer-url"},
 	}
+	// Web3SignerTimeoutFlag defines the timeout for Web3Signer HTTP requests.
+	Web3SignerTimeoutFlag = &cli.DurationFlag{
+		Name:  "validators-external-signer-timeout",
+		Usage: "Timeout for requests to the Web3Signer server.",
+		Value: 10 * time.Second,
+	}
 	// Web3SignerPublicValidatorKeysFlag defines a comma-separated list of hex string public keys or external url for web3signer to use for validator signing.
 	// example with external url: --validators-external-signer-public-keys= https://web3signer.com/api/v1/eth2/publicKeys
 	// example with public key: --validators-external-signer-public-keys=0xa99a...e44c,0xb89b...4a0b

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -298,6 +298,21 @@ var (
 		Usage: "Timeout for requests to the Web3Signer server.",
 		Value: 10 * time.Second,
 	}
+	// Web3SignerCACertFlag defines a CA certificate for Web3Signer TLS.
+	Web3SignerCACertFlag = &cli.StringFlag{
+		Name:  "validators-external-signer-ca-cert",
+		Usage: "Path to a PEM-encoded CA certificate for the Web3Signer server.",
+	}
+	// Web3SignerClientCertFlag defines a client certificate for Web3Signer mTLS.
+	Web3SignerClientCertFlag = &cli.StringFlag{
+		Name:  "validators-external-signer-client-cert",
+		Usage: "Path to a PEM-encoded client certificate for Web3Signer mTLS.",
+	}
+	// Web3SignerClientKeyFlag defines a client key for Web3Signer mTLS.
+	Web3SignerClientKeyFlag = &cli.StringFlag{
+		Name:  "validators-external-signer-client-key",
+		Usage: "Path to a PEM-encoded client key for Web3Signer mTLS.",
+	}
 	// Web3SignerPublicValidatorKeysFlag defines a comma-separated list of hex string public keys or external url for web3signer to use for validator signing.
 	// example with external url: --validators-external-signer-public-keys= https://web3signer.com/api/v1/eth2/publicKeys
 	// example with public key: --validators-external-signer-public-keys=0xa99a...e44c,0xb89b...4a0b

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -77,6 +77,7 @@ var appFlags = []cli.Flag{
 	flags.MaxHealthChecksFlag,
 	// Consensys' Web3Signer flags
 	flags.Web3SignerURLFlag,
+	flags.Web3SignerTimeoutFlag,
 	flags.Web3SignerPublicValidatorKeysFlag,
 	flags.Web3SignerKeyFileFlag,
 	flags.SuggestedFeeRecipientFlag,

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -78,6 +78,9 @@ var appFlags = []cli.Flag{
 	// Consensys' Web3Signer flags
 	flags.Web3SignerURLFlag,
 	flags.Web3SignerTimeoutFlag,
+	flags.Web3SignerCACertFlag,
+	flags.Web3SignerClientCertFlag,
+	flags.Web3SignerClientKeyFlag,
 	flags.Web3SignerPublicValidatorKeysFlag,
 	flags.Web3SignerKeyFileFlag,
 	flags.SuggestedFeeRecipientFlag,

--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -126,6 +126,7 @@ var appHelpFlagGroups = []flagGroup{
 		Name: "remote signer",
 		Flags: []cli.Flag{
 			flags.Web3SignerURLFlag,
+			flags.Web3SignerTimeoutFlag,
 			flags.Web3SignerPublicValidatorKeysFlag,
 			flags.Web3SignerKeyFileFlag,
 		},

--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -127,6 +127,9 @@ var appHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			flags.Web3SignerURLFlag,
 			flags.Web3SignerTimeoutFlag,
+			flags.Web3SignerCACertFlag,
+			flags.Web3SignerClientCertFlag,
+			flags.Web3SignerClientKeyFlag,
 			flags.Web3SignerPublicValidatorKeysFlag,
 			flags.Web3SignerKeyFileFlag,
 		},

--- a/validator/keymanager/remote-web3signer/README.md
+++ b/validator/keymanager/remote-web3signer/README.md
@@ -16,6 +16,14 @@ detailed info found on https://docs.prylabs.network/docs/wallet/web3signer
 
 Flags used on validator client
 - `--validators-external-signer-url=http://localhost:9000`
+- `--validators-external-signer-timeout=10s`
+
+with a custom CA
+- `--validators-external-signer-ca-cert=/path/to/ca.pem`
+
+with mTLS
+- `--validators-external-signer-client-cert=/path/to/client.pem`
+- `--validators-external-signer-client-key=/path/to/client-key.pem`
 
 with hex keys
 - `--validators-external-signer-public-keys=0xa99a...e44c,0xb89b...4a0b`

--- a/validator/keymanager/remote-web3signer/internal/BUILD.bazel
+++ b/validator/keymanager/remote-web3signer/internal/BUILD.bazel
@@ -25,9 +25,13 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["client_test.go"],
+    srcs = [
+        "client_test.go",
+        "metrics_test.go",
+    ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
+        "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/validator/keymanager/remote-web3signer/internal/client.go
+++ b/validator/keymanager/remote-web3signer/internal/client.go
@@ -47,7 +47,7 @@ type ApiClient struct {
 }
 
 // NewApiClient method instantiates a new ApiClient object.
-func NewApiClient(baseEndpoint string) (*ApiClient, error) {
+func NewApiClient(baseEndpoint string, timeout time.Duration) (*ApiClient, error) {
 	u, err := url.ParseRequestURI(baseEndpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid format, unable to parse url")
@@ -57,7 +57,7 @@ func NewApiClient(baseEndpoint string) (*ApiClient, error) {
 	}
 	return &ApiClient{
 		BaseURL:    u,
-		RestClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
+		RestClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport), Timeout: timeout},
 	}, nil
 }
 

--- a/validator/keymanager/remote-web3signer/internal/client.go
+++ b/validator/keymanager/remote-web3signer/internal/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -106,7 +105,7 @@ func newTransport(caCertPath, clientCertPath, clientKeyPath string) (*http.Trans
 // Sign is a wrapper method around the web3signer sign api.
 func (client *ApiClient) Sign(ctx context.Context, pubKey string, request SignRequestJson) (bls.Signature, error) {
 	requestPath := ethApiNamespace + pubKey
-	resp, err := client.doRequest(ctx, http.MethodPost, client.BaseURL.String()+requestPath, bytes.NewBuffer(request))
+	resp, err := client.doRequest(ctx, "sign", http.MethodPost, client.BaseURL.String()+requestPath, bytes.NewBuffer(request))
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +129,7 @@ func (client *ApiClient) Sign(ctx context.Context, pubKey string, request SignRe
 
 // GetPublicKeys is a wrapper method around the web3signer publickeys api (this may be removed in the future or moved to another location due to its usage).
 func (client *ApiClient) GetPublicKeys(ctx context.Context, url string) ([]string, error) {
-	resp, err := client.doRequest(ctx, http.MethodGet, url, http.NoBody)
+	resp, err := client.doRequest(ctx, "public_keys", http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +155,7 @@ func (client *ApiClient) GetPublicKeys(ctx context.Context, url string) ([]strin
 // ReloadSignerKeys is a wrapper method around the web3signer reload api.
 func (client *ApiClient) ReloadSignerKeys(ctx context.Context) error {
 	const requestPath = "/reload"
-	if _, err := client.doRequest(ctx, http.MethodPost, client.BaseURL.String()+requestPath, nil); err != nil {
+	if _, err := client.doRequest(ctx, "reload", http.MethodPost, client.BaseURL.String()+requestPath, nil); err != nil {
 		return err
 	}
 	return nil
@@ -165,7 +164,7 @@ func (client *ApiClient) ReloadSignerKeys(ctx context.Context) error {
 // GetServerStatus is a wrapper method around the web3signer upcheck api
 func (client *ApiClient) GetServerStatus(ctx context.Context) (string, error) {
 	const requestPath = "/upcheck"
-	resp, err := client.doRequest(ctx, http.MethodGet, client.BaseURL.String()+requestPath, nil /* no body needed on get request */)
+	resp, err := client.doRequest(ctx, "upcheck", http.MethodGet, client.BaseURL.String()+requestPath, nil /* no body needed on get request */)
 	if err != nil {
 		return "", err
 	}
@@ -177,8 +176,7 @@ func (client *ApiClient) GetServerStatus(ctx context.Context) (string, error) {
 }
 
 // doRequest is a utility method for requests.
-func (client *ApiClient) doRequest(ctx context.Context, httpMethod, fullPath string, body io.Reader) (*http.Response, error) {
-	var requestDump []byte
+func (client *ApiClient) doRequest(ctx context.Context, requestType, httpMethod, fullPath string, body io.Reader) (*http.Response, error) {
 	ctx, span := trace.StartSpan(ctx, "remote_web3signer.Client.doRequest")
 	defer span.End()
 	span.SetAttributes(
@@ -196,26 +194,20 @@ func (client *ApiClient) doRequest(ctx context.Context, httpMethod, fullPath str
 	resp, err := client.RestClient.Do(req)
 	duration := time.Since(start)
 	if err != nil {
-		signRequestDurationSeconds.WithLabelValues(req.Method, "error").Observe(duration.Seconds())
+		status := requestStatus(err)
+		signRequestDurationSeconds.WithLabelValues(requestType, req.Method, status).Observe(duration.Seconds())
+		log.WithFields(logrus.Fields{"url": fullPath, "requestType": requestType, "status": status}).WithError(err).Error("Web3Signer request failed")
 		err = errors.Wrap(err, "failed to execute json request")
 		tracing.AnnotateError(span, err)
 		return resp, err
 	} else {
-		signRequestDurationSeconds.WithLabelValues(req.Method, strconv.Itoa(resp.StatusCode)).Observe(duration.Seconds())
+		signRequestDurationSeconds.WithLabelValues(requestType, req.Method, strconv.Itoa(resp.StatusCode)).Observe(duration.Seconds())
 	}
 	if resp.StatusCode != http.StatusOK {
-		requestDump, err = httputil.DumpRequestOut(req, true)
-		if err != nil {
-			return nil, err
-		}
-		responseDump, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return nil, err
-		}
 		log.WithFields(logrus.Fields{
-			"status":   resp.StatusCode,
-			"request":  string(requestDump),
-			"response": string(responseDump),
+			"url":         fullPath,
+			"requestType": requestType,
+			"status":      resp.StatusCode,
 		}).Error("Web3signer request failed")
 	}
 	if resp.StatusCode == http.StatusInternalServerError {
@@ -228,6 +220,13 @@ func (client *ApiClient) doRequest(ctx context.Context, httpMethod, fullPath str
 		return nil, err
 	}
 	return resp, nil
+}
+
+func requestStatus(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	return "error"
 }
 
 // unmarshalResponse is a utility method for unmarshalling responses.

--- a/validator/keymanager/remote-web3signer/internal/client.go
+++ b/validator/keymanager/remote-web3signer/internal/client.go
@@ -3,12 +3,16 @@ package internal
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -47,7 +51,7 @@ type ApiClient struct {
 }
 
 // NewApiClient method instantiates a new ApiClient object.
-func NewApiClient(baseEndpoint string, timeout time.Duration) (*ApiClient, error) {
+func NewApiClient(baseEndpoint string, timeout time.Duration, caCertPath, clientCertPath, clientKeyPath string) (*ApiClient, error) {
 	u, err := url.ParseRequestURI(baseEndpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid format, unable to parse url")
@@ -55,10 +59,48 @@ func NewApiClient(baseEndpoint string, timeout time.Duration) (*ApiClient, error
 	if u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("web3signer url must be in the format of http(s)://host:port url used: %v", baseEndpoint)
 	}
+	transport, err := newTransport(caCertPath, clientCertPath, clientKeyPath)
+	if err != nil {
+		return nil, err
+	}
 	return &ApiClient{
 		BaseURL:    u,
-		RestClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport), Timeout: timeout},
+		RestClient: &http.Client{Transport: otelhttp.NewTransport(transport), Timeout: timeout},
 	}, nil
+}
+
+func newTransport(caCertPath, clientCertPath, clientKeyPath string) (*http.Transport, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if caCertPath == "" && clientCertPath == "" && clientKeyPath == "" {
+		return transport, nil
+	}
+	if (clientCertPath == "") != (clientKeyPath == "") {
+		return nil, errors.New("web3signer client certificate and key must be provided together")
+	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if caCertPath != "" {
+		roots, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not load system CA certificates")
+		}
+		caCert, err := os.ReadFile(filepath.Clean(caCertPath)) // #nosec G304 -- path is supplied by the operator.
+		if err != nil {
+			return nil, errors.Wrap(err, "could not read web3signer CA certificate")
+		}
+		if !roots.AppendCertsFromPEM(caCert) {
+			return nil, errors.New("could not parse web3signer CA certificate")
+		}
+		tlsConfig.RootCAs = roots
+	}
+	if clientCertPath != "" {
+		certificate, err := tls.LoadX509KeyPair(filepath.Clean(clientCertPath), filepath.Clean(clientKeyPath))
+		if err != nil {
+			return nil, errors.Wrap(err, "could not load web3signer client certificate and key")
+		}
+		tlsConfig.Certificates = []tls.Certificate{certificate}
+	}
+	transport.TLSClientConfig = tlsConfig
+	return transport, nil
 }
 
 // Sign is a wrapper method around the web3signer sign api.

--- a/validator/keymanager/remote-web3signer/internal/client_test.go
+++ b/validator/keymanager/remote-web3signer/internal/client_test.go
@@ -2,11 +2,16 @@ package internal_test
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -27,10 +32,44 @@ func (m *mockTransport) RoundTrip(*http.Request) (*http.Response, error) {
 }
 
 func TestNewApiClient(t *testing.T) {
-	apiClient, err := internal.NewApiClient("http://localhost:8545", 5*time.Second)
+	apiClient, err := internal.NewApiClient("http://localhost:8545", 5*time.Second, "", "", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, apiClient)
 	assert.Equal(t, 5*time.Second, apiClient.RestClient.Timeout)
+}
+
+func TestNewApiClientTLS(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`"ok"`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	caCertPath := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caCertPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}), 0o600))
+	apiClient, err := internal.NewApiClient(server.URL, time.Second, caCertPath, "", "")
+	require.NoError(t, err)
+	status, err := apiClient.GetServerStatus(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "ok", status)
+}
+
+func TestNewApiClientMutualTLSConfig(t *testing.T) {
+	server := httptest.NewTLSServer(http.NotFoundHandler())
+	defer server.Close()
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "client.pem")
+	keyPath := filepath.Join(dir, "client-key.pem")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}), 0o600))
+	key, err := x509.MarshalPKCS8PrivateKey(server.TLS.Certificates[0].PrivateKey)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}), 0o600))
+	_, err = internal.NewApiClient(server.URL, time.Second, "", certPath, keyPath)
+	require.NoError(t, err)
+
+	_, err = internal.NewApiClient(server.URL, time.Second, "", certPath, "")
+	require.ErrorContains(t, "client certificate and key must be provided together", err)
 }
 
 func TestClient_Sign_HappyPath(t *testing.T) {

--- a/validator/keymanager/remote-web3signer/internal/client_test.go
+++ b/validator/keymanager/remote-web3signer/internal/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/validator/keymanager/remote-web3signer/internal"
@@ -26,9 +27,10 @@ func (m *mockTransport) RoundTrip(*http.Request) (*http.Response, error) {
 }
 
 func TestNewApiClient(t *testing.T) {
-	apiClient, err := internal.NewApiClient("http://localhost:8545")
+	apiClient, err := internal.NewApiClient("http://localhost:8545", 5*time.Second)
 	assert.NoError(t, err)
 	assert.NotNil(t, apiClient)
+	assert.Equal(t, 5*time.Second, apiClient.RestClient.Timeout)
 }
 
 func TestClient_Sign_HappyPath(t *testing.T) {

--- a/validator/keymanager/remote-web3signer/internal/metrics.go
+++ b/validator/keymanager/remote-web3signer/internal/metrics.go
@@ -12,6 +12,6 @@ var (
 			Help:    "Time (in seconds) spent doing client HTTP requests",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"method", "status_code"},
+		[]string{"request_type", "method", "status_code"},
 	)
 )

--- a/validator/keymanager/remote-web3signer/internal/metrics_test.go
+++ b/validator/keymanager/remote-web3signer/internal/metrics_test.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+)
+
+func TestRequestStatus(t *testing.T) {
+	assert.Equal(t, "timeout", requestStatus(context.DeadlineExceeded))
+	assert.Equal(t, "error", requestStatus(errors.New("failed")))
+}

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -46,6 +46,9 @@ type SetupConfig struct {
 	BaseEndpoint          string
 	GenesisValidatorsRoot []byte
 	RequestTimeout        time.Duration
+	CACertPath            string
+	ClientCertPath        string
+	ClientKeyPath         string
 
 	// Either URL or keylist must be set.
 	// If the URL is set, the keymanager will fetch the public keys from the URL.
@@ -78,7 +81,7 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 	if cfg.BaseEndpoint == "" || !bytesutil.IsValidRoot(cfg.GenesisValidatorsRoot) {
 		return nil, fmt.Errorf("invalid setup config, one or more configs are empty: BaseEndpoint: %v, GenesisValidatorsRoot: %#x", cfg.BaseEndpoint, cfg.GenesisValidatorsRoot)
 	}
-	client, err := internal.NewApiClient(cfg.BaseEndpoint, cfg.RequestTimeout)
+	client, err := internal.NewApiClient(cfg.BaseEndpoint, cfg.RequestTimeout, cfg.CACertPath, cfg.ClientCertPath, cfg.ClientKeyPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create apiClient")
 	}

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -45,6 +45,7 @@ type SetupConfig struct {
 	KeyFilePath           string
 	BaseEndpoint          string
 	GenesisValidatorsRoot []byte
+	RequestTimeout        time.Duration
 
 	// Either URL or keylist must be set.
 	// If the URL is set, the keymanager will fetch the public keys from the URL.
@@ -77,7 +78,7 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 	if cfg.BaseEndpoint == "" || !bytesutil.IsValidRoot(cfg.GenesisValidatorsRoot) {
 		return nil, fmt.Errorf("invalid setup config, one or more configs are empty: BaseEndpoint: %v, GenesisValidatorsRoot: %#x", cfg.BaseEndpoint, cfg.GenesisValidatorsRoot)
 	}
-	client, err := internal.NewApiClient(cfg.BaseEndpoint)
+	client, err := internal.NewApiClient(cfg.BaseEndpoint, cfg.RequestTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create apiClient")
 	}

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -363,7 +363,7 @@ func TestKeymanager_Sign(t *testing.T) {
 	config := &SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
-		PublicKeysURL:         "http://example2.com/api/v1/eth2/publicKeys",
+		ProvidedPublicKeys:    []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"},
 	}
 	km, err := NewKeymanager(ctx, config)
 	require.NoError(t, err)

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -461,6 +461,9 @@ func Web3SignerConfig(cliCtx *cli.Context) (*remoteweb3signer.SetupConfig, error
 			BaseEndpoint:          u.String(),
 			GenesisValidatorsRoot: nil,
 			RequestTimeout:        cliCtx.Duration(flags.Web3SignerTimeoutFlag.Name),
+			CACertPath:            cliCtx.String(flags.Web3SignerCACertFlag.Name),
+			ClientCertPath:        cliCtx.String(flags.Web3SignerClientCertFlag.Name),
+			ClientKeyPath:         cliCtx.String(flags.Web3SignerClientKeyFlag.Name),
 		}
 		if cliCtx.IsSet(flags.WalletPasswordFileFlag.Name) {
 			log.Warnf("%s was provided while using web3signer and will be ignored", flags.WalletPasswordFileFlag.Name)

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -460,6 +460,7 @@ func Web3SignerConfig(cliCtx *cli.Context) (*remoteweb3signer.SetupConfig, error
 		web3signerConfig = &remoteweb3signer.SetupConfig{
 			BaseEndpoint:          u.String(),
 			GenesisValidatorsRoot: nil,
+			RequestTimeout:        cliCtx.Duration(flags.Web3SignerTimeoutFlag.Name),
 		}
 		if cliCtx.IsSet(flags.WalletPasswordFileFlag.Name) {
 			log.Warnf("%s was provided while using web3signer and will be ignored", flags.WalletPasswordFileFlag.Name)

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
@@ -231,6 +232,7 @@ func TestWeb3SignerConfig(t *testing.T) {
 			want: &remoteweb3signer.SetupConfig{
 				BaseEndpoint:          "http://localhost:8545",
 				GenesisValidatorsRoot: nil,
+				RequestTimeout:        10 * time.Second,
 				PublicKeysURL:         "",
 				ProvidedPublicKeys: []string{
 					"0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
@@ -247,6 +249,7 @@ func TestWeb3SignerConfig(t *testing.T) {
 			want: &remoteweb3signer.SetupConfig{
 				BaseEndpoint:          "http://localhost:8545",
 				GenesisValidatorsRoot: nil,
+				RequestTimeout:        10 * time.Second,
 				PublicKeysURL:         "http://localhost:8545/api/v1/eth2/publicKeys",
 				ProvidedPublicKeys:    nil,
 			},
@@ -277,8 +280,9 @@ func TestWeb3SignerConfig(t *testing.T) {
 				persistentFile: "/remote/key/file.txt",
 			},
 			want: &remoteweb3signer.SetupConfig{
-				BaseEndpoint: "http://localhost:8545",
-				KeyFilePath:  "/remote/key/file.txt",
+				BaseEndpoint:   "http://localhost:8545",
+				KeyFilePath:    "/remote/key/file.txt",
+				RequestTimeout: 10 * time.Second,
 			},
 		},
 	}
@@ -288,6 +292,7 @@ func TestWeb3SignerConfig(t *testing.T) {
 			set := flag.NewFlagSet(tt.name, 0)
 			set.String("validators-external-signer-url", tt.args.baseURL, "baseUrl")
 			set.String(flags.Web3SignerKeyFileFlag.Name, "", "")
+			require.NoError(t, flags.Web3SignerTimeoutFlag.Apply(set))
 			c := &cli.StringSliceFlag{
 				Name: "validators-external-signer-public-keys",
 			}

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -293,6 +293,9 @@ func TestWeb3SignerConfig(t *testing.T) {
 			set.String("validators-external-signer-url", tt.args.baseURL, "baseUrl")
 			set.String(flags.Web3SignerKeyFileFlag.Name, "", "")
 			require.NoError(t, flags.Web3SignerTimeoutFlag.Apply(set))
+			require.NoError(t, flags.Web3SignerCACertFlag.Apply(set))
+			require.NoError(t, flags.Web3SignerClientCertFlag.Apply(set))
+			require.NoError(t, flags.Web3SignerClientKeyFlag.Apply(set))
 			c := &cli.StringSliceFlag{
 				Name: "validators-external-signer-public-keys",
 			}


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR improves more fine-grained transport controls for Web3Signer. These are already provided in other CL clients (e.g., [Teku](https://docs.teku.consensys.io/reference/cli/subcommands/validator-client), [Lighthouse](https://lighthouse-book.sigmaprime.io/advanced_web3signer.html?highlight=client_identity_path#usage)) so this PR makes Prysm reach baseline feature parity with other clients:

- Request timeout has an upper bound, default to 10 seconds.
- Trusted & self-signed server certificates are supported.
- Web3Signer can require client-certificate auth.

Also this PR improves observability and safety of logging when request failed: dumping req/resp to log is not required IMO.

**Which issue(s) does this PR fix?**

Part of 
- #9994

especially
- TLS configurations which accepts connections from clients that use trusted CA certificates or self-signed certificates. -> By `--validators-external-signer-ca-cert`
- TLS support for web3signer -> By `--validators-external-signer-client-cert` & `--validators-external-signer-client-key`

**Other notes for review**

Newly added flags table:

| Primary flag | Alias | Default |
| - | - | - |
| `--validators-external-signer-timeout` | `--remote-signer-timeout` | 10s |
| `--validators-external-signer-ca-cert` | `--remote-signer-ca-cert` | unset | 
| `--validators-external-signer-client-cert` | `--remote-signer-client-cert` | unset | 
| `--validators-external-signer-client-key` | `--remote-signer-client-key` | unset | 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 