### PR TITLE
fix(e2e): isolate blob transactions across Fulu boundary

### DIFF
--- a/changelog/preston_fix-e2e-blob-txs-deneb-to-fulu.md
+++ b/changelog/preston_fix-e2e-blob-txs-deneb-to-fulu.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Restored blob transaction generation between the Deneb and Fulu forks in e2e tests, using a dedicated sender account so V0 sidecar leftovers at the Osaka boundary cannot block post-Fulu cell-proof transactions.

--- a/testing/endtoend/components/eth1/BUILD.bazel
+++ b/testing/endtoend/components/eth1/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//beacon-chain/startup:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "//contracts/deposit:go_default_library",
         "//crypto/rand:go_default_library",
         "//encoding/bytesutil:go_default_library",
@@ -48,7 +49,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["depositor_test.go"],
+    srcs = [
+        "depositor_test.go",
+        "transactions_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//config/params:go_default_library",

--- a/testing/endtoend/components/eth1/transactions.go
+++ b/testing/endtoend/components/eth1/transactions.go
@@ -102,13 +102,16 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 		return err
 	}
 	fundedAccount = newKey
-	v0Key := keystore.NewKeyForDirectICAP(newGen)
-	if err := fundAccount(client, mineKey, v0Key); err != nil {
-		return err
+	cfg := params.BeaconConfig()
+	needsBlobV0Account := needsDedicatedBlobV0Account(cfg)
+	if needsBlobV0Account {
+		v0Key := keystore.NewKeyForDirectICAP(newGen)
+		if err := fundAccount(client, mineKey, v0Key); err != nil {
+			return err
+		}
+		blobV0Account = v0Key
 	}
-	blobV0Account = v0Key
-	// Ensure funding tx is mined before generating txs that rely on balance.
-	// Mine 1 block using the miner key to include the funding transfer.
+	// Mine one block to confirm pending account funding before generating transactions.
 	backend := ethclient.NewClient(client)
 	defer backend.Close()
 
@@ -117,13 +120,15 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 	}
 
 	// Ensure the funded account has a comfortable minimum balance for blob and fuzzed txs.
-	minWei := new(big.Int).Mul(big.NewInt(1000), big.NewInt(0).SetUint64(params.BeaconConfig().GweiPerEth))
+	minWei := new(big.Int).Mul(big.NewInt(1000), big.NewInt(0).SetUint64(cfg.GweiPerEth))
 	minWei.Mul(minWei, big.NewInt(1e9)) // 1000 ETH in wei
 	if err := ensureMinBalance(ctx, client, backend, mineKey, fundedAccount, minWei); err != nil {
 		return err
 	}
-	if err := ensureMinBalance(ctx, client, backend, mineKey, blobV0Account, minWei); err != nil {
-		return err
+	if needsBlobV0Account {
+		if err := ensureMinBalance(ctx, client, backend, mineKey, blobV0Account, minWei); err != nil {
+			return err
+		}
 	}
 	// Broadcast Transactions every slot
 	txPeriod := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
@@ -304,7 +309,11 @@ func blobTransactionModeAtEpoch(epoch primitives.Epoch, cfg *params.BeaconChainC
 }
 
 func useDedicatedBlobV0Account(mode blobTransactionMode, cfg *params.BeaconChainConfig) bool {
-	return mode == blobTransactionsWithSidecars && cfg.FuluForkEpoch != cfg.FarFutureEpoch
+	return mode == blobTransactionsWithSidecars && needsDedicatedBlobV0Account(cfg)
+}
+
+func needsDedicatedBlobV0Account(cfg *params.BeaconChainConfig) bool {
+	return cfg.FuluForkEpoch != cfg.FarFutureEpoch
 }
 
 // Pause pauses the component and its underlying process.

--- a/testing/endtoend/components/eth1/transactions.go
+++ b/testing/endtoend/components/eth1/transactions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/rand"
 	e2e "github.com/OffchainLabs/prysm/v7/testing/endtoend/params"
 	"github.com/ethereum/go-ethereum"
@@ -33,6 +34,20 @@ import (
 const txCount = 20
 
 var fundedAccount *keystore.Key
+
+// blobV0Account sends pre-Fulu V0 sidecar blob transactions when Fulu is
+// scheduled. V0 sidecars left in the pool at the Osaka boundary become invalid
+// under geth >= v1.17, so they must not share an account with post-Fulu V1
+// cell-proof transactions.
+var blobV0Account *keystore.Key
+
+type blobTransactionMode uint8
+
+const (
+	blobTransactionsDisabled blobTransactionMode = iota
+	blobTransactionsWithSidecars
+	blobTransactionsWithCellProofs
+)
 
 type TransactionGenerator struct {
 	keystore      string
@@ -87,6 +102,11 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 		return err
 	}
 	fundedAccount = newKey
+	v0Key := keystore.NewKeyForDirectICAP(newGen)
+	if err := fundAccount(client, mineKey, v0Key); err != nil {
+		return err
+	}
+	blobV0Account = v0Key
 	// Ensure funding tx is mined before generating txs that rely on balance.
 	// Mine 1 block using the miner key to include the funding transfer.
 	backend := ethclient.NewClient(client)
@@ -100,6 +120,9 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 	minWei := new(big.Int).Mul(big.NewInt(1000), big.NewInt(0).SetUint64(params.BeaconConfig().GweiPerEth))
 	minWei.Mul(minWei, big.NewInt(1e9)) // 1000 ETH in wei
 	if err := ensureMinBalance(ctx, client, backend, mineKey, fundedAccount, minWei); err != nil {
+		return err
+	}
+	if err := ensureMinBalance(ctx, client, backend, mineKey, blobV0Account, minWei); err != nil {
 		return err
 	}
 	// Broadcast Transactions every slot
@@ -149,18 +172,13 @@ func SendTransaction(client *rpc.Client, key *ecdsa.PrivateKey, gasPrice *big.In
 
 	cfg := params.BeaconConfig()
 	clock := startup.NewClock(e2e.TestParams.CLGenesisTime, [32]byte{})
-	isPostFulu := clock.CurrentEpoch() >= cfg.FuluForkEpoch
-	// Skip pre-Fulu V0 sends only when Fulu is scheduled: V0 sidecars left in
-	// the pool at the Osaka boundary become invalid under geth >= v1.17 and
-	// occupy maxTxsPerAccount=16, blocking later V1 cell-proof txs. When Fulu
-	// is never scheduled (Deneb/Electra-only tests), V0 is the only path.
-	fuluScheduled := cfg.FuluForkEpoch != cfg.FarFutureEpoch
+	blobMode := blobTransactionModeAtEpoch(clock.CurrentEpoch(), cfg)
 
 	g, _ := errgroup.WithContext(context.Background())
 	var txs []*types.Transaction
 
-	switch {
-	case isPostFulu:
+	switch blobMode {
+	case blobTransactionsWithCellProofs:
 		logrus.Info("Sending blob transactions with cell proofs")
 		txs = make([]*types.Transaction, 5)
 		for index := range uint64(5) {
@@ -177,18 +195,26 @@ func SendTransaction(client *rpc.Client, key *ecdsa.PrivateKey, gasPrice *big.In
 				return nil
 			})
 		}
-	case !fuluScheduled:
+	case blobTransactionsWithSidecars:
+		blobSender := fundedAccount
+		if useDedicatedBlobV0Account(blobMode, cfg) {
+			blobSender = blobV0Account
+			nonce, err = backend.PendingNonceAt(context.Background(), blobSender.Address)
+			if err != nil {
+				return err
+			}
+		}
 		logrus.Info("Sending blob transactions with sidecars")
 		txs = make([]*types.Transaction, 5)
 		for index := range uint64(5) {
 			g.Go(func() error {
-				tx, err := RandomBlobTx(client, fundedAccount.Address, nonce+index, gasPrice, chainid, al, useLargeBlobs)
+				tx, err := RandomBlobTx(client, blobSender.Address, nonce+index, gasPrice, chainid, al, useLargeBlobs)
 				if err != nil {
 					logrus.WithError(err).Error("Could not create blob tx")
 					//nolint:nilerr
 					return nil
 				}
-				signedTx, err := types.SignTx(tx, types.NewCancunSigner(chainid), fundedAccount.PrivateKey)
+				signedTx, err := types.SignTx(tx, types.NewCancunSigner(chainid), blobSender.PrivateKey)
 				if err != nil {
 					logrus.WithError(err).Error("Could not sign blob tx")
 					//nolint:nilerr
@@ -198,6 +224,7 @@ func SendTransaction(client *rpc.Client, key *ecdsa.PrivateKey, gasPrice *big.In
 				return nil
 			})
 		}
+	case blobTransactionsDisabled:
 	}
 
 	if err := g.Wait(); err != nil {
@@ -264,6 +291,20 @@ func SendTransaction(client *rpc.Client, key *ecdsa.PrivateKey, gasPrice *big.In
 		}
 	}
 	return nil
+}
+
+func blobTransactionModeAtEpoch(epoch primitives.Epoch, cfg *params.BeaconChainConfig) blobTransactionMode {
+	if epoch < cfg.DenebForkEpoch {
+		return blobTransactionsDisabled
+	}
+	if epoch >= cfg.FuluForkEpoch {
+		return blobTransactionsWithCellProofs
+	}
+	return blobTransactionsWithSidecars
+}
+
+func useDedicatedBlobV0Account(mode blobTransactionMode, cfg *params.BeaconChainConfig) bool {
+	return mode == blobTransactionsWithSidecars && cfg.FuluForkEpoch != cfg.FarFutureEpoch
 }
 
 // Pause pauses the component and its underlying process.

--- a/testing/endtoend/components/eth1/transactions_test.go
+++ b/testing/endtoend/components/eth1/transactions_test.go
@@ -37,3 +37,15 @@ func TestUseDedicatedBlobV0Account(t *testing.T) {
 	cfg.FuluForkEpoch = cfg.FarFutureEpoch
 	require.Equal(t, false, useDedicatedBlobV0Account(blobTransactionsWithSidecars, cfg))
 }
+
+func TestNeedsDedicatedBlobV0Account(t *testing.T) {
+	cfg := &params.BeaconChainConfig{
+		FuluForkEpoch:  16,
+		FarFutureEpoch: math.MaxUint64,
+	}
+
+	require.Equal(t, true, needsDedicatedBlobV0Account(cfg))
+
+	cfg.FuluForkEpoch = cfg.FarFutureEpoch
+	require.Equal(t, false, needsDedicatedBlobV0Account(cfg))
+}

--- a/testing/endtoend/components/eth1/transactions_test.go
+++ b/testing/endtoend/components/eth1/transactions_test.go
@@ -1,0 +1,39 @@
+package eth1
+
+import (
+	"math"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func TestBlobTransactionModeAtEpoch(t *testing.T) {
+	cfg := &params.BeaconChainConfig{
+		DenebForkEpoch: 12,
+		FuluForkEpoch:  math.MaxUint64,
+		FarFutureEpoch: math.MaxUint64,
+	}
+
+	require.Equal(t, blobTransactionsDisabled, blobTransactionModeAtEpoch(cfg.DenebForkEpoch-1, cfg))
+	require.Equal(t, blobTransactionsWithSidecars, blobTransactionModeAtEpoch(cfg.DenebForkEpoch, cfg))
+
+	cfg.FuluForkEpoch = 16
+	require.Equal(t, blobTransactionsWithSidecars, blobTransactionModeAtEpoch(cfg.DenebForkEpoch, cfg))
+	require.Equal(t, blobTransactionsWithSidecars, blobTransactionModeAtEpoch(cfg.FuluForkEpoch-2, cfg))
+	require.Equal(t, blobTransactionsWithSidecars, blobTransactionModeAtEpoch(cfg.FuluForkEpoch-1, cfg))
+	require.Equal(t, blobTransactionsWithCellProofs, blobTransactionModeAtEpoch(cfg.FuluForkEpoch, cfg))
+}
+
+func TestUseDedicatedBlobV0Account(t *testing.T) {
+	cfg := &params.BeaconChainConfig{
+		FuluForkEpoch:  16,
+		FarFutureEpoch: math.MaxUint64,
+	}
+
+	require.Equal(t, true, useDedicatedBlobV0Account(blobTransactionsWithSidecars, cfg))
+	require.Equal(t, false, useDedicatedBlobV0Account(blobTransactionsWithCellProofs, cfg))
+
+	cfg.FuluForkEpoch = cfg.FarFutureEpoch
+	require.Equal(t, false, useDedicatedBlobV0Account(blobTransactionsWithSidecars, cfg))
+}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Previously, pre-Fulu V0 blob sidecars were suppressed when Fulu was scheduled.
This change restores those pre-Fulu transactions while assigning them a
dedicated account. Stale V0 transactions can no longer exhaust the per-account
transaction pool and block post-Fulu V1 cell-proof transactions from the main
sender.

**Which issue(s) does this PR fix?**

N/A - focused E2E bug fix.

**Other notes for review**

Testing:

- `//testing/endtoend/components/eth1:go_default_test` with verbose output,
  including `TestBlobTransactionModeAtEpoch` and
  `TestUseDedicatedBlobV0Account`.
- `//testing/endtoend:go_minimal_postmerge_test` with
  `TestEndToEnd_MinimalConfig_PostMerge` for the pre-Fulu V0-sidecar path.
- `//testing/endtoend:go_default_test` with `TestEndToEnd_MinimalConfig` for
  the post-Fulu V1 cell-proof path.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).
