### PR TITLE
fix(e2e): make voluntary-exit selection deterministic

### DIFF
--- a/changelog/preston_fix-e2e-exit-evaluator-infinite-loop.md
+++ b/changelog/preston_fix-e2e-exit-evaluator-infinite-loop.md
@@ -1,3 +1,3 @@
 ### Ignored
 
-- Fixed an infinite loop in the `proposeVoluntaryExit` e2e evaluator that caused `//testing/endtoend:postsubmit` mainnet tests to hang until the bazel test timeout.
+- Fixed an infinite loop in the `proposeVoluntaryExit` E2E evaluator that caused `//testing/endtoend:postsubmit` mainnet tests to hang until the Bazel test timeout.

--- a/changelog/preston_fix-e2e-exit-evaluator-infinite-loop.md
+++ b/changelog/preston_fix-e2e-exit-evaluator-infinite-loop.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Fixed an infinite loop in the `proposeVoluntaryExit` e2e evaluator that caused `//testing/endtoend:postsubmit` mainnet tests to hang until the bazel test timeout.

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,6 @@ require (
 	go.uber.org/automaxprocs v1.5.2
 	go.uber.org/mock v0.5.2
 	golang.org/x/crypto v0.48.0
-	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476
 	golang.org/x/sync v0.19.0
 	golang.org/x/tools v0.41.0
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
@@ -256,6 +255,7 @@ require (
 	go.uber.org/fx v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.50.0 // indirect

--- a/testing/endtoend/evaluators/BUILD.bazel
+++ b/testing/endtoend/evaluators/BUILD.bazel
@@ -59,7 +59,6 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-        "@org_golang_x_exp//rand:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/testing/endtoend/evaluators/operations.go
+++ b/testing/endtoend/evaluators/operations.go
@@ -488,6 +488,7 @@ func proposeVoluntaryExit(ec *e2etypes.EvaluationContext, conns ...*grpc.ClientC
 		return err
 	}
 
+	exitsSubmitted := 0
 	var sendExit = func(exitedIndex primitives.ValidatorIndex) error {
 		voluntaryExit := &ethpb.VoluntaryExit{
 			Epoch:          chainHead.HeadEpoch,
@@ -516,6 +517,7 @@ func proposeVoluntaryExit(ec *e2etypes.EvaluationContext, conns ...*grpc.ClientC
 		}
 		pubk := bytesutil.ToBytes48(deposits[exitedIndex].Data.PublicKey)
 		ec.ExitedVals[pubk] = chainHead.HeadEpoch // Store submission epoch
+		exitsSubmitted++
 		return nil
 	}
 
@@ -536,6 +538,13 @@ func proposeVoluntaryExit(ec *e2etypes.EvaluationContext, conns ...*grpc.ClientC
 		}
 	}
 
+	return ensureVoluntaryExitSubmitted(exitsSubmitted)
+}
+
+func ensureVoluntaryExitSubmitted(count int) error {
+	if count == 0 {
+		return errors.New("no eligible validators available for voluntary exit")
+	}
 	return nil
 }
 

--- a/testing/endtoend/evaluators/operations.go
+++ b/testing/endtoend/evaluators/operations.go
@@ -28,7 +28,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/rand"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -95,7 +94,7 @@ var DepositedValidatorsAreActive = e2etypes.Evaluator{
 	Evaluation: depositedValidatorsAreActive,
 }
 
-// ProposeVoluntaryExit sends a voluntary exit from randomly selected validator in the genesis set.
+// ProposeVoluntaryExit submits voluntary exits for eligible validators in the genesis set.
 // Uses the default exit submission epoch (7).
 var ProposeVoluntaryExit = ProposeVoluntaryExitAtEpoch(defaultExitSubmissionEpoch)
 
@@ -527,23 +526,48 @@ func proposeVoluntaryExit(ec *e2etypes.EvaluationContext, conns ...*grpc.ClientC
 		}
 	}
 
-	// Send an exit for a non-exited validator.
-	for i := 0; i < numOfExits; {
-		randIndex := primitives.ValidatorIndex(rand.Uint64() % params.BeaconConfig().MinGenesisActiveValidatorCount)
-		randKey := bytesutil.ToBytes48(privKeys[randIndex].PublicKey().Marshal())
-		if _, alreadyExited := ec.ExitedVals[randKey]; alreadyExited {
-			continue
-		}
-		if syncCommitteeKeys[randKey] {
-			continue
-		}
-		if err := sendExit(randIndex); err != nil {
+	keys := make([][48]byte, len(privKeys))
+	for i, key := range privKeys {
+		keys[i] = bytesutil.ToBytes48(key.PublicKey().Marshal())
+	}
+	for _, candidate := range selectVoluntaryExitCandidates(keys, ec.ExitedVals, syncCommitteeKeys, numOfExits) {
+		if err := sendExit(candidate); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
+}
+
+func selectVoluntaryExitCandidates(keys [][48]byte, exited map[[48]byte]primitives.Epoch, reserved map[[48]byte]bool, limit int) []primitives.ValidatorIndex {
+	if limit <= 0 {
+		return nil
+	}
+
+	preferred := make([]primitives.ValidatorIndex, 0, limit)
+	fallback := make([]primitives.ValidatorIndex, 0, limit)
+	for i, key := range keys {
+		if _, alreadyExited := exited[key]; alreadyExited {
+			continue
+		}
+		if reserved[key] {
+			fallback = append(fallback, primitives.ValidatorIndex(i))
+			continue
+		}
+		preferred = append(preferred, primitives.ValidatorIndex(i))
+		if len(preferred) == limit {
+			return preferred
+		}
+	}
+
+	// With the mainnet E2E configuration, the sync committee contains every
+	// validator. Prefer non-members when they exist, but fall back to committee
+	// members so the voluntary-exit scenario still exercises exits and withdrawals.
+	candidates := append(preferred, fallback...)
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	return candidates
 }
 
 func validatorsHaveExited(ec *e2etypes.EvaluationContext, conns ...*grpc.ClientConn) error {

--- a/testing/endtoend/evaluators/operations_test.go
+++ b/testing/endtoend/evaluators/operations_test.go
@@ -40,24 +40,6 @@ func TestValidatorsVoteWithTheMajoritySortsBlocksBySlot(t *testing.T) {
 	require.Equal(t, true, string(ec.ExpectedEth1DataVote) == string(vote))
 }
 
-func TestSelectVoluntaryExitCandidatesFallsBackWhenAllKeysAreReserved(t *testing.T) {
-	keys := [][48]byte{{1}, {2}}
-	reserved := map[[48]byte]bool{{1}: true, {2}: true}
-	exited := map[[48]byte]primitives.Epoch{}
-
-	candidates := selectVoluntaryExitCandidates(keys, exited, reserved, 1)
-	require.DeepEqual(t, []primitives.ValidatorIndex{0}, candidates)
-}
-
-func TestSelectVoluntaryExitCandidatesPrefersUnreservedKeys(t *testing.T) {
-	keys := [][48]byte{{1}, {2}, {3}}
-	exited := map[[48]byte]primitives.Epoch{{1}: 1}
-	reserved := map[[48]byte]bool{{2}: true}
-
-	candidates := selectVoluntaryExitCandidates(keys, exited, reserved, 2)
-	require.DeepEqual(t, []primitives.ValidatorIndex{2, 1}, candidates)
-}
-
 func TestSelectVoluntaryExitCandidatesBoundaries(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/testing/endtoend/evaluators/operations_test.go
+++ b/testing/endtoend/evaluators/operations_test.go
@@ -133,6 +133,37 @@ func TestSelectVoluntaryExitCandidatesBoundaries(t *testing.T) {
 	}
 }
 
+func TestEnsureVoluntaryExitSubmitted(t *testing.T) {
+	tests := []struct {
+		name      string
+		count     int
+		wantError string
+	}{
+		{
+			name:      "returns an error when no exits are submitted",
+			wantError: "no eligible validators available for voluntary exit",
+		},
+		{
+			name:  "allows one submitted exit",
+			count: 1,
+		},
+		{
+			name:  "allows multiple submitted exits",
+			count: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ensureVoluntaryExitSubmitted(test.count)
+			if test.wantError != "" {
+				require.ErrorContains(t, test.wantError, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func phase0BlockContainer(slot primitives.Slot, vote []byte) *ethpb.BeaconBlockContainer {
 	return &ethpb.BeaconBlockContainer{
 		Block: &ethpb.BeaconBlockContainer_Phase0Block{

--- a/testing/endtoend/evaluators/operations_test.go
+++ b/testing/endtoend/evaluators/operations_test.go
@@ -40,6 +40,99 @@ func TestValidatorsVoteWithTheMajoritySortsBlocksBySlot(t *testing.T) {
 	require.Equal(t, true, string(ec.ExpectedEth1DataVote) == string(vote))
 }
 
+func TestSelectVoluntaryExitCandidatesFallsBackWhenAllKeysAreReserved(t *testing.T) {
+	keys := [][48]byte{{1}, {2}}
+	reserved := map[[48]byte]bool{{1}: true, {2}: true}
+	exited := map[[48]byte]primitives.Epoch{}
+
+	candidates := selectVoluntaryExitCandidates(keys, exited, reserved, 1)
+	require.DeepEqual(t, []primitives.ValidatorIndex{0}, candidates)
+}
+
+func TestSelectVoluntaryExitCandidatesPrefersUnreservedKeys(t *testing.T) {
+	keys := [][48]byte{{1}, {2}, {3}}
+	exited := map[[48]byte]primitives.Epoch{{1}: 1}
+	reserved := map[[48]byte]bool{{2}: true}
+
+	candidates := selectVoluntaryExitCandidates(keys, exited, reserved, 2)
+	require.DeepEqual(t, []primitives.ValidatorIndex{2, 1}, candidates)
+}
+
+func TestSelectVoluntaryExitCandidatesBoundaries(t *testing.T) {
+	tests := []struct {
+		name     string
+		keys     [][48]byte
+		exited   map[[48]byte]primitives.Epoch
+		reserved map[[48]byte]bool
+		limit    int
+		wantNil  bool
+		want     []primitives.ValidatorIndex
+	}{
+		{
+			name:    "returns nil for zero limit",
+			keys:    [][48]byte{{1}},
+			limit:   0,
+			wantNil: true,
+		},
+		{
+			name:    "returns nil for negative limit",
+			keys:    [][48]byte{{1}},
+			limit:   -1,
+			wantNil: true,
+		},
+		{
+			name:  "returns empty candidates for empty keys",
+			limit: 1,
+			want:  []primitives.ValidatorIndex{},
+		},
+		{
+			name:  "returns fewer eligible candidates than limit",
+			keys:  [][48]byte{{1}, {2}},
+			limit: 3,
+			want:  []primitives.ValidatorIndex{0, 1},
+		},
+		{
+			name:   "skips exited keys",
+			keys:   [][48]byte{{1}, {2}},
+			exited: map[[48]byte]primitives.Epoch{{1}: 1},
+			limit:  1,
+			want:   []primitives.ValidatorIndex{1},
+		},
+		{
+			name:     "falls back when all keys are reserved",
+			keys:     [][48]byte{{1}, {2}},
+			reserved: map[[48]byte]bool{{1}: true, {2}: true},
+			limit:    2,
+			want:     []primitives.ValidatorIndex{0, 1},
+		},
+		{
+			name:     "prefers unreserved keys before reserved keys",
+			keys:     [][48]byte{{1}, {2}, {3}},
+			exited:   map[[48]byte]primitives.Epoch{{1}: 1},
+			reserved: map[[48]byte]bool{{2}: true},
+			limit:    2,
+			want:     []primitives.ValidatorIndex{2, 1},
+		},
+		{
+			name:   "selects first and last indices",
+			keys:   [][48]byte{{1}, {2}, {3}},
+			exited: map[[48]byte]primitives.Epoch{{2}: 1},
+			limit:  2,
+			want:   []primitives.ValidatorIndex{0, 2},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidates := selectVoluntaryExitCandidates(test.keys, test.exited, test.reserved, test.limit)
+			if test.wantNil {
+				require.Equal(t, true, candidates == nil)
+				return
+			}
+			require.DeepEqual(t, test.want, candidates)
+		})
+	}
+}
+
 func phase0BlockContainer(slot primitives.Slot, vote []byte) *ethpb.BeaconBlockContainer {
 	return &ethpb.BeaconBlockContainer{
 		Block: &ethpb.BeaconBlockContainer_Phase0Block{


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The voluntary-exit evaluator previously used `rand.Intn` to pick a validator, which made test runs non-deterministic and could silently skip the exit scenario when all selected candidates happened to be in the upcoming sync committee with no fallback.

This PR makes selection deterministic and bounded:

- Eligible validators are iterated in index order so every run picks the same candidate given the same state.
- Validators outside the upcoming sync committee are preferred. When every eligible validator is in the committee, the evaluator falls back to those reserved candidates rather than skipping the scenario entirely.
- If no exit is successfully submitted after both the execution-credential path and the selected-candidate path run, the evaluator now returns an explicit `no eligible validators available for voluntary exit` error instead of silently succeeding.
- The `rand` import is removed from the evaluator.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Testing performed:

- Evaluator selector unit tests ran three times uncached (verbose Bazel) and once with `-race` and randomized test order; all passed.
- Minimal e2e voluntary-exit chain passed: proposal, exited, withdrawal-submission, and withdrawn evaluators all green.
- Mainnet-style exit chain passed in all three attempts for the voluntary-exit proposal, exited, and withdrawal-submission evaluators.
- The mainnet parent target was nonzero across all three runs solely because the unrelated `blobs_included_in_blocks_epoch_13` evaluator reported no blobs in epoch 12. This PR does not claim a fully green mainnet parent target.
- `make build` and `gopls`/Gazelle checks passed.
- The zero-submission guard is covered by a table-driven test that checks the explicit error and the one- and two-submission success cases.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
