### PR TITLE
ignore claude directory (avoiding issues with worktrees + gazelle)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,6 +17,7 @@ exports_files([
 # gazelle:map_kind go_repository go_repository @prysm//tools/go:def.bzl
 # gazelle:build_tags bazel
 # gazelle:exclude tools/analyzers/**/testdata/**
+# gazelle:exclude .claude
 gazelle(
     name = "gazelle",
     prefix = prefix,

--- a/changelog/kasey_gazelle-worktree-fix.md
+++ b/changelog/kasey_gazelle-worktree-fix.md
@@ -1,0 +1,2 @@
+### Ignored
+- Avoid awkward interaction between gazelle and claude worktrees by instructing gazelle to ignore the `.claude` directory.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Gazelle gets confused when there are duplicates of the bazel package structure inside the same directory tree as the current workspace. When claude creates a worktree inside the `.claude` directory, this causes gazelle to detect ambiguous paths, resulting in unwanted edits to BUILD files. Asking gazelle to ignore this path works around the issue.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
