### PR TITLE
Remove unused data_column_obtained_via_el_count metric

### DIFF
--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -283,13 +283,6 @@ var (
 		},
 	)
 
-	dataColumnSidecarsObtainedViaELCount = promauto.NewSummary(
-		prometheus.SummaryOpts{
-			Name: "data_column_obtained_via_el_count",
-			Help: "Count the number of data column sidecars obtained via the execution layer.",
-		},
-	)
-
 	ignoredPreJustifiedBlockCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "gossip_ignored_pre_justified_block_total",
 		Help: "Count of blocks ignored because their canonical parent is before the justified checkpoint.",

--- a/changelog/terence_remove_dead_column_el_metric.md
+++ b/changelog/terence_remove_dead_column_el_metric.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Unused `data_column_obtained_via_el_count` metric that was never recorded.


### PR DESCRIPTION
- Defined but never recorded anywhere, permanently zero
- `data_columns_recovered_from_el_{attempts,total}` already cover this