### PR TITLE
Reduce Gloas get-payload timeout

### DIFF
--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -49,6 +49,16 @@ var (
 	_ = EngineCaller(&mocks.EngineClient{})
 )
 
+func TestGetPayloadTimeout(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 2
+	params.OverrideBeaconConfig(cfg)
+
+	require.Equal(t, defaultEngineTimeout, getPayloadTimeout(cfg.SlotsPerEpoch))
+	require.Equal(t, gloasGetPayloadTimeout, getPayloadTimeout(2*cfg.SlotsPerEpoch))
+}
+
 type RPCClientBad struct {
 }
 

--- a/beacon-chain/execution/engine_jsonrpc.go
+++ b/beacon-chain/execution/engine_jsonrpc.go
@@ -114,6 +114,8 @@ const (
 	GetClientVersionV1 = "engine_getClientVersionV1"
 	// Defines the seconds before timing out engine endpoints with non-block execution semantics.
 	defaultEngineTimeout = time.Second
+	// gloasGetPayloadTimeout is the maximum time allowed for engine_getPayloadV6.
+	gloasGetPayloadTimeout = 300 * time.Millisecond
 )
 
 // NewPayload request calls the engine_newPayloadVX method via JSON-RPC.
@@ -295,6 +297,13 @@ func getPayloadMethodAndMessage(slot primitives.Slot) (string, proto.Message) {
 	return GetPayloadMethod, &pb.ExecutionPayload{}
 }
 
+func getPayloadTimeout(slot primitives.Slot) time.Duration {
+	if slots.ToEpoch(slot) >= params.BeaconConfig().GloasForkEpoch {
+		return gloasGetPayloadTimeout
+	}
+	return defaultEngineTimeout
+}
+
 // GetPayload calls the engine_getPayloadVX method via JSON-RPC.
 // It returns the execution data as well as the blobs bundle.
 func (s *Service) GetPayload(ctx context.Context, payloadId [8]byte, slot primitives.Slot) (*blocks.GetPayloadResponse, error) {
@@ -304,7 +313,7 @@ func (s *Service) GetPayload(ctx context.Context, payloadId [8]byte, slot primit
 	defer func() {
 		getPayloadLatency.Observe(float64(time.Since(start).Milliseconds()))
 	}()
-	d := time.Now().Add(defaultEngineTimeout)
+	d := time.Now().Add(getPayloadTimeout(slot))
 	ctx, cancel := context.WithDeadline(ctx, d)
 	defer cancel()
 

--- a/changelog/terence_reduce-gloas-get-payload-timeout.md
+++ b/changelog/terence_reduce-gloas-get-payload-timeout.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reduce the Gloas Engine API get-payload timeout to 300 milliseconds.


### PR DESCRIPTION
- use a 300ms deadline for engine_getPayloadV6 while retaining the 1s timeout before Gloas