### PR TITLE
Validate execution payload envelopes fetched by root

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -518,8 +518,15 @@ func (s *Service) fetchAndQueuePayloadEnvelopesForRoots(
 	}
 }
 
+// Signature is not verified here, processing revalidates fully and the slot bound plus caps bound memory.
 func (s *Service) queuePendingPayloadEnvelopeFromRootRequest(signedEnvelope *ethpb.SignedExecutionPayloadEnvelope) {
-	if signedEnvelope == nil || signedEnvelope.Message == nil {
+	if signedEnvelope == nil || signedEnvelope.Message == nil || signedEnvelope.Message.Payload == nil {
+		return
+	}
+	// A future slot would never fall below the finalized epoch, defeating pruning and pinning memory.
+	slot := primitives.Slot(signedEnvelope.Message.Payload.SlotNumber)
+	if slot > s.cfg.clock.CurrentSlot() {
+		log.WithField("envelopeSlot", slot).Debug("Ignoring fetched payload envelope with future slot")
 		return
 	}
 
@@ -530,6 +537,17 @@ func (s *Service) queuePendingPayloadEnvelopeFromRootRequest(signedEnvelope *eth
 	defer s.pendingEnvelopeLock.Unlock()
 
 	inner, ok := s.pendingPayloadEnvelopes[root]
+	if !ok && len(s.pendingPayloadEnvelopes) >= maxPendingPayloadRoots {
+		log.Debug("Too many pending payload roots, ignoring fetched payload envelope")
+		return
+	}
+	if len(inner) >= maxPendingBuildersPerRoot {
+		log.Debug("Too many pending builders for root, ignoring fetched payload envelope")
+		return
+	}
+	if _, exists := inner[builderIdx]; exists {
+		return
+	}
 	if !ok {
 		inner = make(map[uint64]*ethpb.SignedExecutionPayloadEnvelope)
 		s.pendingPayloadEnvelopes[root] = inner

--- a/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
@@ -48,7 +48,7 @@ func makeSignedEnvelope(root [32]byte, slot primitives.Slot) *ethpb.SignedExecut
 func newEnvelopeFetchService(t *testing.T, p1 p2p.P2P) *Service {
 	chain := &mock.ChainService{
 		ValidatorsRoot: [32]byte{},
-		Genesis:        time.Now(),
+		Genesis:        time.Now().Add(-time.Hour),
 	}
 	r := &Service{
 		cfg: &config{
@@ -109,6 +109,51 @@ func TestFetchAndQueuePayloadEnvelopesForRoots_QueuesWithoutPendingBlock(t *test
 	require.Equal(t, true, ok)
 	require.Equal(t, 1, len(inner))
 	assert.NotNil(t, inner[0])
+}
+
+// A future slot must not defeat finalization based pruning by pinning memory.
+func TestQueuePendingPayloadEnvelopeFromRootRequest_RejectsFutureSlot(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	p1 := p2ptest.NewTestP2P(t)
+	r := newEnvelopeFetchService(t, p1)
+
+	r.queuePendingPayloadEnvelopeFromRootRequest(makeSignedEnvelope([32]byte{0xDD}, 1_000_000))
+
+	r.pendingEnvelopeLock.RLock()
+	defer r.pendingEnvelopeLock.RUnlock()
+	assert.Equal(t, 0, len(r.pendingPayloadEnvelopes))
+}
+
+func TestQueuePendingPayloadEnvelopeFromRootRequest_RootsCap(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	p1 := p2ptest.NewTestP2P(t)
+	r := newEnvelopeFetchService(t, p1)
+
+	for i := 0; i < maxPendingPayloadRoots; i++ {
+		r.queuePendingPayloadEnvelopeFromRootRequest(makeSignedEnvelope([32]byte{byte(i), byte(i >> 8)}, 1))
+	}
+	r.queuePendingPayloadEnvelopeFromRootRequest(makeSignedEnvelope([32]byte{0xFF, 0xFF, 0xFF}, 1))
+
+	r.pendingEnvelopeLock.RLock()
+	defer r.pendingEnvelopeLock.RUnlock()
+	assert.Equal(t, maxPendingPayloadRoots, len(r.pendingPayloadEnvelopes))
+}
+
+func TestQueuePendingPayloadEnvelopeFromRootRequest_BuildersPerRootCap(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	p1 := p2ptest.NewTestP2P(t)
+	r := newEnvelopeFetchService(t, p1)
+
+	root := [32]byte{0x01}
+	for i := 0; i <= maxPendingBuildersPerRoot; i++ {
+		env := makeSignedEnvelope(root, 1)
+		env.Message.BuilderIndex = primitives.BuilderIndex(i)
+		r.queuePendingPayloadEnvelopeFromRootRequest(env)
+	}
+
+	r.pendingEnvelopeLock.RLock()
+	defer r.pendingEnvelopeLock.RUnlock()
+	assert.Equal(t, maxPendingBuildersPerRoot, len(r.pendingPayloadEnvelopes[root]))
 }
 
 // Pre-Gloas: the chain-level CurrentSlot() < gloasStartSlot gate short-circuits

--- a/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_payload_envelopes_test.go
@@ -129,7 +129,7 @@ func TestQueuePendingPayloadEnvelopeFromRootRequest_RootsCap(t *testing.T) {
 	p1 := p2ptest.NewTestP2P(t)
 	r := newEnvelopeFetchService(t, p1)
 
-	for i := 0; i < maxPendingPayloadRoots; i++ {
+	for i := range maxPendingPayloadRoots {
 		r.queuePendingPayloadEnvelopeFromRootRequest(makeSignedEnvelope([32]byte{byte(i), byte(i >> 8)}, 1))
 	}
 	r.queuePendingPayloadEnvelopeFromRootRequest(makeSignedEnvelope([32]byte{0xFF, 0xFF, 0xFF}, 1))

--- a/changelog/terence_fix-envelope-byroot-validation.md
+++ b/changelog/terence_fix-envelope-byroot-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Reject future-slot execution payload envelopes fetched by root and enforce pending caps, preventing an unbounded pending-envelope memory exhaustion.


### PR DESCRIPTION
- Envelopes fetched by root were stored without any validation, letting a peer pin unprunable future-slot envelopes and exhaust memory
- Reject envelopes with a slot above the current slot and enforce the same pending caps as gossip before storing, signature is not checked since processing revalidates fully and the caps bound memory