### PR TITLE
FCR: Add `fast_confirmation` SSE topic

### DIFF
--- a/api/server/structs/endpoints_events.go
+++ b/api/server/structs/endpoints_events.go
@@ -42,6 +42,12 @@ type BlockGossipEvent struct {
 	Block string `json:"block"`
 }
 
+type FastConfirmationEvent struct {
+	Block       string `json:"block"`
+	Slot        string `json:"slot"`
+	CurrentSlot string `json:"current_slot"`
+}
+
 type DataColumnGossipEvent struct {
 	Slot           string   `json:"slot"`
 	Index          string   `json:"index"`

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/features"
@@ -113,11 +115,34 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 					// The spec requires running FCR at slot start, after attestations are applied.
 					if s.fcr != nil {
 						s.fcr.OnFastConfirmation(s.ctx, slotInterval.Slot)
+						s.notifyFastConfirmation(slotInterval.Slot)
 					}
 				}
 			}
 		}
 	}()
+}
+
+// notifyFastConfirmation emits a fast_confirmation event after every run of the fast
+// confirmation rule regardless of whether the confirmed block changed.
+func (s *Service) notifyFastConfirmation(currentSlot primitives.Slot) {
+	root := s.fcr.ConfirmedRoot()
+
+	s.cfg.ForkChoiceStore.RLock()
+	slot, err := s.cfg.ForkChoiceStore.Slot(root)
+	s.cfg.ForkChoiceStore.RUnlock()
+	if err != nil {
+		return
+	}
+
+	s.cfg.StateNotifier.StateFeed().Send(&feed.Event{
+		Type: statefeed.FastConfirmation,
+		Data: &statefeed.FastConfirmationData{
+			Slot:        slot,
+			BlockRoot:   root,
+			CurrentSlot: currentSlot,
+		},
+	})
 }
 
 // UpdateHead updates the canonical head of the chain based on information from fork-choice attestations and votes.

--- a/beacon-chain/core/feed/state/events.go
+++ b/beacon-chain/core/feed/state/events.go
@@ -39,6 +39,8 @@ const (
 	ExecutionPayloadAvailable
 	// ExecutionPayloadProcessed is sent after a payload envelope has been processed.
 	ExecutionPayloadProcessed
+	// FastConfirmation is sent after every run of the fast confirmation rule.
+	FastConfirmation
 )
 
 // BlockProcessedData is the data sent with BlockProcessed events.
@@ -83,6 +85,13 @@ type InitializedData struct {
 type ExecutionPayloadAvailableData struct {
 	Slot      primitives.Slot
 	BlockRoot [32]byte
+}
+
+// FastConfirmationData is the data sent with FastConfirmation events.
+type FastConfirmationData struct {
+	Slot        primitives.Slot
+	BlockRoot   [32]byte
+	CurrentSlot primitives.Slot
 }
 
 // ExecutionPayloadProcessedData is the data sent with ExecutionPayloadProcessed events.

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -65,6 +65,8 @@ const (
 	BLSToExecutionChangeTopic = "bls_to_execution_change"
 	// PayloadAttributesTopic represents a new payload attributes for execution payload building event topic.
 	PayloadAttributesTopic = "payload_attributes"
+	// FastConfirmationTopic is emitted after every run of the fast confirmation rule.
+	FastConfirmationTopic = "fast_confirmation"
 	// BlobSidecarTopic represents a new blob sidecar event topic
 	BlobSidecarTopic = "blob_sidecar"
 	// ProposerSlashingTopic represents a new proposer slashing event topic
@@ -145,6 +147,7 @@ var stateFeedEventTopics = map[feed.EventType]string{
 	statefeed.PayloadAttributes:           PayloadAttributesTopic,
 	statefeed.ExecutionPayloadAvailable:   ExecutionPayloadAvailableTopic,
 	statefeed.ExecutionPayloadProcessed:   ExecutionPayloadTopic,
+	statefeed.FastConfirmation:            FastConfirmationTopic,
 }
 
 var topicsForStateFeed = topicsForFeed(stateFeedEventTopics)
@@ -509,6 +512,8 @@ func topicForEvent(event *feed.Event) string {
 		return ExecutionPayloadAvailableTopic
 	case *statefeed.ExecutionPayloadProcessedData:
 		return ExecutionPayloadTopic
+	case *statefeed.FastConfirmationData:
+		return FastConfirmationTopic
 	case *operation.ExecutionPayloadGossipReceivedData:
 		return ExecutionPayloadGossipTopic
 	default:
@@ -712,6 +717,14 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 			return jsonMarshalReader(eventName, &structs.ExecutionPayloadAvailableEvent{
 				Slot:      fmt.Sprintf("%d", v.Slot),
 				BlockRoot: hexutil.Encode(v.BlockRoot[:]),
+			})
+		}, nil
+	case *statefeed.FastConfirmationData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, &structs.FastConfirmationEvent{
+				Block:       hexutil.Encode(v.BlockRoot[:]),
+				Slot:        fmt.Sprintf("%d", v.Slot),
+				CurrentSlot: fmt.Sprintf("%d", v.CurrentSlot),
 			})
 		}, nil
 	case *statefeed.ExecutionPayloadProcessedData:

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -481,6 +481,7 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 			BlockTopic,
 			ExecutionPayloadAvailableTopic,
 			ExecutionPayloadTopic,
+			FastConfirmationTopic,
 		})
 		require.NoError(t, err)
 		request := topics.testHttpRequest(testSync.ctx, t)
@@ -562,6 +563,14 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 					BlockHash:    [32]byte{0xbb},
 					BlockRoot:    [32]byte{0x9a},
 					Optimistic:   true,
+				},
+			},
+			{
+				Type: statefeed.FastConfirmation,
+				Data: &statefeed.FastConfirmationData{
+					Slot:        13,
+					BlockRoot:   [32]byte{0xcc},
+					CurrentSlot: 14,
 				},
 			},
 		}

--- a/changelog/syjn99_fcr-event-stream.md
+++ b/changelog/syjn99_fcr-event-stream.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add a `fast_confirmation` event topic to `/eth/v1/events`, emitted after every run of the fast confirmation rule.


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

https://github.com/ethereum/beacon-APIs/blob/7a58b5a44ceb6174162f75e1bb6666efbb6ec07f/apis/eventstream/index.yaml#L193-L197

This PR adds SSE topic for fast confirmation. It's worth noting that the event emits every FCR run according to `beacon-APIs`:

> This event should be emitted every time the algorithm is run, regardless of whether the most recent confirmed block has changed since the previous run. 

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

### Kurtosis config

```yaml
participants:
  - el_type: geth
    cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    cl_extra_params:
      - "--enable-fast-confirmation"
    supernode: true
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    count: 1
  - el_type: geth
    cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    supernode: true
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    count: 1

network_params:
  fulu_fork_epoch: 0
  genesis_delay: 40

additional_services:
  - dora
  - prometheus_grafana

global_log_level: debug
```

With this `curl` command, you can subscribe to FCR event:

```bash
curl -sN -H 'Accept: text/event-stream' "<BN>/eth/v1/events?topics=fast_confirmation"
```

```text
event: fast_confirmation
data: {"block":"0x882ff2e4b716eaa6798c348ea2248a11dd7eec17bf3711e3ed7ba932a199739b","slot":"33","current_slot":"34"}
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
