### PR TITLE
FCR: Performance improvements regarding `SupportMap`

### DIFF
--- a/beacon-chain/blockchain/fcr_accessors.go
+++ b/beacon-chain/blockchain/fcr_accessors.go
@@ -8,6 +8,7 @@ import (
 	coreTime "github.com/OffchainLabs/prysm/v7/beacon-chain/core/time"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
@@ -41,6 +42,16 @@ func (a *fcrCommitteeAccessor) Committee(ctx context.Context, slot primitives.Sl
 		result = append(result, committee...)
 	}
 	return result, nil
+}
+
+func (a *fcrCommitteeAccessor) Seed(_ context.Context, epoch primitives.Epoch) ([32]byte, error) {
+	a.s.headLock.RLock()
+	headState := a.s.head.state
+	a.s.headLock.RUnlock()
+	if headState == nil || headState.IsNil() {
+		return [32]byte{}, errors.New("head state not available")
+	}
+	return helpers.Seed(headState, epoch, params.BeaconConfig().DomainBeaconAttester)
 }
 
 type fcrBalanceAccessor struct {

--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -29,10 +29,8 @@ type FastConfirmationRule struct {
 	prevSupportBuf *SupportMap
 	votesBuf       []forkchoicetypes.VoteData
 
-	// Assignment tables for epochs [current-2, current].
-	// Rebuilt at epoch boundaries.
-	tables      []*epochSlotTable
-	tablesEpoch primitives.Epoch
+	// Assignment tables for epochs [current-2, current], keyed by shuffling seed.
+	tables []*epochSlotTable
 
 	fc         ForkchoiceReader
 	committees CommitteeAccessor
@@ -175,13 +173,10 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 	))
 }
 
-// rebuildTables rebuilds the per-epoch assignment tables when the epoch changes.
+// rebuildTables refreshes the per-epoch assignment tables. The tables
+// are cached by shuffling seed.
 func (f *FastConfirmationRule) rebuildTables(ctx context.Context, currentSlot primitives.Slot, sizeHint int) error {
 	epoch := slots.ToEpoch(currentSlot)
-	// Current tables are built for the current epoch, no rebuild needed.
-	if f.tables != nil && f.tablesEpoch == epoch {
-		return nil
-	}
 
 	// Bound the start epoch to zero.
 	startEpoch := primitives.Epoch(0)
@@ -192,17 +187,36 @@ func (f *FastConfirmationRule) rebuildTables(ctx context.Context, currentSlot pr
 	// Build tables for epochs [current-2, current].
 	tables := make([]*epochSlotTable, 0, 3)
 	for e := startEpoch; e <= epoch; e++ {
-		t, err := newEpochSlotTable(ctx, f.committees, e, sizeHint)
+		// Compute seed, and check whether the table for this epoch is already cached.
+		seed, err := f.committees.Seed(ctx, e)
+		if err != nil {
+			return fmt.Errorf("failed to get shuffling seed for epoch %d: %w", e, err)
+		}
+		if existing := f.tableForSeed(seed); existing != nil {
+			tables = append(tables, existing)
+			continue
+		}
+
+		// Build a new table for this epoch.
+		t, err := newEpochSlotTable(ctx, f.committees, e, seed, sizeHint)
 		if err != nil {
 			return fmt.Errorf("failed to create epoch slot table: %w", err)
 		}
 		tables = append(tables, t)
 	}
 
-	// Update the tables and epoch after successful rebuild.
+	// Update the tables after successful rebuild.
 	f.tables = tables
-	f.tablesEpoch = epoch
+	return nil
+}
 
+// tableForSeed returns the cached table built from the given shuffling seed.
+func (f *FastConfirmationRule) tableForSeed(seed [32]byte) *epochSlotTable {
+	for _, t := range f.tables {
+		if t.seed == seed {
+			return t
+		}
+	}
 	return nil
 }
 

--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -4,6 +4,7 @@ package confirmation
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
@@ -28,8 +29,10 @@ type FastConfirmationRule struct {
 	prevSupportBuf *SupportMap
 	votesBuf       []forkchoicetypes.VoteData
 
-	committeeCache      *cachedCommittees
-	committeeCacheEpoch primitives.Epoch
+	// Assignment tables for epochs [current-2, current].
+	// Rebuilt at epoch boundaries.
+	tables      []*epochSlotTable
+	tablesEpoch primitives.Epoch
 
 	fc         ForkchoiceReader
 	committees CommitteeAccessor
@@ -131,23 +134,20 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 		ffg = &FFGStateInfo{TotalActiveBalance: totalActiveBalance}
 	}
 
+	// Committee assignment tables read the head state, keep it off the forkchoice lock.
+	if err := f.rebuildTables(ctx, currentSlot, len(balances)); err != nil {
+		return
+	}
+
 	f.fc.RLock()
 	defer f.fc.RUnlock()
 
 	equivocating := f.fc.SlashedIndices()
-	// Committee shuffles are fixed within an epoch, reuse across slots and drop at the boundary.
-	if f.committeeCache == nil || f.committeeCacheEpoch != slots.ToEpoch(currentSlot) {
-		f.committeeCache = newCachedCommittees(f.committees)
-		f.committeeCacheEpoch = slots.ToEpoch(currentSlot)
-	}
-	committees := f.committeeCache
 	f.votesBuf = f.fc.VoteSnapshot(f.votesBuf[:0])
 	votes := f.votesBuf
-	if err := f.support.Build(ctx, votes, balances, committees, equivocating, currentSlot, f.fc); err != nil {
-		return
-	}
+	f.support.Build(votes, balances, f.tables, equivocating, f.fc)
 
-	equivScorer := newMemoizedEquivScorer(ctx, committees, equivocating, balances)
+	equivScorer := EquivocationScorer(f.support.EquivocationScore)
 
 	prevSupport := f.support
 	prevTotalActiveBalance := totalActiveBalance
@@ -157,11 +157,10 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 			f.prevSupportBuf = NewSupportMap()
 		}
 		ps := f.prevSupportBuf
-		if err := ps.Build(ctx, votes, prevBalances, committees, equivocating, currentSlot, f.fc); err == nil {
-			prevSupport = ps
-			prevTotalActiveBalance = prevTotalActive
-			prevEquivScorer = newMemoizedEquivScorer(ctx, committees, equivocating, prevBalances)
-		}
+		ps.Build(votes, prevBalances, f.tables, equivocating, f.fc)
+		prevSupport = ps
+		prevTotalActiveBalance = prevTotalActive
+		prevEquivScorer = EquivocationScorer(ps.EquivocationScore)
 	}
 
 	currentTarget := f.getCurrentTarget(ctx, slots.ToEpoch(currentSlot))
@@ -176,23 +175,35 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 	))
 }
 
-func newMemoizedEquivScorer(
-	ctx context.Context,
-	committees CommitteeAccessor,
-	equivocating map[primitives.ValidatorIndex]bool,
-	balances []uint64,
-) EquivocationScorer {
-	type slotRange struct{ start, end primitives.Slot }
-	cache := make(map[slotRange]uint64)
-	return func(startSlot, endSlot primitives.Slot) uint64 {
-		k := slotRange{startSlot, endSlot}
-		if v, ok := cache[k]; ok {
-			return v
-		}
-		v := EquivocationScoreByCommittee(ctx, committees, equivocating, balances, startSlot, endSlot)
-		cache[k] = v
-		return v
+// rebuildTables rebuilds the per-epoch assignment tables when the epoch changes.
+func (f *FastConfirmationRule) rebuildTables(ctx context.Context, currentSlot primitives.Slot, sizeHint int) error {
+	epoch := slots.ToEpoch(currentSlot)
+	// Current tables are built for the current epoch, no rebuild needed.
+	if f.tables != nil && f.tablesEpoch == epoch {
+		return nil
 	}
+
+	// Bound the start epoch to zero.
+	startEpoch := primitives.Epoch(0)
+	if epoch > 2 {
+		startEpoch = epoch - 2
+	}
+
+	// Build tables for epochs [current-2, current].
+	tables := make([]*epochSlotTable, 0, 3)
+	for e := startEpoch; e <= epoch; e++ {
+		t, err := newEpochSlotTable(ctx, f.committees, e, sizeHint)
+		if err != nil {
+			return fmt.Errorf("failed to create epoch slot table: %w", err)
+		}
+		tables = append(tables, t)
+	}
+
+	// Update the tables and epoch after successful rebuild.
+	f.tables = tables
+	f.tablesEpoch = epoch
+
+	return nil
 }
 
 // getLatestConfirmed executes the FCR algorithm: revert, restart, then advance.

--- a/beacon-chain/confirmation/confirmation_test.go
+++ b/beacon-chain/confirmation/confirmation_test.go
@@ -79,6 +79,11 @@ func (m *mockCommitteeAccessor) Committee(_ context.Context, _ primitives.Slot) 
 	return nil, nil
 }
 
+func (m *mockCommitteeAccessor) Seed(_ context.Context, epoch primitives.Epoch) ([32]byte, error) {
+	// Derive different value per epoch.
+	return [32]byte{0x5E, byte(epoch), byte(epoch >> 8)}, nil
+}
+
 // mockBalanceAccessor is a minimal mock of BalanceAccessor.
 type mockBalanceAccessor struct{}
 

--- a/beacon-chain/confirmation/interfaces.go
+++ b/beacon-chain/confirmation/interfaces.go
@@ -29,6 +29,7 @@ type ForkchoiceReader interface {
 // CommitteeAccessor implements the spec's get_slot_committee, it must support slots from current_epoch - 2 onward.
 type CommitteeAccessor interface {
 	Committee(ctx context.Context, slot primitives.Slot) ([]primitives.ValidatorIndex, error)
+	Seed(ctx context.Context, epoch primitives.Epoch) ([32]byte, error)
 }
 
 // BalanceAccessor maps to the spec's balance_source and get_pulled_up_head_state state reads.

--- a/beacon-chain/confirmation/support.go
+++ b/beacon-chain/confirmation/support.go
@@ -2,79 +2,108 @@ package confirmation
 
 import (
 	"context"
+	"fmt"
 
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
+// noAssignment marks a validator with no attestation duty in an epoch.
+const noAssignment = uint8(0xFF)
+
+// epochSlotTable maps every validator to its assigned attestation slot within one
+// epoch. This makes membership queries O(1).
+type epochSlotTable struct {
+	start      primitives.Slot
+	slotOffset []uint8 // val index -> slot offset
+}
+
+// newEpochSlotTable builds the table for one epoch.
+func newEpochSlotTable(ctx context.Context, committees CommitteeAccessor, epoch primitives.Epoch, sizeHint int) (*epochSlotTable, error) {
+	start, err := slots.EpochStart(epoch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get epoch start: %w", err)
+	}
+
+	// Initialize slot offset tables filling with noAssignment sentinel.
+	offs := make([]uint8, sizeHint)
+	for i := range offs {
+		offs[i] = noAssignment
+	}
+
+	// Loop through the given epoch.
+	spe := primitives.Slot(params.BeaconConfig().SlotsPerEpoch)
+	for slot := start; slot < start+spe; slot++ {
+		// Fetch the committee information.
+		members, err := committees.Committee(ctx, slot)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get committee for slot %d: %w", slot, err)
+		}
+
+		// Iterate through the committee members and assign their slot offsets.
+		for _, v := range members {
+			// Grow the slice if the validator index exceeds the current length.
+			if uint64(v) >= uint64(len(offs)) {
+				grown := make([]uint8, v+1)
+				copy(grown, offs)
+				for i := len(offs); i < len(grown); i++ {
+					grown[i] = noAssignment
+				}
+				offs = grown
+			}
+
+			offs[v] = uint8(slot - start)
+		}
+	}
+	return &epochSlotTable{start: start, slotOffset: offs}, nil
+}
+
+// assignedSlot computes the attestation slot assigned to a validator in this epoch, if any.
+// Caller should check the boolean return value before using the slot.
+func (t *epochSlotTable) assignedSlot(v primitives.ValidatorIndex) (primitives.Slot, bool) {
+	// Validator index is out of range.
+	if uint64(v) >= uint64(len(t.slotOffset)) {
+		return 0, false
+	}
+
+	// Validator has no attestation duty in this epoch.
+	if t.slotOffset[v] == noAssignment {
+		return 0, false
+	}
+
+	return t.start + primitives.Slot(t.slotOffset[v]), true
+}
+
 // SupportMap pre-aggregates vote support for the slot-range queries FCR needs.
-// slotRootVoters backs get_block_support_between_slots (direct vote equality),
-// totalSupport backs get_attestation_score (a vote credits every ancestor).
+// totalSupport backs get_attestation_score (a vote credits every ancestor);
 type SupportMap struct {
-	slotRootVoters map[primitives.Slot]map[[32]byte][]primitives.ValidatorIndex
-	balances       []uint64
-	totalSupport   map[[32]byte]uint64
+	votes        []forkchoicetypes.VoteData
+	balances     []uint64
+	equivocating map[primitives.ValidatorIndex]bool
+	tables       []*epochSlotTable
+	totalSupport map[[32]byte]uint64
 }
 
 func NewSupportMap() *SupportMap {
-	return &SupportMap{
-		slotRootVoters: make(map[primitives.Slot]map[[32]byte][]primitives.ValidatorIndex),
-		totalSupport:   make(map[[32]byte]uint64),
-	}
+	return &SupportMap{totalSupport: make(map[[32]byte]uint64)}
 }
 
+// Build snapshots the query inputs and aggregates totalSupport.
 func (s *SupportMap) Build(
-	ctx context.Context,
 	votes []forkchoicetypes.VoteData,
 	balances []uint64,
-	committees CommitteeAccessor,
+	tables []*epochSlotTable,
 	equivocating map[primitives.ValidatorIndex]bool,
-	currentSlot primitives.Slot,
 	fc ForkchoiceReader,
-) error {
-	if currentSlot == 0 {
-		return nil
-	}
-	// is_confirmed_chain_safe reconfirmation can query empty-slot discounts down to current_epoch - 2.
-	currentEpoch := slots.ToEpoch(currentSlot)
-	startSlot := primitives.Slot(0)
-	if currentEpoch > 2 {
-		es, err := slots.EpochStart(currentEpoch - 2)
-		if err == nil {
-			startSlot = es
-		}
-	}
-	endSlot := currentSlot - 1
-
-	// Reuse the map buckets across the per-slot rebuilds.
-	clear(s.slotRootVoters)
+) {
+	s.votes = votes
 	s.balances = balances
+	s.tables = tables
+	s.equivocating = equivocating
 
-	for slot := startSlot; slot <= endSlot; slot++ {
-		members, err := committees.Committee(ctx, slot)
-		if err != nil {
-			return err
-		}
-
-		slotMap := make(map[[32]byte][]primitives.ValidatorIndex)
-		for _, idx := range members {
-			if equivocating[idx] {
-				continue
-			}
-
-			i := uint64(idx)
-			if i < uint64(len(balances)) && i < uint64(len(votes)) && balances[i] > 0 {
-				root := votes[i].Root
-				if root != [32]byte{} {
-					slotMap[root] = append(slotMap[root], idx)
-				}
-			}
-		}
-		if len(slotMap) > 0 {
-			s.slotRootVoters[slot] = slotMap
-		}
-	}
+	hasEquivocating := len(equivocating) > 0
 
 	clear(s.totalSupport)
 	globalVotes := make(map[[32]byte]uint64)
@@ -85,7 +114,7 @@ func (s *SupportMap) Build(
 		if i >= len(balances) || balances[i] == 0 {
 			continue
 		}
-		if equivocating[primitives.ValidatorIndex(i)] {
+		if hasEquivocating && equivocating[primitives.ValidatorIndex(i)] {
 			continue
 		}
 		globalVotes[vote.Root] += balances[i]
@@ -101,8 +130,6 @@ func (s *SupportMap) Build(
 			r = parent
 		}
 	}
-
-	return nil
 }
 
 // BlockSupportBetweenSlots implements get_block_support_between_slots.
@@ -119,16 +146,25 @@ func (s *SupportMap) Build(
 //	    and i not in equivocating_indices)
 //	</spec>
 func (s *SupportMap) BlockSupportBetweenSlots(root [32]byte, startSlot, endSlot primitives.Slot) uint64 {
+	if root == ([32]byte{}) {
+		return 0
+	}
+	hasEquivocating := len(s.equivocating) > 0
 	total := uint64(0)
-	seen := make(map[primitives.ValidatorIndex]bool)
-	for slot := startSlot; slot <= endSlot; slot++ {
-		for _, idx := range s.slotRootVoters[slot][root] {
-			if seen[idx] {
-				continue
-			}
-			seen[idx] = true
-			if uint64(idx) < uint64(len(s.balances)) {
-				total += s.balances[idx]
+	for i, vote := range s.votes {
+		if vote.Root != root {
+			continue
+		}
+		if i >= len(s.balances) || s.balances[i] == 0 {
+			continue
+		}
+		if hasEquivocating && s.equivocating[primitives.ValidatorIndex(i)] {
+			continue
+		}
+		for _, t := range s.tables {
+			if sl, ok := t.assignedSlot(primitives.ValidatorIndex(i)); ok && sl >= startSlot && sl <= endSlot {
+				total += s.balances[i]
+				break
 			}
 		}
 	}
@@ -147,55 +183,19 @@ func (s *SupportMap) AttestationScore(root [32]byte) uint64 {
 	return s.totalSupport[root]
 }
 
-// EquivocationScoreByCommittee implements the spec's get_equivocation_score.
-func EquivocationScoreByCommittee(
-	ctx context.Context,
-	committees CommitteeAccessor,
-	equivocating map[primitives.ValidatorIndex]bool,
-	balances []uint64,
-	startSlot, endSlot primitives.Slot,
-) uint64 {
-	if len(equivocating) == 0 {
-		return 0
-	}
+// EquivocationScore implements the spec's get_equivocation_score.
+func (s *SupportMap) EquivocationScore(startSlot, endSlot primitives.Slot) uint64 {
 	total := uint64(0)
-	seen := make(map[primitives.ValidatorIndex]bool)
-	for slot := startSlot; slot <= endSlot; slot++ {
-		members, err := committees.Committee(ctx, slot)
-		if err != nil {
+	for idx, isEquivocating := range s.equivocating {
+		if !isEquivocating || uint64(idx) >= uint64(len(s.balances)) {
 			continue
 		}
-		for _, idx := range members {
-			if seen[idx] {
-				continue
-			}
-			seen[idx] = true
-			if equivocating[idx] && uint64(idx) < uint64(len(balances)) {
-				total += balances[idx]
+		for _, t := range s.tables {
+			if sl, ok := t.assignedSlot(idx); ok && sl >= startSlot && sl <= endSlot {
+				total += s.balances[idx]
+				break
 			}
 		}
 	}
 	return total
-}
-
-// cachedCommittees memoizes per-slot committee lookups for the duration of one FCR run.
-type cachedCommittees struct {
-	inner CommitteeAccessor
-	m     map[primitives.Slot][]primitives.ValidatorIndex
-}
-
-func newCachedCommittees(inner CommitteeAccessor) *cachedCommittees {
-	return &cachedCommittees{inner: inner, m: make(map[primitives.Slot][]primitives.ValidatorIndex)}
-}
-
-func (c *cachedCommittees) Committee(ctx context.Context, slot primitives.Slot) ([]primitives.ValidatorIndex, error) {
-	if v, ok := c.m[slot]; ok {
-		return v, nil
-	}
-	v, err := c.inner.Committee(ctx, slot)
-	if err != nil {
-		return nil, err
-	}
-	c.m[slot] = v
-	return v, nil
 }

--- a/beacon-chain/confirmation/support.go
+++ b/beacon-chain/confirmation/support.go
@@ -17,11 +17,12 @@ const noAssignment = uint8(0xFF)
 // epoch. This makes membership queries O(1).
 type epochSlotTable struct {
 	start      primitives.Slot
-	slotOffset []uint8 // val index -> slot offset
+	seed       [32]byte // attester shuffling seed
+	slotOffset []uint8  // val index -> slot offset
 }
 
-// newEpochSlotTable builds the table for one epoch.
-func newEpochSlotTable(ctx context.Context, committees CommitteeAccessor, epoch primitives.Epoch, sizeHint int) (*epochSlotTable, error) {
+// newEpochSlotTable builds the table for one epoch
+func newEpochSlotTable(ctx context.Context, committees CommitteeAccessor, epoch primitives.Epoch, seed [32]byte, sizeHint int) (*epochSlotTable, error) {
 	start, err := slots.EpochStart(epoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get epoch start: %w", err)
@@ -57,7 +58,7 @@ func newEpochSlotTable(ctx context.Context, committees CommitteeAccessor, epoch 
 			offs[v] = uint8(slot - start)
 		}
 	}
-	return &epochSlotTable{start: start, slotOffset: offs}, nil
+	return &epochSlotTable{start: start, seed: seed, slotOffset: offs}, nil
 }
 
 // assignedSlot computes the attestation slot assigned to a validator in this epoch, if any.

--- a/beacon-chain/confirmation/support_test.go
+++ b/beacon-chain/confirmation/support_test.go
@@ -7,6 +7,7 @@ import (
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
 // testForkchoiceReader extends the mock to support parent chain walking for TotalSupport.
@@ -23,26 +24,43 @@ func (m *testForkchoiceReader) ParentRoot(root [32]byte) ([32]byte, error) {
 	return p, nil
 }
 
-// addTestSupport registers a fresh synthetic validator voting for root in the given slot.
+// addTestSupport registers a fresh synthetic validator voting for root, assigned to
+// attest in the given slot.
 func addTestSupport(sm *SupportMap, slot primitives.Slot, root [32]byte, balance uint64) {
 	idx := primitives.ValidatorIndex(len(sm.balances))
 	sm.balances = append(sm.balances, balance)
-	if sm.slotRootVoters[slot] == nil {
-		sm.slotRootVoters[slot] = make(map[[32]byte][]primitives.ValidatorIndex)
+	sm.votes = append(sm.votes, forkchoicetypes.VoteData{Root: root, Slot: slot})
+
+	epochStart, err := slots.EpochStart(slots.ToEpoch(slot))
+	if err != nil {
+		panic(err)
 	}
-	sm.slotRootVoters[slot][root] = append(sm.slotRootVoters[slot][root], idx)
+	var table *epochSlotTable
+	for _, t := range sm.tables {
+		if t.start == epochStart {
+			table = t
+			break
+		}
+	}
+	if table == nil {
+		table = &epochSlotTable{start: epochStart}
+		sm.tables = append(sm.tables, table)
+	}
+	for int(idx) >= len(table.slotOffset) {
+		table.slotOffset = append(table.slotOffset, noAssignment)
+	}
+	table.slotOffset[idx] = uint8(slot - epochStart)
 }
 
-// rebuildTotalSupportFromSlotRoot rebuilds totalSupport from the registered voters by walking the ancestor chain.
+// rebuildTotalSupportFromSlotRoot rebuilds totalSupport from the registered votes by walking the ancestor chain.
 func rebuildTotalSupportFromSlotRoot(sm *SupportMap, fc ForkchoiceReader) {
 	sm.totalSupport = make(map[[32]byte]uint64)
 	globalVotes := make(map[[32]byte]uint64)
-	for _, rootMap := range sm.slotRootVoters {
-		for root, voters := range rootMap {
-			for _, idx := range voters {
-				globalVotes[root] += sm.balances[idx]
-			}
+	for i, vote := range sm.votes {
+		if vote.Root == ([32]byte{}) {
+			continue
 		}
+		globalVotes[vote.Root] += sm.balances[i]
 	}
 	for root, bal := range globalVotes {
 		if bal == 0 {
@@ -67,6 +85,17 @@ type testCommitteeAccessor struct {
 
 func (m *testCommitteeAccessor) Committee(_ context.Context, slot primitives.Slot) ([]primitives.ValidatorIndex, error) {
 	return m.committees[slot], nil
+}
+
+// buildTestTables builds assignment tables for the given epochs from the accessor.
+func buildTestTables(t testing.TB, ca CommitteeAccessor, epochs []primitives.Epoch, sizeHint int) []*epochSlotTable {
+	tables := make([]*epochSlotTable, 0, len(epochs))
+	for _, e := range epochs {
+		table, err := newEpochSlotTable(context.Background(), ca, e, sizeHint)
+		require.NoError(t, err)
+		tables = append(tables, table)
+	}
+	return tables
 }
 
 // TestSupportMap_Build tests the full build path including ancestor-based TotalSupport.
@@ -118,9 +147,11 @@ func TestSupportMap_Build(t *testing.T) {
 	}
 	balances := []uint64{100, 200, 300, 400, 500}
 
+	// sizeHint 0 exercises the table's grow-on-demand path.
+	tables := buildTestTables(t, committees, []primitives.Epoch{0}, 0)
+
 	sm := NewSupportMap()
-	err := sm.Build(context.Background(), votes, balances, committees, nil, 4, fc)
-	require.NoError(t, err)
+	sm.Build(votes, balances, tables, nil, fc)
 
 	// --- BlockSupportBetweenSlots (direct votes) ---
 	// Slot 1: validator 0 (100) votes root1, validator 1 (200) votes root2
@@ -161,7 +192,7 @@ func TestSupportMap_Build(t *testing.T) {
 }
 
 // TestSupportMap_Equivocation tests that equivocating validators are excluded
-// from the support maps.
+// from the support maps and counted by the equivocation score.
 func TestSupportMap_Equivocation(t *testing.T) {
 	root1 := [32]byte{1}
 
@@ -183,13 +214,18 @@ func TestSupportMap_Equivocation(t *testing.T) {
 		1: true, // validator 1 is equivocating
 	}
 
+	tables := buildTestTables(t, committees, []primitives.Epoch{0}, len(balances))
+
 	sm := NewSupportMap()
-	err := sm.Build(context.Background(), votes, balances, committees, equivocating, 2, fc)
-	require.NoError(t, err)
+	sm.Build(votes, balances, tables, equivocating, fc)
 
 	// Validator 1 (200) is equivocating: excluded from support
 	require.Equal(t, uint64(400), sm.BlockSupportBetweenSlots(root1, 1, 1)) // 100 + 300
 	require.Equal(t, uint64(400), sm.AttestationScore(root1))
+
+	// ... but counted by the equivocation score in its assigned slot only.
+	require.Equal(t, uint64(200), sm.EquivocationScore(1, 1))
+	require.Equal(t, uint64(0), sm.EquivocationScore(2, 5))
 }
 
 // TestSupportMap_EmptySlots tests that querying slots with no committees returns 0.
@@ -197,4 +233,5 @@ func TestSupportMap_EmptySlots(t *testing.T) {
 	sm := NewSupportMap()
 	require.Equal(t, uint64(0), sm.BlockSupportBetweenSlots([32]byte{1}, 5, 10))
 	require.Equal(t, uint64(0), sm.AttestationScore([32]byte{1}))
+	require.Equal(t, uint64(0), sm.EquivocationScore(5, 10))
 }

--- a/beacon-chain/confirmation/support_test.go
+++ b/beacon-chain/confirmation/support_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
@@ -81,17 +82,28 @@ func rebuildTotalSupportFromSlotRoot(sm *SupportMap, fc ForkchoiceReader) {
 // testCommitteeAccessor returns fixed committee assignments.
 type testCommitteeAccessor struct {
 	committees map[primitives.Slot][]primitives.ValidatorIndex
+	seeds      map[primitives.Epoch][32]byte
 }
 
 func (m *testCommitteeAccessor) Committee(_ context.Context, slot primitives.Slot) ([]primitives.ValidatorIndex, error) {
 	return m.committees[slot], nil
 }
 
+func (m *testCommitteeAccessor) Seed(_ context.Context, epoch primitives.Epoch) ([32]byte, error) {
+	if s, ok := m.seeds[epoch]; ok {
+		return s, nil
+	}
+	// Derive a distinct default per epoch.
+	return [32]byte{0x5E, byte(epoch), byte(epoch >> 8)}, nil
+}
+
 // buildTestTables builds assignment tables for the given epochs from the accessor.
 func buildTestTables(t testing.TB, ca CommitteeAccessor, epochs []primitives.Epoch, sizeHint int) []*epochSlotTable {
 	tables := make([]*epochSlotTable, 0, len(epochs))
 	for _, e := range epochs {
-		table, err := newEpochSlotTable(context.Background(), ca, e, sizeHint)
+		seed, err := ca.Seed(context.Background(), e)
+		require.NoError(t, err)
+		table, err := newEpochSlotTable(context.Background(), ca, e, seed, sizeHint)
 		require.NoError(t, err)
 		tables = append(tables, table)
 	}
@@ -234,4 +246,45 @@ func TestSupportMap_EmptySlots(t *testing.T) {
 	require.Equal(t, uint64(0), sm.BlockSupportBetweenSlots([32]byte{1}, 5, 10))
 	require.Equal(t, uint64(0), sm.AttestationScore([32]byte{1}))
 	require.Equal(t, uint64(0), sm.EquivocationScore(5, 10))
+}
+
+func TestRebuildTables_SeedKeyed(t *testing.T) {
+	ctx := context.Background()
+	ca := &testCommitteeAccessor{
+		committees: map[primitives.Slot][]primitives.ValidatorIndex{},
+		seeds: map[primitives.Epoch][32]byte{
+			0: {1}, 1: {2}, 2: {3}, 3: {4},
+		},
+	}
+	fcr := New(&mockForkchoiceReader{}, ca, &mockBalanceAccessor{}, forkchoicetypes.Checkpoint{})
+	spe := primitives.Slot(params.BeaconConfig().SlotsPerEpoch)
+
+	// Epoch 2: builds tables for epochs 0..2.
+	require.NoError(t, fcr.rebuildTables(ctx, 2*spe, 0))
+	require.Equal(t, 3, len(fcr.tables))
+	e1, e2 := fcr.tables[1], fcr.tables[2]
+
+	// Next slot, same seeds: every table is reused.
+	prev := fcr.tables
+	require.NoError(t, fcr.rebuildTables(ctx, 2*spe+1, 0))
+	require.Equal(t, 3, len(fcr.tables))
+	for i := range prev {
+		require.Equal(t, true, prev[i] == fcr.tables[i])
+	}
+
+	// Epoch rotation to epochs 1..3: 1 and 2 reused, 3 freshly built.
+	require.NoError(t, fcr.rebuildTables(ctx, 3*spe, 0))
+	require.Equal(t, 3, len(fcr.tables))
+	require.Equal(t, true, e1 == fcr.tables[0])
+	require.Equal(t, true, e2 == fcr.tables[1])
+	require.Equal(t, 3*spe, fcr.tables[2].start)
+
+	// A deep reorg changes epoch 2's shuffling: only that table is rebuilt.
+	e3 := fcr.tables[2]
+	ca.seeds[2] = [32]byte{9}
+	require.NoError(t, fcr.rebuildTables(ctx, 3*spe+1, 0))
+	require.Equal(t, true, e1 == fcr.tables[0])
+	require.Equal(t, true, e2 != fcr.tables[1])
+	require.Equal(t, 2*spe, fcr.tables[1].start)
+	require.Equal(t, true, e3 == fcr.tables[2])
 }


### PR DESCRIPTION
**What type of PR is this?**

> Optimization

**What does this PR do? Why is it needed?**

Improve performance in terms of time and memory allocation when running `OnFastConfirmation`. The hardest bottleneck for `OnFastConfirmation` is building a `SupportMap` as

1. iterates `2V` times every slot where `V` is the count of active validators.
2. randomly accesses `balances` slice.
3. constructs `slotMap` by appending `2V` times.
4. checks `equivocating[idx]` every time - even map lookup for empty one has a tiny overhead.

(Commit message of https://github.com/OffchainLabs/prysm/pull/17179/changes/34e479d05e8f1b9a9c0ac36a006bb0047e4fdfcc describes the problem.)

```
func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSlot primitives.Slot) {
        // ...
	f.fc.RLock()
	defer f.fc.RUnlock()
        // ...
```

As `OnFastConfirmation` holds forkchoice lock **while** building the `SupportMap`, I think minimizing lock retention is important here. The performance got worse when `V` increases, which is now ~900k in mainnet these days.

So this PR introduces a concept of `epochSlotTable` which is cached by attester shuffling seed. So normally these tables precompute in every epoch for last three epochs ([`current_epoch-2, current_epoch]`) which makes the attester duty query `O(1)`.

```go
type epochSlotTable struct {
	start      primitives.Slot
	seed       [32]byte // attester shuffling seed
	slotOffset []uint8  // val index -> slot offset
}
```

Appending `slotOffset` is minimized with `sizeHint` which is the length of `balances`.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

### Benchmark for 1M validators

| Case | as-is (fcr) | improved (perf/fcr) | Speedup |
| --- | --- | --- | --- |
| `no_equivocators` — time | 106.2 ms | 11.95 ms | 8.9× |
| `no_equivocators` — mem / allocs | 62.6 MB / 2697 | 10.4 KB / 9 | ~6000× / 300× |
| `100_equivocators` — time | 147.6 ms | 26.21 ms | 5.6× |
| `100_equivocators` — mem / allocs | 62.6 MB / 2698 | 10.5 KB / 9 | ~6000× / 300× |

See [gist](https://gist.github.com/syjn99/f67c05b6faca62719ddff7f4898afe00) for the benchmark setup.

### Verified with

```bash
bazel test //testing/spectest/minimal:go_default_test --test_filter=FastConfirmation --test_output=summary
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
