### PR TITLE
Only increment PTC vote count metric for newly set votes

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -541,7 +541,9 @@ func (f *ForkChoice) SetPTCVote(root [32]byte, ptcIdx uint64, payloadPresent, bl
 	if n == nil {
 		return
 	}
-	ptcVoteCount.Inc()
+	if !n.node.payloadAttesters.BitAt(ptcIdx) {
+		ptcVoteCount.Inc()
+	}
 	n.node.payloadAttesters.SetBitAt(ptcIdx, true)
 	n.node.payloadAvailabilityVote.SetBitAt(ptcIdx, payloadPresent)
 	n.node.payloadDataAvailabilityVote.SetBitAt(ptcIdx, blobDataAvailable)

--- a/changelog/terence_fix_ptc_vote_count.md
+++ b/changelog/terence_fix_ptc_vote_count.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Count each PTC vote once in `forkchoice_ptc_vote_count` instead of on every re-application.


### PR DESCRIPTION
- `forkchoice_ptc_vote_count` incremented on every `SetPTCVote` call, so the same vote applied from gossip and again from a block aggregate counted twice (~883/slot observed on devnet-7 vs PTC size 512)
- Only increment when the attester bit was previously unset