### PR TITLE
reduce state diff cache memory usage

### DIFF
--- a/beacon-chain/db/kv/state_diff_cache.go
+++ b/beacon-chain/db/kv/state_diff_cache.go
@@ -223,7 +223,9 @@ func (c *stateDiffCache) setAnchor(level int, anchor state.ReadOnlyBeaconState) 
 	if err != nil {
 		return err
 	}
-	compressed := snappy.Encode(nil, versionedAnchorBytes)
+	encoded := snappy.Encode(nil, versionedAnchorBytes)
+	compressed := make([]byte, len(encoded))
+	copy(compressed, encoded)
 
 	c.anchors[level] = compressed
 	stateDiffAnchorCacheBytes.WithLabelValues(strconv.Itoa(level)).Set(float64(len(compressed)))

--- a/beacon-chain/db/kv/state_diff_test.go
+++ b/beacon-chain/db/kv/state_diff_test.go
@@ -842,6 +842,7 @@ func TestStateDiff_AnchorCache(t *testing.T) {
 			err = db.saveStateByDiff(context.Background(), st)
 			require.NoError(t, err)
 			localCache[0] = st
+			require.Equal(t, len(db.stateDiffCache.anchors[0]), cap(db.stateDiffCache.anchors[0]))
 
 			// level 0 should be the same
 			localSSZ, err := localCache[0].MarshalSSZ()

--- a/changelog/bastin_state-diff-cache-memory-optimization-1.md
+++ b/changelog/bastin_state-diff-cache-memory-optimization-1.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fixed an oversight where a larger slice is retained in state diff cache than needed.


### PR DESCRIPTION

**What does this PR do? Why is it needed?**

Reduces the retained memory of the state-diff anchor cache.

snappy.Encode(nil, ...) allocates capacity for Snappy’s maximum encoded size, but the resulting compressed data is usually smaller. Because the cache retained that slice, it also retained the oversized backing allocation.

This change copies the encoded result into an exact-sized allocation before caching it, ensuring cap == len.

Anchor writes now perform one additional allocation and copy.

**Testing**
if you run the test that I modified, you can see that what we are saving in the cache is actually much larger than what it should be.
