### PR TITLE
Fix PTC blob_data_available to use data column availability

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -51,6 +51,7 @@ type ForkchoiceFetcher interface {
 	HasNode([32]byte) bool
 	HasFullNode([32]byte) bool
 	PayloadEarly([32]byte) (bool, bool)
+	DataAvailable(context.Context, [32]byte, primitives.Slot) (bool, error)
 	FullBeatsEmpty([32]byte) bool
 	ReceivedBlocksLastEpoch() (uint64, error)
 	InsertNode(context.Context, state.BeaconState, consensus_blocks.ROBlock) error

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -32,6 +32,14 @@ type ChainInfoFetcher interface {
 	ForkFetcher
 	HeadDomainFetcher
 	ForkchoiceFetcher
+	PayloadAvailabilityFetcher
+}
+
+// PayloadAvailabilityFetcher provides the payload arrival and blob data availability status
+// used to build payload attestations.
+type PayloadAvailabilityFetcher interface {
+	PayloadEarly([32]byte) (bool, bool)
+	DataAvailable(context.Context, [32]byte, primitives.Slot) (bool, error)
 }
 
 // ForkchoiceFetcher defines a common interface for methods that access directly
@@ -50,8 +58,6 @@ type ForkchoiceFetcher interface {
 	HighestReceivedBlockRoot() [32]byte
 	HasNode([32]byte) bool
 	HasFullNode([32]byte) bool
-	PayloadEarly([32]byte) (bool, bool)
-	DataAvailable(context.Context, [32]byte, primitives.Slot) (bool, error)
 	FullBeatsEmpty([32]byte) bool
 	ReceivedBlocksLastEpoch() (uint64, error)
 	InsertNode(context.Context, state.BeaconState, consensus_blocks.ROBlock) error

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -388,9 +388,17 @@ func (s *Service) DataAvailable(ctx context.Context, root [32]byte, slot primiti
 		return true, nil
 	}
 
-	b, err := s.getBlock(ctx, root)
-	if err != nil {
-		return false, errors.Wrap(err, "could not get block")
+	s.headLock.RLock()
+	var b interfaces.ReadOnlySignedBeaconBlock
+	if s.head != nil && s.head.root == root {
+		b = s.head.block
+	}
+	s.headLock.RUnlock()
+	if b == nil {
+		b, err = s.getBlock(ctx, root)
+		if err != nil {
+			return false, errors.Wrap(err, "could not get block")
+		}
 	}
 	sbid, err := b.Block().Body().SignedExecutionPayloadBid()
 	if err != nil {

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -378,6 +378,27 @@ func (s *Service) PayloadEarly(root [32]byte) (bool, bool) {
 	return s.payloadArrivals.isEarly(root)
 }
 
+// DataAvailable reports whether all blob data committed to by the block at root is available now.
+func (s *Service) DataAvailable(ctx context.Context, root [32]byte, slot primitives.Slot) (bool, error) {
+	available, err := s.dataColumnsAvailableNow(ctx, root, slot)
+	if err != nil {
+		return false, errors.Wrap(err, "data columns available now")
+	}
+	if available {
+		return true, nil
+	}
+
+	b, err := s.getBlock(ctx, root)
+	if err != nil {
+		return false, errors.Wrap(err, "could not get block")
+	}
+	sbid, err := b.Block().Body().SignedExecutionPayloadBid()
+	if err != nil {
+		return false, errors.Wrap(err, "could not get signed execution payload bid from block")
+	}
+	return len(sbid.GetMessage().GetBlobKzgCommitments()) == 0, nil
+}
+
 // notifyForkchoiceUpdateGloas takes the block hash directly because Gloas
 // blocks don't carry an execution payload in the body.
 func (s *Service) notifyForkchoiceUpdateGloas(ctx context.Context, blockHash [32]byte, attributes payloadattribute.Attributer) (*enginev1.PayloadIDBytes, error) {

--- a/beacon-chain/blockchain/receive_execution_payload_envelope_test.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/execution"
 	mockExecution "github.com/OffchainLabs/prysm/v7/beacon-chain/execution/testing"
 	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
@@ -20,6 +21,7 @@ import (
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
@@ -245,6 +247,39 @@ func TestReceiveExecutionPayloadEnvelope_EmitsHeadV2Event(t *testing.T) {
 		require.Equal(t, 1, len(headV2))
 		require.Equal(t, blockRoot, headV2[0].Block)
 		require.Equal(t, "full", headV2[0].PayloadStatus.String())
+	})
+}
+
+func TestDataAvailable(t *testing.T) {
+	saveGloasBlock := func(t *testing.T, service *Service, commitments [][]byte) [32]byte {
+		b := util.NewBeaconBlockGloas()
+		b.Block.Body.SignedExecutionPayloadBid.Message.BlobKzgCommitments = commitments
+		sb, err := blocks.NewSignedBeaconBlock(b)
+		require.NoError(t, err)
+		root, err := sb.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, service.cfg.BeaconDB.SaveBlock(t.Context(), sb))
+		return root
+	}
+
+	t.Run("unknown block returns error", func(t *testing.T) {
+		service, _ := minimalTestService(t, WithDataColumnStorage(filesystem.NewEphemeralDataColumnStorage(t)))
+		_, err := service.DataAvailable(t.Context(), [32]byte{'a'}, 0)
+		require.NotNil(t, err)
+	})
+	t.Run("no blob commitments", func(t *testing.T) {
+		service, _ := minimalTestService(t, WithDataColumnStorage(filesystem.NewEphemeralDataColumnStorage(t)))
+		root := saveGloasBlock(t, service, nil)
+		available, err := service.DataAvailable(t.Context(), root, 0)
+		require.NoError(t, err)
+		require.Equal(t, true, available)
+	})
+	t.Run("commitments with no columns stored", func(t *testing.T) {
+		service, _ := minimalTestService(t, WithDataColumnStorage(filesystem.NewEphemeralDataColumnStorage(t)))
+		root := saveGloasBlock(t, service, [][]byte{bytesutil.PadTo([]byte{0x01}, 48)})
+		available, err := service.DataAvailable(t.Context(), root, 0)
+		require.NoError(t, err)
+		require.Equal(t, false, available)
 	})
 }
 

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -52,6 +52,8 @@ type ChainService struct {
 	MockCanonicalRoots          map[primitives.Slot][32]byte
 	InitSyncBlockRoots          map[[32]byte]bool
 	MockPayloadEarly            map[[32]byte]bool
+	MockDataAvailable           map[[32]byte]bool
+	MockDataAvailableErr        error
 	ParentPayloadReadyVal       *bool
 	BlockSlot                   primitives.Slot
 	OptimisticRoots             map[[32]byte]bool
@@ -807,6 +809,14 @@ func (s *ChainService) PayloadEarly(root [32]byte) (bool, bool) {
 	}
 	early, ok := s.MockPayloadEarly[root]
 	return early, ok
+}
+
+// DataAvailable mocks the same method in the chain service.
+func (s *ChainService) DataAvailable(_ context.Context, root [32]byte, _ primitives.Slot) (bool, error) {
+	if s.MockDataAvailableErr != nil {
+		return false, s.MockDataAvailableErr
+	}
+	return s.MockDataAvailable[root], nil
 }
 
 // FullBeatsEmpty mocks the same method in the chain service.

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -1024,11 +1024,11 @@ func (s *Service) buildPayloadAttestationData(ctx context.Context, slot primitiv
 	if !s.hasCanonicalShuffling(root, slot) {
 		return nil, &RpcError{Reason: Unavailable, Err: fmt.Errorf("no canonical shuffling block for slot %d", slot)}
 	}
-	available, err := s.ForkchoiceFetcher.DataAvailable(ctx, root, slot)
+	available, err := s.ChainInfoFetcher.DataAvailable(ctx, root, slot)
 	if err != nil {
 		return nil, &RpcError{Reason: Internal, Err: fmt.Errorf("could not check data availability for block root %#x: %w", root, err)}
 	}
-	payloadEarly, _ := s.ForkchoiceFetcher.PayloadEarly(root)
+	payloadEarly, _ := s.ChainInfoFetcher.PayloadEarly(root)
 	return &ethpb.PayloadAttestationData{
 		BeaconBlockRoot:   root[:],
 		Slot:              slot,

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -939,7 +939,7 @@ func (s *Service) PayloadAttestationData(
 	ctx context.Context,
 	slot primitives.Slot,
 ) (*ethpb.PayloadAttestationData, *RpcError) {
-	_, span := trace.StartSpan(ctx, "coreService.PayloadAttestationData")
+	ctx, span := trace.StartSpan(ctx, "coreService.PayloadAttestationData")
 	defer span.End()
 
 	if slots.ToEpoch(slot) < params.BeaconConfig().GloasForkEpoch {
@@ -965,7 +965,7 @@ func (s *Service) PayloadAttestationData(
 		if cached := s.payloadAttestationData.Load(); cached != nil && cached.Slot == slot {
 			return cached, nil
 		}
-		data, rpcErr := s.buildPayloadAttestationData(slot)
+		data, rpcErr := s.buildPayloadAttestationData(ctx, slot)
 		if rpcErr != nil {
 			return rpcErr, nil
 		}
@@ -1012,7 +1012,7 @@ func (s *Service) hasCanonicalShuffling(root [32]byte, slot primitives.Slot) boo
 
 // buildPayloadAttestationData builds a payload attestation message for the validator to sign. It attempts first
 // to build from the highest received slot but only if it is compatible with the head view.
-func (s *Service) buildPayloadAttestationData(slot primitives.Slot) (*ethpb.PayloadAttestationData, *RpcError) {
+func (s *Service) buildPayloadAttestationData(ctx context.Context, slot primitives.Slot) (*ethpb.PayloadAttestationData, *RpcError) {
 	highestReceivedSlot := s.ForkchoiceFetcher.HighestReceivedBlockSlot()
 	if highestReceivedSlot != slot {
 		return nil, &RpcError{Reason: NoContent, Err: fmt.Errorf("no block found at slot=%d", slot)}
@@ -1024,11 +1024,15 @@ func (s *Service) buildPayloadAttestationData(slot primitives.Slot) (*ethpb.Payl
 	if !s.hasCanonicalShuffling(root, slot) {
 		return nil, &RpcError{Reason: Unavailable, Err: fmt.Errorf("no canonical shuffling block for slot %d", slot)}
 	}
+	available, err := s.ForkchoiceFetcher.DataAvailable(ctx, root, slot)
+	if err != nil {
+		return nil, &RpcError{Reason: Internal, Err: fmt.Errorf("could not check data availability for block root %#x: %w", root, err)}
+	}
 	payloadEarly, _ := s.ForkchoiceFetcher.PayloadEarly(root)
 	return &ethpb.PayloadAttestationData{
 		BeaconBlockRoot:   root[:],
 		Slot:              slot,
 		PayloadPresent:    payloadEarly,
-		BlobDataAvailable: s.ForkchoiceFetcher.HasFullNode(root),
+		BlobDataAvailable: available,
 	}, nil
 }

--- a/beacon-chain/rpc/core/validator_test.go
+++ b/beacon-chain/rpc/core/validator_test.go
@@ -218,7 +218,7 @@ func TestPayloadAttestationData(t *testing.T) {
 		slot := primitives.Slot(5)
 		root := bytesutil.PadTo([]byte("head-root"), 32)
 		chain := &mockChain.ChainService{Slot: &slot, Root: root}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.IsNil(t, rpcErr)
@@ -242,7 +242,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.IsNil(t, rpcErr)
@@ -267,7 +267,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.IsNil(t, rpcErr)
@@ -288,7 +288,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			MockCanonicalRoots:   map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
 			MockDataAvailableErr: errors.New("block lookup failed"),
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		_, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.NotNil(t, rpcErr)
@@ -307,7 +307,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			Genesis: time.Now(),
 			Root:    bytesutil.PadTo([]byte{0xAA}, 32),
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		_, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.NotNil(t, rpcErr)
@@ -331,7 +331,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.IsNil(t, rpcErr)
@@ -354,7 +354,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
 			MockCanonicalFull:  map[primitives.Slot]bool{slot: false},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		first, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.IsNil(t, rpcErr)
@@ -400,7 +400,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
 			MockCanonicalFull:  map[primitives.Slot]bool{slot: false},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		const callers = 16
 		results := make([]*ethpb.PayloadAttestationData, callers)
@@ -440,7 +440,7 @@ func TestPayloadAttestationData(t *testing.T) {
 				return bytesutil.ToBytes32(bytesutil.PadTo([]byte{0x02}, 32)), nil
 			},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		_, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.NotNil(t, rpcErr)
@@ -468,7 +468,7 @@ func TestPayloadAttestationData(t *testing.T) {
 				return dependent, nil
 			},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.IsNil(t, rpcErr)
@@ -498,7 +498,7 @@ func TestPayloadAttestationData(t *testing.T) {
 				return dependent, nil
 			},
 		}
-		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain}
 
 		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
 		require.IsNil(t, rpcErr)

--- a/beacon-chain/rpc/core/validator_test.go
+++ b/beacon-chain/rpc/core/validator_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/binary"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -238,7 +239,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			Slot:               &slot,
 			Root:               root,
 			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
-			MockCanonicalFull:  map[primitives.Slot]bool{slot: true},
+			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 		}
 		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
@@ -249,6 +250,50 @@ func TestPayloadAttestationData(t *testing.T) {
 		assert.Equal(t, slot, data.Slot)
 		assert.Equal(t, true, data.PayloadPresent)
 		assert.Equal(t, true, data.BlobDataAvailable)
+	})
+	t.Run("data available while payload not yet inserted", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		slot := primitives.Slot(5)
+		root := bytesutil.PadTo([]byte("head-root"), 32)
+		chain := &mockChain.ChainService{
+			Slot:               &slot,
+			Root:               root,
+			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
+			MockCanonicalFull:  map[primitives.Slot]bool{slot: false},
+			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
+			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
+		}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+
+		data, rpcErr := s.PayloadAttestationData(t.Context(), slot)
+		require.IsNil(t, rpcErr)
+		assert.Equal(t, true, data.PayloadPresent)
+		assert.Equal(t, true, data.BlobDataAvailable)
+	})
+	t.Run("data availability lookup error → Internal", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		slot := primitives.Slot(5)
+		root := bytesutil.PadTo([]byte("head-root"), 32)
+		chain := &mockChain.ChainService{
+			Slot:                 &slot,
+			Root:                 root,
+			MockCanonicalRoots:   map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
+			MockDataAvailableErr: errors.New("block lookup failed"),
+		}
+		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
+
+		_, rpcErr := s.PayloadAttestationData(t.Context(), slot)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, ErrorReason(Internal), rpcErr.Reason)
+		assert.ErrorContains(t, "could not check data availability", rpcErr.Err)
 	})
 	t.Run("before PTC deadline and not final → Unavailable", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
@@ -283,7 +328,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			Genesis:            time.Now(),
 			Root:               root,
 			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
-			MockCanonicalFull:  map[primitives.Slot]bool{slot: true},
+			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 		}
 		s := &Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain}
@@ -416,7 +461,7 @@ func TestPayloadAttestationData(t *testing.T) {
 			Slot:               &slot,
 			Root:               root,
 			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
-			MockCanonicalFull:  map[primitives.Slot]bool{slot: true},
+			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			HeadDependentRoot:  dependent,
 			DependentRootCB: func(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -4052,7 +4052,7 @@ func TestGetPayloadAttestationData(t *testing.T) {
 			HeadFetcher:           chainService,
 			TimeFetcher:           chainService,
 			OptimisticModeFetcher: chainService,
-			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService},
+			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService, ChainInfoFetcher: chainService},
 		}
 
 		request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/validator/payload_attestation_data?slot=0", nil)
@@ -4108,7 +4108,7 @@ func TestGetPayloadAttestationData(t *testing.T) {
 			HeadFetcher:           chainService,
 			TimeFetcher:           chainService,
 			OptimisticModeFetcher: chainService,
-			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService},
+			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService, ChainInfoFetcher: chainService},
 		}
 
 		request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/validator/payload_attestation_data?slot=5", nil)
@@ -4141,7 +4141,7 @@ func TestGetPayloadAttestationData(t *testing.T) {
 			HeadFetcher:           chainService,
 			TimeFetcher:           chainService,
 			OptimisticModeFetcher: chainService,
-			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService},
+			CoreService:           &core.Service{GenesisTimeFetcher: chainService, ForkchoiceFetcher: chainService, HeadFetcher: chainService, ChainInfoFetcher: chainService},
 		}
 
 		request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/validator/payload_attestation_data?slot=5", nil)

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -4100,7 +4100,7 @@ func TestGetPayloadAttestationData(t *testing.T) {
 			Slot:               &slot,
 			Root:               root,
 			MockCanonicalRoots: map[primitives.Slot][32]byte{slot: bytesutil.ToBytes32(root)},
-			MockCanonicalFull:  map[primitives.Slot]bool{slot: true},
+			MockDataAvailable:  map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 			MockPayloadEarly:   map[[32]byte]bool{bytesutil.ToBytes32(root): true},
 		}
 		s := &Server{

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation_test.go
@@ -55,7 +55,7 @@ func TestPayloadAttestationData_OK(t *testing.T) {
 		TimeFetcher:       chain,
 		HeadFetcher:       chain,
 		ForkchoiceFetcher: chain,
-		CoreService:       &core.Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain},
+		CoreService:       &core.Service{GenesisTimeFetcher: chain, ForkchoiceFetcher: chain, HeadFetcher: chain, ChainInfoFetcher: chain},
 	}
 
 	resp, err := vs.PayloadAttestationData(t.Context(), &ethpb.PayloadAttestationDataRequest{Slot: slot})

--- a/changelog/terence_fix_ptc_blob_da_getter.md
+++ b/changelog/terence_fix_ptc_blob_da_getter.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- PTC payload attestation now reports blob data availability from the data column store instead of forkchoice payload insertion.


### PR DESCRIPTION
- `BlobDataAvailable` in payload attestation data was populated from `HasFullNode`, which only flips after the envelope is fully imported
- Per spec, `blob_data_available` is `is_data_available(beacon_block_root)`, independent of envelope import
- New `DataAvailable` getter checks the non-blocking column store status first, and only reads the block's bid when no columns are stored, since an empty column summary can't distinguish a blobless payload from missing data and this order avoids a DB block read in the common case