### PR TITLE
`--max-builder-consecutive-missed-slots` and `--max-builder-epoch-missed-slots` help text: Reports the mainnet config value as the default instead of a hardcoded, false and unused values.

### DIFF
--- a/changelog/manu_builder-missed-slots-default-text.md
+++ b/changelog/manu_builder-missed-slots-default-text.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `--max-builder-consecutive-missed-slots` and `--max-builder-epoch-missed-slots` help text: Reports the mainnet config value as the default instead of a hardcoded, false and unused values.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -3,6 +3,7 @@
 package flags
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
@@ -44,14 +45,14 @@ var (
 	}
 
 	MaxBuilderConsecutiveMissedSlots = &cli.IntFlag{
-		Name:  "max-builder-consecutive-missed-slots",
-		Usage: "Number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction",
-		Value: 3,
+		Name:        "max-builder-consecutive-missed-slots",
+		Usage:       "Number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction",
+		DefaultText: fmt.Sprintf("%d", params.BeaconConfig().MaxBuilderConsecutiveMissedSlots),
 	}
 	MaxBuilderEpochMissedSlots = &cli.IntFlag{
-		Name: "max-builder-epoch-missed-slots",
-		Usage: "Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window. " +
-			"The values are on the basis of the networks and the default value for mainnet is 5.",
+		Name:        "max-builder-epoch-missed-slots",
+		Usage:       "Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window",
+		DefaultText: fmt.Sprintf("%d", params.BeaconConfig().MaxBuilderEpochMissedSlots),
 	}
 	// LocalBlockValueBoost sets a percentage boost for local block construction while using a custom builder.
 	LocalBlockValueBoost = &cli.Uint64Flag{


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Currently, this is the printed help:

```
--max-builder-consecutive-missed-slots value  Number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction (default: 3)
--max-builder-epoch-missed-slots value        Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window. The values are on the basis of the networks and the default value for mainnet is 5. (default: 0)
```

There is 2 issues here:
1. The displayed default value of `--max-builder-consecutive-missed-slots` is the correct one, but is actually hard coded. The real default value comes from the config.
2. The displayed default value of `--max-builder-epoch-missed-slots` is simply wrong.

This PR fixes these 2 issues, by using the correct default values.

Now:
```
 --max-builder-consecutive-missed-slots value  Number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction (default: 3)
 --max-builder-epoch-missed-slots value        Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window. (default: 5)
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
