### PR TITLE
Increment newPayload node count metrics on Gloas envelope path

### DIFF
--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -275,9 +275,11 @@ func (s *Service) callNewPayload(
 ) (bool, error) {
 	_, err := s.cfg.ExecutionEngineCaller.NewPayload(ctx, payload, versionedHashes, &parentRoot, requests)
 	if err == nil {
+		newPayloadValidNodeCount.Inc()
 		return true, nil
 	}
 	if errors.Is(err, execution.ErrAcceptedSyncingPayloadStatus) {
+		newPayloadOptimisticNodeCount.Inc()
 		log.WithFields(logrus.Fields{
 			"slot":             slot,
 			"payloadBlockHash": fmt.Sprintf("%#x", bytesutil.Trunc(payload.BlockHash())),
@@ -285,6 +287,7 @@ func (s *Service) callNewPayload(
 		return false, nil
 	}
 	if errors.Is(err, execution.ErrInvalidPayloadStatus) {
+		newPayloadInvalidNodeCount.Inc()
 		return false, invalidBlock{error: ErrInvalidPayload}
 	}
 	return false, errors.WithMessage(ErrUndefinedExecutionEngineError, err.Error())

--- a/changelog/terence_gloas_envelope_newpayload_metrics.md
+++ b/changelog/terence_gloas_envelope_newpayload_metrics.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Increment `new_payload_*_node_count` metrics on the Gloas payload envelope path.


### PR DESCRIPTION
- `new_payload_{valid,optimistic,invalid}_node_count` were only incremented on the pre-Gloas block path, so they stay flat under Gloas while the envelope path makes all the newPayload calls
- Increment them in `callNewPayload`