### PR TITLE
fix(p2p): preserve valid static peers

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -789,7 +789,8 @@ func PeersFromStringAddrs(addrs []string) ([]ma.Multiaddr, error) {
 		}
 		nodeAddrs, err := retrieveMultiAddrsFromNode(enodeAddr)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Could not get multiaddr")
+			log.WithError(err).Errorf("Could not get multiaddr from peer %s", stringAddr)
+			continue
 		}
 		allAddrs = append(allAddrs, nodeAddrs...)
 	}

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -436,6 +436,23 @@ func TestMultiAddrConversion_OK(t *testing.T) {
 	require.LogsDoNotContain(t, hook, "Could not get multiaddr")
 }
 
+func TestPeersFromStringAddrs_SkipsUnusablePeer(t *testing.T) {
+	const validAddr = "/ip4/127.0.0.1/tcp/13000"
+	_, pkey := createAddrAndPrivKey(t)
+
+	db, err := enode.OpenDB("")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	localNode := enode.NewLocalNode(db, pkey)
+	localNode.Set(enr.TCP(13001))
+
+	addrs, err := PeersFromStringAddrs([]string{validAddr, localNode.Node().String()})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(addrs))
+	assert.Equal(t, validAddr, addrs[0].String())
+}
+
 func TestStaticPeering_PeersAreAdded(t *testing.T) {
 	const port = uint(6000)
 	cs := startup.NewClockSynchronizer()

--- a/changelog/pengqima_fix-static-peer-list.md
+++ b/changelog/pengqima_fix-static-peer-list.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Skip unusable static peer ENRs without discarding other valid peer addresses.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

`PeersFromStringAddrs` previously returned immediately when an ENR could be parsed but could not be converted into a dialable multiaddress. As a result, one unusable static peer caused all other valid addresses in the same peer list to be discarded.

This change logs the per-peer conversion error and continues processing the remaining entries. It also adds a regression test covering a list containing both a valid multiaddress and an unusable ENR.


**Which issue(s) does this PR fix?**

Fixes #17115

**Other notes for review**

Testing:

- `bazel test //beacon-chain/p2p:go_default_test --test_filter=TestPeersFromStringAddrs_SkipsUnusablePeer`
- `make build`

The full P2P test target was also attempted. The existing network-dependent `TestService_BroadcastAttestationWithDiscoveryAttempts` test timed out after five minutes on all three retries; the targeted regression test passes.



**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
