### PR TITLE
Add native proposer timing games support

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -88,6 +88,11 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
+
+	return nil
+}
+
+func configureBuilderGetHeaderTimeout(cliCtx *cli.Context) error {
 	if cliCtx.IsSet(flags.BuilderGetHeaderTimeout.Name) {
 		c := params.BeaconConfig().Copy()
 		c.BuilderGetHeaderTimeout = cliCtx.Duration(flags.BuilderGetHeaderTimeout.Name)
@@ -95,7 +100,6 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -88,6 +88,13 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
+	if cliCtx.IsSet(flags.BuilderGetHeaderTimeout.Name) {
+		c := params.BeaconConfig().Copy()
+		c.BuilderGetHeaderTimeout = cliCtx.Duration(flags.BuilderGetHeaderTimeout.Name)
+		if err := params.SetActive(c); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
@@ -37,6 +38,20 @@ func TestConfigureHistoricalSlasher(t *testing.T) {
 			params.BeaconConfig().SlotsPerArchivedPoint,
 			int(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().MaxAttestations))),
 	)
+}
+
+func TestConfigureBuilderGetHeaderTimeout(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.Duration(flags.BuilderGetHeaderTimeout.Name, 0, "")
+	require.NoError(t, set.Set(flags.BuilderGetHeaderTimeout.Name, "950ms"))
+	cliCtx := cli.NewContext(&app, set, nil)
+
+	require.NoError(t, configureBuilderCircuitBreaker(cliCtx))
+
+	assert.Equal(t, 950*time.Millisecond, params.BeaconConfig().BuilderGetHeaderTimeout)
 }
 
 func TestConfigureSlotsPerArchivedPoint(t *testing.T) {

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -49,7 +49,7 @@ func TestConfigureBuilderGetHeaderTimeout(t *testing.T) {
 	require.NoError(t, set.Set(flags.BuilderGetHeaderTimeout.Name, "950ms"))
 	cliCtx := cli.NewContext(&app, set, nil)
 
-	require.NoError(t, configureBuilderCircuitBreaker(cliCtx))
+	require.NoError(t, configureBuilderGetHeaderTimeout(cliCtx))
 
 	assert.Equal(t, 950*time.Millisecond, params.BeaconConfig().BuilderGetHeaderTimeout)
 }

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -317,6 +317,10 @@ func configureBeacon(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "could not configure builder circuit breaker")
 	}
 
+	if err := configureBuilderGetHeaderTimeout(cliCtx); err != nil {
+		return errors.Wrap(err, "could not configure builder getHeader timeout")
+	}
+
 	if err := configureSlotsPerArchivedPoint(cliCtx); err != nil {
 		return errors.Wrap(err, "could not configure slots per archived point")
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -208,7 +208,13 @@ func (vs *Server) getPayloadHeaderFromBuilder(
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, blockBuilderTimeout)
+	// Bound the getHeader call by the configurable builder timeout, falling back
+	// to the default BUILDER_PROPOSAL_DELAY_TOLERANCE when unset.
+	timeout := blockBuilderTimeout
+	if t := params.BeaconConfig().BuilderGetHeaderTimeout; t > 0 {
+		timeout = t
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	signedBid, err := vs.BlockBuilder.GetHeader(ctx, slot, bytesutil.ToBytes32(h.BlockHash()), pk)

--- a/changelog/ethermachine_proposer-timing-games.md
+++ b/changelog/ethermachine_proposer-timing-games.md
@@ -1,0 +1,3 @@
+### Added
+
+- Opt-in proposer timing games support: `--enable-proposer-timing-games` and `--proposer-timing-game-delay` validator flags delay the block proposal request within the slot (clamped to stay safely before the attestation deadline), and a new `--builder-getheader-timeout` beacon node flag makes the previously hardcoded 1s builder getHeader timeout configurable.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -78,6 +78,13 @@ var (
 			" and the beacon will revert to local building.",
 		Value: 0,
 	}
+	// BuilderGetHeaderTimeout bounds how long the beacon node waits for a builder relay getHeader response.
+	BuilderGetHeaderTimeout = &cli.DurationFlag{
+		Name: "builder-getheader-timeout",
+		Usage: "Maximum time to wait for a builder relay getHeader response before falling back to local block building (e.g. 1s, 950ms). " +
+			"Lower values reduce missed-slot risk when using proposer timing games; higher values tolerate slower relays.",
+		DefaultText: params.BeaconConfig().BuilderGetHeaderTimeout.String(),
+	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer
 	ExecutionEngineEndpoint = &cli.StringFlag{
 		Name:  "execution-endpoint",

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -87,6 +87,7 @@ var appFlags = []cli.Flag{
 	flags.LocalBlockValueBoost,
 	flags.MinBuilderBid,
 	flags.MinBuilderDiff,
+	flags.BuilderGetHeaderTimeout,
 	flags.BeaconDBPruning,
 	flags.PrunerRetentionEpochs,
 	flags.DisableBuilderSSZ,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -144,6 +144,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.MevRelayEndpoint,
 			flags.MinBuilderBid,
 			flags.MinBuilderDiff,
+			flags.BuilderGetHeaderTimeout,
 			flags.SuggestedFeeRecipient,
 			flags.DisableBuilderSSZ,
 		},

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -92,6 +92,14 @@ type Flags struct {
 	// AggregateIntervals specifies the time durations at which we aggregate attestations preparing for forkchoice.
 	AggregateIntervals [3]time.Duration
 
+	// EnableProposerTimingGames delays the block proposal request within the slot so
+	// builders have more time to accrue MEV (proposer timing games). Off by default.
+	EnableProposerTimingGames bool
+	// ProposerTimingGameDelay is the target time into the slot at which the block
+	// proposal request is released when EnableProposerTimingGames is set. Only read
+	// when EnableProposerTimingGames is true; the effective value is clamped at use.
+	ProposerTimingGameDelay time.Duration
+
 	// Feature related flags (alignment forced in the end)
 	ForceHead        string                // ForceHead forces the head block to be a specific block root, the last head block, or the last finalized block.
 	BlacklistedRoots map[[32]byte]struct{} // BlacklistedRoots is a list of roots that are blacklisted from processing.
@@ -371,6 +379,11 @@ func ConfigureValidator(ctx *cli.Context) error {
 	}
 
 	cfg.KeystoreImportDebounceInterval = ctx.Duration(dynamicKeyReloadDebounceInterval.Name)
+	if ctx.Bool(enableProposerTimingGames.Name) {
+		logEnabled(enableProposerTimingGames)
+		cfg.EnableProposerTimingGames = true
+		cfg.ProposerTimingGameDelay = ctx.Duration(proposerTimingGameDelay.Name)
+	}
 	Init(cfg)
 	return nil
 }

--- a/config/features/config_test.go
+++ b/config/features/config_test.go
@@ -3,6 +3,7 @@ package features
 import (
 	"flag"
 	"testing"
+	"time"
 
 	validatorflags "github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -58,6 +59,31 @@ func TestConfigureValidator_RESTApiEnabledByEndpoint(t *testing.T) {
 	context = cli.NewContext(&app, set, nil)
 	require.NoError(t, ConfigureValidator(context))
 	assert.Equal(t, false, Get().EnableBeaconRESTApi)
+}
+
+func TestConfigureValidator_ProposerTimingGames(t *testing.T) {
+	defer Init(&Flags{})
+	app := cli.App{}
+
+	// Enabling timing games reads the configured delay.
+	set := flag.NewFlagSet("test", 0)
+	set.Bool(enableProposerTimingGames.Name, true, "test")
+	set.Duration(proposerTimingGameDelay.Name, 2*time.Second, "test")
+	require.NoError(t, set.Set(enableProposerTimingGames.Name, "true"))
+	require.NoError(t, set.Set(proposerTimingGameDelay.Name, "2s"))
+	context := cli.NewContext(&app, set, nil)
+	require.NoError(t, ConfigureValidator(context))
+	assert.Equal(t, true, Get().EnableProposerTimingGames)
+	assert.Equal(t, 2*time.Second, Get().ProposerTimingGameDelay)
+
+	// Without the gate the delay is ignored and stays zero (behavior unchanged).
+	set = flag.NewFlagSet("test", 0)
+	set.Duration(proposerTimingGameDelay.Name, 2*time.Second, "test")
+	require.NoError(t, set.Set(proposerTimingGameDelay.Name, "2s"))
+	context = cli.NewContext(&app, set, nil)
+	require.NoError(t, ConfigureValidator(context))
+	assert.Equal(t, false, Get().EnableProposerTimingGames)
+	assert.Equal(t, time.Duration(0), Get().ProposerTimingGameDelay)
 }
 
 func TestConfigureBeaconConfig(t *testing.T) {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -227,6 +227,24 @@ var (
 		Name:  "track-equivocations",
 		Usage: "Records proposer equivocations observed on gossip and marks the slot in forkchoice if the equivocation arrives before the configured early deadline.",
 	}
+	// enableProposerTimingGames opts the validator into proposer timing games:
+	// delaying the block proposal request within the slot so builders have more
+	// time to accrue MEV. Gated behind this experimental flag; off by default.
+	enableProposerTimingGames = &cli.BoolFlag{
+		Name: "enable-proposer-timing-games",
+		Usage: "(Experimental): Delays the block proposal request within the slot so builders have more time to accrue MEV (proposer timing games). " +
+			"Opt-in and off by default. Tune the delay with --proposer-timing-game-delay. WARNING: this increases the risk of orphaned/reorged blocks; " +
+			"the effective delay is clamped to remain before the attestation deadline.",
+		Value: false,
+	}
+	// proposerTimingGameDelay is the target time into the slot at which the block
+	// proposal request is released when timing games are enabled.
+	proposerTimingGameDelay = &cli.DurationFlag{
+		Name: "proposer-timing-game-delay",
+		Usage: "(Experimental): Target time into the slot at which the block proposal request is released when --enable-proposer-timing-games is set " +
+			"(e.g. 1500ms, 2s). Clamped to a safe maximum before the attestation deadline. Has no effect unless timing games are enabled.",
+		Value: 1500 * time.Millisecond,
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -249,6 +267,8 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	EnableBeaconRESTApi,
 	DisableDutiesV2,
 	EnableWebFlag,
+	enableProposerTimingGames,
+	proposerTimingGameDelay,
 }...)
 
 // E2EValidatorFlags contains a list of the validator feature flags to be tested in E2E.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -267,6 +267,7 @@ type BeaconChainConfig struct {
 	LocalBlockValueBoost             uint64          // LocalBlockValueBoost is the value boost for local block construction. This is used to prioritize local block construction over relay/builder block construction.
 	MinBuilderBid                    uint64          // MinBuilderBid is the minimum value that the builder's block can have to be considered by this node.
 	MinBuilderDiff                   uint64          // MinBuilderDiff is the minimum value above the local block value that the builder has to bid to be considered by this node
+	BuilderGetHeaderTimeout          time.Duration   // BuilderGetHeaderTimeout is the maximum time to wait for a builder getHeader response (known as BUILDER_PROPOSAL_DELAY_TOLERANCE in the builder spec). Configurable to support proposer timing games.
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue uint64 // ExecutionEngineTimeoutValue defines the seconds to wait before timing out engine endpoints with execution payload execution semantics (newPayload, forkchoiceUpdated).
 

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -303,6 +303,8 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
+	// Builder getHeader timeout (BUILDER_PROPOSAL_DELAY_TOLERANCE)
+	BuilderGetHeaderTimeout: 1 * time.Second,
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core
 

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/async"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/config/proposer"
@@ -58,6 +59,16 @@ func (v *validator) ProposeBlock(ctx context.Context, slot primitives.Slot, pubK
 	fmtKey := fmt.Sprintf("%#x", pubKey[:])
 	span.SetAttributes(trace.StringAttribute("validator", fmtKey))
 	log := log.WithField("pubkey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:])))
+
+	// Proposer timing games: optionally delay the block request into the slot so
+	// builders have more time to accrue MEV. Gated behind an experimental flag and
+	// clamped to remain before the attestation deadline (see proposalReleaseDelay).
+	if features.Get().EnableProposerTimingGames {
+		if delay := v.proposalReleaseDelay(slot); delay > 0 {
+			log.WithField("slot", slot).WithField("delay", delay).Debug("Delaying block proposal for timing games")
+			v.waitUntilSlotOffset(ctx, slot, delay)
+		}
+	}
 
 	// Sign randao reveal, it's used to request block from beacon node
 	epoch := primitives.Epoch(slot / params.BeaconConfig().SlotsPerEpoch)

--- a/validator/client/wait_helpers.go
+++ b/validator/client/wait_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing"
@@ -11,6 +12,12 @@ import (
 	prysmTime "github.com/OffchainLabs/prysm/v7/time"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
+
+// proposerTimingGameSafetyBudget is the time reserved at the end of the
+// timing-game window for the builder getHeader round-trip (~1s) plus block
+// propagation, so that a delayed proposal still lands before the attestation
+// deadline and the slot is not missed.
+const proposerTimingGameSafetyBudget = 1500 * time.Millisecond
 
 // slotComponentDeadline returns the absolute time corresponding to the provided slot component.
 func (v *validator) slotComponentDeadline(slot primitives.Slot, component primitives.BP) (time.Time, error) {
@@ -71,6 +78,68 @@ func (v *validator) waitForPayloadAvailableOrDeadline(ctx context.Context, slot 
 	case <-available:
 	case <-t.C:
 	}
+}
+
+// waitUntilSlotOffset blocks until the given absolute offset into the slot has
+// elapsed (slot start + offset), or the context is cancelled. It is used by the
+// proposer timing-game path to release the block proposal request later in the slot.
+func (v *validator) waitUntilSlotOffset(ctx context.Context, slot primitives.Slot, offset time.Duration) {
+	ctx, span := trace.StartSpan(ctx, "validator.waitProposerTimingGame")
+	defer span.End()
+
+	startTime, err := slots.StartTime(v.genesisTime, slot)
+	if err != nil {
+		log.WithError(err).WithField("slot", slot).Error("Slot overflows, unable to wait for proposer timing-game delay")
+		return
+	}
+	wait := prysmTime.Until(startTime.Add(offset))
+	if wait <= 0 {
+		return
+	}
+	t := time.NewTimer(wait)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		tracing.AnnotateError(span, ctx.Err())
+		return
+	case <-t.C:
+		return
+	}
+}
+
+// proposalReleaseDelay returns the proposer timing-game delay to apply before
+// releasing the block proposal request for slot. The configured delay is clamped
+// so that the request, the builder getHeader round-trip and block propagation
+// still complete before the attestation deadline (never missing the slot because
+// of the delay). It logs a warning when the value is clamped, or when it is set
+// beyond the honest-reorg-safe threshold.
+func (v *validator) proposalReleaseDelay(slot primitives.Slot) time.Duration {
+	configured := features.Get().ProposerTimingGameDelay
+	if configured <= 0 {
+		return 0
+	}
+	cfg := params.BeaconConfig()
+	// The attestation deadline is the point by which attesters vote on the head;
+	// the block must be requested early enough to fetch the builder bid and
+	// propagate before it. Use the fork-appropriate deadline.
+	dueBPS := cfg.AttestationDueBPS
+	if slots.ToEpoch(slot) >= cfg.GloasForkEpoch {
+		dueBPS = cfg.AttestationDueBPSGloas
+	}
+	maxDelay := cfg.SlotComponentDuration(dueBPS) - proposerTimingGameSafetyBudget
+	if maxDelay < 0 {
+		maxDelay = 0
+	}
+	if configured > maxDelay {
+		log.WithField("configuredDelay", configured).WithField("clampedDelay", maxDelay).
+			Warn("Proposer timing-game delay exceeds the safe maximum before the attestation deadline; clamping to avoid a missed slot")
+		return maxDelay
+	}
+	if reorgCutoff := cfg.SlotComponentDuration(cfg.ProposerReorgCutoffBPS); configured > reorgCutoff {
+		log.WithField("configuredDelay", configured).WithField("reorgCutoff", reorgCutoff).
+			Warn("Proposer timing-game delay is beyond the honest-reorg-safe threshold; the block may be orphaned")
+	}
+	return configured
 }
 
 func (v *validator) slotComponentSpanName(component primitives.BP) string {

--- a/validator/client/wait_helpers_test.go
+++ b/validator/client/wait_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -83,5 +84,81 @@ func TestWaitUntilSlotComponent_ContextCancelReturnsImmediately(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("waitUntilSlotComponent did not return after context cancellation")
+	}
+}
+
+func TestWaitUntilSlotOffset_ReturnsImmediatelyWhenOffsetElapsed(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+
+	// Genesis far enough in the past that slot 1's start + offset is already elapsed.
+	v := &validator{genesisTime: time.Now().Add(-time.Hour)}
+
+	done := make(chan struct{})
+	go func() {
+		v.waitUntilSlotOffset(context.Background(), 1, 1500*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitUntilSlotOffset did not return when the offset had already elapsed")
+	}
+}
+
+func TestWaitUntilSlotOffset_ContextCancelReturnsImmediately(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+
+	// Genesis in the future so the offset has not elapsed; only ctx cancel unblocks.
+	v := &validator{genesisTime: time.Now().Add(time.Hour)}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		v.waitUntilSlotOffset(ctx, 1, 2*time.Second)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitUntilSlotOffset did not return after context cancellation")
+	}
+}
+
+func TestProposalReleaseDelay(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+
+	v := &validator{genesisTime: time.Now()}
+	slot := primitives.Slot(5)
+
+	// Compute the fork-appropriate bounds the same way the implementation does.
+	dueBPS := cfg.AttestationDueBPS
+	if slots.ToEpoch(slot) >= cfg.GloasForkEpoch {
+		dueBPS = cfg.AttestationDueBPSGloas
+	}
+	maxDelay := cfg.SlotComponentDuration(dueBPS) - proposerTimingGameSafetyBudget
+	reorgCutoff := cfg.SlotComponentDuration(cfg.ProposerReorgCutoffBPS)
+	require.Equal(t, true, maxDelay > 0)
+	require.Equal(t, true, reorgCutoff < maxDelay)
+
+	tests := []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{name: "disabled returns zero", configured: 0, want: 0},
+		{name: "below cutoff passes through", configured: reorgCutoff - time.Second, want: reorgCutoff - time.Second},
+		{name: "beyond reorg cutoff still allowed", configured: reorgCutoff + 100*time.Millisecond, want: reorgCutoff + 100*time.Millisecond},
+		{name: "above max is clamped", configured: maxDelay + time.Second, want: maxDelay},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reset := features.InitWithReset(&features.Flags{ProposerTimingGameDelay: tt.configured})
+			defer reset()
+			assert.Equal(t, tt.want, v.proposalReleaseDelay(slot))
+		})
 	}
 }

--- a/validator/client/wait_helpers_test.go
+++ b/validator/client/wait_helpers_test.go
@@ -129,6 +129,9 @@ func TestWaitUntilSlotOffset_ContextCancelReturnsImmediately(t *testing.T) {
 
 func TestProposalReleaseDelay(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
+	// Pin the mainnet config: the bounds below assume the pre-Gloas attestation
+	// deadline, and other tests in this package activate Gloas globally.
+	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
 	cfg := params.BeaconConfig()
 
 	v := &validator{genesisTime: time.Now()}


### PR DESCRIPTION
## Summary

Adds **opt-in, experimental** support for **proposer timing games** to Prysm: the validator can delay its block proposal request within the slot so builders have more time to accrue MEV (higher proposer rewards), while safety rails prevent the block from being requested so late that it misses the attestation deadline (and the slot).

Today Prysm requests the block — and therefore the builder `getHeader` bid — immediately at the start of the slot (`t=0`), leaving MEV on the table. Other stacks expose this only through sidecars/relays (mev-boost `target_first_request_ms`, commit-boost, Vouch, relay-side `headerDelay`). This change makes it a first-class, native knob in the validator client, **defaulting off** so existing behavior is unchanged.

## What's added

### Validator client
- `--enable-proposer-timing-games` — experimental gate. Off by default; behavior is untouched unless set.
- `--proposer-timing-game-delay` — target time into the slot at which the block proposal request is released (default `1500ms`). Only takes effect when the gate is on.

The delay is applied at the top of `ProposeBlock`, before the RANDAO signature and the block request. It is **clamped** so the request, the builder `getHeader` round-trip (~1s) and block propagation still finish before the attestation deadline (`ATTESTATION_DUE_BPS`, ~4s on mainnet) — so the delay can never, by itself, cause a missed slot. On mainnet the effective maximum is ~2.5s. A warning is logged when the configured value:
- exceeds the safe maximum (the value is clamped), or
- is beyond the honest-reorg-safe threshold (`PROPOSER_REORG_CUTOFF_BPS`, ~2s), where orphan risk rises.

The clamp is fork-aware (uses the Gloas attestation deadline once Gloas is active).

### Beacon node
- `--builder-getheader-timeout` — makes the previously hardcoded 1s builder `getHeader` timeout (`BUILDER_PROPOSAL_DELAY_TOLERANCE`) configurable. Falls back to 1s when unset. Useful to tighten the relay budget (mev-boost uses 950ms) when playing timing games.

## How to use

Validator — release the proposal ~2s into the slot:

```
validator \
  --enable-proposer-timing-games \
  --proposer-timing-game-delay=2s \
  ...
```

Beacon node — tighten the relay getHeader budget (optional, complementary):

```
beacon-chain \
  --http-mev-relay=<relay-endpoint> \
  --builder-getheader-timeout=950ms \
  ...
```

### Notes
- Both flags are opt-in. With neither set, behavior is identical to before (proposal at `t=0`, 1s getHeader timeout).
- The delay is most valuable with an external builder/relay (`--http-mev-relay`): it directly pushes back the `getHeader` bid request. With local block building it only slightly delays payload assembly.
- Sensible range on mainnet is ~1.4–2.2s. The value is clamped to a safe maximum (~2.5s) regardless of what is configured.
- Timing games increase the risk of orphaned/reorged blocks. The existing builder circuit breakers (`--max-builder-consecutive-missed-slots`, `--max-builder-epoch-missed-slots`) and the local-vs-builder value knobs (`--local-block-value-boost`, `--min-builder-bid`, `--min-builder-to-local-difference`) continue to apply and complement this feature.

## Safety
- Delay clamped to remain before the attestation deadline → the design invariant is "never miss a slot because of the delay".
- Loud warnings for aggressive configuration.
- Gated behind an experimental flag; default off.

## Testing
- `proposalReleaseDelay`: clamp and warning thresholds (mainnet, fork-aware).
- `waitUntilSlotOffset`: returns when the offset has elapsed and on context cancellation.
- `ConfigureValidator`: the gate reads the delay; without the gate the delay is ignored.
- `configureBuilderCircuitBreaker`: `--builder-getheader-timeout` is applied to the active config.
- Existing `ProposeBlock` tests pass unchanged (gate off by default).

## Files
- `config/features/flags.go`, `config/features/config.go` — flags + gate wiring
- `validator/client/wait_helpers.go`, `validator/client/propose.go` — delay + clamp, applied in `ProposeBlock`
- `config/params/config.go`, `config/params/mainnet_config.go` — configurable builder getHeader timeout (default 1s)
- `cmd/beacon-chain/flags/base.go`, `cmd/beacon-chain/main.go`, `cmd/beacon-chain/usage.go`, `beacon-chain/node/config.go`, `beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go` — beacon-side flag + wiring
