### PR TITLE
Mark pending payload envelope seen only after successful import

### DIFF
--- a/beacon-chain/sync/pending_payload_envelope.go
+++ b/beacon-chain/sync/pending_payload_envelope.go
@@ -57,12 +57,12 @@ func (s *Service) processPendingPayloadEnvelope(ctx context.Context, root [32]by
 			s.setSeenPayloadEnvelope(root, env.BuilderIndex())
 			continue
 		}
-		s.setSeenPayloadEnvelope(root, env.BuilderIndex())
 
 		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(ctx, e); err != nil {
 			log.WithError(err).Debug("Could not process pending payload envelope")
 			continue
 		}
+		s.setSeenPayloadEnvelope(root, env.BuilderIndex())
 		if err := s.cfg.p2p.Broadcast(ctx, signedEnvelope); err != nil {
 			log.WithError(err).Warn("Could not broadcast pending payload envelope")
 		}

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -159,6 +159,7 @@ func TestProcessPendingPayloadEnvelope_DoesNotBroadcastOnReceiveError(t *testing
 
 	s.processPendingPayloadEnvelope(ctx, root)
 	require.Equal(t, false, broadcaster.BroadcastCalled.Load())
+	require.Equal(t, false, s.hasSeenPayloadEnvelope(root, builderIdx))
 }
 
 func TestProcessPendingPayloadEnvelopes_Sweep(t *testing.T) {

--- a/changelog/terence_pending-envelope-seen-after-import.md
+++ b/changelog/terence_pending-envelope-seen-after-import.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Mark pending payload envelopes as seen only after successful import so transient failures can be retried.


### PR DESCRIPTION
- Pending payload envelopes were marked seen before `ReceiveExecutionPayloadEnvelope`, so a transient import failure poisoned the seen cache and blocked retries via gossip and by-root refetch.
- Mark seen only after successful import, keeping the bad-block path marked seen.