### PR TITLE
fix(validator): synchronize remote web3signer key file watcher startup

### DIFF
--- a/changelog/pvl_fix-web3signer-key-watcher.md
+++ b/changelog/pvl_fix-web3signer-key-watcher.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Remote web3signer keymanager: `NewKeymanager` now waits for the key-file watcher to initialize before returning, and key-update notifications are sent without holding the keymanager lock, preventing a startup race and a potential lock-ordering deadlock.
+- Remote web3signer keymanager: `NewKeymanager` now waits for the key-file watcher to initialize before returning and fails startup immediately if the watcher cannot be initialized, key-update notifications are sent without holding the keymanager lock, and keys are reloaded from the key file when the watcher recovers from a failure. This prevents a startup race, a potential lock-ordering deadlock, and a stale flag-only key set after watcher recovery.

--- a/changelog/pvl_fix-web3signer-key-watcher.md
+++ b/changelog/pvl_fix-web3signer-key-watcher.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Remote web3signer keymanager: `NewKeymanager` now waits for the key-file watcher to initialize before returning, and key-update notifications are sent without holding the keymanager lock, preventing a startup race and a potential lock-ordering deadlock.

--- a/validator/keymanager/remote-web3signer/BUILD.bazel
+++ b/validator/keymanager/remote-web3signer/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     srcs = ["keymanager_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//config/fieldparams:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//io/file:go_default_library",

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -178,14 +178,28 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 }
 
 func (km *Keymanager) refreshRemoteKeysFromFileChangesWithRetry(ctx context.Context, retryDelay time.Duration, markReady func(error)) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
+	initialized := false
+	markInitialized := func(err error) {
+		initialized = true
+		markReady(err)
 	}
-	if km.retriesRemaining == 0 {
-		return errors.New("file check retries remaining exceeded")
-	}
-	err := km.refreshRemoteKeysFromFileChanges(ctx, markReady)
-	if err != nil {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if km.retriesRemaining == 0 {
+			return errors.New("file check retries remaining exceeded")
+		}
+		err := km.refreshRemoteKeysFromFileChanges(ctx, markInitialized)
+		if err == nil {
+			return nil
+		}
+		// Retries only make sense once the watcher has worked at least once.
+		// Before that, fail startup immediately instead of blocking NewKeymanager
+		// through the retry ladder.
+		if !initialized {
+			return err
+		}
 		km.updatePublicKeys(slices.Collect(maps.Values(km.flagLoadedKeysMap))) // update the keys to flag provided defaults
 		km.retriesRemaining--
 		log.WithError(err).Debug("Error occurred on key refresh")
@@ -195,9 +209,7 @@ func (km *Keymanager) refreshRemoteKeysFromFileChangesWithRetry(ctx context.Cont
 			return ctx.Err()
 		case <-time.After(retryDelay):
 		}
-		return km.refreshRemoteKeysFromFileChangesWithRetry(ctx, retryDelay, markReady)
 	}
-	return nil
 }
 
 func (km *Keymanager) readKeyFile() ([][48]byte, map[string][48]byte, error) {
@@ -287,12 +299,6 @@ func (km *Keymanager) savePublicKeysToFile(providedPublicKeys map[string][48]byt
 	return nil
 }
 
-func (km *Keymanager) arePublicKeysEmpty() bool {
-	km.lock.RLock()
-	defer km.lock.RUnlock()
-	return len(km.providedPublicKeys) == 0
-}
-
 func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, markReady func(error)) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -313,16 +319,23 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 	}
 	log.WithField("path", km.keyFilePath).Info("Successfully initialized file watcher")
 	km.retriesRemaining = maxRetries // reset retries to default
-	if km.arePublicKeysEmpty() {
-		_, fk, err := km.readKeyFile()
-		if err != nil {
-			return errors.Wrap(err, "could not read key file")
-		}
-		maps.Copy(fk, km.flagLoadedKeysMap)
-		// savePublicKeysToFile updates the public keys and notifies subscribers.
-		if err = km.savePublicKeysToFile(fk); err != nil {
-			return errors.Wrap(err, "could not save public keys to file")
-		}
+	// Reload keys on every watcher (re)initialization: a failed refresh resets the
+	// in-memory keys to flag-provided defaults, so a recovery must restore the
+	// file-loaded set even when the flag-provided keys are not empty.
+	fileKeys, _, err := km.readKeyFile()
+	if err != nil {
+		return errors.Wrap(err, "could not read key file")
+	}
+	if len(fileKeys) == 0 {
+		log.Warnln("Remote signer key file no longer has keys, defaulting to flag provided keys")
+		fileKeys = slices.Collect(maps.Values(km.flagLoadedKeysMap))
+	}
+	currentKeys, err := km.FetchValidatingPublicKeys(ctx)
+	if err != nil {
+		return errors.Wrap(err, "could not fetch current keys")
+	}
+	if !slices.Equal(currentKeys, fileKeys) {
+		km.updatePublicKeys(fileKeys)
 	}
 	markReady(nil)
 	for {

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -148,13 +148,21 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 		km.lock.Lock()
 		km.providedPublicKeys = slices.Collect(maps.Values(fileKeys))
 		km.lock.Unlock()
-		// create a file watcher
+		watcherReady := make(chan error, 1)
+		var watcherReadyOnce sync.Once
+		markWatcherReady := func(err error) {
+			watcherReadyOnce.Do(func() { watcherReady <- err })
+		}
 		go func() {
-			err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, retryDelay)
-			if err != nil {
-				log.WithError(err).Error("Could not refresh remote keys from file changes")
+			watchErr := km.refreshRemoteKeysFromFileChangesWithRetry(ctx, retryDelay, markWatcherReady)
+			if watchErr != nil {
+				markWatcherReady(watchErr)
+				log.WithError(watchErr).Error("Could not refresh remote keys from file changes")
 			}
 		}()
+		if err := <-watcherReady; err != nil {
+			return nil, errors.Wrap(err, "could not initialize remote signer key file watcher")
+		}
 	} else {
 		km.lock.Lock()
 		km.providedPublicKeys = slices.Collect(maps.Values(flagLoadedKeys))
@@ -164,21 +172,21 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 	return km, nil
 }
 
-func (km *Keymanager) refreshRemoteKeysFromFileChangesWithRetry(ctx context.Context, retryDelay time.Duration) error {
+func (km *Keymanager) refreshRemoteKeysFromFileChangesWithRetry(ctx context.Context, retryDelay time.Duration, markReady func(error)) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 	if km.retriesRemaining == 0 {
 		return errors.New("file check retries remaining exceeded")
 	}
-	err := km.refreshRemoteKeysFromFileChanges(ctx)
+	err := km.refreshRemoteKeysFromFileChanges(ctx, markReady)
 	if err != nil {
 		km.updatePublicKeys(slices.Collect(maps.Values(km.flagLoadedKeysMap))) // update the keys to flag provided defaults
 		km.retriesRemaining--
 		log.WithError(err).Debug("Error occurred on key refresh")
 		log.WithFields(logrus.Fields{"path": km.keyFilePath, "retriesRemaining": km.retriesRemaining, "retryDelay": retryDelay}).Warnf("Could not refresh keys. Retrying...")
 		time.Sleep(retryDelay)
-		return km.refreshRemoteKeysFromFileChangesWithRetry(ctx, retryDelay)
+		return km.refreshRemoteKeysFromFileChangesWithRetry(ctx, retryDelay, markReady)
 	}
 	return nil
 }
@@ -276,7 +284,7 @@ func (km *Keymanager) arePublicKeysEmpty() bool {
 	return len(km.providedPublicKeys) == 0
 }
 
-func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context) error {
+func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, markReady func(error)) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return errors.Wrap(err, "could not initialize file watcher")
@@ -296,7 +304,6 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context) erro
 	}
 	log.WithField("path", km.keyFilePath).Info("Successfully initialized file watcher")
 	km.retriesRemaining = maxRetries // reset retries to default
-	// reinitialize keys if watcher reinitialized
 	if km.arePublicKeysEmpty() {
 		_, fk, err := km.readKeyFile()
 		if err != nil {
@@ -308,6 +315,7 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context) erro
 		}
 		km.updatePublicKeys(slices.Collect(maps.Values(fk)))
 	}
+	markReady(nil)
 	for {
 		select {
 		case e, ok := <-watcher.Events:
@@ -361,10 +369,10 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context) erro
 
 func (km *Keymanager) updatePublicKeys(keys [][48]byte) {
 	km.lock.Lock()
-	defer km.lock.Unlock()
 	km.providedPublicKeys = keys
+	km.lock.Unlock()
 	km.accountsChangedFeed.Send(keys)
-	log.WithField("count", len(km.providedPublicKeys)).Debug("Updated public keys")
+	log.WithField("count", len(keys)).Debug("Updated public keys")
 }
 
 // FetchValidatingPublicKeys fetches the validating public keys

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -160,8 +160,13 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 				log.WithError(watchErr).Error("Could not refresh remote keys from file changes")
 			}
 		}()
-		if err := <-watcherReady; err != nil {
-			return nil, errors.Wrap(err, "could not initialize remote signer key file watcher")
+		select {
+		case err := <-watcherReady:
+			if err != nil {
+				return nil, errors.Wrap(err, "could not initialize remote signer key file watcher")
+			}
+		case <-ctx.Done():
+			return nil, errors.Wrap(ctx.Err(), "could not initialize remote signer key file watcher")
 		}
 	} else {
 		km.lock.Lock()
@@ -185,7 +190,11 @@ func (km *Keymanager) refreshRemoteKeysFromFileChangesWithRetry(ctx context.Cont
 		km.retriesRemaining--
 		log.WithError(err).Debug("Error occurred on key refresh")
 		log.WithFields(logrus.Fields{"path": km.keyFilePath, "retriesRemaining": km.retriesRemaining, "retryDelay": retryDelay}).Warnf("Could not refresh keys. Retrying...")
-		time.Sleep(retryDelay)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryDelay):
+		}
 		return km.refreshRemoteKeysFromFileChangesWithRetry(ctx, retryDelay, markReady)
 	}
 	return nil
@@ -310,10 +319,10 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 			return errors.Wrap(err, "could not read key file")
 		}
 		maps.Copy(fk, km.flagLoadedKeysMap)
+		// savePublicKeysToFile updates the public keys and notifies subscribers.
 		if err = km.savePublicKeysToFile(fk); err != nil {
 			return errors.Wrap(err, "could not save public keys to file")
 		}
-		km.updatePublicKeys(slices.Collect(maps.Values(fk)))
 	}
 	markReady(nil)
 	for {

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -283,8 +283,7 @@ func TestNewKeyManager_FileAndFlagsWithDifferentKeys(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	// test fall back by clearing file
 	go func() {
-		err = file.WriteFile(keyFilePath, []byte(" "))
-		require.NoError(t, err)
+		require.NoError(t, file.WriteFile(keyFilePath, []byte(" ")))
 	}()
 	// waiting for writing to be done
 	time.Sleep(2 * time.Second)
@@ -319,10 +318,9 @@ func TestRefreshRemoteKeysFromFileChangesWithRetry(t *testing.T) {
 	require.LogsContain(t, logHook, "Could not refresh keys")
 	go func() {
 		bytesBuf := new(bytes.Buffer)
-		_, err = bytesBuf.WriteString("8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055") // test without 0x
-		require.NoError(t, err)
-		err = file.WriteFile(keyFilePath, bytesBuf.Bytes())
-		require.NoError(t, err)
+		_, wErr := bytesBuf.WriteString("8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055") // test without 0x
+		require.NoError(t, wErr)
+		require.NoError(t, file.WriteFile(keyFilePath, bytesBuf.Bytes()))
 	}()
 	// wait for file write to reinitialize
 	time.Sleep(2 * time.Second)
@@ -363,6 +361,25 @@ func TestRefreshRemoteKeysFromFileChangesWithRetry_maxRetryReached(t *testing.T)
 	km.retriesRemaining = 1
 	err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Millisecond, func(error) {})
 	require.ErrorContains(t, "file check retries remaining exceeded", err)
+}
+
+func TestRefreshRemoteKeysFromFileChangesWithRetry_ctxCancelDuringRetryWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+	})
+	require.NoError(t, err)
+	km.keyFilePath = filepath.Join(t.TempDir(), "missing.txt")
+
+	timer := time.AfterFunc(100*time.Millisecond, cancel)
+	defer timer.Stop()
+	// The hour-long retry delay would hang the test if cancellation did not interrupt the wait.
+	err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Hour, func(error) {})
+	require.ErrorContains(t, context.Canceled.Error(), err)
 }
 
 func TestKeymanager_Sign(t *testing.T) {

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -11,6 +11,8 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -296,39 +298,46 @@ func TestNewKeyManager_FileAndFlagsWithDifferentKeys(t *testing.T) {
 	require.Equal(t, "0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6", hexutil.Encode(keys[0][:]))
 }
 
-func TestRefreshRemoteKeysFromFileChangesWithRetry(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	logHook := logTest.NewGlobal()
+func TestRefreshRemoteKeysFromFileChangesWithRetry_failsFastBeforeInitialized(t *testing.T) {
+	ctx := t.Context()
 	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
-	require.NoError(t, err)
-	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
-
 	require.NoError(t, err)
 	km, err := NewKeymanager(ctx, &SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
 	})
 	require.NoError(t, err)
+	km.keyFilePath = filepath.Join(t.TempDir(), "missing.txt")
+
+	// The hour-long retry delay would hang the test if the first failure did not
+	// return immediately.
+	err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Hour, func(error) {})
+	require.ErrorContains(t, "could not stat remote signer public key file", err)
+	require.Equal(t, maxRetries, km.retriesRemaining)
+}
+
+// startFailingWatcher starts the retry helper on a valid key file, waits for the
+// watcher to initialize, then removes the file so every subsequent refresh fails.
+func startFailingWatcher(t *testing.T, ctx context.Context, km *Keymanager, keyFilePath string, retryDelay time.Duration) chan error {
+	t.Helper()
+	require.NoError(t, file.WriteFile(keyFilePath, []byte("0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055\n")))
+	km.keyFilePath = keyFilePath
+
+	ready := make(chan struct{})
+	result := make(chan error, 1)
 	go func() {
-		km.keyFilePath = keyFilePath
-		require.NoError(t, km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Second, func(error) {}))
+		var readyOnce sync.Once
+		result <- km.refreshRemoteKeysFromFileChangesWithRetry(ctx, retryDelay, func(error) {
+			readyOnce.Do(func() { close(ready) })
+		})
 	}()
-	// wait for file detection
-	time.Sleep(1 * time.Second)
-	require.LogsContain(t, logHook, "Could not refresh keys")
-	go func() {
-		bytesBuf := new(bytes.Buffer)
-		_, wErr := bytesBuf.WriteString("8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055") // test without 0x
-		require.NoError(t, wErr)
-		require.NoError(t, file.WriteFile(keyFilePath, bytesBuf.Bytes()))
-	}()
-	// wait for file write to reinitialize
-	time.Sleep(2 * time.Second)
-	cancel()
-	require.LogsContain(t, logHook, "Successfully initialized file watcher")
-	keys, err := km.FetchValidatingPublicKeys(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(keys))
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the watcher to initialize")
+	}
+	require.NoError(t, os.Remove(keyFilePath))
+	return result
 }
 
 func TestReadKeyFile_PathMissing(t *testing.T) {
@@ -349,23 +358,25 @@ func TestRefreshRemoteKeysFromFileChangesWithRetry_maxRetryReached(t *testing.T)
 	ctx := t.Context()
 	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
 	require.NoError(t, err)
-	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
-
-	require.NoError(t, err)
 	km, err := NewKeymanager(ctx, &SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
 	})
 	require.NoError(t, err)
-	km.keyFilePath = keyFilePath
-	km.retriesRemaining = 1
-	err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Millisecond, func(error) {})
-	require.ErrorContains(t, "file check retries remaining exceeded", err)
+
+	result := startFailingWatcher(t, ctx, km, filepath.Join(t.TempDir(), "keyfile.txt"), time.Millisecond)
+	select {
+	case err := <-result:
+		require.ErrorContains(t, "file check retries remaining exceeded", err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for retries to be exhausted")
+	}
 }
 
 func TestRefreshRemoteKeysFromFileChangesWithRetry_ctxCancelDuringRetryWait(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
+	logHook := logTest.NewGlobal()
 	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
 	require.NoError(t, err)
 	km, err := NewKeymanager(ctx, &SetupConfig{
@@ -373,13 +384,34 @@ func TestRefreshRemoteKeysFromFileChangesWithRetry_ctxCancelDuringRetryWait(t *t
 		GenesisValidatorsRoot: root,
 	})
 	require.NoError(t, err)
-	km.keyFilePath = filepath.Join(t.TempDir(), "missing.txt")
 
-	timer := time.AfterFunc(100*time.Millisecond, cancel)
-	defer timer.Stop()
-	// The hour-long retry delay would hang the test if cancellation did not interrupt the wait.
-	err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Hour, func(error) {})
-	require.ErrorContains(t, context.Canceled.Error(), err)
+	// The hour-long retry delay would hang the test if cancellation did not
+	// interrupt the wait.
+	result := startFailingWatcher(t, ctx, km, filepath.Join(t.TempDir(), "keyfile.txt"), time.Hour)
+	// Wait until the helper reaches the retry wait before cancelling.
+	deadline := time.Now().Add(5 * time.Second)
+	for !logsContain(logHook, "Could not refresh keys") {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the retry warning")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-result:
+		require.ErrorContains(t, context.Canceled.Error(), err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancellation did not interrupt the retry wait")
+	}
+}
+
+func logsContain(hook *logTest.Hook, substr string) bool {
+	for _, entry := range hook.AllEntries() {
+		if strings.Contains(entry.Message, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestKeymanager_Sign(t *testing.T) {

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/io/file"
@@ -217,8 +218,9 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 		keys[i] = hexutil.Encode(key[:])
 		require.Equal(t, slices.Contains(wantSlice, keys[i]), true)
 	}
-	// sleep needs to be at the front because of how watching the file works
-	time.Sleep(1 * time.Second)
+	pubKeysChan := make(chan [][fieldparams.BLSPubkeyLength]byte)
+	sub := km.SubscribeAccountChanges(pubKeysChan)
+	defer sub.Unsubscribe()
 
 	// Open the file for writing, create it if it does not exist, and truncate it if it does.
 	f, err := os.OpenFile(keyFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
@@ -235,8 +237,18 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 	require.Equal(t, 1, len(ks))
 	require.Equal(t, "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", hexutil.Encode(ks[0][:]))
 
-	require.Equal(t, 1, len(km.providedPublicKeys))
-	require.Equal(t, "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", hexutil.Encode(km.providedPublicKeys[0][:]))
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case updatedKeys := <-pubKeysChan:
+			if len(updatedKeys) == 1 && hexutil.Encode(updatedKeys[0][:]) == "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055" {
+				return
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for the key file update")
+		}
+	}
 }
 
 func TestNewKeyManager_FileAndFlagsWithDifferentKeys(t *testing.T) {
@@ -300,7 +312,7 @@ func TestRefreshRemoteKeysFromFileChangesWithRetry(t *testing.T) {
 	require.NoError(t, err)
 	go func() {
 		km.keyFilePath = keyFilePath
-		require.NoError(t, km.refreshRemoteKeysFromFileChangesWithRetry(ctx, 1*time.Second))
+		require.NoError(t, km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Second, func(error) {}))
 	}()
 	// wait for file detection
 	time.Sleep(1 * time.Second)
@@ -349,7 +361,7 @@ func TestRefreshRemoteKeysFromFileChangesWithRetry_maxRetryReached(t *testing.T)
 	require.NoError(t, err)
 	km.keyFilePath = keyFilePath
 	km.retriesRemaining = 1
-	err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, 1*time.Millisecond)
+	err = km.refreshRemoteKeysFromFileChangesWithRetry(ctx, time.Millisecond, func(error) {})
 	require.ErrorContains(t, "file check retries remaining exceeded", err)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes two issues in the remote web3signer keymanager that affect validators
running with `--validators-external-signer-key-file`.

1. **Startup race.** `NewKeymanager` launched the key-file watcher in a
   background goroutine and returned immediately. Validator startup then raced
   watcher initialization: early key lookups could observe an empty or stale
   key set before the watcher performed its initial read, and a watcher
   initialization failure was only logged, never surfaced to the caller.
   `NewKeymanager` now blocks until the watcher signals readiness through a
   buffered channel guarded by `sync.Once`, and returns an error if the watcher
   fails to initialize. `refreshRemoteKeysFromFileChanges` threads a
   `markReady` callback that fires once the file is registered and the initial
   key load completes.

2. **Lock-ordering deadlock.** `updatePublicKeys` called
   `accountsChangedFeed.Send` while holding the keymanager write lock.
   `Feed.Send` blocks until every subscriber receives, and subscribers re-enter
   the keymanager under the read lock (e.g. `FetchValidatingPublicKeys`), so the
   send could deadlock against the held write lock. The lock is now released
   before the send, and the debug log reads the local slice instead of the
   shared field.

Tests now wait on an account-change subscription instead of sleeping on the
watcher, removing a fixed one-second sleep and a flaky post-write assertion.

**Which issue(s) does this PR fix?**

N/A — small bug fix (no tracking issue).

**Other notes for review**

- Behavioral change: `NewKeymanager` now returns an error when the file
  watcher cannot initialize (previously logged and continued), and blocks
  briefly until the watcher is ready.
- Testing plan: `bazel test //validator/keymanager/remote-web3signer:go_default_test`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).
