### PR TITLE
Validate bid parent block hash correctly

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -41,6 +41,7 @@ type ChainInfoFetcher interface {
 type ForkchoiceFetcher interface {
 	Ancestor(context.Context, []byte, primitives.Slot) ([]byte, error)
 	BlockHash(root [32]byte) ([32]byte, error)
+	HasPayloadBlockHash(root, blockHash [32]byte) bool
 	GasLimit(root [32]byte) (uint64, error)
 	CachedHeadRoot() [32]byte
 	GetProposerHead() [32]byte

--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@ -56,6 +56,13 @@ func (s *Service) BlockHash(root [32]byte) ([32]byte, error) {
 	return s.cfg.ForkChoiceStore.BlockHash(root)
 }
 
+// HasPayloadBlockHash reports whether blockHash is an available payload parent at root.
+func (s *Service) HasPayloadBlockHash(root, blockHash [32]byte) bool {
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
+	return s.cfg.ForkChoiceStore.HasPayloadBlockHash(root, blockHash)
+}
+
 // GasLimit returns the gas limit of the latest full payload at or before the given beacon block root from forkchoice.
 func (s *Service) GasLimit(root [32]byte) (uint64, error) {
 	s.cfg.ForkChoiceStore.RLock()

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -635,6 +635,16 @@ func (s *ChainService) BlockHash(root [32]byte) ([32]byte, error) {
 	return [32]byte{}, errors.New("block hash not found")
 }
 
+// HasPayloadBlockHash mocks the same method in the chain service.
+func (s *ChainService) HasPayloadBlockHash(root, blockHash [32]byte) bool {
+	if s.ForkChoiceStore == nil {
+		return false
+	}
+	s.ForkChoiceStore.RLock()
+	defer s.ForkChoiceStore.RUnlock()
+	return s.ForkChoiceStore.HasPayloadBlockHash(root, blockHash)
+}
+
 // IsOptimisticForRoot mocks the same method in the chain service.
 func (s *ChainService) IsOptimisticForRoot(_ context.Context, root [32]byte) (bool, error) {
 	s.OptimisticCheckRootReceived = root

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -575,6 +575,18 @@ func (f *ForkChoice) HasFullNode(root [32]byte) bool {
 	return ok
 }
 
+// HasPayloadBlockHash reports whether blockHash is an available payload parent at root.
+func (f *ForkChoice) HasPayloadBlockHash(root, blockHash [32]byte) bool {
+	en := f.store.emptyNodeByRoot[root]
+	if en == nil || en.node == nil {
+		return false
+	}
+	if blockHash == en.node.blockHash {
+		return f.HasFullNode(root)
+	}
+	return slots.ToEpoch(en.node.slot) >= params.BeaconConfig().GloasForkEpoch && blockHash == f.store.parentHash(en)
+}
+
 // FullBeatsEmpty returns whether fork choice would select the full payload variant
 // for the given beacon block root. The caller MUST hold the forkchoice lock.
 func (f *ForkChoice) FullBeatsEmpty(root [32]byte) bool {

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -582,9 +582,10 @@ func (f *ForkChoice) HasPayloadBlockHash(root, blockHash [32]byte) bool {
 		return false
 	}
 	if blockHash == en.node.blockHash {
-		return f.HasFullNode(root)
+		_, ok := f.store.fullNodeByRoot[root]
+		return ok
 	}
-	return slots.ToEpoch(en.node.slot) >= params.BeaconConfig().GloasForkEpoch && blockHash == f.store.parentHash(en)
+	return blockHash == f.store.parentHash(en)
 }
 
 // FullBeatsEmpty returns whether fork choice would select the full payload variant

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -434,6 +434,46 @@ func TestParentHash_UnknownRoot(t *testing.T) {
 	assert.Equal(t, [32]byte{}, f.ParentHash(indexToHash(999)))
 }
 
+func TestHasPayloadBlockHash(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+
+	root := indexToHash(1)
+	fullHash := indexToHash(100)
+	emptyHash := params.BeaconConfig().ZeroHash
+	st, roblock, err := prepareGloasForkchoiceState(ctx, 1, root, emptyHash, fullHash, emptyHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	assert.Equal(t, true, f.HasPayloadBlockHash(root, emptyHash))
+	assert.Equal(t, false, f.HasPayloadBlockHash(root, fullHash))
+	assert.Equal(t, false, f.HasPayloadBlockHash(root, indexToHash(999)))
+
+	pe, err := prepareGloasForkchoicePayload(root)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+	assert.Equal(t, true, f.HasPayloadBlockHash(root, fullHash))
+	assert.Equal(t, false, f.HasPayloadBlockHash(indexToHash(999), fullHash))
+}
+
+func TestHasPayloadBlockHash_PreGloasHasNoEmptyBranch(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 1
+	params.OverrideBeaconConfig(cfg)
+	f := setup(0, 0)
+
+	root := indexToHash(1)
+	fullHash := indexToHash(100)
+	st, roblock, err := prepareForkchoiceState(t.Context(), params.BeaconConfig().SlotsPerEpoch-1, root,
+		params.BeaconConfig().ZeroHash, fullHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(t.Context(), st, roblock))
+
+	assert.Equal(t, true, f.HasPayloadBlockHash(root, fullHash))
+	assert.Equal(t, false, f.HasPayloadBlockHash(root, f.ParentHash(root)))
+}
+
 func TestGloasBlock_ChildBuildsOnFull(t *testing.T) {
 	f := setupGloas(t, 0, 0)
 	ctx := t.Context()

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -456,24 +456,6 @@ func TestHasPayloadBlockHash(t *testing.T) {
 	assert.Equal(t, false, f.HasPayloadBlockHash(indexToHash(999), fullHash))
 }
 
-func TestHasPayloadBlockHash_PreGloasHasNoEmptyBranch(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.GloasForkEpoch = 1
-	params.OverrideBeaconConfig(cfg)
-	f := setup(0, 0)
-
-	root := indexToHash(1)
-	fullHash := indexToHash(100)
-	st, roblock, err := prepareForkchoiceState(t.Context(), params.BeaconConfig().SlotsPerEpoch-1, root,
-		params.BeaconConfig().ZeroHash, fullHash, 0, 0)
-	require.NoError(t, err)
-	require.NoError(t, f.InsertNode(t.Context(), st, roblock))
-
-	assert.Equal(t, true, f.HasPayloadBlockHash(root, fullHash))
-	assert.Equal(t, false, f.HasPayloadBlockHash(root, f.ParentHash(root)))
-}
-
 func TestGloasBlock_ChildBuildsOnFull(t *testing.T) {
 	f := setupGloas(t, 0, 0)
 	ctx := t.Context()

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -96,6 +96,7 @@ type FastGetter interface {
 	Weight(root [32]byte) (uint64, error)
 	ConsensusNodeWeight(root [32]byte) (uint64, error)
 	PayloadWeights(root [32]byte) (emptyWeight, fullWeight uint64, err error)
+	HasPayloadBlockHash(root, blockHash [32]byte) bool
 	PTCVotedEarlyAndAvailable(root [32]byte) bool
 	PTCVotedLate(root [32]byte) bool
 	ParentRoot(root [32]byte) ([32]byte, error)

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -177,6 +177,13 @@ func (ro *ROForkChoice) PayloadWeights(root [32]byte) (uint64, uint64, error) {
 	return ro.getter.PayloadWeights(root)
 }
 
+// HasPayloadBlockHash delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) HasPayloadBlockHash(root, blockHash [32]byte) bool {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.HasPayloadBlockHash(root, blockHash)
+}
+
 // IsOptimistic delegates to the underlying forkchoice call, under a lock.
 func (ro *ROForkChoice) IsOptimistic(root [32]byte) (bool, error) {
 	ro.l.RLock()

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -50,6 +50,7 @@ const (
 	dependentRootForEpochCalled
 	canonicalNodeAtSlotCalled
 	payloadWeightsCalled
+	hasPayloadBlockHashCalled
 )
 
 func _discard(t *testing.T, e error) {
@@ -198,6 +199,11 @@ func TestROLocking(t *testing.T) {
 			cb:   func(g FastGetter) { _, err := g.GasLimit([32]byte{}); _discard(t, err) },
 		},
 		{
+			name: "hasPayloadBlockHashCalled",
+			call: hasPayloadBlockHashCalled,
+			cb:   func(g FastGetter) { g.HasPayloadBlockHash([32]byte{}, [32]byte{}) },
+		},
+		{
 			name: "parentHashCalled",
 			call: parentHashCalled,
 			cb:   func(g FastGetter) { g.ParentHash([32]byte{}) },
@@ -342,6 +348,11 @@ func (ro *mockROForkchoice) ConsensusNodeWeight(_ [32]byte) (uint64, error) {
 func (ro *mockROForkchoice) PayloadWeights(_ [32]byte) (uint64, uint64, error) {
 	ro.calls = append(ro.calls, payloadWeightsCalled)
 	return 0, 0, nil
+}
+
+func (ro *mockROForkchoice) HasPayloadBlockHash(_, _ [32]byte) bool {
+	ro.calls = append(ro.calls, hasPayloadBlockHashCalled)
+	return false
 }
 
 func (ro *mockROForkchoice) IsOptimistic(_ [32]byte) (bool, error) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -223,7 +223,9 @@ func (vs *Server) validateBuilderBid(head state.BeaconState, signed *ethpb.Signe
 	if err := v.VerifyParentBlockRootSeen(func(root [32]byte) bool { return root == q.parentRoot }); err != nil {
 		return err
 	}
-	if err := v.VerifyParentBlockHash(func([32]byte) ([32]byte, error) { return q.parentHash, nil }); err != nil {
+	if err := v.VerifyParentBlockHash(func(root, hash [32]byte) bool {
+		return root == q.parentRoot && hash == q.parentHash
+	}); err != nil {
 		return err
 	}
 	if err := v.VerifyBuilderActive(head); err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
@@ -27,7 +27,7 @@ type fakeBidVerifier struct {
 	slotErr, activeErr, versionErr, coverErr, blobErr, randaoErr, sigErr error
 	rootSeenErr, parentHashErr, feeErr, gasErr                           error
 	rootSeenFn                                                           func([32]byte) bool
-	resolveFn                                                            func([32]byte) ([32]byte, error)
+	hasPayloadFn                                                         func([32]byte, [32]byte) bool
 }
 
 func (v *fakeBidVerifier) VerifyCurrentOrNextSlot() error             { return nil }
@@ -49,8 +49,8 @@ func (v *fakeBidVerifier) VerifyParentBlockRootSeen(fn func([32]byte) bool) erro
 	return v.rootSeenErr
 }
 func (v *fakeBidVerifier) VerifyBidSlotHigherThanParent(primitives.Slot) error { return nil }
-func (v *fakeBidVerifier) VerifyParentBlockHash(fn func([32]byte) ([32]byte, error)) error {
-	v.resolveFn = fn
+func (v *fakeBidVerifier) VerifyParentBlockHash(fn func([32]byte, [32]byte) bool) error {
+	v.hasPayloadFn = fn
 	return v.parentHashErr
 }
 func (v *fakeBidVerifier) VerifyGasLimitTargetCompatible(uint64, uint64) error { return v.gasErr }
@@ -203,9 +203,8 @@ func TestValidateBuilderBid(t *testing.T) {
 		// The parent-linkage closures must match only the block being produced.
 		require.Equal(t, true, captured.rootSeenFn(parentRoot))
 		require.Equal(t, false, captured.rootSeenFn([32]byte{7, 7, 7}))
-		gotHash, err := captured.resolveFn([32]byte{})
-		require.NoError(t, err)
-		require.Equal(t, parentHash, gotHash)
+		require.Equal(t, true, captured.hasPayloadFn(parentRoot, parentHash))
+		require.Equal(t, false, captured.hasPayloadFn(parentRoot, [32]byte{8, 8, 8}))
 	})
 
 	t.Run("verifier check fails", func(t *testing.T) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
@@ -113,7 +113,7 @@ func (vs *Server) validateSubmittedBid(ctx context.Context, signed *ethpb.Signed
 	if err := v.VerifyBuilderCanCoverBid(st); err != nil {
 		return status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	if err := v.VerifyParentBlockHash(vs.ForkchoiceFetcher.BlockHash); err != nil {
+	if err := v.VerifyParentBlockHash(vs.ForkchoiceFetcher.HasPayloadBlockHash); err != nil {
 		return status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	parentGasLimit, err := vs.ForkchoiceFetcher.GasLimit(parentRoot)

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -123,7 +123,7 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	}
 	// [IGNORE] bid.parent_block_hash is the block hash of a known execution payload in fork choice
 	// and bid.gas_limit is compatible with parent_gas_limit and the proposer's target.
-	if err := v.VerifyParentBlockHash(s.cfg.chain.BlockHash); err != nil {
+	if err := v.VerifyParentBlockHash(s.cfg.chain.HasPayloadBlockHash); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 	parentGasLimit, err := s.cfg.chain.GasLimit(parentBlockRoot)

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -463,7 +463,7 @@ func (m *mockExecutionPayloadBidVerifier) VerifyBidSlotHigherThanParent(primitiv
 	return m.errSlotHigherThanParent
 }
 
-func (m *mockExecutionPayloadBidVerifier) VerifyParentBlockHash(func([32]byte) ([32]byte, error)) error {
+func (m *mockExecutionPayloadBidVerifier) VerifyParentBlockHash(func([32]byte, [32]byte) bool) error {
 	return m.errParentBlockHash
 }
 

--- a/beacon-chain/verification/execution_payload_bid.go
+++ b/beacon-chain/verification/execution_payload_bid.go
@@ -285,23 +285,19 @@ func (v *BidVerifier) VerifyBidSlotHigherThanParent(parentSlot primitives.Slot) 
 	return nil
 }
 
-// VerifyParentBlockHash verifies the parent execution block hash matches forkchoice for the bid parent root.
-func (v *BidVerifier) VerifyParentBlockHash(resolveBlockHash func([32]byte) ([32]byte, error)) (err error) {
+// VerifyParentBlockHash verifies that the bid references an available parent payload.
+func (v *BidVerifier) VerifyParentBlockHash(hasPayloadBlockHash func([32]byte, [32]byte) bool) (err error) {
 	defer v.record(RequireBidParentBlockHashValid, &err)
 
 	bid, err := v.b.Bid()
 	if err != nil {
 		return errors.Wrap(err, "failed to get bid")
 	}
-	if resolveBlockHash == nil {
-		return fmt.Errorf("%w: no parent block hash resolver", ErrBidParentBlockHashMismatch)
+	if hasPayloadBlockHash == nil {
+		return fmt.Errorf("%w: no parent block hash lookup", ErrBidParentBlockHashMismatch)
 	}
-	parentHash, err := resolveBlockHash(bid.ParentBlockRoot())
-	if err != nil {
-		return errors.Wrap(err, "failed to resolve parent block hash")
-	}
-	if parentHash != bid.ParentBlockHash() {
-		return fmt.Errorf("%w: bid=%#x forkchoice=%#x", ErrBidParentBlockHashMismatch, bid.ParentBlockHash(), parentHash)
+	if !hasPayloadBlockHash(bid.ParentBlockRoot(), bid.ParentBlockHash()) {
+		return fmt.Errorf("%w: root=%#x hash=%#x", ErrBidParentBlockHashMismatch, bid.ParentBlockRoot(), bid.ParentBlockHash())
 	}
 	return nil
 }

--- a/beacon-chain/verification/execution_payload_bid_test.go
+++ b/beacon-chain/verification/execution_payload_bid_test.go
@@ -174,14 +174,15 @@ func TestBidVerifier_VerifyParentBlockHash(t *testing.T) {
 	require.NoError(t, err)
 
 	wantHash := [32]byte(signed.Message.ParentBlockHash)
+	wantRoot := [32]byte(signed.Message.ParentBlockRoot)
 	verifier := &BidVerifier{results: newResults(RequireBidParentBlockHashValid), b: wrapped}
-	require.NoError(t, verifier.VerifyParentBlockHash(func([32]byte) ([32]byte, error) {
-		return wantHash, nil
+	require.NoError(t, verifier.VerifyParentBlockHash(func(root, hash [32]byte) bool {
+		return root == wantRoot && hash == wantHash
 	}))
 
 	verifier = &BidVerifier{results: newResults(RequireBidParentBlockHashValid), b: wrapped}
-	require.ErrorIs(t, verifier.VerifyParentBlockHash(func([32]byte) ([32]byte, error) {
-		return [32]byte{0xFF}, nil
+	require.ErrorIs(t, verifier.VerifyParentBlockHash(func([32]byte, [32]byte) bool {
+		return false
 	}), ErrBidParentBlockHashMismatch)
 }
 

--- a/beacon-chain/verification/interface.go
+++ b/beacon-chain/verification/interface.go
@@ -110,7 +110,7 @@ type ExecutionPayloadBidVerifier interface {
 	VerifyPrevRandao(state.ReadOnlyBeaconState) error
 	VerifyParentBlockRootSeen(func([32]byte) bool) error
 	VerifyBidSlotHigherThanParent(parentSlot primitives.Slot) error
-	VerifyParentBlockHash(func([32]byte) ([32]byte, error)) error
+	VerifyParentBlockHash(func([32]byte, [32]byte) bool) error
 	VerifyGasLimitTargetCompatible(parentGasLimit, targetGasLimit uint64) error
 	VerifyBuilderCanCoverBid(state.ReadOnlyBeaconState) error
 	VerifySignature(state.ReadOnlyBeaconState) error

--- a/changelog/terence_fix-gloas-bid-parent-payload-status.md
+++ b/changelog/terence_fix-gloas-bid-parent-payload-status.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Accept execution payload bids building on the parent's empty branch, fixing valid bid rejections after a missed payload reveal.


### PR DESCRIPTION
- Bid validation resolved the expected parent hash via `ForkChoice.BlockHash`, which returns the hash committed in the parent block's bid even when the payload was never revealed. 
- Add `ForkChoice.HasPayloadBlockHash(root, hash)`
- Change `VerifyParentBlockHash` to take a `(root, hash) bool` lookup and wire the new method into bid gossip validation and `SubmitSignedExecutionPayloadBid`