### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 <h1 align="left">Prysm: An Ethereum Consensus Implementation Written in Go</h1>
 
 <div align="left">
-  
-[![Build status](https://badge.buildkite.com/b555891daf3614bae4284dcf365b2340cefc0089839526f096.svg?branch=master)](https://buildkite.com/prysmatic-labs/prysm)
-[![Go Report Card](https://goreportcard.com/badge/github.com/OffchainLabs/prysm)](https://goreportcard.com/report/github.com/OffchainLabs/prysm)
-[![Consensus_Spec_Version 1.4.0](https://img.shields.io/badge/Consensus%20Spec%20Version-v1.4.0-blue.svg)](https://github.com/ethereum/consensus-specs/tree/v1.4.0)
-[![Execution_API_Version 1.0.0-beta.2](https://img.shields.io/badge/Execution%20API%20Version-v1.0.0.beta.2-blue.svg)](https://github.com/ethereum/execution-apis/tree/v1.0.0-beta.2/src/engine)
-[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/qEZK94mFXP)
-[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/OffchainLabs/prysm/badge)](https://www.gitpoap.io/gh/OffchainLabs/prysm)
+[![Buildkite](https://badge.buildkite.com/b555891daf3614bae4284dcf365b2340cefc0089839526f096.svg?branch=develop)](https://buildkite.com/prysmatic-labs/prysm)
+[![Build status](https://github.com/OffchainLabs/prysm/actions/workflows/go.yml/badge.svg?branch=develop)](https://github.com/OffchainLabs/prysm/actions/workflows/go.yml)
+[![Consensus Spec Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FOffchainLabs%2Fprysm%2Fdevelop%2FWORKSPACE&search=consensus_spec_version%20%3D%20%22%28%5B%5E%22%5D%2B%29%22&replace=%241&label=Consensus%20Spec%20Version&color=blue)](https://github.com/ethereum/consensus-specs/releases)
+[![Discord](https://img.shields.io/discord/476244492043812875?logo=discord&label=Discord)](https://discord.gg/qEZK94mFXP)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <h1 align="left">Prysm: An Ethereum Consensus Implementation Written in Go</h1>
 
 <div align="left">
+
 [![Buildkite](https://badge.buildkite.com/b555891daf3614bae4284dcf365b2340cefc0089839526f096.svg?branch=develop)](https://buildkite.com/prysmatic-labs/prysm)
 [![Build status](https://github.com/OffchainLabs/prysm/actions/workflows/go.yml/badge.svg?branch=develop)](https://github.com/OffchainLabs/prysm/actions/workflows/go.yml)
 [![Consensus Spec Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FOffchainLabs%2Fprysm%2Fdevelop%2FWORKSPACE&search=consensus_spec_version%20%3D%20%22%28%5B%5E%22%5D%2B%29%22&replace=%241&label=Consensus%20Spec%20Version&color=blue)](https://github.com/ethereum/consensus-specs/releases)

--- a/changelog/syjn99_readme-badge-revamp.md
+++ b/changelog/syjn99_readme-badge-revamp.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Update README badges.


### PR DESCRIPTION
**What type of PR is this?**

> Documentation

**What does this PR do? Why is it needed?**

<img width="2192" height="468" alt="image" src="https://github.com/user-attachments/assets/0e42028a-bb16-47b5-8917-3bfae1ebd618" />

Our badges in README are outdated, including:
- Buildkite status is watching `master` branch
- [Go Report Card](https://goreportcard.com/) has been sunset.
- consensus-specs version: human manually pins it every time.
- execution API version: Removing this as it is quite unrelated with CL stuff
- GitPOAP: somehow this seems gone as well

Now it looks like:

<img width="1072" height="216" alt="image" src="https://github.com/user-attachments/assets/45dfca91-88f4-4ac5-8465-679f49cfc7bc" />


**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Changing Buildkite status from `master` to `develop` - this surfaces our CI as red.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
