### PR TITLE
fix(e2e): support JSON and SSZ in mock builder

### DIFF
--- a/changelog/pvl_fix-e2e-mock-builder-json-ssz.md
+++ b/changelog/pvl_fix-e2e-mock-builder-json-ssz.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Taught the E2E mock builder in `testing/middleware/builder` to accept and emit both JSON and SSZ for validator registrations, header retrieval, and pre- and post-Fulu blinded block submission, so JSON and SSZ builder clients exercise the same relay.

--- a/testing/middleware/builder/BUILD.bazel
+++ b/testing/middleware/builder/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
         "@com_github_ethereum_go_ethereum//trie:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prysmaticlabs_fastssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/testing/middleware/builder/BUILD.bazel
+++ b/testing/middleware/builder/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v7/testing/middleware/builder",
     visibility = ["//visibility:public"],
     deps = [
+        "//api:go_default_library",
         "//api/client/builder:go_default_library",
         "//api/server/structs:go_default_library",
         "//beacon-chain/core/signing:go_default_library",
@@ -21,6 +22,7 @@ go_library(
         "//encoding/bytesutil:go_default_library",
         "//network:go_default_library",
         "//network/authorization:go_default_library",
+        "//network/httputil:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//runtime/version:go_default_library",
@@ -31,6 +33,30 @@ go_library(
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
         "@com_github_ethereum_go_ethereum//trie:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["builder_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//api:go_default_library",
+        "//api/client/builder:go_default_library",
+        "//api/server/structs:go_default_library",
+        "//config/params:go_default_library",
+        "//consensus-types/blocks:go_default_library",
+        "//consensus-types/interfaces:go_default_library",
+        "//proto/engine/v1:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
+        "//runtime/version:go_default_library",
+        "//testing/require:go_default_library",
+        "//testing/util:go_default_library",
+        "@com_github_ethereum_go_ethereum//beacon/engine:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
+        "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
+        "@com_github_ethereum_go_ethereum//rpc:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/testing/middleware/builder/builder.go
+++ b/testing/middleware/builder/builder.go
@@ -38,15 +38,17 @@ import (
 	gethRPC "github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/pkg/errors"
+	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	statusPath      = "GET /eth/v1/builder/status"
-	registerPath    = "POST /eth/v1/builder/validators"
-	headerPath      = "GET /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}"
-	blindedPath     = "POST /eth/v1/builder/blinded_blocks"
-	fuluBlindedPath = "POST /eth/v2/builder/blinded_blocks"
+	statusPath       = "/eth/v1/builder/status"
+	registerPath     = "/eth/v1/builder/validators"
+	headerPath       = "/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}"
+	headerPathPrefix = "/eth/v1/builder/header/"
+	blindedPath      = "/eth/v1/builder/blinded_blocks"
+	fuluBlindedPath  = "/eth/v2/builder/blinded_blocks"
 
 	// ForkchoiceUpdatedMethod v1 request string for JSON-RPC.
 	ForkchoiceUpdatedMethod = "engine_forkchoiceUpdatedV1"
@@ -132,17 +134,16 @@ func New(opts ...Option) (*Builder, error) {
 		return nil, err
 	}
 	router := http.NewServeMux()
-	router.Handle("/", p)
-	router.HandleFunc(statusPath, func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc(http.MethodGet+" "+statusPath, func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
 	})
-	router.HandleFunc(registerPath, p.registerValidators)
-	router.HandleFunc(headerPath, p.handleHeaderRequest)
-	router.HandleFunc(blindedPath, p.handleBlindedBlock)
-	router.HandleFunc(fuluBlindedPath, p.handleBlindedBlockPostFulu)
+	router.HandleFunc(http.MethodPost+" "+registerPath, p.registerValidators)
+	router.HandleFunc(http.MethodGet+" "+headerPath, p.handleHeaderRequest)
+	router.HandleFunc(http.MethodPost+" "+blindedPath, p.handleBlindedBlock)
+	router.HandleFunc(http.MethodPost+" "+fuluBlindedPath, p.handleBlindedBlockPostFulu)
 	addr := net.JoinHostPort(p.cfg.builderHost, strconv.Itoa(p.cfg.builderPort))
 	srv := &http.Server{
-		Handler:           router,
+		Handler:           p,
 		Addr:              addr,
 		ReadHeaderTimeout: time.Second,
 	}
@@ -268,8 +269,31 @@ func (p *Builder) handleEngineCalls(req, resp []byte) {
 	}
 }
 
-func (*Builder) isBuilderCall(req *http.Request) bool {
-	return strings.Contains(req.URL.Path, "/eth/v1/builder/") || strings.Contains(req.URL.Path, "/eth/v2/builder/")
+func (p *Builder) isBuilderCall(req *http.Request) bool {
+	switch req.URL.Path {
+	case statusPath, registerPath, blindedPath, fuluBlindedPath:
+		return true
+	default:
+		return isHeaderCall(req.URL.Path)
+	}
+}
+
+// isHeaderCall requires all three header params so malformed header paths fall
+// through to the proxy, keeping unknown routes proxied once rather than 404'd.
+func isHeaderCall(path string) bool {
+	if !strings.HasPrefix(path, headerPathPrefix) {
+		return false
+	}
+	params := strings.Split(strings.TrimPrefix(path, headerPathPrefix), "/")
+	if len(params) != 3 {
+		return false
+	}
+	for _, seg := range params {
+		if seg == "" {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *Builder) registerValidators(w http.ResponseWriter, req *http.Request) {
@@ -341,11 +365,7 @@ func decodeSingleJSON[T any](reader io.Reader) (T, error) {
 	return value, nil
 }
 
-type sszMarshaler interface {
-	MarshalSSZ() ([]byte, error)
-}
-
-func writeBuilderResponse(w http.ResponseWriter, req *http.Request, forkVersion int, jsonResponse any, sszResponse sszMarshaler) error {
+func writeBuilderResponse(w http.ResponseWriter, req *http.Request, forkVersion int, jsonResponse any, sszResponse ssz.Marshaler) error {
 	w.Header().Set(api.VersionHeader, version.String(forkVersion))
 	if httputil.RespondWithSsz(req) {
 		body, err := sszResponse.MarshalSSZ()
@@ -865,7 +885,7 @@ func decodeBlindedBlockFuluRequest(req *http.Request) error {
 	return err
 }
 
-func executionPayloadSSZResponse(v int, data interfaces.ExecutionData, bundle *v1.BlobsBundle) (sszMarshaler, error) {
+func executionPayloadSSZResponse(v int, data interfaces.ExecutionData, bundle *v1.BlobsBundle) (ssz.Marshaler, error) {
 	switch v {
 	case version.Bellatrix:
 		payload, ok := data.Proto().(*v1.ExecutionPayload)

--- a/testing/middleware/builder/builder.go
+++ b/testing/middleware/builder/builder.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/api"
 	builderAPI "github.com/OffchainLabs/prysm/v7/api/client/builder"
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
@@ -26,6 +27,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/network"
 	"github.com/OffchainLabs/prysm/v7/network/authorization"
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	v1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
@@ -40,10 +42,11 @@ import (
 )
 
 const (
-	statusPath   = "GET /eth/v1/builder/status"
-	registerPath = "POST /eth/v1/builder/validators"
-	headerPath   = "GET /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}"
-	blindedPath  = "POST /eth/v1/builder/blinded_blocks"
+	statusPath      = "GET /eth/v1/builder/status"
+	registerPath    = "POST /eth/v1/builder/validators"
+	headerPath      = "GET /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}"
+	blindedPath     = "POST /eth/v1/builder/blinded_blocks"
+	fuluBlindedPath = "POST /eth/v2/builder/blinded_blocks"
 
 	// ForkchoiceUpdatedMethod v1 request string for JSON-RPC.
 	ForkchoiceUpdatedMethod = "engine_forkchoiceUpdatedV1"
@@ -136,6 +139,7 @@ func New(opts ...Option) (*Builder, error) {
 	router.HandleFunc(registerPath, p.registerValidators)
 	router.HandleFunc(headerPath, p.handleHeaderRequest)
 	router.HandleFunc(blindedPath, p.handleBlindedBlock)
+	router.HandleFunc(fuluBlindedPath, p.handleBlindedBlockPostFulu)
 	addr := net.JoinHostPort(p.cfg.builderHost, strconv.Itoa(p.cfg.builderPort))
 	srv := &http.Server{
 		Handler:           router,
@@ -265,27 +269,97 @@ func (p *Builder) handleEngineCalls(req, resp []byte) {
 }
 
 func (*Builder) isBuilderCall(req *http.Request) bool {
-	return strings.Contains(req.URL.Path, "/eth/v1/builder/")
+	return strings.Contains(req.URL.Path, "/eth/v1/builder/") || strings.Contains(req.URL.Path, "/eth/v2/builder/")
 }
 
 func (p *Builder) registerValidators(w http.ResponseWriter, req *http.Request) {
-	var registrations []structs.SignedValidatorRegistration
-	if err := json.NewDecoder(req.Body).Decode(&registrations); err != nil {
+	registrations, err := decodeValidatorRegistrations(req)
+	if err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	for _, r := range registrations {
-		msg, err := r.Message.ToConsensus()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		p.valLock.Lock()
-		p.validatorMap[r.Message.Pubkey] = msg
-		p.valLock.Unlock()
+	p.valLock.Lock()
+	for _, registration := range registrations {
+		p.validatorMap[hexutil.Encode(registration.Message.Pubkey)] = registration.Message
 	}
+	p.valLock.Unlock()
 	// TODO: Verify Signatures from validators
 	w.WriteHeader(http.StatusOK)
+}
+
+func decodeValidatorRegistrations(req *http.Request) ([]*eth.SignedValidatorRegistrationV1, error) {
+	if httputil.IsRequestSsz(req) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		registrationSize := (&eth.SignedValidatorRegistrationV1{}).SizeSSZ()
+		if len(body) == 0 || len(body)%registrationSize != 0 {
+			return nil, errors.New("invalid validator registration SSZ framing")
+		}
+		registrations := make([]*eth.SignedValidatorRegistrationV1, 0, len(body)/registrationSize)
+		for offset := 0; offset < len(body); offset += registrationSize {
+			registration := &eth.SignedValidatorRegistrationV1{}
+			if err := registration.UnmarshalSSZ(body[offset : offset+registrationSize]); err != nil {
+				return nil, err
+			}
+			registrations = append(registrations, registration)
+		}
+		return registrations, nil
+	}
+
+	jsonRegistrations, err := decodeSingleJSON[[]structs.SignedValidatorRegistration](req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(jsonRegistrations) == 0 {
+		return nil, errors.New("empty validator registration JSON batch")
+	}
+	registrations := make([]*eth.SignedValidatorRegistrationV1, 0, len(jsonRegistrations))
+	for _, registration := range jsonRegistrations {
+		consensusRegistration, err := registration.ToConsensus()
+		if err != nil {
+			return nil, err
+		}
+		registrations = append(registrations, consensusRegistration)
+	}
+	return registrations, nil
+}
+
+func decodeSingleJSON[T any](reader io.Reader) (T, error) {
+	var value T
+	decoder := json.NewDecoder(reader)
+	if err := decoder.Decode(&value); err != nil {
+		return value, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return value, errors.New("multiple JSON documents")
+	} else if !errors.Is(err, io.EOF) {
+		return value, err
+	}
+	return value, nil
+}
+
+type sszMarshaler interface {
+	MarshalSSZ() ([]byte, error)
+}
+
+func writeBuilderResponse(w http.ResponseWriter, req *http.Request, forkVersion int, jsonResponse any, sszResponse sszMarshaler) error {
+	w.Header().Set(api.VersionHeader, version.String(forkVersion))
+	if httputil.RespondWithSsz(req) {
+		body, err := sszResponse.MarshalSSZ()
+		if err != nil {
+			return err
+		}
+		w.Header().Set("Content-Type", api.OctetStreamMediaType)
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(body)
+		return err
+	}
+	w.Header().Set("Content-Type", api.JsonMediaType)
+	w.WriteHeader(http.StatusOK)
+	return json.NewEncoder(w).Encode(jsonResponse)
 }
 
 func (p *Builder) handleHeaderRequest(w http.ResponseWriter, req *http.Request) {
@@ -322,17 +396,17 @@ func (p *Builder) handleHeaderRequest(w http.ResponseWriter, req *http.Request) 
 	ax := types.Slot(slot)
 	currEpoch := types.Epoch(ax / params.BeaconConfig().SlotsPerEpoch)
 	if currEpoch >= params.BeaconConfig().ElectraForkEpoch {
-		p.handleHeaderRequestElectra(w)
+		p.handleHeaderRequestElectra(w, req)
 		return
 	}
 
 	if currEpoch >= params.BeaconConfig().DenebForkEpoch {
-		p.handleHeaderRequestDeneb(w)
+		p.handleHeaderRequestDeneb(w, req)
 		return
 	}
 
 	if currEpoch >= params.BeaconConfig().CapellaForkEpoch {
-		p.handleHeaderRequestCapella(w)
+		p.handleHeaderRequestCapella(w, req)
 		return
 	}
 
@@ -405,8 +479,7 @@ func (p *Builder) handleHeaderRequest(w http.ResponseWriter, req *http.Request) 
 			Message:   bid,
 		},
 	}
-	w.WriteHeader(http.StatusOK)
-	err = json.NewEncoder(w).Encode(hdrResp)
+	err = writeBuilderResponse(w, req, version.Bellatrix, hdrResp, &eth.SignedBuilderBid{Message: sszBid, Signature: sig.Marshal()})
 	if err != nil {
 		p.cfg.logger.WithError(err).Error("Could not encode response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -416,7 +489,7 @@ func (p *Builder) handleHeaderRequest(w http.ResponseWriter, req *http.Request) 
 	p.currPayload = wObj
 }
 
-func (p *Builder) handleHeaderRequestCapella(w http.ResponseWriter) {
+func (p *Builder) handleHeaderRequestCapella(w http.ResponseWriter, req *http.Request) {
 	b, err := p.retrievePendingBlockCapella()
 	if err != nil {
 		p.cfg.logger.WithError(err).Error("Could not retrieve pending block")
@@ -487,8 +560,7 @@ func (p *Builder) handleHeaderRequestCapella(w http.ResponseWriter) {
 			Message:   bid,
 		},
 	}
-	w.WriteHeader(http.StatusOK)
-	err = json.NewEncoder(w).Encode(hdrResp)
+	err = writeBuilderResponse(w, req, version.Capella, hdrResp, &eth.SignedBuilderBidCapella{Message: sszBid, Signature: sig.Marshal()})
 	if err != nil {
 		p.cfg.logger.WithError(err).Error("Could not encode response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -498,7 +570,7 @@ func (p *Builder) handleHeaderRequestCapella(w http.ResponseWriter) {
 	p.currPayload = wObj
 }
 
-func (p *Builder) handleHeaderRequestDeneb(w http.ResponseWriter) {
+func (p *Builder) handleHeaderRequestDeneb(w http.ResponseWriter, req *http.Request) {
 	b, err := p.retrievePendingBlockDeneb()
 	if err != nil {
 		p.cfg.logger.WithError(err).Error("Could not retrieve pending block")
@@ -577,8 +649,7 @@ func (p *Builder) handleHeaderRequestDeneb(w http.ResponseWriter) {
 			Message:   bid,
 		},
 	}
-	w.WriteHeader(http.StatusOK)
-	err = json.NewEncoder(w).Encode(hdrResp)
+	err = writeBuilderResponse(w, req, version.Deneb, hdrResp, &eth.SignedBuilderBidDeneb{Message: sszBid, Signature: sig.Marshal()})
 	if err != nil {
 		p.cfg.logger.WithError(err).Error("Could not encode response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -589,7 +660,7 @@ func (p *Builder) handleHeaderRequestDeneb(w http.ResponseWriter) {
 	p.blobBundle = b.BlobsBundle
 }
 
-func (p *Builder) handleHeaderRequestElectra(w http.ResponseWriter) {
+func (p *Builder) handleHeaderRequestElectra(w http.ResponseWriter, req *http.Request) {
 	b, err := p.retrievePendingBlockElectra()
 	if err != nil {
 		p.cfg.logger.WithError(err).Error("Could not retrieve pending block")
@@ -679,8 +750,7 @@ func (p *Builder) handleHeaderRequestElectra(w http.ResponseWriter) {
 			Message:   bid,
 		},
 	}
-	w.WriteHeader(http.StatusOK)
-	err = json.NewEncoder(w).Encode(hdrResp)
+	err = writeBuilderResponse(w, req, version.Electra, hdrResp, &eth.SignedBuilderBidElectra{Message: sszBid, Signature: sig.Marshal()})
 	if err != nil {
 		p.cfg.logger.WithError(err).Error("Could not encode response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -692,25 +762,11 @@ func (p *Builder) handleHeaderRequestElectra(w http.ResponseWriter) {
 }
 
 func (p *Builder) handleBlindedBlock(w http.ResponseWriter, req *http.Request) {
-	// Decode blinded block based on the current fork version.
-	// The beacon node sends JSON using api/server/structs types.
-	var err error
-	switch p.currVersion {
-	case version.Electra:
-		var sb structs.SignedBlindedBeaconBlockElectra
-		err = json.NewDecoder(req.Body).Decode(&sb)
-	case version.Deneb:
-		var sb structs.SignedBlindedBeaconBlockDeneb
-		err = json.NewDecoder(req.Body).Decode(&sb)
-	case version.Capella:
-		var sb structs.SignedBlindedBeaconBlockCapella
-		err = json.NewDecoder(req.Body).Decode(&sb)
-	default:
-		var sb structs.SignedBlindedBeaconBlockBellatrix
-		err = json.NewDecoder(req.Body).Decode(&sb)
-	}
+	err := p.decodeBlindedBlockRequest(req)
 	if err != nil {
 		p.cfg.logger.WithError(err).WithField("version", version.String(p.currVersion)).Error("Could not decode blinded block")
+		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	if p.currPayload == nil {
 		p.cfg.logger.Error("No payload is cached")
@@ -724,12 +780,113 @@ func (p *Builder) handleBlindedBlock(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
-	err = json.NewEncoder(w).Encode(resp)
+	sszResponse, err := executionPayloadSSZResponse(p.currVersion, p.currPayload, p.blobBundle)
 	if err != nil {
-		p.cfg.logger.WithError(err).Error("Could not encode full payload response")
+		p.cfg.logger.WithError(err).Error("Could not encode full payload SSZ response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if err = writeBuilderResponse(w, req, p.currVersion, resp, sszResponse); err != nil {
+		p.cfg.logger.WithError(err).Error("Could not encode full payload response")
+	}
+}
+
+func (p *Builder) handleBlindedBlockPostFulu(w http.ResponseWriter, req *http.Request) {
+	if err := decodeBlindedBlockFuluRequest(req); err != nil {
+		p.cfg.logger.WithError(err).Error("Could not decode Fulu blinded block")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (p *Builder) decodeBlindedBlockRequest(req *http.Request) error {
+	if httputil.IsRequestSsz(req) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return err
+		}
+		switch p.currVersion {
+		case version.Electra:
+			return (&eth.SignedBlindedBeaconBlockElectra{}).UnmarshalSSZ(body)
+		case version.Deneb:
+			return (&eth.SignedBlindedBeaconBlockDeneb{}).UnmarshalSSZ(body)
+		case version.Capella:
+			return (&eth.SignedBlindedBeaconBlockCapella{}).UnmarshalSSZ(body)
+		default:
+			return (&eth.SignedBlindedBeaconBlockBellatrix{}).UnmarshalSSZ(body)
+		}
+	}
+	switch p.currVersion {
+	case version.Electra:
+		block, err := decodeSingleJSON[structs.SignedBlindedBeaconBlockElectra](req.Body)
+		if err != nil || block.Message == nil {
+			return errors.New("invalid blinded block")
+		}
+		_, err = block.ToConsensus()
+		return err
+	case version.Deneb:
+		block, err := decodeSingleJSON[structs.SignedBlindedBeaconBlockDeneb](req.Body)
+		if err != nil || block.Message == nil {
+			return errors.New("invalid blinded block")
+		}
+		_, err = block.ToConsensus()
+		return err
+	case version.Capella:
+		block, err := decodeSingleJSON[structs.SignedBlindedBeaconBlockCapella](req.Body)
+		if err != nil || block.Message == nil {
+			return errors.New("invalid blinded block")
+		}
+		_, err = block.ToGeneric()
+		return err
+	default:
+		block, err := decodeSingleJSON[structs.SignedBlindedBeaconBlockBellatrix](req.Body)
+		if err != nil || block.Message == nil {
+			return errors.New("invalid blinded block")
+		}
+		_, err = block.ToGeneric()
+		return err
+	}
+}
+
+func decodeBlindedBlockFuluRequest(req *http.Request) error {
+	if httputil.IsRequestSsz(req) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return err
+		}
+		return (&eth.SignedBlindedBeaconBlockFulu{}).UnmarshalSSZ(body)
+	}
+	block, err := decodeSingleJSON[structs.SignedBlindedBeaconBlockFulu](req.Body)
+	if err != nil || block.Message == nil {
+		return errors.New("invalid Fulu blinded block")
+	}
+	_, err = block.ToConsensus()
+	return err
+}
+
+func executionPayloadSSZResponse(v int, data interfaces.ExecutionData, bundle *v1.BlobsBundle) (sszMarshaler, error) {
+	switch v {
+	case version.Bellatrix:
+		payload, ok := data.Proto().(*v1.ExecutionPayload)
+		if !ok {
+			return nil, errInvalidTypeConversion
+		}
+		return payload, nil
+	case version.Capella:
+		payload, ok := data.Proto().(*v1.ExecutionPayloadCapella)
+		if !ok {
+			return nil, errInvalidTypeConversion
+		}
+		return payload, nil
+	case version.Deneb, version.Electra:
+		payload, ok := data.Proto().(*v1.ExecutionPayloadDeneb)
+		if !ok {
+			return nil, errInvalidTypeConversion
+		}
+		return &v1.ExecutionPayloadDenebAndBlobsBundle{Payload: payload, BlobsBundle: bundle}, nil
+	default:
+		return nil, errInvalidTypeConversion
 	}
 }
 

--- a/testing/middleware/builder/builder.go
+++ b/testing/middleware/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -288,12 +289,7 @@ func isHeaderCall(path string) bool {
 	if len(params) != 3 {
 		return false
 	}
-	for _, seg := range params {
-		if seg == "" {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(params, "")
 }
 
 func (p *Builder) registerValidators(w http.ResponseWriter, req *http.Request) {

--- a/testing/middleware/builder/builder_test.go
+++ b/testing/middleware/builder/builder_test.go
@@ -1,0 +1,716 @@
+package builder
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/api"
+	builderClient "github.com/OffchainLabs/prysm/v7/api/client/builder"
+	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	v1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethRPC "github.com/ethereum/go-ethereum/rpc"
+	"github.com/sirupsen/logrus"
+)
+
+type testEngineService struct {
+	payload  *engine.ExecutableData
+	envelope *engine.ExecutionPayloadEnvelope
+}
+
+func (s *testEngineService) GetPayloadV1(v1.PayloadIDBytes) (*engine.ExecutableData, error) {
+	return s.payload, nil
+}
+
+func (s *testEngineService) GetPayloadV2(v1.PayloadIDBytes) (*engine.ExecutionPayloadEnvelope, error) {
+	return s.envelope, nil
+}
+
+func (s *testEngineService) GetPayloadV3(v1.PayloadIDBytes) (*engine.ExecutionPayloadEnvelope, error) {
+	return s.envelope, nil
+}
+
+func (s *testEngineService) GetPayloadV4(v1.PayloadIDBytes) (*engine.ExecutionPayloadEnvelope, error) {
+	return s.envelope, nil
+}
+
+func TestGetHeaderBaselineJSON(t *testing.T) {
+	builder, server, _ := headerTestServer(t)
+	client, err := builderClient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	bid, err := client.GetHeader(t.Context(), 1, [32]byte{1}, [48]byte{2})
+
+	require.NoError(t, err)
+	require.NotNil(t, bid)
+	require.Equal(t, version.Bellatrix, builder.currVersion)
+	t.Logf("endpoint=%s fork=bellatrix accept=%s status=%d content_type=%s version=%s decoded_type=%T", headerPath, api.JsonMediaType, http.StatusOK, api.JsonMediaType, "bellatrix", bid)
+}
+
+func TestHandleBlindedBlockBaselineJSON(t *testing.T) {
+	// Given
+	config := params.BeaconConfig().Copy()
+	params.SetActiveTestCleanup(t, config)
+	params.SetGenesisFork(t, config, version.Bellatrix)
+	builder, server, observed := headerTestServer(t)
+	client, err := builderClient.NewClient(server.URL)
+	require.NoError(t, err)
+	_, err = client.GetHeader(t.Context(), 1, [32]byte{1}, [48]byte{2})
+	require.NoError(t, err)
+	block, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockBellatrix())
+	require.NoError(t, err)
+
+	// When
+	payload, _, err := client.SubmitBlindedBlock(t.Context(), block)
+
+	// Then
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	require.DeepEqual(t, builder.currPayload.BlockHash(), payload.BlockHash())
+	require.Equal(t, http.StatusOK, observed.status)
+	t.Logf("endpoint=%s fork=bellatrix encoding=json status=%d content_type=%s version=%s decoded_type=%T body_length=%d", blindedPath, observed.status, observed.header.Get("Content-Type"), observed.header.Get(api.VersionHeader), payload, observed.body.Len())
+}
+
+func TestGetHeader(t *testing.T) {
+	tests := []struct {
+		name          string
+		forkVersion   int
+		decodeJSON    func(*testing.T, []byte)
+		decodeSSZ     func(*testing.T, []byte)
+		assertBidType func(*testing.T, builderClient.Bid)
+	}{
+		{
+			name:        "Bellatrix",
+			forkVersion: version.Bellatrix,
+			decodeJSON: func(t *testing.T, body []byte) {
+				require.NoError(t, json.Unmarshal(body, &builderClient.ExecHeaderResponse{}))
+			},
+			decodeSSZ: func(t *testing.T, body []byte) {
+				require.NoError(t, (&eth.SignedBuilderBid{}).UnmarshalSSZ(body))
+			},
+		},
+		{
+			name:        "Capella",
+			forkVersion: version.Capella,
+			decodeJSON: func(t *testing.T, body []byte) {
+				require.NoError(t, json.Unmarshal(body, &builderClient.ExecHeaderResponseCapella{}))
+			},
+			decodeSSZ: func(t *testing.T, body []byte) {
+				require.NoError(t, (&eth.SignedBuilderBidCapella{}).UnmarshalSSZ(body))
+			},
+		},
+		{
+			name:        "Deneb",
+			forkVersion: version.Deneb,
+			decodeJSON: func(t *testing.T, body []byte) {
+				require.NoError(t, json.Unmarshal(body, &builderClient.ExecHeaderResponseDeneb{}))
+			},
+			decodeSSZ: func(t *testing.T, body []byte) {
+				require.NoError(t, (&eth.SignedBuilderBidDeneb{}).UnmarshalSSZ(body))
+			},
+			assertBidType: func(t *testing.T, bid builderClient.Bid) {
+				_, ok := bid.(builderClient.BidDeneb)
+				require.Equal(t, true, ok)
+			},
+		},
+		{
+			name:        "Electra",
+			forkVersion: version.Electra,
+			decodeJSON: func(t *testing.T, body []byte) {
+				require.NoError(t, json.Unmarshal(body, &builderClient.ExecHeaderResponseElectra{}))
+			},
+			decodeSSZ: func(t *testing.T, body []byte) {
+				require.NoError(t, (&eth.SignedBuilderBidElectra{}).UnmarshalSSZ(body))
+			},
+			assertBidType: func(t *testing.T, bid builderClient.Bid) {
+				_, ok := bid.(builderClient.BidElectra)
+				require.Equal(t, true, ok)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := params.BeaconConfig().Copy()
+			params.SetActiveTestCleanup(t, config)
+			params.SetGenesisFork(t, config, test.forkVersion)
+			for _, encoding := range []string{api.JsonMediaType, api.OctetStreamMediaType} {
+				t.Run(encoding, func(t *testing.T) {
+					builder, server, observed := headerTestServer(t)
+					client, err := builderClient.NewClient(server.URL, clientOptions(encoding)...)
+					require.NoError(t, err)
+
+					bid, err := client.GetHeader(t.Context(), 1, [32]byte{1}, [48]byte{2})
+
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, observed.status)
+					require.Equal(t, encoding, observed.header.Get("Content-Type"))
+					require.Equal(t, version.String(test.forkVersion), observed.header.Get(api.VersionHeader))
+					require.Equal(t, test.forkVersion, builder.currVersion)
+					if encoding == api.JsonMediaType {
+						test.decodeJSON(t, observed.body.Bytes())
+					} else {
+						test.decodeSSZ(t, observed.body.Bytes())
+					}
+					require.Equal(t, test.forkVersion, bid.Version())
+					message, err := bid.Message()
+					require.NoError(t, err)
+					require.Equal(t, test.forkVersion, message.Version())
+					require.NotNil(t, message.Value())
+					require.Equal(t, 96, len(bid.Signature()))
+					header, err := message.Header()
+					require.NoError(t, err)
+					require.Equal(t, 32, len(header.BlockHash()))
+					if test.assertBidType != nil {
+						test.assertBidType(t, message)
+					}
+					t.Logf("endpoint=%s fork=%s accept=%s status=%d content_type=%s version=%s decoded_type=%T", headerPath, version.String(test.forkVersion), encoding, observed.status, observed.header.Get("Content-Type"), observed.header.Get(api.VersionHeader), bid)
+				})
+			}
+		})
+	}
+}
+
+func TestWriteBuilderResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		forkVersion int
+		accept      string
+		contentType string
+	}{
+		{name: "Bellatrix JSON", forkVersion: version.Bellatrix, accept: api.JsonMediaType, contentType: api.JsonMediaType},
+		{name: "Bellatrix SSZ", forkVersion: version.Bellatrix, accept: api.OctetStreamMediaType, contentType: api.OctetStreamMediaType},
+		{name: "Capella JSON", forkVersion: version.Capella, accept: api.JsonMediaType, contentType: api.JsonMediaType},
+		{name: "Capella SSZ", forkVersion: version.Capella, accept: api.OctetStreamMediaType, contentType: api.OctetStreamMediaType},
+		{name: "Deneb JSON", forkVersion: version.Deneb, accept: api.JsonMediaType, contentType: api.JsonMediaType},
+		{name: "Deneb SSZ", forkVersion: version.Deneb, accept: api.OctetStreamMediaType, contentType: api.OctetStreamMediaType},
+		{name: "Electra JSON", forkVersion: version.Electra, accept: api.JsonMediaType, contentType: api.JsonMediaType},
+		{name: "Electra SSZ", forkVersion: version.Electra, accept: api.OctetStreamMediaType, contentType: api.OctetStreamMediaType},
+		{name: "Absent Accept defaults JSON", forkVersion: version.Bellatrix, contentType: api.JsonMediaType},
+		{name: "Unrelated Accept defaults JSON", forkVersion: version.Bellatrix, accept: "text/plain", contentType: api.JsonMediaType},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/header", nil)
+			if test.accept != "" {
+				req.Header.Set("Accept", test.accept)
+			}
+
+			err := writeBuilderResponse(recorder, req, test.forkVersion, map[string]string{"encoding": "json"}, testSSZResponse{body: []byte("ssz")})
+
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, recorder.Code)
+			require.Equal(t, test.contentType, recorder.Header().Get("Content-Type"))
+			require.Equal(t, version.String(test.forkVersion), recorder.Header().Get(api.VersionHeader))
+			if test.contentType == api.OctetStreamMediaType {
+				require.Equal(t, true, bytes.Equal([]byte("ssz"), recorder.Body.Bytes()))
+			} else {
+				var response map[string]string
+				require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+				require.Equal(t, "json", response["encoding"])
+			}
+			t.Logf("endpoint=%s fork=%s accept=%s status=%d content_type=%s version=%s decoded_type=%T", headerPath, version.String(test.forkVersion), test.accept, recorder.Code, recorder.Header().Get("Content-Type"), recorder.Header().Get(api.VersionHeader), testSSZResponse{})
+		})
+	}
+}
+
+type testSSZResponse struct {
+	body []byte
+}
+
+func (r testSSZResponse) MarshalSSZ() ([]byte, error) {
+	return r.body, nil
+}
+
+func clientOptions(accept string) []builderClient.ClientOpt {
+	if accept == api.OctetStreamMediaType {
+		return []builderClient.ClientOpt{builderClient.WithSSZ()}
+	}
+	return nil
+}
+
+type observedHeaderResponse struct {
+	http.ResponseWriter
+	status        int
+	header        http.Header
+	requestHeader http.Header
+	body          bytes.Buffer
+}
+
+func (w *observedHeaderResponse) reset(responseWriter http.ResponseWriter, request *http.Request) {
+	w.ResponseWriter = responseWriter
+	w.status = 0
+	w.header = nil
+	w.requestHeader = request.Header.Clone()
+	w.body.Reset()
+}
+
+func (w *observedHeaderResponse) WriteHeader(status int) {
+	w.status = status
+	w.header = w.ResponseWriter.Header().Clone()
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *observedHeaderResponse) Write(body []byte) (int, error) {
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	_, _ = w.body.Write(body)
+	return w.ResponseWriter.Write(body)
+}
+
+func headerTestServer(t *testing.T) (*Builder, *httptest.Server, *observedHeaderResponse) {
+	t.Helper()
+	rpcServer := gethRPC.NewServer()
+	blobGasUsed := uint64(0)
+	excessBlobGas := uint64(0)
+	payload := &engine.ExecutableData{
+		ParentHash:    common.Hash{1},
+		FeeRecipient:  common.Address{2},
+		StateRoot:     common.Hash{3},
+		ReceiptsRoot:  common.Hash{4},
+		LogsBloom:     bytes.Repeat([]byte{5}, 256),
+		Random:        common.Hash{6},
+		Number:        1,
+		GasLimit:      30_000_000,
+		GasUsed:       1,
+		Timestamp:     1,
+		ExtraData:     []byte{7},
+		BaseFeePerGas: big.NewInt(1),
+		BlockHash:     common.Hash{8},
+		Transactions:  [][]byte{},
+		BlobGasUsed:   &blobGasUsed,
+		ExcessBlobGas: &excessBlobGas,
+	}
+	envelope := &engine.ExecutionPayloadEnvelope{
+		ExecutionPayload: payload,
+		BlockValue:       big.NewInt(1),
+		BlobsBundle:      &engine.BlobsBundle{},
+	}
+	require.NoError(t, rpcServer.RegisterName("engine", &testEngineService{payload: payload, envelope: envelope}))
+	t.Cleanup(rpcServer.Stop)
+	builder := &Builder{
+		cfg:            &config{logger: logrus.New()},
+		currId:         &v1.PayloadIDBytes{1},
+		prevBeaconRoot: common.Hash{9}.Bytes(),
+		execClient:     gethRPC.DialInProc(rpcServer),
+	}
+	mux := http.NewServeMux()
+	observed := &observedHeaderResponse{}
+	mux.HandleFunc(headerPath, func(w http.ResponseWriter, req *http.Request) {
+		observed.reset(w, req)
+		builder.handleHeaderRequest(observed, req)
+	})
+	mux.HandleFunc(blindedPath, func(w http.ResponseWriter, req *http.Request) {
+		observed.reset(w, req)
+		builder.handleBlindedBlock(observed, req)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return builder, server, observed
+}
+
+func TestRegisterValidatorsBaselineJSON(t *testing.T) {
+	// Given
+	builder, server := registrationTestServer(t)
+	registrations := validRegistrations()
+	client, err := builderClient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	// When
+	err = client.RegisterValidator(t.Context(), registrations)
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, 2, len(builder.validatorMap))
+	for _, registration := range registrations {
+		require.DeepEqual(t, registration.Message, builder.validatorMap[hexutil.Encode(registration.Message.Pubkey)])
+	}
+	t.Logf("endpoint=%s encoding=json status=%d map_size=%d", registerPath, http.StatusOK, len(builder.validatorMap))
+}
+
+func TestRegisterValidators(t *testing.T) {
+	registrations := validRegistrations()
+
+	t.Run("accepts two JSON registrations", func(t *testing.T) {
+		// Given
+		builder, server := registrationTestServer(t)
+		client, err := builderClient.NewClient(server.URL)
+		require.NoError(t, err)
+
+		// When
+		err = client.RegisterValidator(t.Context(), registrations)
+
+		// Then
+		require.NoError(t, err)
+		assertRegistrations(t, builder, registrations)
+		t.Logf("endpoint=%s encoding=json status=%d map_size=%d", registerPath, http.StatusOK, len(builder.validatorMap))
+	})
+
+	t.Run("accepts two concatenated SSZ registrations", func(t *testing.T) {
+		// Given
+		builder, server := registrationTestServer(t)
+		client, err := builderClient.NewClient(server.URL, builderClient.WithSSZ())
+		require.NoError(t, err)
+
+		// When
+		err = client.RegisterValidator(t.Context(), registrations)
+
+		// Then
+		require.NoError(t, err)
+		assertRegistrations(t, builder, registrations)
+		t.Logf("endpoint=%s encoding=ssz status=%d map_size=%d", registerPath, http.StatusOK, len(builder.validatorMap))
+	})
+
+	validJSON := registrationJSON(t, registrations)
+	validSSZ, err := registrations[0].MarshalSSZ()
+	require.NoError(t, err)
+	invalidMessage := registrationAPI(registrations[1])
+	invalidMessage.Message.Pubkey = "0x01"
+	invalidSignature := registrationAPI(registrations[1])
+	invalidSignature.Signature = "0x01"
+	nilMessage := registrationAPI(registrations[1])
+	nilMessage.Message = nil
+	invalidSecond, err := json.Marshal([]*structs.SignedValidatorRegistration{registrationAPI(registrations[0]), invalidMessage})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        []byte
+	}{
+		{name: "rejects zero-length SSZ", contentType: api.OctetStreamMediaType},
+		{name: "rejects empty JSON array", contentType: api.JsonMediaType, body: []byte("[]")},
+		{name: "rejects JSON null", contentType: api.JsonMediaType, body: []byte("null")},
+		{name: "rejects truncated SSZ", contentType: api.OctetStreamMediaType, body: validSSZ[:len(validSSZ)-1]},
+		{name: "rejects syntax-invalid JSON", contentType: api.JsonMediaType, body: []byte("[{")},
+		{name: "rejects a second JSON document", contentType: api.JsonMediaType, body: append(validJSON, []byte(" []")...)},
+		{name: "rejects malformed trailing JSON", contentType: api.JsonMediaType, body: append(validJSON, []byte(" trailing")...)},
+		{name: "rejects nil message", contentType: api.JsonMediaType, body: marshalJSON(t, []*structs.SignedValidatorRegistration{nilMessage})},
+		{name: "rejects wrong fixed-length message field", contentType: api.JsonMediaType, body: marshalJSON(t, []*structs.SignedValidatorRegistration{invalidMessage})},
+		{name: "rejects wrong-length signature", contentType: api.JsonMediaType, body: marshalJSON(t, []*structs.SignedValidatorRegistration{invalidSignature})},
+		{name: "does not partially mutate after invalid second record", contentType: api.JsonMediaType, body: invalidSecond},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given
+			builder, server := registrationTestServer(t)
+			existing := validRegistration(0xff).Message
+			expected := map[string]*eth.ValidatorRegistrationV1{hexutil.Encode(existing.Pubkey): existing}
+			builder.validatorMap = map[string]*eth.ValidatorRegistrationV1{hexutil.Encode(existing.Pubkey): existing}
+
+			// When
+			status := postRegistration(t, server, test.contentType, test.body)
+
+			// Then
+			require.Equal(t, http.StatusBadRequest, status)
+			require.DeepEqual(t, expected, builder.validatorMap)
+			t.Logf("endpoint=%s encoding=%s status=%d map_size=%d", registerPath, test.contentType, status, len(builder.validatorMap))
+		})
+	}
+}
+
+func registrationTestServer(t *testing.T) (*Builder, *httptest.Server) {
+	t.Helper()
+	builder := &Builder{validatorMap: make(map[string]*eth.ValidatorRegistrationV1)}
+	mux := http.NewServeMux()
+	mux.HandleFunc(registerPath, builder.registerValidators)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return builder, server
+}
+
+func validRegistrations() []*eth.SignedValidatorRegistrationV1 {
+	return []*eth.SignedValidatorRegistrationV1{
+		validRegistration(0x41),
+		validRegistration(0x42),
+	}
+}
+
+func validRegistration(pubkeyByte byte) *eth.SignedValidatorRegistrationV1 {
+	return &eth.SignedValidatorRegistrationV1{
+		Message: &eth.ValidatorRegistrationV1{
+			FeeRecipient: bytes.Repeat([]byte{0x24}, 20),
+			GasLimit:     30_000_000,
+			Timestamp:    1,
+			Pubkey:       bytes.Repeat([]byte{pubkeyByte}, 48),
+		},
+		Signature: bytes.Repeat([]byte{0x11}, 96),
+	}
+}
+
+func assertRegistrations(t *testing.T, builder *Builder, registrations []*eth.SignedValidatorRegistrationV1) {
+	t.Helper()
+	require.Equal(t, len(registrations), len(builder.validatorMap))
+	for _, registration := range registrations {
+		require.DeepEqual(t, registration.Message, builder.validatorMap[hexutil.Encode(registration.Message.Pubkey)])
+	}
+}
+
+func registrationJSON(t *testing.T, registrations []*eth.SignedValidatorRegistrationV1) []byte {
+	t.Helper()
+	jsonRegistrations := make([]*structs.SignedValidatorRegistration, len(registrations))
+	for index, registration := range registrations {
+		jsonRegistrations[index] = registrationAPI(registration)
+	}
+	return marshalJSON(t, jsonRegistrations)
+}
+
+func registrationAPI(registration *eth.SignedValidatorRegistrationV1) *structs.SignedValidatorRegistration {
+	return structs.SignedValidatorRegistrationFromConsensus(registration)
+}
+
+func marshalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return encoded
+}
+
+func postRegistration(t *testing.T, server *httptest.Server, contentType string, body []byte) int {
+	t.Helper()
+	endpoint := strings.TrimPrefix(registerPath, http.MethodPost+" ")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, server.URL+endpoint, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", contentType)
+	resp, err := server.Client().Do(req)
+	require.NoError(t, err)
+	status := resp.StatusCode
+	require.NoError(t, resp.Body.Close())
+	return status
+}
+
+func TestHandleBlindedBlock(t *testing.T) {
+	tests := []struct {
+		name    string
+		fork    int
+		block   func() interfaces.ReadOnlySignedBeaconBlock
+		decode  func(*testing.T, []byte)
+		bundles bool
+	}{
+		{"bellatrix", version.Bellatrix, func() interfaces.ReadOnlySignedBeaconBlock {
+			return blindedBlock(t, util.NewBlindedBeaconBlockBellatrix())
+		}, func(t *testing.T, body []byte) { require.NoError(t, (&v1.ExecutionPayload{}).UnmarshalSSZ(body)) }, false},
+		{"capella", version.Capella, func() interfaces.ReadOnlySignedBeaconBlock {
+			return blindedBlock(t, util.NewBlindedBeaconBlockCapella())
+		}, func(t *testing.T, body []byte) {
+			require.NoError(t, (&v1.ExecutionPayloadCapella{}).UnmarshalSSZ(body))
+		}, false},
+		{"deneb", version.Deneb, func() interfaces.ReadOnlySignedBeaconBlock { return blindedBlock(t, util.NewBlindedBeaconBlockDeneb()) }, func(t *testing.T, body []byte) {
+			require.NoError(t, (&v1.ExecutionPayloadDenebAndBlobsBundle{}).UnmarshalSSZ(body))
+		}, true},
+		{"electra", version.Electra, func() interfaces.ReadOnlySignedBeaconBlock {
+			return blindedBlock(t, util.NewBlindedBeaconBlockElectra())
+		}, func(t *testing.T, body []byte) {
+			require.NoError(t, (&v1.ExecutionPayloadDenebAndBlobsBundle{}).UnmarshalSSZ(body))
+		}, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := params.BeaconConfig().Copy()
+			params.SetActiveTestCleanup(t, config)
+			params.SetGenesisFork(t, config, test.fork)
+			for _, encoding := range []string{api.JsonMediaType, api.OctetStreamMediaType} {
+				t.Run(encoding, func(t *testing.T) {
+					builder, server, observed := headerTestServer(t)
+					client, err := builderClient.NewClient(server.URL, clientOptions(encoding)...)
+					require.NoError(t, err)
+					_, err = client.GetHeader(t.Context(), 1, [32]byte{1}, [48]byte{2})
+					require.NoError(t, err)
+
+					payload, bundle, err := client.SubmitBlindedBlock(t.Context(), test.block())
+
+					require.NoError(t, err)
+					require.Equal(t, encoding, observed.requestHeader.Get("Content-Type"))
+					require.Equal(t, http.StatusOK, observed.status)
+					require.Equal(t, encoding, observed.header.Get("Content-Type"))
+					require.Equal(t, version.String(test.fork), observed.header.Get(api.VersionHeader))
+					require.DeepEqual(t, builder.currPayload.BlockHash(), payload.BlockHash())
+					if test.bundles {
+						require.NotNil(t, bundle)
+					}
+					if encoding == api.OctetStreamMediaType {
+						test.decode(t, observed.body.Bytes())
+					} else {
+						var response builderClient.ExecutionPayloadResponse
+						require.NoError(t, json.Unmarshal(observed.body.Bytes(), &response))
+					}
+					t.Logf("endpoint=%s fork=%s encoding=%s status=%d content_type=%s version=%s decoded_type=%T body_length=%d", blindedPath, test.name, encoding, observed.status, observed.header.Get("Content-Type"), observed.header.Get(api.VersionHeader), payload, observed.body.Len())
+				})
+			}
+		})
+	}
+}
+
+func TestHandleBlindedBlockRejectsMalformedInput(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		fork  int
+		block func() interfaces.ReadOnlySignedBeaconBlock
+	}{
+		{"bellatrix", version.Bellatrix, func() interfaces.ReadOnlySignedBeaconBlock {
+			return blindedBlock(t, util.NewBlindedBeaconBlockBellatrix())
+		}},
+		{"capella", version.Capella, func() interfaces.ReadOnlySignedBeaconBlock {
+			return blindedBlock(t, util.NewBlindedBeaconBlockCapella())
+		}},
+		{"deneb", version.Deneb, func() interfaces.ReadOnlySignedBeaconBlock { return blindedBlock(t, util.NewBlindedBeaconBlockDeneb()) }},
+		{"electra", version.Electra, func() interfaces.ReadOnlySignedBeaconBlock {
+			return blindedBlock(t, util.NewBlindedBeaconBlockElectra())
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			valid := blindedBlockJSON(t, test.block())
+			for _, input := range []struct {
+				name, contentType string
+				body              []byte
+			}{
+				{"malformed ssz", api.OctetStreamMediaType, []byte{1}},
+				{"syntax invalid json", api.JsonMediaType, []byte(`{"message":`)},
+				{"nil message", api.JsonMediaType, mutateBlindedBlockJSON(t, valid, func(message map[string]json.RawMessage) { message["message"] = []byte("null") })},
+				{"wrong fixed length field", api.JsonMediaType, mutateBlindedBlockMessageJSON(t, valid, func(message map[string]json.RawMessage) { message["parent_root"] = []byte(`"0x01"`) })},
+				{"second json document", api.JsonMediaType, append(valid, []byte(" {}")...)},
+				{"malformed trailing bytes", api.JsonMediaType, append(valid, []byte(" trailing")...)},
+			} {
+				t.Run(input.name, func(t *testing.T) {
+					builder := &Builder{cfg: &config{logger: logrus.New()}, currVersion: test.fork}
+					mux := http.NewServeMux()
+					mux.HandleFunc(blindedPath, builder.handleBlindedBlock)
+					server := httptest.NewServer(mux)
+					t.Cleanup(server.Close)
+					status, response := postBlindedBlock(t, server.URL, blindedPath, input.contentType, input.body)
+					require.Equal(t, http.StatusBadRequest, status)
+					require.Equal(t, 0, len(response))
+					t.Logf("endpoint=%s fork=%s encoding=%s status=%d body_length=%d", blindedPath, test.name, input.contentType, status, len(response))
+				})
+			}
+		})
+	}
+}
+
+func TestSubmitBlindedBlockPostFulu(t *testing.T) {
+	for _, encoding := range []string{api.JsonMediaType, api.OctetStreamMediaType} {
+		t.Run(encoding, func(t *testing.T) {
+			builder, server, fallbackHits := fuluTestServer(t)
+			client, err := builderClient.NewClient(server.URL, clientOptions(encoding)...)
+			require.NoError(t, err)
+
+			err = client.SubmitBlindedBlockPostFulu(t.Context(), blindedBlock(t, util.NewBlindedBeaconBlockFulu()))
+
+			require.NoError(t, err)
+			require.Equal(t, int32(0), fallbackHits.Load())
+			t.Logf("endpoint=/eth/v2/builder/blinded_blocks fork=fulu encoding=%s status=%d body_length=%d fallback_hits=%d", encoding, http.StatusAccepted, 0, fallbackHits.Load())
+			_ = builder
+		})
+	}
+}
+
+func TestServeHTTPRoutesBuilderV2(t *testing.T) {
+	_, server, fallbackHits := fuluTestServer(t)
+	status, _ := postBlindedBlock(t, server.URL, "/not-builder", api.JsonMediaType, []byte(`{}`))
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, int32(1), fallbackHits.Load())
+	t.Logf("endpoint=/not-builder status=%d fallback_hits=%d", status, fallbackHits.Load())
+}
+
+func TestSubmitBlindedBlockPostFuluRejectsMalformedInput(t *testing.T) {
+	valid := blindedBlockJSON(t, blindedBlock(t, util.NewBlindedBeaconBlockFulu()))
+	for _, input := range []struct {
+		name, contentType string
+		body              []byte
+	}{
+		{"malformed ssz", api.OctetStreamMediaType, []byte{1}},
+		{"syntax invalid json", api.JsonMediaType, []byte(`{"message":`)},
+		{"nil message", api.JsonMediaType, mutateBlindedBlockJSON(t, valid, func(message map[string]json.RawMessage) { message["message"] = []byte("null") })},
+		{"wrong fixed length field", api.JsonMediaType, mutateBlindedBlockMessageJSON(t, valid, func(message map[string]json.RawMessage) { message["parent_root"] = []byte(`"0x01"`) })},
+		{"second json document", api.JsonMediaType, append(valid, []byte(" {}")...)},
+		{"malformed trailing bytes", api.JsonMediaType, append(valid, []byte(" trailing")...)},
+	} {
+		t.Run(input.name, func(t *testing.T) {
+			_, server, fallbackHits := fuluTestServer(t)
+			status, response := postBlindedBlock(t, server.URL, "/eth/v2/builder/blinded_blocks", input.contentType, input.body)
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Equal(t, 0, len(response))
+			require.Equal(t, int32(0), fallbackHits.Load())
+			t.Logf("endpoint=/eth/v2/builder/blinded_blocks fork=fulu encoding=%s status=%d body_length=%d fallback_hits=%d", input.contentType, status, len(response), fallbackHits.Load())
+		})
+	}
+}
+
+func blindedBlock(t *testing.T, proto any) interfaces.ReadOnlySignedBeaconBlock {
+	t.Helper()
+	block, err := blocks.NewSignedBeaconBlock(proto)
+	require.NoError(t, err)
+	return block
+}
+
+func blindedBlockJSON(t *testing.T, block interfaces.ReadOnlySignedBeaconBlock) []byte {
+	t.Helper()
+	jsonBlock, err := structs.SignedBeaconBlockMessageJsoner(block)
+	require.NoError(t, err)
+	return marshalJSON(t, jsonBlock)
+}
+
+func mutateBlindedBlockJSON(t *testing.T, body []byte, mutate func(map[string]json.RawMessage)) []byte {
+	t.Helper()
+	var message map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &message))
+	mutate(message)
+	return marshalJSON(t, message)
+}
+
+func mutateBlindedBlockMessageJSON(t *testing.T, body []byte, mutate func(map[string]json.RawMessage)) []byte {
+	t.Helper()
+	var root map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &root))
+	var message map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(root["message"], &message))
+	mutate(message)
+	root["message"] = marshalJSON(t, message)
+	return marshalJSON(t, root)
+}
+
+func postBlindedBlock(t *testing.T, baseURL, path, contentType string, body []byte) (int, []byte) {
+	t.Helper()
+	path = strings.TrimPrefix(path, http.MethodPost+" ")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, baseURL+path, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", contentType)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+	response, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, response
+}
+
+func fuluTestServer(t *testing.T) (*Builder, *httptest.Server, *atomic.Int32) {
+	t.Helper()
+	fallbackHits := &atomic.Int32{}
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fallbackHits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(fallback.Close)
+	builder, err := New(WithDestinationAddress(fallback.URL))
+	require.NoError(t, err)
+	server := httptest.NewServer(builder)
+	t.Cleanup(server.Close)
+	return builder, server, fallbackHits
+}

--- a/testing/middleware/builder/builder_test.go
+++ b/testing/middleware/builder/builder_test.go
@@ -64,7 +64,6 @@ func TestGetHeaderBaselineJSON(t *testing.T) {
 }
 
 func TestHandleBlindedBlockBaselineJSON(t *testing.T) {
-	// Given
 	config := params.BeaconConfig().Copy()
 	params.SetActiveTestCleanup(t, config)
 	params.SetGenesisFork(t, config, version.Bellatrix)
@@ -76,10 +75,8 @@ func TestHandleBlindedBlockBaselineJSON(t *testing.T) {
 	block, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockBellatrix())
 	require.NoError(t, err)
 
-	// When
 	payload, _, err := client.SubmitBlindedBlock(t.Context(), block)
 
-	// Then
 	require.NoError(t, err)
 	require.NotNil(t, payload)
 	require.DeepEqual(t, builder.currPayload.BlockHash(), payload.BlockHash())
@@ -238,6 +235,14 @@ func (r testSSZResponse) MarshalSSZ() ([]byte, error) {
 	return r.body, nil
 }
 
+func (r testSSZResponse) MarshalSSZTo(dst []byte) ([]byte, error) {
+	return append(dst, r.body...), nil
+}
+
+func (r testSSZResponse) SizeSSZ() int {
+	return len(r.body)
+}
+
 func clientOptions(accept string) []builderClient.ClientOpt {
 	if accept == api.OctetStreamMediaType {
 		return []builderClient.ClientOpt{builderClient.WithSSZ()}
@@ -313,11 +318,11 @@ func headerTestServer(t *testing.T) (*Builder, *httptest.Server, *observedHeader
 	}
 	mux := http.NewServeMux()
 	observed := &observedHeaderResponse{}
-	mux.HandleFunc(headerPath, func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc(http.MethodGet+" "+headerPath, func(w http.ResponseWriter, req *http.Request) {
 		observed.reset(w, req)
 		builder.handleHeaderRequest(observed, req)
 	})
-	mux.HandleFunc(blindedPath, func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc(http.MethodPost+" "+blindedPath, func(w http.ResponseWriter, req *http.Request) {
 		observed.reset(w, req)
 		builder.handleBlindedBlock(observed, req)
 	})
@@ -327,16 +332,13 @@ func headerTestServer(t *testing.T) (*Builder, *httptest.Server, *observedHeader
 }
 
 func TestRegisterValidatorsBaselineJSON(t *testing.T) {
-	// Given
 	builder, server := registrationTestServer(t)
 	registrations := validRegistrations()
 	client, err := builderClient.NewClient(server.URL)
 	require.NoError(t, err)
 
-	// When
 	err = client.RegisterValidator(t.Context(), registrations)
 
-	// Then
 	require.NoError(t, err)
 	require.Equal(t, 2, len(builder.validatorMap))
 	for _, registration := range registrations {
@@ -349,30 +351,24 @@ func TestRegisterValidators(t *testing.T) {
 	registrations := validRegistrations()
 
 	t.Run("accepts two JSON registrations", func(t *testing.T) {
-		// Given
 		builder, server := registrationTestServer(t)
 		client, err := builderClient.NewClient(server.URL)
 		require.NoError(t, err)
 
-		// When
 		err = client.RegisterValidator(t.Context(), registrations)
 
-		// Then
 		require.NoError(t, err)
 		assertRegistrations(t, builder, registrations)
 		t.Logf("endpoint=%s encoding=json status=%d map_size=%d", registerPath, http.StatusOK, len(builder.validatorMap))
 	})
 
 	t.Run("accepts two concatenated SSZ registrations", func(t *testing.T) {
-		// Given
 		builder, server := registrationTestServer(t)
 		client, err := builderClient.NewClient(server.URL, builderClient.WithSSZ())
 		require.NoError(t, err)
 
-		// When
 		err = client.RegisterValidator(t.Context(), registrations)
 
-		// Then
 		require.NoError(t, err)
 		assertRegistrations(t, builder, registrations)
 		t.Logf("endpoint=%s encoding=ssz status=%d map_size=%d", registerPath, http.StatusOK, len(builder.validatorMap))
@@ -409,16 +405,13 @@ func TestRegisterValidators(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Given
 			builder, server := registrationTestServer(t)
 			existing := validRegistration(0xff).Message
 			expected := map[string]*eth.ValidatorRegistrationV1{hexutil.Encode(existing.Pubkey): existing}
 			builder.validatorMap = map[string]*eth.ValidatorRegistrationV1{hexutil.Encode(existing.Pubkey): existing}
 
-			// When
 			status := postRegistration(t, server, test.contentType, test.body)
 
-			// Then
 			require.Equal(t, http.StatusBadRequest, status)
 			require.DeepEqual(t, expected, builder.validatorMap)
 			t.Logf("endpoint=%s encoding=%s status=%d map_size=%d", registerPath, test.contentType, status, len(builder.validatorMap))
@@ -430,7 +423,7 @@ func registrationTestServer(t *testing.T) (*Builder, *httptest.Server) {
 	t.Helper()
 	builder := &Builder{validatorMap: make(map[string]*eth.ValidatorRegistrationV1)}
 	mux := http.NewServeMux()
-	mux.HandleFunc(registerPath, builder.registerValidators)
+	mux.HandleFunc(http.MethodPost+" "+registerPath, builder.registerValidators)
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 	return builder, server
@@ -485,8 +478,7 @@ func marshalJSON(t *testing.T, value any) []byte {
 
 func postRegistration(t *testing.T, server *httptest.Server, contentType string, body []byte) int {
 	t.Helper()
-	endpoint := strings.TrimPrefix(registerPath, http.MethodPost+" ")
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, server.URL+endpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, server.URL+registerPath, bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", contentType)
 	resp, err := server.Client().Do(req)
@@ -591,7 +583,7 @@ func TestHandleBlindedBlockRejectsMalformedInput(t *testing.T) {
 				t.Run(input.name, func(t *testing.T) {
 					builder := &Builder{cfg: &config{logger: logrus.New()}, currVersion: test.fork}
 					mux := http.NewServeMux()
-					mux.HandleFunc(blindedPath, builder.handleBlindedBlock)
+					mux.HandleFunc(http.MethodPost+" "+blindedPath, builder.handleBlindedBlock)
 					server := httptest.NewServer(mux)
 					t.Cleanup(server.Close)
 					status, response := postBlindedBlock(t, server.URL, blindedPath, input.contentType, input.body)
@@ -622,11 +614,84 @@ func TestSubmitBlindedBlockPostFulu(t *testing.T) {
 }
 
 func TestServeHTTPRoutesBuilderV2(t *testing.T) {
-	_, server, fallbackHits := fuluTestServer(t)
-	status, _ := postBlindedBlock(t, server.URL, "/not-builder", api.JsonMediaType, []byte(`{}`))
-	require.Equal(t, http.StatusOK, status)
-	require.Equal(t, int32(1), fallbackHits.Load())
-	t.Logf("endpoint=/not-builder status=%d fallback_hits=%d", status, fallbackHits.Load())
+	for _, test := range []struct {
+		path         string
+		wantStatus   int
+		wantFallback int32
+	}{
+		{"/eth/v2/builder/blinded_blocks", http.StatusAccepted, 0},
+		{"/eth/v2/builder/unknown", http.StatusOK, 1},
+		{"/not-builder", http.StatusOK, 1},
+		{"/eth/v1/builder/header/1/0x01", http.StatusOK, 1},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			_, server, fallbackHits := fuluTestServer(t)
+			body := []byte(`{}`)
+			if test.path == "/eth/v2/builder/blinded_blocks" {
+				body = blindedBlockJSON(t, blindedBlock(t, util.NewBlindedBeaconBlockFulu()))
+			}
+			status, _ := postBlindedBlock(t, server.URL, test.path, api.JsonMediaType, body)
+			require.Equal(t, test.wantStatus, status)
+			require.Equal(t, test.wantFallback, fallbackHits.Load())
+			t.Logf("endpoint=%s status=%d fallback_hits=%d", test.path, status, fallbackHits.Load())
+		})
+	}
+}
+
+func TestServeHTTPRoutesBuilderReturnsMethodNotAllowedForRegisteredPaths(t *testing.T) {
+	for _, test := range []struct {
+		name, method, path string
+	}{
+		{"status", http.MethodPost, "/eth/v1/builder/status"},
+		{"validators", http.MethodGet, "/eth/v1/builder/validators"},
+		{"header", http.MethodPost, "/eth/v1/builder/header/1/0x01/0x02"},
+		{"v1 blinded block", http.MethodGet, "/eth/v1/builder/blinded_blocks"},
+		{"v2 blinded block", http.MethodGet, "/eth/v2/builder/blinded_blocks"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, server, fallbackHits := fuluTestServer(t)
+			req, err := http.NewRequestWithContext(t.Context(), test.method, server.URL+test.path, bytes.NewReader([]byte(`{}`)))
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+			require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+			require.Equal(t, int32(0), fallbackHits.Load())
+			t.Logf("endpoint=%s method=%s status=%d fallback_hits=%d", test.path, test.method, resp.StatusCode, fallbackHits.Load())
+		})
+	}
+}
+
+func TestIsBuilderCall(t *testing.T) {
+	builder, _, _ := fuluTestServer(t)
+	for _, test := range []struct {
+		name, method, path string
+		want               bool
+	}{
+		{"status", http.MethodGet, "/eth/v1/builder/status", true},
+		{"status method mismatch", http.MethodPost, "/eth/v1/builder/status", true},
+		{"validators", http.MethodPost, "/eth/v1/builder/validators", true},
+		{"validators method mismatch", http.MethodGet, "/eth/v1/builder/validators", true},
+		{"header", http.MethodGet, "/eth/v1/builder/header/1/0x01/0x02", true},
+		{"header method mismatch", http.MethodPost, "/eth/v1/builder/header/1/0x01/0x02", true},
+		{"v1 blinded block", http.MethodPost, "/eth/v1/builder/blinded_blocks", true},
+		{"v1 blinded block method mismatch", http.MethodGet, "/eth/v1/builder/blinded_blocks", true},
+		{"v2 blinded block", http.MethodPost, "/eth/v2/builder/blinded_blocks", true},
+		{"v2 blinded block method mismatch", http.MethodGet, "/eth/v2/builder/blinded_blocks", true},
+		{"unknown v1 builder path", http.MethodGet, "/eth/v1/builder/unknown", false},
+		{"unknown v2 builder path", http.MethodPost, "/eth/v2/builder/unknown", false},
+		{"engine path", http.MethodPost, "/", false},
+		{"header missing segments", http.MethodGet, "/eth/v1/builder/header/1/0x01", false},
+		{"header extra segments", http.MethodGet, "/eth/v1/builder/header/1/0x01/0x02/extra", false},
+		{"header empty segment", http.MethodGet, "/eth/v1/builder/header/1//0x02", false},
+		{"header trailing slash", http.MethodGet, "/eth/v1/builder/header/1/0x01/0x02/", false},
+		{"header prefix only", http.MethodGet, "/eth/v1/builder/header/", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(test.method, test.path, nil)
+			require.Equal(t, test.want, builder.isBuilderCall(req))
+		})
+	}
 }
 
 func TestSubmitBlindedBlockPostFuluRejectsMalformedInput(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Updates the E2E mock builder for the SSZ-first builder client. It accepts JSON and SSZ registrations and blinded blocks, negotiates JSON or SSZ responses, and supports the post-Fulu V2 blinded-block endpoint.

Includes direct JSON/SSZ and malformed-request coverage across Bellatrix through Fulu.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Testing: `bazel test //testing/middleware/builder:go_default_test`

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).
