### PR TITLE
Don't downscore honest peers for foreign data column sidecars

### DIFF
--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -41,6 +41,7 @@ type DataColumnSidecarsParams struct {
 	Storage                 filesystem.DataColumnStorageReader  // Data columns storage
 	NewVerifier             verification.NewDataColumnsVerifier // Data columns verifier to check to conformity of incoming data column sidecars
 	DownscorePeerOnRPCFault bool                                // Downscore a peer if it commits an RPC fault. Not responding sidecars at all is considered as a fault.
+	RequestByRoot           bool
 }
 
 // FetchDataColumnSidecars retrieves data column sidecars for the given blocks and indices
@@ -785,10 +786,14 @@ func sendDataColumnSidecarsRequest(
 		"requestedSidecars": requestedSidecarsCount,
 	})
 
-	// Try to build a by range byRangeRequest first.
-	byRangeRequests, err := buildByRangeRequests(slotByRoot, slotsWithCommitments, indicesByRoot, batchSize)
-	if err != nil {
-		return nil, errors.Wrap(err, "craft by range request")
+	var byRangeRequests []*ethpb.DataColumnSidecarsByRangeRequest
+	if !params.RequestByRoot {
+		// Try to build a by range byRangeRequest first.
+		requests, err := buildByRangeRequests(slotByRoot, slotsWithCommitments, indicesByRoot, batchSize)
+		if err != nil {
+			return nil, errors.Wrap(err, "craft by range request")
+		}
+		byRangeRequests = requests
 	}
 
 	// If we have a valid by range request, send it.
@@ -1001,6 +1006,15 @@ func verifyByRootDataColumnSidecars(
 	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 	roDataColumns []blocks.RODataColumn,
 ) ([]blocks.VerifiedRODataColumn, error) {
+	n := 0
+	for i := range roDataColumns {
+		if _, ok := blockByRoot[roDataColumns[i].BlockRoot()]; ok {
+			roDataColumns[n] = roDataColumns[i]
+			n++
+		}
+	}
+	roDataColumns = roDataColumns[:n]
+
 	// Gloas sidecars carry no commitments; seed them from the block's bid before the Fulu verifier runs.
 	for i := range roDataColumns {
 		if !roDataColumns[i].IsGloas() {

--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -1020,10 +1020,7 @@ func verifyByRootDataColumnSidecars(
 		if !roDataColumns[i].IsGloas() {
 			continue
 		}
-		block, ok := blockByRoot[roDataColumns[i].BlockRoot()]
-		if !ok {
-			return nil, fmt.Errorf("no local block for sidecar root %#x: %w", roDataColumns[i].BlockRoot(), ErrSidecarHeaderMismatch)
-		}
+		block := blockByRoot[roDataColumns[i].BlockRoot()]
 		commitments, err := block.Block().Body().BlobKzgCommitments()
 		if err != nil {
 			return nil, errors.Wrap(err, "get bid blob kzg commitments")
@@ -1046,11 +1043,7 @@ func verifyByRootDataColumnSidecars(
 	}
 
 	for _, sidecar := range roDataColumns {
-		block, ok := blockByRoot[sidecar.BlockRoot()]
-		if !ok {
-			return nil, fmt.Errorf("no local block for sidecar root %#x: %w", sidecar.BlockRoot(), ErrSidecarHeaderMismatch)
-		}
-
+		block := blockByRoot[sidecar.BlockRoot()]
 		if err := verifySidecarHeaderMatchesBlock(sidecar, block); err != nil {
 			return nil, fmt.Errorf("root %#x: %w", sidecar.BlockRoot(), err)
 		}

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -633,6 +633,64 @@ func TestSendDataColumnSidecarsRequest(t *testing.T) {
 		require.NoError(t, err)
 		require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
 	})
+
+	t.Run("recovery forces by root", func(t *testing.T) {
+		// A contiguous, uniform-index set would normally be sent as a by-range request;
+		// with RequestByRoot set it must be sent by root instead.
+		indicesByRoot := map[[fieldparams.RootLength]byte]map[uint64]bool{
+			expectedResponse.BlockRoot(): {1: true, 2: true},
+			{3}:                          {1: true, 2: true},
+			{4}:                          {1: true, 2: true},
+			{7}:                          {1: true, 2: true},
+		}
+
+		slotByRoot := map[[fieldparams.RootLength]byte]primitives.Slot{
+			expectedResponse.BlockRoot(): 1,
+			{3}:                          3,
+			{4}:                          4,
+			{7}:                          7,
+		}
+
+		slotsWithCommitments := map[primitives.Slot]bool{1: true, 3: true, 4: true, 7: true}
+
+		byRootProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRootTopicV1)
+		byRangeProtocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCDataColumnSidecarsByRangeTopicV1)
+		p2p, other := testp2p.NewTestP2P(t), testp2p.NewTestP2P(t)
+		p2p.Connect(other)
+
+		byRootCalled := false
+		other.SetStreamHandler(byRootProtocol, func(stream network.Stream) {
+			byRootCalled = true
+			receivedRequest := new(p2ptypes.DataColumnsByRootIdentifiers)
+			err := other.Encoding().DecodeWithMaxLength(stream, receivedRequest)
+			assert.NoError(t, err)
+			assert.Equal(t, 4, len(*receivedRequest))
+
+			err = WriteDataColumnSidecarChunk(stream, clock, other.Encoding(), expectedResponse)
+			assert.NoError(t, err)
+
+			err = stream.CloseWrite()
+			assert.NoError(t, err)
+		})
+		other.SetStreamHandler(byRangeProtocol, func(stream network.Stream) {
+			t.Error("by-range request must not be sent when RequestByRoot is set")
+			_ = stream.CloseWrite()
+		})
+
+		params := DataColumnSidecarsParams{
+			Ctx:           t.Context(),
+			Tor:           clock,
+			P2P:           p2p,
+			CtxMap:        ctxMap,
+			RateLimiter:   leakybucket.NewCollector(1., 1, time.Second, false /* deleteEmptyBuckets */),
+			RequestByRoot: true,
+		}
+
+		actualResponse, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, other.PeerID(), indicesByRoot)
+		require.NoError(t, err)
+		require.Equal(t, true, byRootCalled)
+		require.DeepSSZEqual(t, expectedResponse.DataColumnSidecar(), actualResponse[0].DataColumnSidecar())
+	})
 }
 
 func TestBuildByRangeRequests(t *testing.T) {
@@ -865,6 +923,10 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 			expectedSidecar := expected[index]
 			require.DeepSSZEqual(t, expectedSidecar.DataColumnSidecar(), actualSidecar.DataColumnSidecar())
 		}
+
+		scorer := p2p.Peers().Scorers().BadResponsesScorer()
+		require.Equal(t, true, scorer.Score("peer3") < 0)   // genuine KZG-proof fault is downscored
+		require.Equal(t, float64(0), scorer.Score("peer1")) // honest peer is not penalized
 	})
 
 	t.Run("rogue peer with junk header signature", func(t *testing.T) {
@@ -943,6 +1005,45 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(actual))
+		// The peer is NOT downscored for returning sidecars whose block we don't hold locally.
+		require.Equal(t, float64(0), p2p.Peers().Scorers().BadResponsesScorer().Score("peer1"))
+	})
+
+	t.Run("foreign roots dropped without downscore", func(t *testing.T) {
+		const blobCount = 1
+
+		p2p := testp2p.NewTestP2P(t)
+
+		roBlock, localSidecars, expected := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
+		// A second block at a different slot yields a different root that we do NOT hold locally.
+		_, foreignSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, blobCount, util.WithSlot(1))
+
+		// One peer returns valid local-root sidecars mixed with sidecars for the foreign block.
+		mixed := append([]blocks.RODataColumn{}, localSidecars[0:5]...)
+		mixed = append(mixed, foreignSidecars[0:5]...)
+		roDataColumnsByPeer := map[peer.ID][]blocks.RODataColumn{"peer1": mixed}
+
+		gs := startup.NewClockSynchronizer()
+		err := gs.SetClock(startup.NewClock(time.Unix(4113849600, 0), [fieldparams.RootLength]byte{}))
+		require.NoError(t, err)
+
+		waiter := verification.NewInitializerWaiter(gs, nil, nil, nil)
+		initializer, err := waiter.WaitForInitializer(t.Context())
+		require.NoError(t, err)
+
+		blockByRoot := map[[fieldparams.RootLength]byte]blocks.ROBlock{roBlock.Root(): roBlock}
+
+		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, blockByRoot, roDataColumnsByPeer)
+		require.NoError(t, err)
+
+		// Only the local-root sidecars are returned; foreign ones are silently dropped.
+		require.Equal(t, 5, len(actual))
+		for i := range actual {
+			require.DeepSSZEqual(t, expected[actual[i].Index()].DataColumnSidecar(), actual[i].DataColumnSidecar())
+		}
+		// The peer is not penalized for the foreign-root sidecars.
+		require.Equal(t, float64(0), p2p.Peers().Scorers().BadResponsesScorer().Score("peer1"))
 	})
 }
 
@@ -1150,8 +1251,11 @@ func TestVerifyByRootDataColumnSidecars_SeedsGloasBidCommitments(t *testing.T) {
 		require.Equal(t, len(commitments), len(got))
 	})
 
-	t.Run("errors when the block is not local", func(t *testing.T) {
-		_, err := verifyByRootDataColumnSidecars(newVerifier, map[[fieldparams.RootLength]byte]blocks.ROBlock{}, []blocks.RODataColumn{gloasColumn})
-		require.ErrorIs(t, err, ErrSidecarHeaderMismatch)
+	t.Run("drops sidecar without error when the block is not local", func(t *testing.T) {
+		// A sidecar for a block we do not hold locally (e.g. a by-range response for a slot
+		// where our local block differs) is dropped, not treated as a peer fault.
+		verified, err := verifyByRootDataColumnSidecars(newVerifier, map[[fieldparams.RootLength]byte]blocks.ROBlock{}, []blocks.RODataColumn{gloasColumn})
+		require.NoError(t, err)
+		require.Equal(t, 0, len(verified))
 	})
 }

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -477,7 +477,6 @@ func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock) error {
 		Storage:                 s.cfg.DataColumnStorage,
 		NewVerifier:             s.newDataColumnsVerifier,
 		DownscorePeerOnRPCFault: true,
-		RequestByRoot:           true,
 	}
 
 	for attempt := uint64(0); ; attempt++ {

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -477,6 +477,7 @@ func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock) error {
 		Storage:                 s.cfg.DataColumnStorage,
 		NewVerifier:             s.newDataColumnsVerifier,
 		DownscorePeerOnRPCFault: true,
+		RequestByRoot:           true,
 	}
 
 	for attempt := uint64(0); ; attempt++ {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -122,12 +122,13 @@ func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock)
 
 	// Fetch missing data column sidecars.
 	params := DataColumnSidecarsParams{
-		Ctx:         s.ctx,
-		Tor:         s.cfg.clock,
-		P2P:         s.cfg.p2p,
-		CtxMap:      s.ctxMap,
-		Storage:     s.cfg.dataColumnStorage,
-		NewVerifier: s.newColumnsVerifier,
+		Ctx:           s.ctx,
+		Tor:           s.cfg.clock,
+		P2P:           s.cfg.p2p,
+		CtxMap:        s.ctxMap,
+		Storage:       s.cfg.dataColumnStorage,
+		NewVerifier:   s.newColumnsVerifier,
+		RequestByRoot: true,
 	}
 
 	sidecarsByRoot, missingIndicesByRoot, err := FetchDataColumnSidecars(params, blks, info.CustodyColumns)

--- a/changelog/potuz_fix-gloas-column-fetch-downscore.md
+++ b/changelog/potuz_fix-gloas-column-fetch-downscore.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Stop downscoring and disconnecting honest peers when a data column sidecar response references a block the node does not hold locally (a forked/behind node would otherwise self-isolate); recovery fetches now request columns by root.


### PR DESCRIPTION
The data-column fetch flow intends to fetch columns for specific local blocks, but `sendDataColumnSidecarsRequest` prefers a **by-range (by-slot)** request. A slot is not a root: on a fork the node holds orphan block `R_orphan` at slot `S`, and a peer correctly answers the by-range request with the **canonical** block's sidecars (`R_canon`) for that slot.

Gloas column sidecars carry a self-declared `beacon_block_root` with no header binding to verify against. `verifyByRootDataColumnSidecars` then looks up `blockByRoot[R_canon]`, misses (we only hold `R_orphan`), and returns `no local block for sidecar root …`. `verifyDataColumnSidecarsByPeer` treats that as a peer fault and increments `BadResponsesScorer` — **unconditionally**, unlike the RPC-layer faults. Repeated across every canonical peer, the node disconnects them all and stays isolated on the dead fork.

## Fix

- **Drop, don't downscore.** `verifyByRootDataColumnSidecars` filters out sidecars whose root isn't a local block *before* verification. A by-range response for a slot where our local block differs is not a peer fault, so it's silently dropped instead of counting as a bad response. Genuine crypto/format faults (KZG, inclusion proof, Fulu header-signature mismatch) still downscore the actually-faulty peer.
- **Request by root on recovery paths.** New `DataColumnSidecarsParams.RequestByRoot` forces by-root requests (the by-root RPC layer already validates returned roots against the request). Set on the pending/by-root recovery path (`rpc_beacon_blocks_by_root.go`) and the origin backfill (`initial-sync/service.go`). Forward round-robin initial-sync keeps by-range for throughput; the drop-not-downscore filter is its safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)