### PR TITLE
Upgrading go-libp2p-gossipsub to v0.17.0

### DIFF
--- a/changelog/kasey_libp2p-pubsub-v0170.md
+++ b/changelog/kasey_libp2p-pubsub-v0170.md
@@ -1,0 +1,5 @@
+### Changed
+- Upgrading go-libp2p-pubsub to v0.17.0.
+
+### Fixed
+- Includes go-libp2p-pubsub fix to allow publishing of messages that were previously ignored ([issue](https://github.com/OffchainLabs/prysm/issues/17035)).

--- a/deps.bzl
+++ b/deps.bzl
@@ -1884,8 +1884,8 @@ def prysm_deps():
         name = "com_github_libp2p_go_libp2p_pubsub",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/libp2p/go-libp2p-pubsub",
-        sum = "h1:UMiJ408NqO9Sf2ANutEM3An8Em3K+qn78eoIgzY3PIY=",
-        version = "v0.16.1-0.20260611143718-41b11d5cb1a7",
+        sum = "h1:SNdvB6V0eYMXLRR95n+4vpxJKbFsbHhgjPdDiTpGoo0=",
+        version = "v0.17.0",
     )
     go_repository(
         name = "com_github_libp2p_go_libp2p_testing",
@@ -2564,12 +2564,6 @@ def prysm_deps():
         importpath = "github.com/pion/srtp/v3",
         sum = "h1:E2gyj1f5X10sB/qILUGIkL4C2CqK269Xq167PbGCc/4=",
         version = "v3.0.6",
-    )
-    go_repository(
-        name = "com_github_pion_stun",
-        importpath = "github.com/pion/stun",
-        sum = "h1:8lp6YejULeHBF8NmV8e2787BogQhduZugh5PdhDyyN4=",
-        version = "v0.6.1",
     )
     go_repository(
         name = "com_github_pion_stun_v2",

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/libp2p/go-libp2p-mplex v0.11.0
-	github.com/libp2p/go-libp2p-pubsub v0.16.1-0.20260611143718-41b11d5cb1a7
+	github.com/libp2p/go-libp2p-pubsub v0.17.0
 	github.com/libp2p/go-mplex v0.7.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.7.0


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Upgrades to the latest (v0.17.0) go-libp2p-pubsub release. This release includes a fix to how go-libp2p-pubsub filters publishing of previously seen messages, allowing the node to publish a message that previously failed validation (see #17035).

**Which issue(s) does this PR fix?**

Fixes #17035

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
