### PR TITLE
Stop downscoring peers when pruning pending Gloas data columns

### DIFF
--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -356,45 +356,12 @@ func (s *Service) prunePendingGloasColumns() {
 	}
 }
 
-// pruneStaleGloasColumns drops entries whose slot has passed. A column queued for
-// a block root that never became known is treated as fabricated and its forwarding
-// peer is downscored; known-but-orphaned roots (honest reorgs) are spared.
 func (s *Service) pruneStaleGloasColumns(currentSlot primitives.Slot) {
-	type prunedRoot struct {
-		root  [fieldparams.RootLength]byte
-		peers []peer.ID
-	}
-	var pruned []prunedRoot
 	s.pendingGloasColumnsLock.Lock()
+	defer s.pendingGloasColumnsLock.Unlock()
 	for r, e := range s.pendingGloasColumns {
-		if e.slot+1 >= currentSlot {
-			continue
-		}
-		// Dedupe forwarders: a peer that relayed many columns for one root is downscored once, not per column.
-		seen := make(map[peer.ID]struct{})
-		peers := make([]peer.ID, 0, fieldparams.NumberOfColumns)
-		for _, pe := range e.columns {
-			if pe == nil {
-				continue
-			}
-			if _, ok := seen[pe.peer]; ok {
-				continue
-			}
-			seen[pe.peer] = struct{}{}
-			peers = append(peers, pe.peer)
-		}
-		pruned = append(pruned, prunedRoot{root: r, peers: peers})
-		delete(s.pendingGloasColumns, r)
-	}
-	s.pendingGloasColumnsLock.Unlock()
-
-	// HasBlock + downscore outside the lock; a root we never learned of was fabricated.
-	for _, p := range pruned {
-		if s.cfg.chain == nil || s.cfg.chain.HasBlock(s.ctx, p.root) {
-			continue
-		}
-		for _, pid := range p.peers {
-			s.downscorePeer(pid, "pendingGloasColumnUnknownRoot", logrus.Fields{"root": fmt.Sprintf("%#x", p.root)})
+		if e.slot+1 < currentSlot {
+			delete(s.pendingGloasColumns, r)
 		}
 	}
 }

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -630,54 +630,29 @@ func TestPendingGloasColumns(t *testing.T) {
 		s.processPendingGloasColumns(context.Background(), root, blk)
 	})
 
-	t.Run("prune downscores fabricated root, spares known root", func(t *testing.T) {
-		ctx := t.Context()
-
+	t.Run("prune drops stale entries without penalizing peers", func(t *testing.T) {
 		p := p2ptest.NewTestP2P(t)
-		db := dbtest.SetupDB(t)
-
-		// A known root: a real block saved to the DB (e.g. an orphaned but seen block).
-		_, signedBlock := gloasFixture(t)
-		knownRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
-		require.NoError(t, db.SaveBlock(ctx, signedBlock))
-
-		// A fabricated root the node never learned of.
-		fabricatedRoot := [32]byte{0x99}
-
 		s := &Service{
-			cfg:                 &config{p2p: p, clock: clock, chain: &mock.ChainService{DB: db}},
-			ctx:                 ctx,
+			cfg:                 &config{p2p: p, clock: clock},
+			ctx:                 t.Context(),
 			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
 		}
 
-		// Honest peer queued one column for the known root.
-		known := &pendingGloasEntry{slot: 0}
-		known.columns[0] = &pendingColumnEntry{peer: "honestpeer"}
-		s.pendingGloasColumns[knownRoot] = known
+		unknownRoot := [32]byte{0x99}
+		e := &pendingGloasEntry{slot: 0}
+		e.columns[0] = &pendingColumnEntry{peer: "peerA"}
+		e.columns[1] = &pendingColumnEntry{peer: "peerA"}
+		e.columns[2] = &pendingColumnEntry{peer: "peerB"}
+		s.pendingGloasColumns[unknownRoot] = e
 
-		// Evil peer queued three columns for the fabricated root.
-		fab := &pendingGloasEntry{slot: 0}
-		fab.columns[0] = &pendingColumnEntry{peer: "evilpeer"}
-		fab.columns[1] = &pendingColumnEntry{peer: "evilpeer"}
-		fab.columns[2] = &pendingColumnEntry{peer: "evilpeer"}
-		s.pendingGloasColumns[fabricatedRoot] = fab
-
-		// Both entries are stale relative to slot 5.
 		s.pruneStaleGloasColumns(5)
 
-		require.Equal(t, false, s.hasPendingGloasColumns(knownRoot))
-		require.Equal(t, false, s.hasPendingGloasColumns(fabricatedRoot))
+		require.Equal(t, false, s.hasPendingGloasColumns(unknownRoot))
 
 		scorer := p.Peers().Scorers().BadResponsesScorer()
-
-		// One increment for the fabricated root even though the peer forwarded three columns.
-		evilCount, err := scorer.Count("evilpeer")
-		require.NoError(t, err)
-		require.Equal(t, 1, evilCount)
-
-		// The peer on the known (orphaned) root is untouched.
-		_, err = scorer.Count("honestpeer")
+		_, err := scorer.Count("peerA")
+		require.NotNil(t, err)
+		_, err = scorer.Count("peerB")
 		require.NotNil(t, err)
 	})
 

--- a/changelog/terence_gloas-no-downscore-on-prune.md
+++ b/changelog/terence_gloas-no-downscore-on-prune.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Stop downscoring peers when pending Gloas data columns are pruned for a block root this node has not imported.


### PR DESCRIPTION
- Pruning the pending Gloas column queue no longer downscores forwarding peers, `!HasBlock(root)` only means this node has not imported the block yet
- Under ordinary lag every peer forwards columns for the same unimported canonical root, so the penalty banned the entire peer set against a threshold of 5 and the node self-isolated to 0 peers with a stalled EL
- Verification failure downscores in `processPendingGloasColumns` are unchanged
- Fixes #17166