### PR TITLE
Only count actually invalid envelopes in envelope invalid metric

### DIFF
--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -37,10 +37,14 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 	ctx, span := trace.StartSpan(ctx, "blockChain.ReceiveExecutionPayloadEnvelope")
 	defer span.End()
 	start := time.Now()
+
+	var consensusInvalid bool
 	defer func() {
 		beaconExecutionPayloadEnvelopeProcessingDurationSeconds.Observe(time.Since(start).Seconds())
 		if err != nil {
-			beaconExecutionPayloadEnvelopeInvalidTotal.Inc()
+			if consensusInvalid || IsInvalidBlock(err) {
+				beaconExecutionPayloadEnvelopeInvalidTotal.Inc()
+			}
 			return
 		}
 		beaconExecutionPayloadEnvelopeValidTotal.Inc()
@@ -81,6 +85,7 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 	availGroup, availCtx := errgroup.WithContext(ctx)
 	availGroup.Go(func() error {
 		if err := gloas.VerifyExecutionPayloadEnvelope(availCtx, blockState, signed); err != nil {
+			consensusInvalid = true
 			return err
 		}
 		s.recordPayloadArrival(root, envelope.Slot(), start)

--- a/changelog/terence_gloas_envelope_invalid_metric.md
+++ b/changelog/terence_gloas_envelope_invalid_metric.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `beacon_execution_payload_envelope_invalid_total` no longer counts internal processing failures, only invalid envelopes.


### PR DESCRIPTION
- `beacon_execution_payload_envelope_invalid_total` incremented on any `ReceiveExecutionPayloadEnvelope` error, including local failures like missing prestate or EL timeouts, so a flaky EL reads as invalid envelopes
- Count only EL INVALID status and consensus verification failures