### PR TITLE
Remove racy lock assertion in RPC rate limiter

### DIFF
--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -233,8 +233,7 @@ func (l *limiter) removePeer(pid peer.ID) {
 	}
 }
 
-// not to be used outside the rate limiter file as it is unsafe for concurrent usage
-// and is protected by a lock on all of its usages here.
+// Callers must hold l.RWMutex, the map is mutated by free.
 func (l *limiter) retrieveCollector(topic string) (*leakybucket.Collector, error) {
 	collector, ok := l.limiterMap[topic]
 	if !ok {

--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -9,7 +9,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/trailofbits/go-mutexasserts"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
@@ -237,9 +236,6 @@ func (l *limiter) removePeer(pid peer.ID) {
 // not to be used outside the rate limiter file as it is unsafe for concurrent usage
 // and is protected by a lock on all of its usages here.
 func (l *limiter) retrieveCollector(topic string) (*leakybucket.Collector, error) {
-	if !mutexasserts.RWMutexLocked(&l.RWMutex) && !mutexasserts.RWMutexRLocked(&l.RWMutex) {
-		return nil, errors.New("limiter.retrieveCollector: caller must hold read/write lock")
-	}
 	collector, ok := l.limiterMap[topic]
 	if !ok {
 		return nil, errors.Errorf("collector does not exist for topic %s", topic)

--- a/beacon-chain/sync/rate_limiter_test.go
+++ b/beacon-chain/sync/rate_limiter_test.go
@@ -105,10 +105,10 @@ func TestRateLimiter_ExceedRawCapacity(t *testing.T) {
 	}
 }
 
-func Test_limiter_retrieveCollector_requiresLock(t *testing.T) {
+func Test_limiter_retrieveCollector_unknownTopic(t *testing.T) {
 	l := limiter{}
 	_, err := l.retrieveCollector("")
-	require.ErrorContains(t, "caller must hold read/write lock", err)
+	require.ErrorContains(t, "collector does not exist for topic", err)
 }
 
 func TestRateLimiter_RemovePeer(t *testing.T) {

--- a/beacon-chain/sync/rate_limiter_test.go
+++ b/beacon-chain/sync/rate_limiter_test.go
@@ -105,9 +105,9 @@ func TestRateLimiter_ExceedRawCapacity(t *testing.T) {
 	}
 }
 
-func Test_limiter_retrieveCollector_unknownTopic(t *testing.T) {
+func Test_limiter_topicCollector_unknownTopic(t *testing.T) {
 	l := limiter{}
-	_, err := l.retrieveCollector("")
+	_, err := l.topicCollector("")
 	require.ErrorContains(t, "collector does not exist for topic", err)
 }
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -427,9 +427,7 @@ func TestRecentBeaconBlocksRPCHandler_HandleZeroBlocks(t *testing.T) {
 		t.Fatal("Did not receive stream within 1 sec")
 	}
 
-	r.rateLimiter.RLock() // retrieveCollector requires a lock to be held.
-	defer r.rateLimiter.RUnlock()
-	lter, err := r.rateLimiter.retrieveCollector(topic)
+	lter, err := r.rateLimiter.topicCollector(topic)
 	require.NoError(t, err)
 	assert.Equal(t, 1, int(lter.Count(stream1.Conn().RemotePeer().String())))
 }

--- a/changelog/terence_fix-rate-limiter-lock-assert.md
+++ b/changelog/terence_fix-rate-limiter-lock-assert.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Removed a racy lock assertion in the RPC rate limiter that spuriously rejected valid peer requests.


### PR DESCRIPTION
The rate limiter guards its topic map with an RWMutex, and `retrieveCollector` asserted that its caller holds the lock:

```go
if !mutexasserts.RWMutexLocked(&l.RWMutex) && !mutexasserts.RWMutexRLocked(&l.RWMutex) {
    return nil, errors.New("limiter.retrieveCollector: caller must hold read/write lock")
}
```

The reader-side check in the mutexasserts library is a raw peek at the mutex's private counter:

```go
func RWMutexRLocked(rw *sync.RWMutex) bool {
    return readerCount(rw) > 0
}
```

But that counter is not a plain headcount. Go's `RWMutex.Lock()` subtracts `1<<30` from `readerCount` the moment a writer starts waiting (its "no new readers" signal) and decodes it back when reading. The library does not decode. So:

- a goroutine holds `RLock` (readerCount = 1) and runs the assert, first read sees no writer → false
- another goroutine calls `add()` (every served RPC does), starts waiting for the write lock, readerCount flips to `1 - 1<<30`
- second read: negative is not > 0 → "no readers" → false
- both false → "nobody holds the lock" → error → a healthy peer's RPC is rejected

On glamsterdam-devnet-7 this fires ~267x/day/node on the ping and `execution_payload_envelopes_by_root` topics. Standalone repro (one goroutine holding `RLock` in a loop, 4 writers cycling `Lock`/`Unlock`) trips the assert ~10 times per 4k checks within 0.5s.

Why deleting is safe: the assert protects a single invariant, that `limiterMap` is never read while mutated. Every call site of `retrieveCollector` acquires the lock immediately before the call with a deferred unlock, so the invariant holds without the assert:

| caller | lock | lines |
|---|---|---|
| `topicCollector` | `RLock` | rate_limiter.go:117→119 |
| `validateRequest` | `RLock` | rate_limiter.go:124→130 |
| `validateRawRpcRequest` | `RLock` | rate_limiter.go:150→154 |
| `add` | `Lock` | rate_limiter.go:171→177 |
| `addRawStream` | `Lock` | rate_limiter.go:188→194 |

The only map writers are `free()` (shutdown only, under `Lock`) and the test-only `setRateCollector`. No caller outside the file remains; the test that previously locked manually now goes through `topicCollector`, the public self-locking path.

The assert is also unfixable in principle: a mutex counts readers but cannot say whether the *caller* is one of them, which is the question the assert needs answered. Even a corrected predicate would pass whenever any other goroutine holds the lock, so it cannot catch the forgotten-lock bug it was written for. The same pattern in `slashings/pool.go` is deterministically safe (all callers hold the write lock, which short-circuits the racy branch) and is left for a follow-up.