### PR TITLE
math: add defensive nil check to IsValidUint256

### DIFF
--- a/changelog/AkiraTamai_fix-isvaliduint256-nil-check.md
+++ b/changelog/AkiraTamai_fix-isvaliduint256-nil-check.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix a panic in `math.IsValidUint256` when passed a nil `*big.Int`.

--- a/math/math_helper.go
+++ b/math/math_helper.go
@@ -192,5 +192,8 @@ func AddInt(i ...int) (int, error) {
 
 // IsValidUint256 given a bigint checks if the value is a valid Uint256
 func IsValidUint256(bi *big.Int) bool {
+	if bi == nil {
+		return false
+	}
 	return bi.Cmp(big.NewInt(0)) >= 0 && bi.BitLen() <= 256
 }

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -3,6 +3,7 @@ package math_test
 import (
 	"fmt"
 	stdmath "math"
+	"math/big"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/math"
@@ -472,6 +473,45 @@ func TestAddInt(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("AddInt() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIsValidUint256(t *testing.T) {
+	tests := []struct {
+		name string
+		bi   *big.Int
+		want bool
+	}{
+		{
+			name: "nil",
+			bi:   nil,
+			want: false,
+		},
+		{
+			name: "negative",
+			bi:   big.NewInt(-1),
+			want: false,
+		},
+		{
+			name: "zero",
+			bi:   big.NewInt(0),
+			want: true,
+		},
+		{
+			name: "max uint256",
+			bi:   new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)),
+			want: true,
+		},
+		{
+			name: "max uint256 plus one",
+			bi:   new(big.Int).Lsh(big.NewInt(1), 256),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, math.IsValidUint256(tt.bi))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Bug fix  (defensive: guards a potential nil-pointer panic rather than fixing an observed one) 🙇‍♂️

**What does this PR do? Why is it needed?**

Adds a defensive `nil` guard to `math.IsValidUint256(bi *big.Int)`. 

In practice a `nil` value is very unlikely to reach this function through the current call sites,
but if one ever does, `bi.Cmp(...)` dereferences a nil pointer and panics.

This change hardens the function to return `false` for `nil` instead of panicking,
and adds a regression test (`TestIsValidUint256`) covering the nil, negative, zero, 
max-uint256, and max-uint256-plus-one cases.

```
func IsValidUint256(bi *big.Int) bool {
	if bi == nil {
		return false
	}
	return bi.Cmp(big.NewInt(0)) >= 0 && bi.BitLen() <= 256
}
```

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

This is defensive hardening plus a regression test rather than a fix for an observed production crash.
 
Testing — `bazel test //math:go_default_test --keep_going --test_output=errors --flaky_test_attempts=3 --build_tests_only` passes:
 
​```
$ bazel test //math:go_default_test --keep_going --test_output=errors --flaky_test_attempts=3 --build_tests_only
//math:go_default_test                                                   PASSED in 0.0s
Executed 1 out of 1 test: 1 test passes.
​```

Without the fix (removing the nil guard and running the same test), the nil case panics, confirming the test guards the regression:
 
​```
$ bazel test //math:go_default_test --test_output=all --test_filter='TestIsValidUint256'
--- FAIL: TestIsValidUint256/nil (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
math/big.(*Int).Cmp(...)          GOROOT/src/math/big/int.go:386
math.IsValidUint256(0x0)          math/math_helper.go:195
//math:go_default_test                                                   FAILED in 0.1s
Executed 1 out of 1 test: 1 fails locally.
​```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
