### PR TITLE
Return envelope publish after broadcast, import in background

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_gloas.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_gloas.go
@@ -176,15 +176,13 @@ func (s *Server) publishBareEnvelope(ctx context.Context, w http.ResponseWriter,
 	w.WriteHeader(http.StatusOK)
 }
 
-// writeEnvelopePublishError maps the v1alpha1 publish outcome to the spec status codes:
-// InvalidArgument/FailedPrecondition -> 400, Aborted -> 202 (broadcast ok, import failed).
+// writeEnvelopePublishError maps the v1alpha1 publish outcome to the spec status codes,
+// InvalidArgument/FailedPrecondition -> 400.
 func writeEnvelopePublishError(w http.ResponseWriter, err error) {
 	if st, ok := status.FromError(err); ok {
 		switch st.Code() {
 		case codes.InvalidArgument, codes.FailedPrecondition:
 			httputil.HandleError(w, st.Message(), http.StatusBadRequest)
-		case codes.Aborted:
-			httputil.HandleError(w, st.Message(), http.StatusAccepted)
 		default:
 			httputil.HandleError(w, st.Message(), http.StatusInternalServerError)
 		}

--- a/beacon-chain/rpc/eth/beacon/handlers_gloas_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_gloas_test.go
@@ -328,32 +328,6 @@ func TestPublishExecutionPayloadEnvelope_StatelessContents_NoBlobs(t *testing.T)
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
-// DB integration failed -> Aborted maps to 202.
-func TestPublishExecutionPayloadEnvelope_ImportFailureReturns202(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	signed := testSignedEnvelope()
-	contents, err := structs.SignedExecutionPayloadEnvelopeContentsFromConsensus(signed, nil, nil)
-	require.NoError(t, err)
-	body, err := json.Marshal(contents)
-	require.NoError(t, err)
-
-	v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-	v1alpha1Server.EXPECT().PublishExecutionPayloadEnvelope(
-		gomock.Any(), gomock.Any(),
-	).Return(nil, status.Error(codes.Aborted, "import failed"))
-
-	s := &Server{V1Alpha1ValidatorServer: v1alpha1Server}
-	wireEnvelopeGossipDeps(t, s)
-	req := httptest.NewRequest(http.MethodPost, "/eth/v1/beacon/execution_payload_envelope", bytes.NewReader(body))
-	req.Header.Set(api.VersionHeader, version.String(version.Gloas))
-	req.Header.Set(api.BlobDataIncludedHeader, "true")
-	w := httptest.NewRecorder()
-	w.Body = &bytes.Buffer{}
-
-	s.PublishExecutionPayloadEnvelope(w, req)
-	require.Equal(t, http.StatusAccepted, w.Code)
-}
-
 // statelessContentsBody builds a SignedExecutionPayloadEnvelopeContents JSON
 // body with real blobs+proofs, returning the body bytes and the signed
 // envelope used to construct it.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
@@ -145,8 +145,7 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 	})
 	log.Debug("Publishing execution payload envelope")
 
-	// Broadcast sidecars BEFORE receiving the envelope so the DA check sees them. Stateless publishes
-	// carry blobs+proofs (this node may not have them cached); stateful publishes rely on the cache.
+	// KZG verification stays synchronous, never gossip unverified sidecars.
 	var sidecars []consensusblocks.RODataColumn
 	if len(blobs) > 0 {
 		sidecars, err = vs.sidecarsFromContents(blobs, kzgProofs, envSlot, beaconBlockRoot)
@@ -156,8 +155,19 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 	} else if cached, ok := vs.ExecutionPayloadEnvelopeCache.Contents(); ok && cached.Envelope.Payload.SlotNumber == envSlot {
 		sidecars = cached.DataColumns
 	}
-	if len(sidecars) > 0 {
-		if err := vs.broadcastAndReceiveDataColumns(ctx, sidecars, nil); err != nil {
+
+	roSigned, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(signed)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not wrap signed envelope: %v", err)
+	}
+
+	// Locally built or verified above, safe to upgrade.
+	verifiedSidecars := make([]consensusblocks.VerifiedRODataColumn, 0, len(sidecars))
+	for _, sidecar := range sidecars {
+		verifiedSidecars = append(verifiedSidecars, consensusblocks.NewVerifiedRODataColumn(sidecar))
+	}
+	if len(verifiedSidecars) > 0 {
+		if err := vs.P2P.BroadcastDataColumnSidecars(ctx, verifiedSidecars, nil); err != nil {
 			log.WithError(err).Error("Failed to broadcast Gloas data column sidecars")
 		}
 	}
@@ -166,18 +176,27 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 		return nil, status.Errorf(codes.Internal, "failed to broadcast execution payload envelope: %v", err)
 	}
 
-	roSigned, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(signed)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not wrap signed envelope: %v", err)
-	}
-	if err := vs.ExecutionPayloadEnvelopeReceiver.ReceiveExecutionPayloadEnvelope(ctx, roSigned); err != nil {
-		// Broadcast already succeeded; import failed. REST maps Aborted -> 202.
-		return nil, status.Errorf(codes.Aborted, "failed to receive execution payload envelope: %v", err)
-	}
+	// Import in the background so the reveal is not delayed past the PTC deadline.
+	go vs.importPublishedEnvelope(log, verifiedSidecars, roSigned)
 
 	log.WithField("duration", time.Since(start)).Info("Published execution payload envelope")
 
 	return &emptypb.Empty{}, nil
+}
+
+// Sidecars first, the DA check needs them.
+func (vs *Server) importPublishedEnvelope(log *logrus.Entry, sidecars []consensusblocks.VerifiedRODataColumn, signed interfaces.ROSignedExecutionPayloadEnvelope) {
+	start := time.Now()
+	if len(sidecars) > 0 {
+		if err := vs.DataColumnReceiver.ReceiveDataColumns(sidecars); err != nil {
+			log.WithError(err).Error("Failed to receive data columns for published envelope")
+		}
+	}
+	if err := vs.ExecutionPayloadEnvelopeReceiver.ReceiveExecutionPayloadEnvelope(vs.Ctx, signed); err != nil {
+		log.WithError(err).Error("Failed to import published execution payload envelope")
+		return
+	}
+	log.WithField("duration", time.Since(start)).Debug("Imported published execution payload envelope")
 }
 
 // resolveEnvelopeToPublish extracts the signed envelope plus any caller-supplied blobs. The stateful

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope_test.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"context"
 	"math/big"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
@@ -290,8 +292,9 @@ func TestPublishExecutionPayloadEnvelope_SignedEnvelopeArm(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		broadcaster := &mockp2p.MockBroadcaster{}
-		receiver := &mockExecutionPayloadEnvelopeReceiver{}
+		receiver := &mockExecutionPayloadEnvelopeReceiver{done: make(chan struct{})}
 		vs := &Server{
+			Ctx:                              t.Context(),
 			P2P:                              broadcaster,
 			ExecutionPayloadEnvelopeReceiver: receiver,
 			ExecutionPayloadEnvelopeCache:    cache.NewExecutionPayloadEnvelopeCache(),
@@ -301,7 +304,8 @@ func TestPublishExecutionPayloadEnvelope_SignedEnvelopeArm(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, true, broadcaster.BroadcastCalled.Load())
-		require.Equal(t, 1, receiver.calls)
+		waitForEnvelopeImport(t, receiver)
+		require.Equal(t, int32(1), receiver.calls.Load())
 	})
 }
 
@@ -312,8 +316,9 @@ func TestPublishExecutionPayloadEnvelope_Success(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	broadcaster := &mockp2p.MockBroadcaster{}
-	receiver := &mockExecutionPayloadEnvelopeReceiver{}
+	receiver := &mockExecutionPayloadEnvelopeReceiver{done: make(chan struct{})}
 	vs := &Server{
+		Ctx:                              t.Context(),
 		P2P:                              broadcaster,
 		ExecutionPayloadEnvelopeReceiver: receiver,
 	}
@@ -349,18 +354,20 @@ func TestPublishExecutionPayloadEnvelope_Success(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
 	require.Equal(t, 1, len(broadcaster.BroadcastMessages))
-	require.Equal(t, 1, receiver.calls)
+	waitForEnvelopeImport(t, receiver)
+	require.Equal(t, int32(1), receiver.calls.Load())
 }
 
-func TestPublishExecutionPayloadEnvelope_ImportFailureIsAborted(t *testing.T) {
+func TestPublishExecutionPayloadEnvelope_ImportFailureDoesNotFailPublish(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig().Copy()
 	cfg.GloasForkEpoch = 0
 	params.OverrideBeaconConfig(cfg)
 
 	broadcaster := &mockp2p.MockBroadcaster{}
-	receiver := &mockExecutionPayloadEnvelopeReceiver{err: errors.New("import failed")}
+	receiver := &mockExecutionPayloadEnvelopeReceiver{err: errors.New("import failed"), done: make(chan struct{})}
 	vs := &Server{
+		Ctx:                              t.Context(),
 		P2P:                              broadcaster,
 		ExecutionPayloadEnvelopeReceiver: receiver,
 	}
@@ -386,23 +393,37 @@ func TestPublishExecutionPayloadEnvelope_ImportFailureIsAborted(t *testing.T) {
 		Signature: make([]byte, 96),
 	}
 
-	_, err := vs.PublishExecutionPayloadEnvelope(t.Context(), &ethpb.GenericSignedExecutionPayloadEnvelope{
+	resp, err := vs.PublishExecutionPayloadEnvelope(t.Context(), &ethpb.GenericSignedExecutionPayloadEnvelope{
 		Envelope: &ethpb.GenericSignedExecutionPayloadEnvelope_Contents{
 			Contents: &ethpb.SignedExecutionPayloadEnvelopeContents{SignedExecutionPayloadEnvelope: req},
 		},
 	})
-	require.NotNil(t, err)
-	// Broadcast must have happened before the import failure (spec 202).
+	// Background import failure must not fail the publish.
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
-	require.Equal(t, codes.Aborted, status.Code(err))
+	waitForEnvelopeImport(t, receiver)
 }
 
 type mockExecutionPayloadEnvelopeReceiver struct {
-	calls int
+	calls atomic.Int32
 	err   error
+	done  chan struct{}
 }
 
 func (m *mockExecutionPayloadEnvelopeReceiver) ReceiveExecutionPayloadEnvelope(_ context.Context, _ interfaces.ROSignedExecutionPayloadEnvelope) error {
-	m.calls++
+	m.calls.Add(1)
+	if m.done != nil {
+		close(m.done)
+	}
 	return m.err
+}
+
+func waitForEnvelopeImport(t *testing.T, m *mockExecutionPayloadEnvelopeReceiver) {
+	t.Helper()
+	select {
+	case <-m.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for background envelope import")
+	}
 }

--- a/changelog/terence_async-envelope-publish.md
+++ b/changelog/terence_async-envelope-publish.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Envelope publish endpoint now returns after broadcast, moving local import off the RPC path.


### PR DESCRIPTION
- `PublishExecutionPayloadEnvelope` now returns once the data column sidecars and envelope are broadcast, and runs the local import (column receive + envelope import) in a background goroutine
- The synchronous import blocked the submission response on EL newPayload + forkchoice, delaying builder envelope reveals past the PTC deadline; on glamsterdam-devnet-7 every PTC-voted-missing payload traced to this (builder configured to reveal at 4s)
- KZG verification of caller-supplied blobs stays synchronous so unverified sidecars are never gossiped, import failures are logged instead of returning Aborted