### PR TITLE
network: send trace context with engine API requests

### DIFF
--- a/changelog/fjl_rpc_traceparent.md
+++ b/changelog/fjl_rpc_traceparent.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Added support for OpenTelemetry distributed tracing. The engine API client now sends a
+  traceparent header, which can be used to correlate traces with the execution layer
+  client.

--- a/network/BUILD.bazel
+++ b/network/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
+        "@io_opentelemetry_go_otel//propagation:go_default_library",
     ],
 )
 

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/network/authorization"
 	gethRPC "github.com/ethereum/go-ethereum/rpc"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // Endpoint is an endpoint with authorization data.
@@ -134,7 +135,11 @@ func NewExecutionRPCClient(ctx context.Context, endpoint Endpoint, headers http.
 	}
 	switch u.Scheme {
 	case "http", "https":
-		client, err = gethRPC.DialOptions(ctx, endpoint.Url, gethRPC.WithHTTPClient(endpoint.HttpClient()), gethRPC.WithHeaders(headers))
+		client, err = gethRPC.DialOptions(ctx, endpoint.Url,
+			gethRPC.WithHTTPClient(endpoint.HttpClient()),
+			gethRPC.WithHeaders(headers),
+			gethRPC.WithTextMapPropagator(propagation.TraceContext{}),
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This adds support for sending a `traceparent` header along with Engine API requests. This header
is used to enable 'distributed tracing', i.e. traces emitted by Prysm can be correlated with traces
from the execution layer client.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
