### PR TITLE
Skip payload attestation quietly when no block exists for the slot

### DIFF
--- a/changelog/terence_ptc-skip-no-block-log.md
+++ b/changelog/terence_ptc-skip-no-block-log.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Validator now skips payload attestation with an info log instead of an error when no block exists for the slot.

--- a/validator/client/log_test.go
+++ b/validator/client/log_test.go
@@ -96,7 +96,7 @@ func TestFromAttData(t *testing.T) {
 	require.NoError(t, key2.FromAttData(att2.Data))
 	assert.NotEqual(t, key, key2, "distinct att data must produce distinct keys")
 }
-  
+
 func TestLogSubmittedSyncCommitteeMessages(t *testing.T) {
 	logHook := logTest.NewGlobal()
 	v := validator{}

--- a/validator/client/payload_attestation.go
+++ b/validator/client/payload_attestation.go
@@ -44,6 +44,12 @@ func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitive
 			tracing.AnnotateError(span, err)
 			return
 		}
+		if status.Code(errors.Cause(err)) == codes.NotFound {
+			validatorPayloadAttestationSubmissionTotal.WithLabelValues("skipped_no_block").Inc()
+			log.WithField("slot", slot).Info("Skipping payload attestation: no block for slot")
+			tracing.AnnotateError(span, err)
+			return
+		}
 		validatorPayloadAttestationSubmissionTotal.WithLabelValues("failed").Inc()
 		log.WithError(err).Error("Could not request payload attestation data")
 		tracing.AnnotateError(span, err)


### PR DESCRIPTION
- the beacon returns NoContent (gRPC NotFound) from GetPayloadAttestationData when no block has arrived for the slot, and the VC logged it as an ERROR and counted it as failed even though there is nothing to attest to
- on glamsterdam-devnet-7 this produced 2073 VC error logs in 24h across 6 nodes
- skip with an info log and a skipped_no_block metric label instead, matching the existing Unavailable handling