### PR TITLE
Do not queue blocks that arrive more than 500ms early

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -82,7 +82,7 @@ var (
 	// Seconds in one epoch.
 	pendingBlockExpTime = time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
 	// time to allow processing early blocks.
-	earlyBlockProcessingTolerance = slots.MultiplySlotBy(2)
+	earlyBlockProcessingTolerance = params.BeaconConfig().MaximumGossipClockDisparityDuration()
 	// time to allow processing early attestations.
 	earlyAttestationProcessingTolerance = params.BeaconConfig().MaximumGossipClockDisparityDuration()
 	errWrongMessage                     = errors.New("wrong pubsub message")

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -113,6 +113,12 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationIgnore, nil
 	}
 
+	genesisTime := s.cfg.clock.GenesisTime()
+	if err := slots.VerifyTime(genesisTime, blk.Block().Slot(), earlyBlockProcessingTolerance); err != nil {
+		log.WithError(err).WithFields(getBlockFields(blk)).Debug("Ignored block: could not verify slot time")
+		return pubsub.ValidationIgnore, nil
+	}
+
 	blockRoot, err := blk.Block().HashTreeRoot()
 	if err != nil {
 		log.WithError(err).WithFields(getBlockFields(blk)).Debug("Ignored block")
@@ -139,15 +145,6 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	}
 	s.pendingQueueLock.RUnlock()
 
-	// Be lenient in handling early blocks. Instead of discarding blocks arriving later than
-	// MAXIMUM_GOSSIP_CLOCK_DISPARITY in future, we tolerate blocks arriving at max two slots
-	// earlier (SECONDS_PER_SLOT * 2 seconds). Queue such blocks and process them at the right slot.
-	genesisTime := s.cfg.clock.GenesisTime()
-	if err := slots.VerifyTime(genesisTime, blk.Block().Slot(), earlyBlockProcessingTolerance); err != nil {
-		log.WithError(err).WithFields(getBlockFields(blk)).Debug("Ignored block: could not verify slot time")
-		return pubsub.ValidationIgnore, nil
-	}
-
 	// Add metrics for block arrival time subtracts slot start time.
 	if err := captureArrivalTimeMetric(genesisTime, blk.Block().Slot()); err != nil {
 		log.WithError(err).WithFields(getBlockFields(blk)).Debug("Ignored block: could not capture arrival time metric")
@@ -171,25 +168,6 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		log.WithFields(getBlockFields(blk)).Debug("Ignoring block with canonical parent before justified checkpoint")
 		ignoredPreJustifiedBlockCount.Inc()
 		return pubsub.ValidationIgnore, nil
-	}
-
-	// Process the block if the clock jitter is less than MAXIMUM_GOSSIP_CLOCK_DISPARITY.
-	// Otherwise queue it for processing in the right slot.
-	if isBlockQueueable(genesisTime, blk.Block().Slot(), receivedTime) {
-		if res, err := s.verifyPendingBlockSignature(ctx, pid, blk, blockRoot); err != nil {
-			log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not verify block signature")
-			return res, err
-		}
-		s.pendingQueueLock.Lock()
-		if err := s.insertBlockToPendingQueue(blk.Block().Slot(), blk, blockRoot); err != nil {
-			s.pendingQueueLock.Unlock()
-			log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not insert block to pending queue")
-			return pubsub.ValidationIgnore, err
-		}
-		s.pendingQueueLock.Unlock()
-		err := fmt.Errorf("early block, with current slot %d < block slot %d", s.cfg.clock.CurrentSlot(), blk.Block().Slot())
-		log.WithError(err).WithFields(getBlockFields(blk)).Debug("Could not process early block")
-		return pubsub.ValidationIgnore, err
 	}
 
 	// Handle block when the parent is unknown.
@@ -576,20 +554,6 @@ func captureArrivalTimeMetric(genesis time.Time, currentSlot primitives.Slot) er
 	arrivalBlockPropagationGauge.Set(float64(ms))
 
 	return nil
-}
-
-// isBlockQueueable checks if the slot_time in the block is greater than
-// current_time +  MAXIMUM_GOSSIP_CLOCK_DISPARITY. in short, this function
-// returns true if the corresponding block should be queued and false if
-// the block should be processed immediately.
-func isBlockQueueable(genesisTime time.Time, slot primitives.Slot, receivedTime time.Time) bool {
-	slotTime, err := slots.StartTime(genesisTime, slot)
-	if err != nil {
-		return false
-	}
-
-	currentTimeWithDisparity := receivedTime.Add(params.BeaconConfig().MaximumGossipClockDisparityDuration())
-	return currentTimeWithDisparity.Unix() < slotTime.Unix()
 }
 
 func getBlockFields(b interfaces.ReadOnlySignedBeaconBlock) logrus.Fields {

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -786,86 +786,6 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 	}
 }
 
-func TestValidateBeaconBlockPubSub_IgnoreAndQueueBlocksFromNearFuture(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	p := p2ptest.NewTestP2P(t)
-	ctx := t.Context()
-
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	parentBlock := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, parentBlock)
-	bRoot, err := parentBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
-	require.NoError(t, db.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	copied := beaconState.Copy()
-	require.NoError(t, copied.SetSlot(1))
-	proposerIdx, err := helpers.BeaconProposerIndex(ctx, copied)
-	require.NoError(t, err)
-
-	msg := util.NewBeaconBlock()
-	msg.Block.Slot = 2 // two slots in future
-	msg.Block.ParentRoot = bRoot[:]
-	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature, err = signing.ComputeDomainAndSign(beaconState, 0, msg.Block, params.BeaconConfig().DomainBeaconProposer, privKeys[proposerIdx])
-	require.NoError(t, err)
-
-	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: time.Now(),
-		FinalizedCheckPoint: &ethpb.Checkpoint{
-			Epoch: 0,
-			Root:  make([]byte, 32),
-		},
-		State: beaconState}
-	r := &Service{
-		cfg: &config{
-			p2p:               p,
-			beaconDB:          db,
-			initialSync:       &mockSync.Sync{IsSyncing: false},
-			chain:             chainService,
-			clock:             startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
-			blockNotifier:     chainService.BlockNotifier(),
-			operationNotifier: chainService.OperationNotifier(),
-			stateGen:          stateGen,
-		},
-		chainStarted:        &atomic.Bool{},
-		seenBlockCache:      lruwrpr.New(10),
-		badBlockCache:       lruwrpr.New(10),
-		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
-		seenPendingBlocks:   make(map[[32]byte]bool),
-	}
-	opChannel := make(chan *feed.Event, 1)
-	opSub := r.cfg.operationNotifier.OperationFeed().Subscribe(opChannel)
-	defer opSub.Unsubscribe()
-
-	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, msg)
-	require.NoError(t, err)
-	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
-	topic = r.addDigestToTopic(topic, digest)
-	m := &pubsub.Message{
-		Message: &pubsubpb.Message{
-			Data:  buf.Bytes(),
-			Topic: &topic,
-		},
-	}
-	res, err := r.validateBeaconBlockPubSub(ctx, "", m)
-	require.ErrorContains(t, "early block, with current slot", err)
-	assert.Equal(t, res, pubsub.ValidationIgnore, "early block should be ignored and queued")
-
-	// check if the block is inserted in the Queue
-	assert.Equal(t, true, len(r.pendingBlocksInCache(msg.Block.Slot)) == 1)
-
-	select {
-	case event := <-opChannel:
-		assert.NotEqual(t, opfeed.BlockGossipReceived, event.Type, "BlockGossipReceived event should not be sent")
-	default:
-		// this case is needed, otherwise the test will never finish
-	}
-}
-
 func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 	db := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
@@ -1548,9 +1468,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromBadParent(t *testing.T) {
 	perSlot := params.BeaconConfig().SecondsPerSlot
 	// current slot time
 	slotsSinceGenesis := primitives.Slot(1000)
-	// max uint, divided by slot time. But avoid losing precision too much.
-	overflowBase := (1 << 63) / (perSlot >> 1)
-	msg.Block.Slot = slotsSinceGenesis.Add(overflowBase)
+	msg.Block.Slot = slotsSinceGenesis
 
 	// valid block
 	msg.Block.ParentRoot = bRoot[:]
@@ -1624,22 +1542,6 @@ func TestService_setBadBlock_DoesntSetWithContextErr(t *testing.T) {
 	if s.hasBadBlock(root) {
 		t.Error("Set bad root with cancelled context")
 	}
-}
-
-func TestService_isBlockQueueable(t *testing.T) {
-	currentTime := time.Now().Round(time.Second)
-	genesisTime := currentTime.Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
-	blockSlot := primitives.Slot(1)
-
-	// slot time within MAXIMUM_GOSSIP_CLOCK_DISPARITY, so don't queue the block.
-	receivedTime := currentTime.Add(-400 * time.Millisecond)
-	result := isBlockQueueable(genesisTime, blockSlot, receivedTime)
-	assert.Equal(t, false, result)
-
-	// slot time just above MAXIMUM_GOSSIP_CLOCK_DISPARITY, so queue the block.
-	receivedTime = currentTime.Add(-600 * time.Millisecond)
-	result = isBlockQueueable(genesisTime, blockSlot, receivedTime)
-	assert.Equal(t, true, result)
 }
 
 func TestValidateBeaconBlockPubSub_ValidExecutionPayload(t *testing.T) {

--- a/changelog/potuz_early_blocks.md
+++ b/changelog/potuz_early_blocks.md
@@ -1,0 +1,2 @@
+### Fixed
+- Do not queue blocks that arrive earlier than the max clock disparity. Also move HTR computation after the timestamp check. 

--- a/time/slots/slottime.go
+++ b/time/slots/slottime.go
@@ -49,13 +49,6 @@ func DivideSlotBy(timesPerSlot int64) time.Duration {
 	return params.BeaconConfig().SlotDuration() / time.Duration(timesPerSlot)
 }
 
-// MultiplySlotBy multiplies the SECONDS_PER_SLOT configuration
-// parameter by a specified number. It returns a value of time.Duration
-// in millisecond-based durations.
-func MultiplySlotBy(times int64) time.Duration {
-	return params.BeaconConfig().SlotDuration() * time.Duration(times)
-}
-
 // AbsoluteValueSlotDifference between two slots.
 func AbsoluteValueSlotDifference(x, y primitives.Slot) uint64 {
 	if x > y {

--- a/time/slots/slottime_test.go
+++ b/time/slots/slottime_test.go
@@ -59,46 +59,6 @@ func TestAbsoluteValueSlotDifference(t *testing.T) {
 	}
 }
 
-func TestMultiplySlotBy(t *testing.T) {
-	type args struct {
-		times int64
-	}
-	tests := []struct {
-		name string
-		args args
-		want time.Duration
-	}{
-		{
-			name: "multiply by 1",
-			args: args{
-				times: 1,
-			},
-			want: time.Duration(12) * time.Second,
-		},
-		{
-			name: "multiply by 2",
-			args: args{
-				times: 2,
-			},
-			want: time.Duration(24) * time.Second,
-		},
-		{
-			name: "multiply by 10",
-			args: args{
-				times: 10,
-			},
-			want: time.Duration(120) * time.Second,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := MultiplySlotBy(tt.args.times); got != tt.want {
-				t.Errorf("MultiplySlotBy() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestEpochStartSlot_OK(t *testing.T) {
 	tests := []struct {
 		epoch     primitives.Epoch


### PR DESCRIPTION
Starting in https://github.com/OffchainLabs/prysm/pull/8975 Prysm added blocks to the pending queue when they arrived even up to 24 seconds into the future. This unnecessarily opens a DOS window for free on the node.

In addition, the node performs an HTR before checking if it's from the future.

This PR removes entirely the pending queue path for these future blocks and just ignores any block that arrives earlier than the 500ms into the slot. Also moves up the check for this earlier than performing the HTR.

h/t to the EF protocol security team for pointing out the issue fixed in this PR.

