### PR TITLE
Fix nil block dereference in Gloas envelope/data-column gossip validation

### DIFF
--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -71,6 +71,10 @@ func (s *Service) validateDataColumnGloas(
 	if err != nil {
 		return blocks.VerifiedRODataColumn{}, ignoreValidation(err)
 	}
+	// A seen block may live in the init-sync cache but not yet in the DB, so Block can return (nil, nil).
+	if err := blocks.BeaconBlockIsNil(block); err != nil {
+		return blocks.VerifiedRODataColumn{}, ignoreValidation(err)
+	}
 	verifier := verification.NewGloasDataColumnVerifier(roDataColumn, block.Block(), verification.GossipDataColumnSidecarRequirementsGloas)
 	verifier.SatisfyRequirement(verification.RequireBlockSeenGloas)
 

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -228,6 +228,38 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		require.ErrorContains(t, "slot does not match block slot", err)
 	})
 
+	t.Run("block seen in cache but absent from db does not panic", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.DenebForkEpoch, cfg.ElectraForkEpoch, cfg.FuluForkEpoch, cfg.GloasForkEpoch = 0, 0, 0, 0
+		params.OverrideBeaconConfig(cfg)
+
+		sidecar, signedBlock := gloasFixture(t)
+		service, _ := serviceAndMessage(t, testVerifierReturnsAll(&verification.MockDataColumnsVerifier{}), sidecar, sidecar.Index)
+		blockRoot, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+
+		db := dbtest.SetupDB(t)
+		// HasBlock reports the root as seen (init-sync cache) but the block is not saved, so beaconDB.Block is nil.
+		chainService := &mock.ChainService{
+			Genesis:            time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+			DB:                 db,
+			InitSyncBlockRoots: map[[32]byte]bool{blockRoot: true},
+		}
+		service.cfg.beaconDB = db
+		service.cfg.chain = chainService
+
+		roDataColumn, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+		require.NoError(t, err)
+		digest, err := service.currentForkDigest()
+		require.NoError(t, err)
+		topic := service.addDigestAndIndexToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.DataColumnSidecarGloas]()], digest, peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index))
+		msg := &pubsub.Message{Message: &pb.Message{Topic: &topic}}
+
+		_, err = service.validateDataColumnGloas(ctx, "aDummyPID", msg, roDataColumn, "/data_column_sidecar_%d/")
+		require.ErrorContains(t, "signed beacon block can't be nil", err)
+	})
+
 	t.Run("rejects oversize column on queue path", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		cfg := params.BeaconConfig()

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -92,6 +92,10 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}
+	// A seen block may live in the init-sync cache but not yet in the DB, so Block can return (nil, nil).
+	if err := blocks.BeaconBlockIsNil(block); err != nil {
+		return pubsub.ValidationIgnore, nil
+	}
 	// [REJECT] block.slot equals envelope.slot.
 	if err := v.VerifySlotMatchesBlock(block.Block().Slot()); err != nil {
 		return pubsub.ValidationReject, err

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -135,9 +135,6 @@ func TestValidateExecutionPayloadEnvelope_HappyPath(t *testing.T) {
 	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
 }
 
-// Regression test: the block root is treated as "seen" (VerifyBlockRootSeen passes; in production this
-// happens when chain.HasBlock finds the block in the init-sync cache) but the block is not yet in the DB,
-// so beaconDB.Block returns (nil, nil). The validator must not nil-deref block.Block().
 func TestValidateExecutionPayloadEnvelope_BlockSeenButNotInDB_NoPanic(t *testing.T) {
 	ctx := context.Background()
 	s, msg, _, _ := newEnvelopeServiceForTest(t, 1, 1, false /* saveBlockToDB */)
@@ -336,10 +333,6 @@ func setupExecutionPayloadEnvelopeService(t *testing.T, envelopeSlot, blockSlot 
 	return newEnvelopeServiceForTest(t, envelopeSlot, blockSlot, true /* saveBlockToDB */)
 }
 
-// newEnvelopeServiceForTest builds a sync Service and a gossip envelope message for tests. When
-// saveBlockToDB is false the referenced block is intentionally left out of the DB, reproducing the
-// init-sync-cache/DB divergence in production where chain.HasBlock reports the block as seen (from the
-// in-memory init-sync cache) but beaconDB.Block returns (nil, nil) because it has not been flushed yet.
 func newEnvelopeServiceForTest(t *testing.T, envelopeSlot, blockSlot primitives.Slot, saveBlockToDB bool) (*Service, *pubsub.Message, primitives.BuilderIndex, [32]byte) {
 	t.Helper()
 

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -135,6 +135,18 @@ func TestValidateExecutionPayloadEnvelope_HappyPath(t *testing.T) {
 	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
 }
 
+// Regression test: the block root is treated as "seen" (VerifyBlockRootSeen passes; in production this
+// happens when chain.HasBlock finds the block in the init-sync cache) but the block is not yet in the DB,
+// so beaconDB.Block returns (nil, nil). The validator must not nil-deref block.Block().
+func TestValidateExecutionPayloadEnvelope_BlockSeenButNotInDB_NoPanic(t *testing.T) {
+	ctx := context.Background()
+	s, msg, _, _ := newEnvelopeServiceForTest(t, 1, 1, false /* saveBlockToDB */)
+	s.newExecutionPayloadEnvelopeVerifier = testNewExecutionPayloadEnvelopeVerifier(mockExecutionPayloadEnvelopeVerifier{})
+	result, err := s.validateExecutionPayloadEnvelope(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+}
+
 func TestValidateExecutionPayloadEnvelope_GossipEvent(t *testing.T) {
 	ctx := context.Background()
 	s, msg, builderIdx, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
@@ -321,6 +333,14 @@ func testNewExecutionPayloadEnvelopeVerifier(m mockExecutionPayloadEnvelopeVerif
 }
 
 func setupExecutionPayloadEnvelopeService(t *testing.T, envelopeSlot, blockSlot primitives.Slot) (*Service, *pubsub.Message, primitives.BuilderIndex, [32]byte) {
+	return newEnvelopeServiceForTest(t, envelopeSlot, blockSlot, true /* saveBlockToDB */)
+}
+
+// newEnvelopeServiceForTest builds a sync Service and a gossip envelope message for tests. When
+// saveBlockToDB is false the referenced block is intentionally left out of the DB, reproducing the
+// init-sync-cache/DB divergence in production where chain.HasBlock reports the block as seen (from the
+// in-memory init-sync cache) but beaconDB.Block returns (nil, nil) because it has not been flushed yet.
+func newEnvelopeServiceForTest(t *testing.T, envelopeSlot, blockSlot primitives.Slot, saveBlockToDB bool) (*Service, *pubsub.Message, primitives.BuilderIndex, [32]byte) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -354,7 +374,9 @@ func setupExecutionPayloadEnvelopeService(t *testing.T, envelopeSlot, blockSlot 
 	require.NoError(t, err)
 	root, err := signedBlock.Block().HashTreeRoot()
 	require.NoError(t, err)
-	require.NoError(t, db.SaveBlock(ctx, signedBlock))
+	if saveBlockToDB {
+		require.NoError(t, db.SaveBlock(ctx, signedBlock))
+	}
 
 	state, err := util.NewBeaconStateFulu()
 	require.NoError(t, err)

--- a/changelog/alleysira_fix-gloas-gossip-nil-block.md
+++ b/changelog/alleysira_fix-gloas-gossip-nil-block.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Guard against a nil block dereference in Gloas execution payload envelope and data column gossip validation.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

tldr: a seen block can still be `nil` in DB.

The Gloas gossip validators for execution payload envelopes and data column sidecars fetch the referenced block with `beaconDB.Block(ctx, root)` and then call `block.Block()` without a nil check. The preceding `chain.HasBlock` gate can report a block as seen while it still lives only in the init-sync cache and hasn't been flushed to the DB, in that case beaconDB.Block returns `(nil, nil)`, and the dereference panics.

This PR: 
- adds a nil guard after the block fetch (Ignore if nil), following guard already used in [here](https://github.com/OffchainLabs/prysm/blob/88ef96684ec080e4e728c85feca7bed8272504c7/beacon-chain/sync/rpc_beacon_blocks_by_root.go#L226). 
- includes regression tests for both cases.

Without this PR, both new regression tests fail, panic with a nil-pointer dereference.

**Which issue(s) does this PR fix?**

None.

**Other notes for review**

Wonder if Ignore is the right result for a nil block? I kept the minimal guard here.

Thanks!

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
