### PR TITLE
Fail payload reconstruction in Gloas if reconstruction correctness cannot be guaranteed

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -180,32 +180,36 @@ func (s *Service) ReconstructFullGloasExecutionPayloadsByHash(
 	}
 
 	for i, h := range requestHashes {
-		body := bodiesV2[i]
-		// eth_getBlockByHash returns nil for the body: cannot reconstruct the payload without the body.
-		if body == nil {
-			return nil, errors.Errorf("payload body V2 not found for block hash %#x", h)
-		}
-		blk := execBlocks[i]
-		payload, err := gloasPayloadFromExecutionBlock(h, blk)
+		payload, err := gloasPayloadFromBlockAndBody(h, execBlocks[i], bodiesV2[i])
 		if err != nil {
 			return nil, err
-		}
-		payload.Transactions = pb.RecastHexutilByteSlice(body.Transactions)
-		payload.Withdrawals = body.Withdrawals
-
-		// Prefer the response from eth_getBlockByHash when reconstructing BAL.
-		if body.BlockAccessList != nil {
-			payload.BlockAccessList = *body.BlockAccessList
-		}
-		// Reconstructed payload must have a non-nil block access list, even if it is empty,
-		// as the empty RLP list is 0xc0.
-		if len(payload.BlockAccessList) == 0 {
-			return nil, errors.Errorf("block access list unavailable for block hash %#x", h)
 		}
 		payloads[h] = payload
 	}
 
 	return payloads, nil
+}
+
+// gloasPayloadFromBlockAndBody constructs a Gloas payload from an execution block and its corresponding payload body.
+func gloasPayloadFromBlockAndBody(
+	requestedHash [32]byte, blk *pb.ExecutionBlock, body *pb.ExecutionPayloadBodyV2,
+) (*pb.ExecutionPayloadGloas, error) {
+	payload, err := gloasPayloadFromExecutionBlock(requestedHash, blk)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not construct payload from execution block")
+	}
+	if body == nil {
+		return nil, errors.Errorf("execution payload body unavailable for block hash %#x", requestedHash)
+	}
+	payload.Transactions = pb.RecastHexutilByteSlice(body.Transactions)
+	payload.Withdrawals = body.Withdrawals
+	if body.BlockAccessList != nil {
+		payload.BlockAccessList = *body.BlockAccessList
+	}
+	if payload.BlockAccessList == nil {
+		return nil, errors.Errorf("block access list unavailable for block hash %#x", requestedHash)
+	}
+	return payload, nil
 }
 
 // gloasPayloadFromExecutionBlock extracts header fields from an execution block.

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -180,17 +180,27 @@ func (s *Service) ReconstructFullGloasExecutionPayloadsByHash(
 	}
 
 	for i, h := range requestHashes {
+		body := bodiesV2[i]
+		// eth_getBlockByHash returns nil for the body: cannot reconstruct the payload without the body.
+		if body == nil {
+			return nil, errors.Errorf("payload body V2 not found for block hash %#x", h)
+		}
 		blk := execBlocks[i]
 		payload, err := gloasPayloadFromExecutionBlock(h, blk)
 		if err != nil {
 			return nil, err
 		}
-		if bodiesV2[i] != nil {
-			payload.Transactions = pb.RecastHexutilByteSlice(bodiesV2[i].Transactions)
-			payload.Withdrawals = bodiesV2[i].Withdrawals
-			if bodiesV2[i].BlockAccessList != nil {
-				payload.BlockAccessList = *bodiesV2[i].BlockAccessList
-			}
+		payload.Transactions = pb.RecastHexutilByteSlice(body.Transactions)
+		payload.Withdrawals = body.Withdrawals
+
+		// Prefer the response from eth_getBlockByHash when reconstructing BAL.
+		if body.BlockAccessList != nil {
+			payload.BlockAccessList = *body.BlockAccessList
+		}
+		// Reconstructed payload must have a non-nil block access list, even if it is empty,
+		// as the empty RLP list is 0xc0.
+		if len(payload.BlockAccessList) == 0 {
+			return nil, errors.Errorf("block access list unavailable for block hash %#x", h)
 		}
 		payloads[h] = payload
 	}

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
+	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	mocks "github.com/OffchainLabs/prysm/v7/beacon-chain/execution/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -26,6 +27,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	pb "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -59,6 +61,25 @@ func (RPCClientBad) BatchCall([]rpc.BatchElem) error {
 
 func (RPCClientBad) CallContext(context.Context, any, string, ...any) error {
 	return ethereum.NotFound
+}
+
+type reconstructionRPCClient struct {
+	block *pb.ExecutionBlock
+	body  *pb.ExecutionPayloadBodyV2
+}
+
+func (reconstructionRPCClient) Close() {}
+
+func (c reconstructionRPCClient) BatchCall(elems []rpc.BatchElem) error {
+	for i := range elems {
+		*elems[i].Result.(*pb.ExecutionBlock) = *c.block
+	}
+	return nil
+}
+
+func (c reconstructionRPCClient) CallContext(_ context.Context, result any, _ string, _ ...any) error {
+	*result.(*[]*pb.ExecutionPayloadBodyV2) = []*pb.ExecutionPayloadBodyV2{c.body}
+	return nil
 }
 
 func TestClient_IPC(t *testing.T) {
@@ -2929,6 +2950,100 @@ func TestGloasPayloadFromExecutionBlock_PropagatesBlockAccessList(t *testing.T) 
 	payload, err := gloasPayloadFromExecutionBlock(hash, blk)
 	require.NoError(t, err)
 	require.DeepEqual(t, bal, payload.BlockAccessList)
+}
+
+func TestReconstructExecutionPayloadEnvelope_BlindedStorage(t *testing.T) {
+	ctx := t.Context()
+	beaconDB := dbtest.SetupDB(t)
+
+	// Construct ExecutionPayloadEnvelope with a BlockAccessList and save it to the database.
+	hash := common.BytesToHash([]byte("envelope-block-hash"))
+	bal := hexutil.Bytes{0xc0}
+	env := &ethpb.SignedExecutionPayloadEnvelope{
+		Message: &ethpb.ExecutionPayloadEnvelope{
+			Payload: &pb.ExecutionPayloadGloas{
+				ParentHash:      bytesutil.PadTo([]byte("parent"), 32),
+				BlockHash:       hash[:],
+				BlockAccessList: bal,
+				SlotNumber:      99,
+			},
+			ExecutionRequests:     &pb.ExecutionRequestsGloas{},
+			BuilderIndex:          primitives.BuilderIndex(42),
+			BeaconBlockRoot:       bytesutil.PadTo([]byte("beaconroot"), 32),
+			ParentBeaconBlockRoot: make([]byte, 32),
+		},
+		Signature: bytesutil.PadTo([]byte("envelope-signature"), 96),
+	}
+	require.NoError(t, beaconDB.SaveExecutionPayloadEnvelope(ctx, env))
+
+	// Assert that signature isn't modifed while saving.
+	blinded, err := beaconDB.ExecutionPayloadEnvelope(ctx, bytesutil.ToBytes32(env.Message.BeaconBlockRoot))
+	require.NoError(t, err)
+	require.DeepEqual(t, env.Signature, blinded.Signature)
+
+	blobGasUsed, excessBlobGas, slotNumber := uint64(131072), uint64(0), uint64(99)
+	elBlock := &pb.ExecutionBlock{
+		Hash: hash,
+		Header: gethtypes.Header{
+			Number:        big.NewInt(100),
+			BaseFee:       big.NewInt(1),
+			BlobGasUsed:   &blobGasUsed,
+			ExcessBlobGas: &excessBlobGas,
+			SlotNumber:    &slotNumber,
+		},
+	}
+
+	// EL returns a block with pruned BAL.
+	// This is possible as the spec (engine_getPayloadBodiesByHashV2) states:
+	// - Client software MUST set the blockAccessList field to null if the block access list has been pruned from storage.
+	t.Run("pruned BAL fails closed", func(t *testing.T) {
+		service := &Service{rpcClient: reconstructionRPCClient{
+			block: elBlock,
+			body:  &pb.ExecutionPayloadBodyV2{Transactions: []hexutil.Bytes{[]byte("tx1")}},
+		}}
+		_, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
+		require.ErrorContains(t, "block access list unavailable", err)
+	})
+
+	t.Run("unavailable payload body fails closed", func(t *testing.T) {
+		service := &Service{rpcClient: reconstructionRPCClient{block: elBlock}}
+		_, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
+		require.ErrorContains(t, "payload body V2 not found", err)
+	})
+
+	t.Run("zero-length BAL fails closed", func(t *testing.T) {
+		zeroLengthBAL := hexutil.Bytes{}
+		service := &Service{rpcClient: reconstructionRPCClient{
+			block: elBlock,
+			body:  &pb.ExecutionPayloadBodyV2{BlockAccessList: &zeroLengthBAL},
+		}}
+		_, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
+		require.ErrorContains(t, "block access list unavailable", err)
+	})
+
+	t.Run("block BAL is used as fallback", func(t *testing.T) {
+		blockWithBAL := *elBlock
+		blockWithBAL.BlockAccessList = bal
+		service := &Service{rpcClient: reconstructionRPCClient{
+			block: &blockWithBAL,
+			body:  &pb.ExecutionPayloadBodyV2{Transactions: []hexutil.Bytes{[]byte("tx1")}},
+		}}
+		full, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
+		require.NoError(t, err)
+		require.DeepEqual(t, []byte(bal), full.Message.Payload.BlockAccessList)
+	})
+
+	// EL returns a block with the original, logically empty BAL encoded as RLP.
+	t.Run("available BAL reconstructs with original signature", func(t *testing.T) {
+		service := &Service{rpcClient: reconstructionRPCClient{
+			block: elBlock,
+			body:  &pb.ExecutionPayloadBodyV2{Transactions: []hexutil.Bytes{[]byte("tx1")}, BlockAccessList: &bal},
+		}}
+		full, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
+		require.NoError(t, err)
+		require.DeepEqual(t, []byte(bal), full.Message.Payload.BlockAccessList)
+		require.DeepEqual(t, env.Signature, full.Signature)
+	})
 }
 
 func TestExecutionBlock_MarshalUnmarshalJSON_BlockAccessList(t *testing.T) {

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
-	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	mocks "github.com/OffchainLabs/prysm/v7/beacon-chain/execution/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -27,7 +26,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	pb "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
-	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -2952,97 +2950,48 @@ func TestGloasPayloadFromExecutionBlock_PropagatesBlockAccessList(t *testing.T) 
 	require.DeepEqual(t, bal, payload.BlockAccessList)
 }
 
-func TestReconstructExecutionPayloadEnvelope_BlindedStorage(t *testing.T) {
-	ctx := t.Context()
-	beaconDB := dbtest.SetupDB(t)
-
-	// Construct ExecutionPayloadEnvelope with a BlockAccessList and save it to the database.
-	hash := common.BytesToHash([]byte("envelope-block-hash"))
-	bal := hexutil.Bytes{0xc0}
-	env := &ethpb.SignedExecutionPayloadEnvelope{
-		Message: &ethpb.ExecutionPayloadEnvelope{
-			Payload: &pb.ExecutionPayloadGloas{
-				ParentHash:      bytesutil.PadTo([]byte("parent"), 32),
-				BlockHash:       hash[:],
-				BlockAccessList: bal,
-				SlotNumber:      99,
+func TestGloasPayloadFromBlockAndBody(t *testing.T) {
+	hash := common.BytesToHash([]byte("block-hash"))
+	blobGasUsed := uint64(123)
+	excessBlobGas := uint64(456)
+	slotNumber := uint64(789)
+	newBlock := func(bal []byte) *pb.ExecutionBlock {
+		return &pb.ExecutionBlock{
+			Hash: hash,
+			Header: gethtypes.Header{
+				Number:        big.NewInt(1),
+				BaseFee:       big.NewInt(1),
+				BlobGasUsed:   &blobGasUsed,
+				ExcessBlobGas: &excessBlobGas,
+				SlotNumber:    &slotNumber,
 			},
-			ExecutionRequests:     &pb.ExecutionRequestsGloas{},
-			BuilderIndex:          primitives.BuilderIndex(42),
-			BeaconBlockRoot:       bytesutil.PadTo([]byte("beaconroot"), 32),
-			ParentBeaconBlockRoot: make([]byte, 32),
-		},
-		Signature: bytesutil.PadTo([]byte("envelope-signature"), 96),
-	}
-	require.NoError(t, beaconDB.SaveExecutionPayloadEnvelope(ctx, env))
-
-	// Assert that signature isn't modifed while saving.
-	blinded, err := beaconDB.ExecutionPayloadEnvelope(ctx, bytesutil.ToBytes32(env.Message.BeaconBlockRoot))
-	require.NoError(t, err)
-	require.DeepEqual(t, env.Signature, blinded.Signature)
-
-	blobGasUsed, excessBlobGas, slotNumber := uint64(131072), uint64(0), uint64(99)
-	elBlock := &pb.ExecutionBlock{
-		Hash: hash,
-		Header: gethtypes.Header{
-			Number:        big.NewInt(100),
-			BaseFee:       big.NewInt(1),
-			BlobGasUsed:   &blobGasUsed,
-			ExcessBlobGas: &excessBlobGas,
-			SlotNumber:    &slotNumber,
-		},
+			BlockAccessList: bal,
+		}
 	}
 
-	// EL returns a block with pruned BAL.
-	// This is possible as the spec (engine_getPayloadBodiesByHashV2) states:
-	// - Client software MUST set the blockAccessList field to null if the block access list has been pruned from storage.
-	t.Run("pruned BAL fails closed", func(t *testing.T) {
-		service := &Service{rpcClient: reconstructionRPCClient{
-			block: elBlock,
-			body:  &pb.ExecutionPayloadBodyV2{Transactions: []hexutil.Bytes{[]byte("tx1")}},
-		}}
-		_, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
+	t.Run("body BAL overrides block BAL", func(t *testing.T) {
+		bodyBal := hexutil.Bytes{0x0a, 0x0b}
+		txs := []hexutil.Bytes{{0x01}}
+		body := &pb.ExecutionPayloadBodyV2{Transactions: txs, BlockAccessList: &bodyBal}
+		payload, err := gloasPayloadFromBlockAndBody(hash, newBlock([]byte{0x01}), body)
+		require.NoError(t, err)
+		require.DeepEqual(t, []byte(bodyBal), payload.BlockAccessList)
+		require.Equal(t, 1, len(payload.Transactions))
+	})
+	t.Run("nil body errors", func(t *testing.T) {
+		_, err := gloasPayloadFromBlockAndBody(hash, newBlock([]byte{0x01}), nil)
+		require.ErrorContains(t, "execution payload body unavailable", err)
+	})
+	t.Run("nil BAL in both sources errors", func(t *testing.T) {
+		body := &pb.ExecutionPayloadBodyV2{}
+		_, err := gloasPayloadFromBlockAndBody(hash, newBlock(nil), body)
 		require.ErrorContains(t, "block access list unavailable", err)
 	})
-
-	t.Run("unavailable payload body fails closed", func(t *testing.T) {
-		service := &Service{rpcClient: reconstructionRPCClient{block: elBlock}}
-		_, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
-		require.ErrorContains(t, "payload body V2 not found", err)
-	})
-
-	t.Run("zero-length BAL fails closed", func(t *testing.T) {
-		zeroLengthBAL := hexutil.Bytes{}
-		service := &Service{rpcClient: reconstructionRPCClient{
-			block: elBlock,
-			body:  &pb.ExecutionPayloadBodyV2{BlockAccessList: &zeroLengthBAL},
-		}}
-		_, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
-		require.ErrorContains(t, "block access list unavailable", err)
-	})
-
-	t.Run("block BAL is used as fallback", func(t *testing.T) {
-		blockWithBAL := *elBlock
-		blockWithBAL.BlockAccessList = bal
-		service := &Service{rpcClient: reconstructionRPCClient{
-			block: &blockWithBAL,
-			body:  &pb.ExecutionPayloadBodyV2{Transactions: []hexutil.Bytes{[]byte("tx1")}},
-		}}
-		full, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
+	t.Run("block BAL used when body BAL is nil", func(t *testing.T) {
+		body := &pb.ExecutionPayloadBodyV2{}
+		payload, err := gloasPayloadFromBlockAndBody(hash, newBlock([]byte{0x01, 0x02}), body)
 		require.NoError(t, err)
-		require.DeepEqual(t, []byte(bal), full.Message.Payload.BlockAccessList)
-	})
-
-	// EL returns a block with the original, logically empty BAL encoded as RLP.
-	t.Run("available BAL reconstructs with original signature", func(t *testing.T) {
-		service := &Service{rpcClient: reconstructionRPCClient{
-			block: elBlock,
-			body:  &pb.ExecutionPayloadBodyV2{Transactions: []hexutil.Bytes{[]byte("tx1")}, BlockAccessList: &bal},
-		}}
-		full, err := service.ReconstructExecutionPayloadEnvelope(ctx, blinded)
-		require.NoError(t, err)
-		require.DeepEqual(t, []byte(bal), full.Message.Payload.BlockAccessList)
-		require.DeepEqual(t, env.Signature, full.Signature)
+		require.DeepEqual(t, []byte{0x01, 0x02}, payload.BlockAccessList)
 	})
 }
 

--- a/changelog/syjn99_fix-fail-unavailable-reconstruction.md
+++ b/changelog/syjn99_fix-fail-unavailable-reconstruction.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fail payload reconstruction in Gloas if correctness cannot be guaranteed.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Reported in Discord ([Message link](https://discord.com/channels/595666850260713488/892088344438255616/1526470317315457165)).

https://github.com/OffchainLabs/prysm/blob/73439ebe08e6cee85e5e9dbc24ac60dd71d4294d/beacon-chain/execution/engine_client.go#L182-L196

Today, Prysm reconstructs the series of execution payload envelopes from multiple sources:
1. DB: Saves (and read) *blinded* payload envelope which deliberately omits large-sized transactions, withdrawals, and **BAL**.
2. Call Engine API (`engine_getPayloadBodiesByHashV2`) for getting payloads. Note that this can return `null` `blockAccessList` when BAL has been pruned from storage. (ref: https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md#engine_getpayloadbodiesbyhashv2)
3. Call Engine API (`eth_getBlockByHash`) for getting execution blocks.

So it is possible to construct a payload with empty BAL, when the envelope originally had non-empty BAL at that slot. The problem is that we uses the signature from the DB, which can be deviated as the message becomes different. (non-empty BAL -> empty BAL)

This PR returns an error when reconstruction cannot guarantee the correctness, which means:
- if EL cannot provide execution payloads or
- length of BAL is zero - BAL shouldn't be zero-byted in terms of RLP.

**Which issue(s) does this PR fix?**

N/A but should solve the issue in `glamsterdam-devnet-6`. ([Discord link](https://discord.com/channels/595666850260713488/892088344438255616/1526470317315457165)))

**Other notes for review**

~~`TestReconstructExecutionPayloadEnvelope_BlindedStorage` covers possible scenarios that I can think of.~~

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
