### PR TITLE
Drop `--interop-num-validators` and `--interop-start-index` usage in E2E test

### DIFF
--- a/changelog/syjn99_refactor-drop-interop-flag-usage.md
+++ b/changelog/syjn99_refactor-drop-interop-flag-usage.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Drop `--interop-num-validators` and `--interop-start-index` usage in E2E test.

--- a/testing/endtoend/components/BUILD.bazel
+++ b/testing/endtoend/components/BUILD.bazel
@@ -37,7 +37,9 @@ go_library(
         "//testing/endtoend/params:go_default_library",
         "//testing/endtoend/types:go_default_library",
         "//testing/middleware/builder:go_default_library",
+        "//validator/accounts/wallet:go_default_library",
         "//validator/keymanager:go_default_library",
+        "//validator/keymanager/local:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_google_uuid//:go_default_library",
@@ -53,15 +55,21 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["web3remotesigner_test.go"],
+    srcs = [
+        "validator_test.go",
+        "web3remotesigner_test.go",
+    ],
     data = [
         "//config/params:custom_configs",
         "@web3signer",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//config/params:go_default_library",
+        "//crypto/bls:go_default_library",
         "//testing/endtoend/params:go_default_library",
         "//testing/require:go_default_library",
+        "//validator/accounts/wallet:go_default_library",
+        "//validator/keymanager/local:go_default_library",
     ],
 )

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -402,6 +402,11 @@ func FeeRecipientFromPubkey(key string) string {
 // createValidatorWallet creates a new validator wallet with the provided keys
 // and returns the path to the password file.
 func createValidatorWallet(ctx context.Context, walletDir string, privKeys []bls.SecretKey, pubKeys []bls.PublicKey) (string, error) {
+	// Remove old encrypted wallet files if they exist, to ensure a clean state.
+	if err := os.RemoveAll(walletDir); err != nil {
+		return "", err
+	}
+
 	passwordBytes := make([]byte, 32)
 	if _, err := rand.Read(passwordBytes); err != nil {
 		return "", err

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -16,19 +16,26 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/features"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	validatorpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1/validator-client"
 	"github.com/OffchainLabs/prysm/v7/runtime/interop"
 	"github.com/OffchainLabs/prysm/v7/testing/endtoend/helpers"
 	e2e "github.com/OffchainLabs/prysm/v7/testing/endtoend/params"
 	e2etypes "github.com/OffchainLabs/prysm/v7/testing/endtoend/types"
+	"github.com/OffchainLabs/prysm/v7/validator/accounts/wallet"
+	"github.com/OffchainLabs/prysm/v7/validator/keymanager"
+	"github.com/OffchainLabs/prysm/v7/validator/keymanager/local"
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 )
 
-const DefaultFeeRecipientAddress = "0x099FB65722e7b2455043bfebF6177f1D2E9738d9"
+const (
+	DefaultFeeRecipientAddress = "0x099FB65722e7b2455043bfebF6177f1D2E9738d9"
+	e2eWalletPassword          = "E2eValidatorWalletPassword"
+)
 
 var _ e2etypes.ComponentRunner = (*ValidatorNode)(nil)
 var _ e2etypes.ComponentRunner = (*ValidatorNodeSet)(nil)
@@ -206,7 +213,7 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, pubs, err := interop.DeterministicallyGenerateKeys(uint64(offset), uint64(validatorNum))
+	privs, pubs, err := interop.DeterministicallyGenerateKeys(uint64(offset), uint64(validatorNum))
 	if err != nil {
 		return err
 	}
@@ -270,10 +277,14 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 			args = append(args, fmt.Sprintf("--%s=%s", flags.Web3SignerPublicValidatorKeysFlag.Name, strings.Join(validatorHexPubKeys, ",")))
 		}
 	} else {
-		// When not using remote key signer, use interop keys.
+		walletDir := filepath.Join(e2e.TestParams.TestPath, fmt.Sprintf("validator-wallet-%d", index))
+		passwordFile, err := createValidatorWallet(ctx, walletDir, privs, pubs)
+		if err != nil {
+			return fmt.Errorf("failed to create validator wallet: %w", err)
+		}
 		args = append(args,
-			fmt.Sprintf("--%s=%d", flags.InteropNumValidators.Name, validatorNum),
-			fmt.Sprintf("--%s=%d", flags.InteropStartIndex.Name, offset),
+			fmt.Sprintf("--%s=%s", flags.WalletDirFlag.Name, walletDir),
+			fmt.Sprintf("--%s=%s", flags.WalletPasswordFileFlag.Name, passwordFile),
 		)
 	}
 	if v.config.UseBuilder {
@@ -381,4 +392,32 @@ func createProposerSettingsPath(pubkeys []string, nodeIdx int) (string, error) {
 func FeeRecipientFromPubkey(key string) string {
 	// pubkey[:(2+fieldparams.FeeRecipientLength*2)] slicing 2 (for the 0x preamble) + 2 hex chars for each byte
 	return common.HexToAddress(key[:(2 + fieldparams.FeeRecipientLength*2)]).Hex()
+}
+
+// createValidatorWallet creates a new validator wallet with the provided keys
+// and returns the path to the password file.
+func createValidatorWallet(ctx context.Context, walletDir string, privKeys []bls.SecretKey, pubKeys []bls.PublicKey) (string, error) {
+	w := wallet.New(&wallet.Config{
+		WalletDir:      walletDir,
+		KeymanagerKind: keymanager.Local,
+		WalletPassword: e2eWalletPassword,
+	})
+	if err := w.SaveWallet(); err != nil {
+		return "", err
+	}
+	km, err := local.NewKeymanager(ctx, &local.SetupConfig{Wallet: w})
+	if err != nil {
+		return "", err
+	}
+	privKeyBytes := make([][]byte, len(privKeys))
+	pubKeyBytes := make([][]byte, len(pubKeys))
+	for i := range privKeys {
+		privKeyBytes[i] = privKeys[i].Marshal()
+		pubKeyBytes[i] = pubKeys[i].Marshal()
+	}
+	if err := km.ImportKeypairs(ctx, privKeyBytes, pubKeyBytes); err != nil {
+		return "", err
+	}
+	passwordFile := filepath.Join(walletDir, wallet.DefaultWalletPasswordFile)
+	return passwordFile, file.WriteFile(passwordFile, []byte(e2eWalletPassword))
 }

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -2,6 +2,8 @@ package components
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -32,10 +34,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	DefaultFeeRecipientAddress = "0x099FB65722e7b2455043bfebF6177f1D2E9738d9"
-	e2eWalletPassword          = "E2eValidatorWalletPassword"
-)
+const DefaultFeeRecipientAddress = "0x099FB65722e7b2455043bfebF6177f1D2E9738d9"
 
 var _ e2etypes.ComponentRunner = (*ValidatorNode)(nil)
 var _ e2etypes.ComponentRunner = (*ValidatorNodeSet)(nil)
@@ -261,6 +260,8 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 	if !v.config.UsePrysmShValidator {
 		args = append(args, features.E2EValidatorFlags...)
 	}
+	// Holds the wallet password file flag; appended just before exec and kept out of the logs below.
+	var walletPasswordArg string
 	if v.config.UseWeb3RemoteSigner {
 		// Write the pubkeys as comma separated hex strings with 0x prefix.
 		// See: https://docs.teku.consensys.net/en/latest/HowTo/External-Signer/Use-External-Signer/
@@ -282,10 +283,8 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to create validator wallet: %w", err)
 		}
-		args = append(args,
-			fmt.Sprintf("--%s=%s", flags.WalletDirFlag.Name, walletDir),
-			fmt.Sprintf("--%s=%s", flags.WalletPasswordFileFlag.Name, passwordFile),
-		)
+		args = append(args, fmt.Sprintf("--%s=%s", flags.WalletDirFlag.Name, walletDir))
+		walletPasswordArg = fmt.Sprintf("--%s=%s", flags.WalletPasswordFileFlag.Name, passwordFile)
 	}
 	if v.config.UseBuilder {
 		args = append(args, fmt.Sprintf("--%s", flags.EnableBuilderFlag.Name))
@@ -295,6 +294,12 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 	if v.config.UsePrysmShValidator {
 		args = append([]string{"validator"}, args...)
 		log.Warning("Using latest release validator via prysm.sh")
+	}
+
+	// Snapshot flags for logging before appending the wallet password file flag, keeping the secret path out of logs.
+	flagsForLog := strings.Join(args, " ")
+	if walletPasswordArg != "" {
+		args = append(args, walletPasswordArg)
 	}
 
 	cmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
@@ -319,7 +324,7 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	log.Infof("Starting validator client %d with flags: %s %s", index, binaryPath, strings.Join(args, " "))
+	log.Infof("Starting validator client %d with flags: %s %s", index, binaryPath, flagsForLog)
 	if err = cmd.Start(); err != nil {
 		return err
 	}
@@ -397,10 +402,15 @@ func FeeRecipientFromPubkey(key string) string {
 // createValidatorWallet creates a new validator wallet with the provided keys
 // and returns the path to the password file.
 func createValidatorWallet(ctx context.Context, walletDir string, privKeys []bls.SecretKey, pubKeys []bls.PublicKey) (string, error) {
+	passwordBytes := make([]byte, 32)
+	if _, err := rand.Read(passwordBytes); err != nil {
+		return "", err
+	}
+	walletPassword := hex.EncodeToString(passwordBytes)
 	w := wallet.New(&wallet.Config{
 		WalletDir:      walletDir,
 		KeymanagerKind: keymanager.Local,
-		WalletPassword: e2eWalletPassword,
+		WalletPassword: walletPassword,
 	})
 	if err := w.SaveWallet(); err != nil {
 		return "", err
@@ -419,5 +429,5 @@ func createValidatorWallet(ctx context.Context, walletDir string, privKeys []bls
 		return "", err
 	}
 	passwordFile := filepath.Join(walletDir, wallet.DefaultWalletPasswordFile)
-	return passwordFile, file.WriteFile(passwordFile, []byte(e2eWalletPassword))
+	return passwordFile, file.WriteFile(passwordFile, []byte(walletPassword))
 }

--- a/testing/endtoend/components/validator_test.go
+++ b/testing/endtoend/components/validator_test.go
@@ -19,6 +19,11 @@ func TestCreateValidatorWallet(t *testing.T) {
 	pubKeys := []bls.PublicKey{privKey.PublicKey()}
 
 	walletDir := t.TempDir()
+
+	// Remove old encrypted wallet files if they exist, to ensure a clean state.
+	_, err = createValidatorWallet(t.Context(), walletDir, privKeys, pubKeys)
+	require.NoError(t, err)
+
 	passwordFile, err := createValidatorWallet(t.Context(), walletDir, privKeys, pubKeys)
 	require.NoError(t, err)
 	password, err := os.ReadFile(passwordFile)

--- a/testing/endtoend/components/validator_test.go
+++ b/testing/endtoend/components/validator_test.go
@@ -23,7 +23,7 @@ func TestCreateValidatorWallet(t *testing.T) {
 	require.NoError(t, err)
 	password, err := os.ReadFile(passwordFile)
 	require.NoError(t, err)
-	require.Equal(t, e2eWalletPassword, string(password))
+	require.Equal(t, 64, len(password))
 
 	w, err := wallet.OpenWallet(t.Context(), &wallet.Config{WalletDir: walletDir, WalletPassword: string(password)})
 	require.NoError(t, err)

--- a/testing/endtoend/components/validator_test.go
+++ b/testing/endtoend/components/validator_test.go
@@ -1,0 +1,36 @@
+package components
+
+import (
+	"os"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/crypto/bls"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/validator/accounts/wallet"
+	"github.com/OffchainLabs/prysm/v7/validator/keymanager/local"
+)
+
+func TestCreateValidatorWallet(t *testing.T) {
+	local.ResetCaches()
+	defer local.ResetCaches()
+	privKey, err := bls.RandKey()
+	require.NoError(t, err)
+	privKeys := []bls.SecretKey{privKey}
+	pubKeys := []bls.PublicKey{privKey.PublicKey()}
+
+	walletDir := t.TempDir()
+	passwordFile, err := createValidatorWallet(t.Context(), walletDir, privKeys, pubKeys)
+	require.NoError(t, err)
+	password, err := os.ReadFile(passwordFile)
+	require.NoError(t, err)
+	require.Equal(t, e2eWalletPassword, string(password))
+
+	w, err := wallet.OpenWallet(t.Context(), &wallet.Config{WalletDir: walletDir, WalletPassword: string(password)})
+	require.NoError(t, err)
+	km, err := local.NewKeymanager(t.Context(), &local.SetupConfig{Wallet: w})
+	require.NoError(t, err)
+	keys, err := km.FetchValidatingPublicKeys(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, len(keys))
+	require.DeepEqual(t, pubKeys[0].Marshal(), keys[0][:])
+}

--- a/validator/accounts/wallet/BUILD.bazel
+++ b/validator/accounts/wallet/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v7/validator/accounts/wallet",
     visibility = [
         "//cmd:__subpackages__",
+        "//testing/endtoend:__subpackages__",
         "//tools:__subpackages__",
         "//validator:__subpackages__",
     ],

--- a/validator/keymanager/local/BUILD.bazel
+++ b/validator/keymanager/local/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v7/validator/keymanager/local",
     visibility = [
         "//cmd/validator:__subpackages__",
+        "//testing/endtoend:__subpackages__",
         "//tools:__subpackages__",
         "//validator:__pkg__",
         "//validator:__subpackages__",


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Today, our E2E test uses `--interop-num-validators` and `--interop-start-index` for validator client to set up the wallet. Using `interop-*` flags is equal to have in-memory wallet for validator keys. This PR uses `--wallet-dir` and `--wallet-password-file` instead, in order to:

1. It's identical in terms of keys as keys are **deterministically** generated before creating a wallet.
2. Also I'm thinking of deprecating `interop-*` flags in the foreseeable futures as this is one of our tech debt.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
