### PR TITLE
fix(e2e): serialize fixed-port postsubmit targets

### DIFF
--- a/changelog/pvl_fix-e2e-fixed-port-collisions.md
+++ b/changelog/pvl_fix-e2e-fixed-port-collisions.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Serialized fixed-port builder and minimal post-merge E2E targets to prevent concurrent shards from colliding on service ports.

--- a/testing/endtoend/BUILD.bazel
+++ b/testing/endtoend/BUILD.bazel
@@ -149,6 +149,9 @@ go_test(
     shard_count = 2,
     tags = [
         "e2e",
+        # E2E ports are derived only from the shard index, so same-index shards
+        # of different targets collide when run concurrently.
+        "exclusive",
         "manual",
         "minimal",
         "requires-network",
@@ -182,6 +185,9 @@ go_test(
     shard_count = 2,
     tags = [
         "e2e",
+        # E2E ports are derived only from the shard index, so same-index shards
+        # of different targets collide when run concurrently.
+        "exclusive",
         "manual",
         "minimal",
         "requires-network",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The `go_builder_test` and `go_minimal_postmerge_test` E2E targets both derive service ports only from the Bazel shard index. Bazel can schedule same-index shards from these targets concurrently, causing both processes to bind the same ports and fail nondeterministically.

This PR tags both fixed-port targets as `exclusive`, preventing Bazel from overlapping them while preserving their existing two-way sharding.

**Which issue(s) does this PR fix?**

N/A - small E2E infrastructure bug fix.

**Other notes for review**

Testing plan:

- `./bazel.sh query --output=build "set(//testing/endtoend:go_builder_test //testing/endtoend:go_minimal_postmerge_test)"`
- Confirmed both target definitions load with `tags = ["e2e", "exclusive", "manual", "minimal", "requires-network"]`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).