### PR TITLE
`ProgressiveList`: Chunk directly byte slice instead of `PackByChunk`

### DIFF
--- a/changelog/syjn99_perf-progressive-byteslice-root.md
+++ b/changelog/syjn99_perf-progressive-byteslice-root.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Improve memory allocations in `ByteSliceRootProgressive` by directly chunking it instead of `PackByChunk`.

--- a/encoding/ssz/progressive_merkleize.go
+++ b/encoding/ssz/progressive_merkleize.go
@@ -89,16 +89,25 @@ func SliceRootProgressive[T Hashable](slice []T) ([32]byte, error) {
 // ByteSliceRootProgressive computes the progressive list root of a byte slice
 // interpreted as ProgressiveByteList (alias of ProgressiveList[byte]).
 func ByteSliceRootProgressive(slice []byte) ([32]byte, error) {
-	var chunks [][32]byte
+	var bytesRoot [32]byte
 	if len(slice) > 0 {
-		var err error
-		chunks, err = PackByChunk([][]byte{slice})
-		if err != nil {
-			return [32]byte{}, err
+		// Total chunks = ceil(length/32)
+		numChunks := (len(slice) + 31) / 32
+		// Count of full(complete) chunks = floor(length/32)
+		full := len(slice) / 32
+
+		chunks := make([][32]byte, numChunks)
+		for i := range full {
+			copy(chunks[i][:], slice[i*32:(i+1)*32])
 		}
+
+		// Handle trailing partial chunk if present.
+		if full < numChunks {
+			copy(chunks[full][:], slice[full*32:])
+		}
+		bytesRoot = MerkleizeProgressiveChunks(chunks)
 	}
 
-	bytesRoot := MerkleizeProgressiveChunks(chunks)
 	var length [32]byte
 	binary.LittleEndian.PutUint64(length[:8], uint64(len(slice)))
 	return MixInLength(bytesRoot, length[:]), nil

--- a/encoding/ssz/progressive_merkleize.go
+++ b/encoding/ssz/progressive_merkleize.go
@@ -91,19 +91,10 @@ func SliceRootProgressive[T Hashable](slice []T) ([32]byte, error) {
 func ByteSliceRootProgressive(slice []byte) ([32]byte, error) {
 	var bytesRoot [32]byte
 	if len(slice) > 0 {
-		// Total chunks = ceil(length/32)
 		numChunks := (len(slice) + 31) / 32
-		// Count of full(complete) chunks = floor(length/32)
-		full := len(slice) / 32
-
 		chunks := make([][32]byte, numChunks)
-		for i := range full {
-			copy(chunks[i][:], slice[i*32:(i+1)*32])
-		}
-
-		// Handle trailing partial chunk if present.
-		if full < numChunks {
-			copy(chunks[full][:], slice[full*32:])
+		for i := range chunks {
+			copy(chunks[i][:], slice[i*BytesPerChunk:])
 		}
 		bytesRoot = MerkleizeProgressiveChunks(chunks)
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Other: Optimization

**What does this PR do? Why is it needed?**

This PR chunks a byte slice directly when it is given for calculating the HTR. Previously, `PackByChunk` is used but chunking it directly can be used for memory optimization. This can save up to 5MB for each `*_participation` fields in `BeaconState` when we have 1M validators, which is close to the current number in mainnet.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Running benchmark:

in `progressive_byteslice_bench_test.go`

```go
func BenchmarkByteSliceRootProgressive(b *testing.B) {
	for _, n := range []int{262144, 1048576} {
		slice := make([]byte, n)
		for i := range slice {
			slice[i] = 0b111
		}
		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
			b.ReportAllocs()
			for b.Loop() {
				if _, err := ssz.ByteSliceRootProgressive(slice); err != nil {
					b.Fatal(err)
				}
			}
		})
	}
}
```

with this command:

```bash
bazel test //encoding/ssz:go_default_test \
    --test_filter='^$' \
    --test_arg=-test.bench=BenchmarkByteSliceRootProgressive/n=1048576 \
    --test_arg=-test.benchtime=2s \
    --test_arg=-test.count=1 \
    --test_arg=-test.benchmem \
    --test_output=streamed \
    --nocache_test_results
```

### Result

#### Before

```
goos: darwin
goarch: arm64
cpu: Apple M5 Pro
BenchmarkByteSliceRootProgressive/n=1048576-18              1981           1095825 ns/op         7703541 B/op        340 allocs/op
```

#### After
```
goos: darwin
goarch: arm64
cpu: Apple M5 Pro
BenchmarkByteSliceRootProgressive/n=1048576-18              3032            807473 ns/op         2768350 B/op        315 allocs/op
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
