### PR TITLE
Don't block gloas block import on missing data columns

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -107,6 +107,23 @@ func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock)
 		s.processPendingGloasColumns(s.ctx, blk.Root(), blk)
 	}
 
+	preGloasBlocks := make([]blocks.ROBlock, 0, len(blks))
+	for _, blk := range blks {
+		if blk.Version() < version.Gloas {
+			preGloasBlocks = append(preGloasBlocks, blk)
+		}
+	}
+
+	return s.fetchAndSaveDataColumnSidecars(preGloasBlocks)
+}
+
+// fetchAndSaveDataColumnSidecars fetches the missing custody columns for the given blocks
+// and saves them to the storage, failing if any remain missing.
+func (s *Service) fetchAndSaveDataColumnSidecars(blks []blocks.ROBlock) error {
+	if len(blks) == 0 {
+		return nil
+	}
+
 	samplesPerSlot := params.BeaconConfig().SamplesPerSlot
 
 	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount(s.ctx)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -550,3 +550,54 @@ func TestFilterUnknownIndices(t *testing.T) {
 	require.Equal(t, expected[1].Index, actual[1].Index)
 	require.DeepEqual(t, actual[1].BlockRoot, expected[1].BlockRoot)
 }
+
+func TestRequestAndSaveMissingDataColumnSidecars_MissingColumns(t *testing.T) {
+	newService := func(t *testing.T) *Service {
+		return &Service{
+			ctx: t.Context(),
+			cfg: &config{
+				p2p:               p2ptest.NewTestP2P(t),
+				clock:             startup.NewClock(time.Now(), [fieldparams.RootLength]byte{}),
+				dataColumnStorage: filesystem.NewEphemeralDataColumnStorage(t),
+			},
+			newColumnsVerifier: func(_ []blocks.RODataColumn, _ []verification.Requirement) verification.DataColumnsVerifier {
+				return &verification.MockDataColumnsVerifier{}
+			},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+	}
+
+	newGloasBlock := func(t *testing.T) blocks.ROBlock {
+		pb := util.NewBeaconBlockGloas()
+		pb.Block.Slot = 1
+		pb.Block.Body.SignedExecutionPayloadBid.Message.BlobKzgCommitments = [][]byte{make([]byte, 48)}
+		sb, err := blocks.NewSignedBeaconBlock(pb)
+		require.NoError(t, err)
+		roBlock, err := blocks.NewROBlockWithRoot(sb, [fieldparams.RootLength]byte{1})
+		require.NoError(t, err)
+		return roBlock
+	}
+
+	t.Run("gloas block imports without columns", func(t *testing.T) {
+		err := newService(t).requestAndSaveMissingDataColumnSidecars([]blocks.ROBlock{newGloasBlock(t)})
+		require.NoError(t, err)
+	})
+
+	t.Run("gloas block fails without columns on the strict path", func(t *testing.T) {
+		err := newService(t).fetchAndSaveDataColumnSidecars([]blocks.ROBlock{newGloasBlock(t)})
+		require.ErrorContains(t, "some sidecars are still missing after fetch", err)
+	})
+
+	t.Run("fulu block fails without columns", func(t *testing.T) {
+		pb := util.NewBeaconBlockFulu()
+		pb.Block.Slot = 1
+		pb.Block.Body.BlobKzgCommitments = [][]byte{make([]byte, 48)}
+		sb, err := blocks.NewSignedBeaconBlock(pb)
+		require.NoError(t, err)
+		roBlock, err := blocks.NewROBlockWithRoot(sb, [fieldparams.RootLength]byte{2})
+		require.NoError(t, err)
+
+		err = newService(t).requestAndSaveMissingDataColumnSidecars([]blocks.ROBlock{roBlock})
+		require.ErrorContains(t, "some sidecars are still missing after fetch", err)
+	})
+}

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -104,7 +104,8 @@ func (s *Service) requestDataColumnsForEnvelope(root [32]byte) {
 		log.WithError(err).Debug("Could not wrap block for payload envelope data columns")
 		return
 	}
-	if err := s.requestAndSaveMissingDataColumnSidecars([]consensusblocks.ROBlock{roBlock}); err != nil {
+	s.processPendingGloasColumns(s.ctx, root, blk)
+	if err := s.fetchAndSaveDataColumnSidecars([]consensusblocks.ROBlock{roBlock}); err != nil {
 		log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Debug("Could not fetch data column sidecars for payload envelope")
 	}
 }

--- a/changelog/terence_gloas_column_fetch_import.md
+++ b/changelog/terence_gloas_column_fetch_import.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Don't block Gloas block import on missing data column sidecars. DA is checked on the payload envelope.


### PR DESCRIPTION
- Fix pending queue gloas block import when custody columns were missing, and the pending queue fetching all 128 columns every ~4s. Orphaned or unrevealed payloads have no columns anywhere,
- `requestAndSaveMissingDataColumnSidecars` now drains queued gossip columns for gloas blocks and skips the peer fetch. Gloas DA is checked on the payload envelope, not at block import already today