### PR TITLE
FCR: Add metrics

### DIFF
--- a/beacon-chain/confirmation/BUILD.bazel
+++ b/beacon-chain/confirmation/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "ffg.go",
         "helpers.go",
         "interfaces.go",
+        "metrics.go",
         "safety.go",
         "support.go",
         "types.go",
@@ -19,6 +20,8 @@ go_library(
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//time/slots:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
 )
 

--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -130,6 +130,9 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 
 		if finalizedSlotOk {
 			fastConfirmationSlot.Set(float64(finalizedSlot))
+			if currentSlot >= finalizedSlot {
+				fastConfirmationDistance.Set(float64(currentSlot - finalizedSlot))
+			}
 		}
 
 		// Fallback only when the confirmed root regresses to finality
@@ -213,6 +216,9 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 	}
 
 	fastConfirmationSlot.Set(float64(newSlot))
+	if currentSlot >= newSlot {
+		fastConfirmationDistance.Set(float64(currentSlot - newSlot))
+	}
 
 	// Check whether the confirmed root regressed to the finalized checkpoint, which is a fallback.
 	finalizedCkpt := f.fc.FinalizedCheckpoint()

--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -92,7 +92,7 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 	// path defaults to "full"; the stale-head branch flips it to "fallback".
 	path := "full"
 	defer func(start time.Time) {
-		fastConfirmationDuration.WithLabelValues(path).Observe(time.Since(start).Seconds())
+		fastConfirmationDuration.WithLabelValues(path).Observe(float64(time.Since(start).Milliseconds()))
 	}(time.Now())
 
 	f.fc.RLock()

--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -88,6 +89,12 @@ func (f *FastConfirmationRule) PreviousEpochGreatestUnrealizedCheckpoint() forkc
 // OnFastConfirmation must run once per slot at slot start after attestations are applied.
 // The spec allows get_latest_confirmed at any point in the slot, so only tree reads hold the forkchoice read lock.
 func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSlot primitives.Slot) {
+	// path defaults to "full"; the stale-head branch flips it to "fallback".
+	path := "full"
+	defer func(start time.Time) {
+		fastConfirmationDuration.WithLabelValues(path).Observe(time.Since(start).Seconds())
+	}(time.Now())
+
 	f.fc.RLock()
 	f.updateFastConfirmationVariables(currentSlot)
 	headSlot, headSlotErr := f.fc.Slot(f.currentSlotHead)
@@ -100,6 +107,7 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 
 	// A head this stale always reverts to finalized, and the head state cannot compute committees past its next epoch.
 	if headSlotErr != nil || slots.ToEpoch(headSlot)+1 < slots.ToEpoch(currentSlot) {
+		path = "fallback"
 		oldConfirmedRoot := f.ConfirmedRoot()
 		f.fc.RLock()
 

--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -100,11 +100,42 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 
 	// A head this stale always reverts to finalized, and the head state cannot compute committees past its next epoch.
 	if headSlotErr != nil || slots.ToEpoch(headSlot)+1 < slots.ToEpoch(currentSlot) {
+		oldConfirmedRoot := f.ConfirmedRoot()
 		f.fc.RLock()
+
+		var (
+			finalizedSlot, oldSlot     primitives.Slot
+			finalizedSlotOk, oldSlotOk bool
+		)
+
 		fc := f.fc.FinalizedCheckpoint()
+
+		// Set finalized slot for metrics.
+		if fc != nil {
+			if s, err := f.fc.Slot(fc.Root); err == nil {
+				finalizedSlot, finalizedSlotOk = s, true
+			}
+		}
+		// Set old slot for fallback detection.
+		if s, err := f.fc.Slot(oldConfirmedRoot); err == nil {
+			oldSlot, oldSlotOk = s, true
+		}
+
 		f.fc.RUnlock()
+
 		if fc != nil {
 			f.setConfirmedRoot(fc.Root)
+
+		}
+
+		if finalizedSlotOk {
+			fastConfirmationSlot.Set(float64(finalizedSlot))
+		}
+
+		// Fallback only when the confirmed root regresses to finality
+		// which means the confirmed slot moves backward.
+		if finalizedSlotOk && oldSlotOk && finalizedSlot < oldSlot {
+			fastConfirmationFallbacksTotal.Inc()
 		}
 		return
 	}
@@ -165,10 +196,46 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 		return s, ffg.TotalActiveBalance
 	}))
 
-	f.setConfirmedRoot(f.getLatestConfirmed(
+	// Back up the old confirmed root for fallback detection.
+	oldConfirmedRoot := f.ConfirmedRoot()
+
+	// Update new confirmed root.
+	newConfirmedRoot := f.getLatestConfirmed(
 		ctx, currentSlot, f.support, totalActiveBalance, currentTarget, honest,
 		prevSupport, prevTotalActiveBalance, equivScorer, prevEquivScorer,
-	))
+	)
+	f.setConfirmedRoot(newConfirmedRoot)
+
+	newSlot, err := f.fc.Slot(newConfirmedRoot)
+	if err != nil {
+		// This should never happen, but if it does, don't update the metrics.
+		return
+	}
+
+	fastConfirmationSlot.Set(float64(newSlot))
+
+	// Check whether the confirmed root regressed to the finalized checkpoint, which is a fallback.
+	finalizedCkpt := f.fc.FinalizedCheckpoint()
+	if finalizedCkpt == nil {
+		// Cannot get the finalized checkpoint, don't update the metrics.
+		return
+	}
+
+	if newConfirmedRoot != finalizedCkpt.Root {
+		// Not a fallback, no need to check the old confirmed root.
+		return
+	}
+
+	oldSlot, err := f.fc.Slot(oldConfirmedRoot)
+	if err != nil {
+		// Cannot get the old confirmed slot, don't update the metrics.
+		return
+	}
+
+	if newSlot < oldSlot {
+		// The confirmed root has regressed to the finalized checkpoint.
+		fastConfirmationFallbacksTotal.Inc()
+	}
 }
 
 // rebuildTables refreshes the per-epoch assignment tables. The tables
@@ -275,6 +342,10 @@ func (f *FastConfirmationRule) getLatestConfirmed(
 		revert = true
 	} else {
 		isAnc, err := f.fc.IsAncestor(head, confirmedRoot)
+		if err == nil && !isAnc {
+			fastConfirmationReorgsTotal.Inc()
+		}
+
 		if err != nil || !isAnc {
 			revert = true
 		}
@@ -302,6 +373,7 @@ func (f *FastConfirmationRule) getLatestConfirmed(
 				confirmedSlot, err := f.fc.Slot(confirmedRoot)
 				if err == nil && confirmedSlot < ojcSlot {
 					confirmedRoot = ojc.Root
+					fastConfirmationRestartsTotal.Inc()
 				}
 			}
 		}

--- a/beacon-chain/confirmation/metrics.go
+++ b/beacon-chain/confirmation/metrics.go
@@ -6,6 +6,7 @@ import (
 )
 
 var (
+	// Standardized metrics for fast confirmation.
 	fastConfirmationSlot = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "beacon_fast_confirmation_slot",
 		Help: "Slot of the most recent confirmed block",
@@ -21,5 +22,11 @@ var (
 	fastConfirmationRestartsTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "beacon_fast_confirmation_restarts_total",
 		Help: "Total number of restarts from a safe unrealized justified block",
+	})
+
+	// Prysm-specific metrics for fast confirmation.
+	fastConfirmationDistance = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_fast_confirmation_distance_slots",
+		Help: "Slots between the current slot and the most recent confirmed block",
 	})
 )

--- a/beacon-chain/confirmation/metrics.go
+++ b/beacon-chain/confirmation/metrics.go
@@ -29,4 +29,9 @@ var (
 		Name: "beacon_fast_confirmation_distance_slots",
 		Help: "Slots between the current slot and the most recent confirmed block",
 	})
+	fastConfirmationDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "beacon_fast_confirmation_duration_seconds",
+		Help:    "Time to run on_fast_confirmation per slot, by code path",
+		Buckets: []float64{.001, .005, .01, .05, .1, .25, .5, 1, 2},
+	}, []string{"path"})
 )

--- a/beacon-chain/confirmation/metrics.go
+++ b/beacon-chain/confirmation/metrics.go
@@ -1,0 +1,25 @@
+package confirmation
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	fastConfirmationSlot = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_fast_confirmation_slot",
+		Help: "Slot of the most recent confirmed block",
+	})
+	fastConfirmationReorgsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_fast_confirmation_reorgs_total",
+		Help: "Total number of confirmed block reorganizations",
+	})
+	fastConfirmationFallbacksTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_fast_confirmation_fallbacks_total",
+		Help: "Total number of fallbacks to finality",
+	})
+	fastConfirmationRestartsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_fast_confirmation_restarts_total",
+		Help: "Total number of restarts from a safe unrealized justified block",
+	})
+)

--- a/beacon-chain/confirmation/metrics.go
+++ b/beacon-chain/confirmation/metrics.go
@@ -30,8 +30,8 @@ var (
 		Help: "Slots between the current slot and the most recent confirmed block",
 	})
 	fastConfirmationDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "beacon_fast_confirmation_duration_seconds",
+		Name:    "beacon_fast_confirmation_duration_milliseconds",
 		Help:    "Time to run on_fast_confirmation per slot, by code path",
-		Buckets: []float64{.001, .005, .01, .05, .1, .25, .5, 1, 2},
+		Buckets: []float64{1, 5, 10, 50, 100, 250, 500, 1000, 2000},
 	}, []string{"path"})
 )

--- a/changelog/syjn99_fcr-metrics.md
+++ b/changelog/syjn99_fcr-metrics.md
@@ -1,4 +1,4 @@
 ### Added
 
 - Add standardized FCR metrics (`beacon_fast_confirmation_{slot,reorgs_total,fallbacks_total,restarts_total}`).
-- Add Prysm-specific FCR metrics(`beacon_fast_confirmation_distance_slots`).
+- Add Prysm-specific FCR metrics(`beacon_fast_confirmation_{distance_slots,duration_seconds}`).

--- a/changelog/syjn99_fcr-metrics.md
+++ b/changelog/syjn99_fcr-metrics.md
@@ -1,3 +1,4 @@
 ### Added
 
 - Add standardized FCR metrics (`beacon_fast_confirmation_{slot,reorgs_total,fallbacks_total,restarts_total}`).
+- Add Prysm-specific FCR metrics(`beacon_fast_confirmation_distance_slots`).

--- a/changelog/syjn99_fcr-metrics.md
+++ b/changelog/syjn99_fcr-metrics.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add standardized FCR metrics (`beacon_fast_confirmation_{slot,reorgs_total,fallbacks_total,restarts_total}`).

--- a/changelog/syjn99_fcr-metrics.md
+++ b/changelog/syjn99_fcr-metrics.md
@@ -1,4 +1,4 @@
 ### Added
 
 - Add standardized FCR metrics (`beacon_fast_confirmation_{slot,reorgs_total,fallbacks_total,restarts_total}`).
-- Add Prysm-specific FCR metrics(`beacon_fast_confirmation_{distance_slots,duration_seconds}`).
+- Add Prysm-specific FCR metrics(`beacon_fast_confirmation_{distance_slots,duration_milliseconds}`).


### PR DESCRIPTION
**What type of PR is this?**

> Other: Observability

**What does this PR do? Why is it needed?**

This PR adds some metrics to track the status of our FCR implementation which includes [standardized one](https://github.com/ethereum/beacon-metrics/blob/master/metrics.md#fast-confirmation) as well as two custom metrics. Here's the list:

- `beacon_fast_confirmation_slot`
- `beacon_fast_confirmation_reorgs_total`
- `beacon_fast_confirmation_fallbacks_total`
- `beacon_fast_confirmation_restarts_total`
- Prysm specific: `beacon_fast_confirmation_distance_slots`
- Prysm specific: `beacon_fast_confirmation_duration_seconds`
  -  This can be useful when we measure the performance of our FCR implementation in mainnet.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

### Kurtosis Config

```yaml
participants:
  - el_type: geth
    cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    cl_extra_params:
      - "--enable-fast-confirmation"
    supernode: true
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    count: 1
  - el_type: geth
    cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    supernode: true
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    count: 1

network_params:
  fulu_fork_epoch: 0
  genesis_delay: 40

additional_services:
  - dora
  - prometheus_grafana

global_log_level: debug
```

### Sample dashboard

<img width="2201" height="909" alt="image" src="https://github.com/user-attachments/assets/09c47265-2de5-4330-ab3a-e3fe91202414" />

See this [gist](https://gist.github.com/syjn99/dcbf4c30cf6211c4215ad4e229d18417).

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
