### PR TITLE
Validate execution payload envelopes fetched by root

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -180,22 +180,36 @@ func (s *Service) ReconstructFullGloasExecutionPayloadsByHash(
 	}
 
 	for i, h := range requestHashes {
-		blk := execBlocks[i]
-		payload, err := gloasPayloadFromExecutionBlock(h, blk)
+		payload, err := gloasPayloadFromBlockAndBody(h, execBlocks[i], bodiesV2[i])
 		if err != nil {
 			return nil, err
-		}
-		if bodiesV2[i] != nil {
-			payload.Transactions = pb.RecastHexutilByteSlice(bodiesV2[i].Transactions)
-			payload.Withdrawals = bodiesV2[i].Withdrawals
-			if bodiesV2[i].BlockAccessList != nil {
-				payload.BlockAccessList = *bodiesV2[i].BlockAccessList
-			}
 		}
 		payloads[h] = payload
 	}
 
 	return payloads, nil
+}
+
+// A nil body or block access list means the EL pruned it, treating it as empty would produce a payload that no longer matches the builder signature.
+func gloasPayloadFromBlockAndBody(
+	requestedHash [32]byte, blk *pb.ExecutionBlock, body *pb.ExecutionPayloadBodyV2,
+) (*pb.ExecutionPayloadGloas, error) {
+	payload, err := gloasPayloadFromExecutionBlock(requestedHash, blk)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return nil, errors.Errorf("execution payload body unavailable for block hash %#x", requestedHash)
+	}
+	payload.Transactions = pb.RecastHexutilByteSlice(body.Transactions)
+	payload.Withdrawals = body.Withdrawals
+	if body.BlockAccessList != nil {
+		payload.BlockAccessList = *body.BlockAccessList
+	}
+	if payload.BlockAccessList == nil {
+		return nil, errors.Errorf("block access list unavailable for block hash %#x", requestedHash)
+	}
+	return payload, nil
 }
 
 // gloasPayloadFromExecutionBlock extracts header fields from an execution block.

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -2931,6 +2931,51 @@ func TestGloasPayloadFromExecutionBlock_PropagatesBlockAccessList(t *testing.T) 
 	require.DeepEqual(t, bal, payload.BlockAccessList)
 }
 
+func TestGloasPayloadFromBlockAndBody(t *testing.T) {
+	hash := common.BytesToHash([]byte("block-hash"))
+	blobGasUsed := uint64(123)
+	excessBlobGas := uint64(456)
+	slotNumber := uint64(789)
+	newBlock := func(bal []byte) *pb.ExecutionBlock {
+		return &pb.ExecutionBlock{
+			Hash: hash,
+			Header: gethtypes.Header{
+				Number:        big.NewInt(1),
+				BaseFee:       big.NewInt(1),
+				BlobGasUsed:   &blobGasUsed,
+				ExcessBlobGas: &excessBlobGas,
+				SlotNumber:    &slotNumber,
+			},
+			BlockAccessList: bal,
+		}
+	}
+
+	t.Run("body BAL overrides block BAL", func(t *testing.T) {
+		bodyBal := hexutil.Bytes{0x0a, 0x0b}
+		txs := []hexutil.Bytes{{0x01}}
+		body := &pb.ExecutionPayloadBodyV2{Transactions: txs, BlockAccessList: &bodyBal}
+		payload, err := gloasPayloadFromBlockAndBody(hash, newBlock([]byte{0x01}), body)
+		require.NoError(t, err)
+		require.DeepEqual(t, []byte(bodyBal), payload.BlockAccessList)
+		require.Equal(t, 1, len(payload.Transactions))
+	})
+	t.Run("nil body errors", func(t *testing.T) {
+		_, err := gloasPayloadFromBlockAndBody(hash, newBlock([]byte{0x01}), nil)
+		require.ErrorContains(t, "execution payload body unavailable", err)
+	})
+	t.Run("nil BAL in both sources errors", func(t *testing.T) {
+		body := &pb.ExecutionPayloadBodyV2{}
+		_, err := gloasPayloadFromBlockAndBody(hash, newBlock(nil), body)
+		require.ErrorContains(t, "block access list unavailable", err)
+	})
+	t.Run("block BAL used when body BAL is nil", func(t *testing.T) {
+		body := &pb.ExecutionPayloadBodyV2{}
+		payload, err := gloasPayloadFromBlockAndBody(hash, newBlock([]byte{0x01, 0x02}), body)
+		require.NoError(t, err)
+		require.DeepEqual(t, []byte{0x01, 0x02}, payload.BlockAccessList)
+	})
+}
+
 func TestExecutionBlock_MarshalUnmarshalJSON_BlockAccessList(t *testing.T) {
 	bal := hexutil.Bytes{0xde, 0xad, 0xbe, 0xef}
 	original := &pb.ExecutionBlock{

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/async"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain"
 	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -514,27 +515,45 @@ func (s *Service) fetchAndQueuePayloadEnvelopesForRoots(
 		if env == nil || env.Message == nil {
 			continue
 		}
-		s.queuePendingPayloadEnvelopeFromRootRequest(env)
+		s.queuePendingPayloadEnvelopeFromRootRequest(ctx, env)
 	}
 }
 
-func (s *Service) queuePendingPayloadEnvelopeFromRootRequest(signedEnvelope *ethpb.SignedExecutionPayloadEnvelope) {
-	if signedEnvelope == nil || signedEnvelope.Message == nil {
+// The responding peer is matched only on root, so apply the same slot, signature, and cap guards as gossip.
+func (s *Service) queuePendingPayloadEnvelopeFromRootRequest(ctx context.Context, signedEnvelope *ethpb.SignedExecutionPayloadEnvelope) {
+	if signedEnvelope == nil || signedEnvelope.Message == nil || signedEnvelope.Message.Payload == nil {
+		return
+	}
+	e, err := blocks.WrappedROSignedExecutionPayloadEnvelope(signedEnvelope)
+	if err != nil {
+		log.WithError(err).Debug("Could not wrap fetched payload envelope")
+		return
+	}
+	env, err := e.Envelope()
+	if err != nil {
+		log.WithError(err).Debug("Could not read fetched payload envelope")
+		return
+	}
+	if !s.payloadEnvelopeSlotInWindow(env.Slot()) {
+		log.WithField("envelopeSlot", env.Slot()).Debug("Ignoring fetched payload envelope outside slot window")
+		return
+	}
+	st, err := s.cfg.chain.HeadStateReadOnly(ctx)
+	if err != nil {
+		log.WithError(err).Debug("Could not get head state to verify fetched payload envelope")
+		return
+	}
+	v := s.newExecutionPayloadEnvelopeVerifier(e, []verification.Requirement{verification.RequireBuilderSignatureValid})
+	if err := v.VerifySignature(ctx, st); err != nil {
+		log.WithError(err).Debug("Ignoring fetched payload envelope with invalid signature")
 		return
 	}
 
-	root := bytesutil.ToBytes32(signedEnvelope.Message.BeaconBlockRoot)
-	builderIdx := uint64(signedEnvelope.Message.BuilderIndex)
-
 	s.pendingEnvelopeLock.Lock()
 	defer s.pendingEnvelopeLock.Unlock()
-
-	inner, ok := s.pendingPayloadEnvelopes[root]
-	if !ok {
-		inner = make(map[uint64]*ethpb.SignedExecutionPayloadEnvelope)
-		s.pendingPayloadEnvelopes[root] = inner
+	if stored, _ := s.storePendingPayloadEnvelope(signedEnvelope, false); !stored {
+		log.Debug("Dropped fetched payload envelope, pending caps reached or duplicate")
 	}
-	inner[builderIdx] = signedEnvelope
 }
 
 // filterOutPendingAndSynced filters out roots that are already seen in pending blocks or being synced.

--- a/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/pkg/errors"
 )
 
 func makeSignedEnvelope(root [32]byte, slot primitives.Slot) *ethpb.SignedExecutionPayloadEnvelope {
@@ -47,8 +48,9 @@ func makeSignedEnvelope(root [32]byte, slot primitives.Slot) *ethpb.SignedExecut
 
 func newEnvelopeFetchService(t *testing.T, p1 p2p.P2P) *Service {
 	chain := &mock.ChainService{
-		ValidatorsRoot: [32]byte{},
-		Genesis:        time.Now(),
+		ValidatorsRoot:      [32]byte{},
+		Genesis:             time.Now().Add(-time.Hour),
+		FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
 	}
 	r := &Service{
 		cfg: &config{
@@ -57,7 +59,8 @@ func newEnvelopeFetchService(t *testing.T, p1 p2p.P2P) *Service {
 			chain:    chain,
 			clock:    startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
 		},
-		pendingPayloadEnvelopes: make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+		pendingPayloadEnvelopes:             make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+		newExecutionPayloadEnvelopeVerifier: testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{}),
 	}
 	ctxMap, err := ContextByteVersionsForValRoot(chain.ValidatorsRoot)
 	require.NoError(t, err)
@@ -109,6 +112,91 @@ func TestFetchAndQueuePayloadEnvelopesForRoots_QueuesWithoutPendingBlock(t *test
 	require.Equal(t, true, ok)
 	require.Equal(t, 1, len(inner))
 	assert.NotNil(t, inner[0])
+}
+
+// An envelope fetched by root with an invalid signature is dropped, not queued.
+func TestQueuePendingPayloadEnvelopeFromRootRequest_RejectsBadSignature(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	params.BeaconConfig().InitializeForkSchedule()
+
+	p1 := p2ptest.NewTestP2P(t)
+	r := newEnvelopeFetchService(t, p1)
+	r.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(
+		mockExecutionPayloadEnvelopeVerifier{errSignature: errors.New("bad signature")},
+	)
+
+	root := [32]byte{0xBB}
+	r.queuePendingPayloadEnvelopeFromRootRequest(t.Context(), makeSignedEnvelope(root, 1))
+
+	r.pendingEnvelopeLock.RLock()
+	defer r.pendingEnvelopeLock.RUnlock()
+	assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
+}
+
+// An envelope fetched by root with a far-future slot is dropped so it cannot defeat
+// finalization based pruning and pin memory permanently.
+func TestQueuePendingPayloadEnvelopeFromRootRequest_RejectsFarFutureSlot(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	params.BeaconConfig().InitializeForkSchedule()
+
+	p1 := p2ptest.NewTestP2P(t)
+	r := newEnvelopeFetchService(t, p1)
+
+	root := [32]byte{0xDD}
+	r.queuePendingPayloadEnvelopeFromRootRequest(t.Context(), makeSignedEnvelope(root, 1_000_000))
+
+	r.pendingEnvelopeLock.RLock()
+	defer r.pendingEnvelopeLock.RUnlock()
+	assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
+}
+
+// storePendingPayloadEnvelope caps the number of roots and builders per root, and
+// self-built envelopes may bypass the caps.
+func TestStorePendingPayloadEnvelope_Caps(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	r := &Service{pendingPayloadEnvelopes: make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope)}
+
+	for i := 0; i < maxPendingPayloadRoots; i++ {
+		env := makeSignedEnvelope([32]byte{byte(i), byte(i >> 8)}, 1)
+		stored, _ := r.storePendingPayloadEnvelope(env, false)
+		require.Equal(t, true, stored)
+	}
+	require.Equal(t, maxPendingPayloadRoots, len(r.pendingPayloadEnvelopes))
+
+	overflow := makeSignedEnvelope([32]byte{0xFF, 0xFF, 0xFF}, 1)
+	stored, _ := r.storePendingPayloadEnvelope(overflow, false)
+	assert.Equal(t, false, stored)
+
+	selfBuild := makeSignedEnvelope([32]byte{0xFE, 0xFE, 0xFE}, 1)
+	selfBuild.Message.BuilderIndex = primitives.BuilderIndex(params.BeaconConfig().BuilderIndexSelfBuild)
+	stored, _ = r.storePendingPayloadEnvelope(selfBuild, true)
+	assert.Equal(t, true, stored)
+}
+
+// storePendingPayloadEnvelope caps the number of builders retained per root.
+func TestStorePendingPayloadEnvelope_BuildersPerRootCap(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	r := &Service{pendingPayloadEnvelopes: make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope)}
+
+	root := [32]byte{0x01}
+	for i := 0; i < maxPendingBuildersPerRoot; i++ {
+		env := makeSignedEnvelope(root, 1)
+		env.Message.BuilderIndex = primitives.BuilderIndex(i)
+		stored, _ := r.storePendingPayloadEnvelope(env, false)
+		require.Equal(t, true, stored)
+	}
+	overflow := makeSignedEnvelope(root, 1)
+	overflow.Message.BuilderIndex = primitives.BuilderIndex(maxPendingBuildersPerRoot)
+	stored, _ := r.storePendingPayloadEnvelope(overflow, false)
+	assert.Equal(t, false, stored)
 }
 
 // Pre-Gloas: the chain-level CurrentSlot() < gloasStartSlot gate short-circuits

--- a/beacon-chain/sync/pending_payload_envelope.go
+++ b/beacon-chain/sync/pending_payload_envelope.go
@@ -6,6 +6,8 @@ import (
 	"github.com/OffchainLabs/prysm/v7/async"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
@@ -25,6 +27,54 @@ func (s *Service) processPendingPayloadEnvelopeQueue() {
 		}
 		s.processPendingPayloadEnvelopes(s.ctx)
 	})
+}
+
+// Caller must hold pendingEnvelopeLock, allowOverflow lets locally self built envelopes bypass the caps.
+func (s *Service) storePendingPayloadEnvelope(signedEnvelope *ethpb.SignedExecutionPayloadEnvelope, allowOverflow bool) (stored, newRoot bool) {
+	msg := signedEnvelope.Message
+	if msg == nil || msg.Payload == nil {
+		return false, false
+	}
+	root := bytesutil.ToBytes32(msg.BeaconBlockRoot)
+	builderIdx := uint64(msg.BuilderIndex)
+
+	inner, rootExists := s.pendingPayloadEnvelopes[root]
+	if !allowOverflow {
+		if !rootExists && len(s.pendingPayloadEnvelopes) >= maxPendingPayloadRoots {
+			return false, false
+		}
+		if len(inner) >= maxPendingBuildersPerRoot {
+			return false, false
+		}
+	}
+	for existingIdx, existing := range inner {
+		if existing == nil || existing.Message == nil || existing.Message.Payload == nil {
+			delete(inner, existingIdx)
+			continue
+		}
+		if existing.Message.Payload.SlotNumber != msg.Payload.SlotNumber {
+			return false, false
+		}
+		break
+	}
+	if _, exists := inner[builderIdx]; exists {
+		return false, false
+	}
+	if !rootExists {
+		inner = make(map[uint64]*ethpb.SignedExecutionPayloadEnvelope)
+		s.pendingPayloadEnvelopes[root] = inner
+	}
+	inner[builderIdx] = signedEnvelope
+	return true, !rootExists
+}
+
+// Bounds the fetch path so a far future slot cannot defeat finalization based pruning.
+func (s *Service) payloadEnvelopeSlotInWindow(slot primitives.Slot) bool {
+	finalizedStart, err := slots.EpochStart(s.cfg.chain.FinalizedCheckpt().Epoch)
+	if err != nil {
+		return false
+	}
+	return slot >= finalizedStart && slot <= s.cfg.clock.CurrentSlot()
 }
 
 // processPendingPayloadEnvelope retrieves all queued payload envelopes for the

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -188,17 +188,8 @@ func (s *Service) queuePendingPayloadEnvelope(
 	}
 	s.pendingEnvelopeLock.Lock()
 	defer s.pendingEnvelopeLock.Unlock()
-	inner, rootExists := s.pendingPayloadEnvelopes[root]
-	if !isSelfBuild && len(s.pendingPayloadEnvelopes) >= maxPendingPayloadRoots {
-		log.Debug("Too many pending payload roots, ignoring new payload envelope")
-		return pubsub.ValidationIgnore, nil
-	}
-	if !isSelfBuild && len(inner) >= maxPendingBuildersPerRoot {
-		log.Debug("Too many pending builders for root, ignoring new payload envelope")
-		return pubsub.ValidationIgnore, nil
-	}
 
-	// The failure budget is per slot, matching admission above, so a burst of bad signatures cannot disable self-build queueing beyond the current slot.
+	// The failure budget is per slot, matching admission below, so a burst of bad signatures cannot disable self-build queueing beyond the current slot.
 	if isSelfBuild && s.selfBuildSigFailSlot != currentSlot {
 		s.selfBuildSigFailSlot = currentSlot
 		s.selfBuildSigFailures = 0
@@ -222,33 +213,16 @@ func (s *Service) queuePendingPayloadEnvelope(
 		log.Debug("Ignoring payload envelope from self-build outside of the Lookahead window")
 		return pubsub.ValidationIgnore, nil
 	}
-	if !rootExists {
-		inner = make(map[uint64]*ethpb.SignedExecutionPayloadEnvelope)
-		s.pendingPayloadEnvelopes[root] = inner
-	} else {
-		for existingBuilderIdx, existing := range inner {
-			if existing == nil || existing.Message == nil || existing.Message.Payload == nil {
-				delete(inner, existingBuilderIdx)
-				log.Debug("Removed malformed pending payload envelope")
-				continue
-			}
-			if existing.Message.Payload.SlotNumber != signedEnvelope.Message.Payload.SlotNumber {
-				log.Debug("Ignoring payload envelope with mismatched slot")
-				return pubsub.ValidationIgnore, nil
-			}
-			break
-		}
-	}
-	if _, exists := inner[builderIdx]; exists {
-		log.Debug("Already have a pending payload envelope for this builder and root, ignoring")
+
+	stored, newRoot := s.storePendingPayloadEnvelope(signedEnvelope, isSelfBuild)
+	if !stored {
 		return pubsub.ValidationIgnore, nil
 	}
-	inner[builderIdx] = signedEnvelope
 
 	s.pendingQueueLock.RLock()
 	inPendingQueue := s.seenPendingBlocks[root]
 	s.pendingQueueLock.RUnlock()
-	if !rootExists && !inPendingQueue && !s.cfg.chain.InForkchoice(root) && !s.cfg.chain.BlockBeingSynced(root) {
+	if newRoot && !inPendingQueue && !s.cfg.chain.InForkchoice(root) && !s.cfg.chain.BlockBeingSynced(root) {
 		go func() {
 			if err := s.sendBatchRootRequest(s.ctx, [][32]byte{root}, rand.NewGenerator()); err != nil {
 				log.WithError(err).Debug("Could not request beacon block for pending payload envelope")

--- a/changelog/terence_fix-envelope-byroot-validation.md
+++ b/changelog/terence_fix-envelope-byroot-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Validate signature, slot, and caps on execution payload envelopes fetched by root, preventing an unbounded pending-envelope memory exhaustion.

--- a/changelog/terence_gloas-reconstruct-bal-check.md
+++ b/changelog/terence_gloas-reconstruct-bal-check.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fail Gloas payload reconstruction when the EL returns no body or no block access list, instead of serving an envelope with an empty BAL that no longer matches the builder signature.


### PR DESCRIPTION
The execution-payload-envelope by-root fetch path inserted every envelope a peer returned into the pending map with no signature, slot, or cap check, so an unauthenticated peer could pin unbounded memory using far-future-slot envelopes that finalization-based pruning never reclaimed.

This routes the gossip and by-root paths through a shared guarded insert and verifies the builder signature plus a finalized-to-current slot window before storing, so fetched envelopes obey the same caps as gossip and stay prunable.