### PR TITLE
Verify by-root block signatures before pending-queue insert

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -688,8 +688,13 @@ func (s *Service) insertBlockToPendingQueue(_ primitives.Slot, b interfaces.Read
 		return nil
 	}
 
-	if err := s.addPendingBlockToCache(b); err != nil {
+	stored, err := s.addPendingBlockToCache(b)
+	if err != nil {
 		return err
+	}
+	// Only mark seen when cached, so the seen root always has a cache entry whose eviction clears it.
+	if !stored {
+		return nil
 	}
 
 	s.seenPendingBlocks[r] = true
@@ -711,21 +716,21 @@ func (s *Service) pendingBlocksInCache(slot primitives.Slot) []interfaces.ReadOn
 }
 
 // This adds input signed beacon block to slotToPendingBlocks cache.
-func (s *Service) addPendingBlockToCache(b interfaces.ReadOnlySignedBeaconBlock) error {
+func (s *Service) addPendingBlockToCache(b interfaces.ReadOnlySignedBeaconBlock) (bool, error) {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return err
+		return false, err
 	}
 
 	blks := s.pendingBlocksInCache(b.Block().Slot())
 
 	if len(blks) >= maxBlocksPerSlot {
-		return nil
+		return false, nil
 	}
 
 	blks = append(blks, b)
 	k := slotToCacheKey(b.Block().Slot())
 	s.slotToPendingBlocks.Set(k, blks, pendingBlockExpTime)
-	return nil
+	return true, nil
 }
 
 // This converts input string to slot.

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -618,7 +618,9 @@ func TestService_BatchRootRequest(t *testing.T) {
 	p1.Connect(p2)
 	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 
+	st, keys := util.DeterministicGenesisState(t, 64)
 	chain := &mock.ChainService{
+		State: st,
 		FinalizedCheckPoint: &ethpb.Checkpoint{
 			Epoch: 1,
 			Root:  make([]byte, 32),
@@ -673,6 +675,11 @@ func TestService_BatchRootRequest(t *testing.T) {
 	b4.Block.ParentRoot = b3Root[:]
 	b4Root, err := b4.Block.HashTreeRoot()
 	require.NoError(t, err)
+
+	for _, blk := range []*ethpb.SignedBeaconBlock{b2, b3, b4, b5} {
+		blk.Signature, err = signing.ComputeDomainAndSign(st, 0, blk.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
+		require.NoError(t, err)
+	}
 
 	// Send in duplicated roots to also test deduplication.
 	sentRoots := p2ptypes.BeaconBlockByRootsReq{b2Root, b2Root, b3Root, b3Root, b4Root, b5Root}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -48,6 +48,11 @@ func (s *Service) sendBeaconBlocksRequest(ctx context.Context, requests *types.B
 			return fmt.Errorf("received unexpected block with root %x", blkRoot)
 		}
 
+		// Verify the signature before queueing, matching the gossip path, since a matched root does not cover it.
+		if _, err := s.verifyPendingBlockSignature(ctx, id, blk, blkRoot); err != nil {
+			return errors.Wrapf(err, "verify block signature for block with root %x", blkRoot)
+		}
+
 		s.pendingQueueLock.Lock()
 		defer s.pendingQueueLock.Unlock()
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -334,6 +334,72 @@ func TestRecentBeaconBlocks_RPCRequestSent_IncorrectRoot(t *testing.T) {
 	require.ErrorContains(t, "received unexpected block with root", r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
 }
 
+func TestRecentBeaconBlocks_RPCRequestSent_InvalidSignature(t *testing.T) {
+	p1 := p2ptest.NewTestP2P(t)
+	p2 := p2ptest.NewTestP2P(t)
+	p1.DelaySend = true
+
+	blockA := util.NewBeaconBlock()
+	blockA.Block.Slot = 111
+	blockARoot, err := blockA.Block.HashTreeRoot()
+	require.NoError(t, err)
+	genesisState, keys := util.DeterministicGenesisState(t, 64)
+	require.NoError(t, genesisState.SetSlot(111))
+	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), blockARoot))
+	// Sign with a key that does not match the proposer index so the root matches but the signature is invalid.
+	blockA.Signature, err = signing.ComputeDomainAndSign(genesisState, slots.ToEpoch(blockA.Block.Slot), blockA.Block, params.BeaconConfig().DomainBeaconProposer, keys[blockA.Block.ProposerIndex+1])
+	require.NoError(t, err)
+
+	expectedRoots := p2pTypes.BeaconBlockByRootsReq{blockARoot}
+
+	chain := &mock.ChainService{
+		State: genesisState,
+		FinalizedCheckPoint: &ethpb.Checkpoint{
+			Epoch: 5,
+			Root:  make([]byte, 32),
+		},
+		Root:           blockARoot[:],
+		Genesis:        time.Now(),
+		ValidatorsRoot: [32]byte{},
+	}
+	r := &Service{
+		cfg: &config{
+			p2p:   p1,
+			chain: chain,
+			clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+		},
+		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
+		seenPendingBlocks:   make(map[[32]byte]bool),
+		ctx:                 t.Context(),
+		rateLimiter:         newRateLimiter(p1),
+	}
+
+	pcl := protocol.ID("/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy")
+	topic := string(pcl)
+	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(10000, 10000, time.Second, false)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+		defer wg.Done()
+		out := new(p2pTypes.BeaconBlockByRootsReq)
+		assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, out))
+		_, err := stream.Write([]byte{responseCodeSuccess})
+		assert.NoError(t, err, "Could not write to stream")
+		_, err = p2.Encoding().EncodeWithMaxLength(stream, blockA)
+		assert.NoError(t, err, "Could not send response back")
+		assert.NoError(t, stream.Close())
+	})
+
+	p1.Connect(p2)
+	require.ErrorContains(t, "verify block signature", r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
+	assert.Equal(t, 0, len(r.seenPendingBlocks), "Block with invalid signature should not be queued")
+
+	if util.WaitTimeout(&wg, 1*time.Second) {
+		t.Fatal("Did not receive stream within 1 sec")
+	}
+}
+
 func TestRecentBeaconBlocksRPCHandler_HandleZeroBlocks(t *testing.T) {
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
 	db "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
@@ -28,6 +29,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -198,10 +200,13 @@ func TestRecentBeaconBlocks_RPCRequestSent(t *testing.T) {
 	require.NoError(t, err)
 	blockBRoot, err := blockB.Block.HashTreeRoot()
 	require.NoError(t, err)
-	genesisState, err := transition.GenesisBeaconState(t.Context(), nil, 0, &ethpb.Eth1Data{})
-	require.NoError(t, err)
+	genesisState, keys := util.DeterministicGenesisState(t, 64)
 	require.NoError(t, genesisState.SetSlot(111))
 	require.NoError(t, genesisState.UpdateBlockRootAtIndex(111%uint64(params.BeaconConfig().SlotsPerHistoricalRoot), blockARoot))
+	blockA.Signature, err = signing.ComputeDomainAndSign(genesisState, slots.ToEpoch(blockA.Block.Slot), blockA.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
+	require.NoError(t, err)
+	blockB.Signature, err = signing.ComputeDomainAndSign(genesisState, slots.ToEpoch(blockB.Block.Slot), blockB.Block, params.BeaconConfig().DomainBeaconProposer, keys[0])
+	require.NoError(t, err)
 	finalizedCheckpt := &ethpb.Checkpoint{
 		Epoch: 5,
 		Root:  blockBRoot[:],

--- a/changelog/terence_pending-block-by-root-signature.md
+++ b/changelog/terence_pending-block-by-root-signature.md
@@ -1,0 +1,2 @@
+### Changed
+- Verify the proposer signature of by-root blocks before adding them to the pending queue.


### PR DESCRIPTION
Verifies the proposer signature of blocks received via beacon_blocks_by_root before adding them to the pending queue, matching the checks the gossip path already runs. A matched root does not cover the signature.