### PR TITLE
fix(ci): restore coverage runfiles and fail fast

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -42,6 +42,7 @@ build --keep_going
 build --test_output=errors
 build --flaky_test_attempts=5
 build --build_runfile_links=false # Only build runfile symlink forest when required by local action, test, or run command.
+coverage --build_runfile_links=true # The coverage report generator requires its runfiles symlink forest.
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race
 

--- a/changelog/pvl_fix-ci-coverage-runfiles.md
+++ b/changelog/pvl_fix-ci-coverage-runfiles.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Restored Bazel runfile links for Buildkite coverage report generation and made coverage failures propagate to CI.

--- a/hack/ci-coverage.sh
+++ b/hack/ci-coverage.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Run coverage tests
 ./bazel.sh --bazelrc=.buildkite-bazelrc coverage --config=remote-cache --config=nostamp --features=norace --test_tag_filters="-race_on" --nocache_test_results -k  //...
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The Buildkite Bazel configuration disables runfile links globally, but the coverage report generator is a local action that needs its runfiles symlink forest. As a result, passing Go tests can still fail during coverage report post-processing because the generator cannot locate its runfiles.

This PR enables `--build_runfile_links` specifically for the `coverage` command while leaving the build default unchanged. It also adds `set -euo pipefail` to the coverage script so Bazel or analysis failures propagate to Buildkite instead of being masked.

**Which issue(s) does this PR fix?**

N/A — small CI bug fix.

**Other notes for review**

Testing plan:

- `bash -n hack/ci-coverage.sh`
- `./bazel.sh --bazelrc=.buildkite-bazelrc help coverage`

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).