### PR TITLE
Support SSZ request bodies for `POST /eth/v2/beacon/pool/attestations` post-Electra

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -728,7 +728,7 @@ func (s *Service) beaconEndpoints(
 			template: "/eth/v2/beacon/pool/attestations",
 			name:     namespace + ".SubmitAttestationsV2",
 			middleware: []middleware.Middleware{
-				middleware.ContentTypeHandler([]string{api.JsonMediaType}),
+				middleware.ContentTypeHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
 				middleware.AcceptEncodingHeaderHandler(),
 			},

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -147,29 +147,46 @@ func (s *Server) SubmitAttestationsV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req structs.SubmitAttestationsRequest
-	err = json.NewDecoder(r.Body).Decode(&req.Data)
-	switch {
-	case errors.Is(err, io.EOF):
-		httputil.HandleError(w, "No data submitted", http.StatusBadRequest)
-		return
-	case err != nil:
-		httputil.HandleError(w, "Could not decode request body: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	var attFailures []*server.IndexedError
-	var failedBroadcasts []*server.IndexedError
-
+	var attFailures, failedBroadcasts, decodeFailures []*server.IndexedError
 	if v >= version.Electra {
-		attFailures, failedBroadcasts, err = s.handleAttestationsPostElectra(ctx, req.Data)
+		currentEpoch := slots.ToEpoch(s.TimeFetcher.CurrentSlot())
+		if currentEpoch < params.BeaconConfig().ElectraForkEpoch {
+			httputil.HandleError(w, fmt.Sprintf("electra attestations have not been enabled, current epoch %d enabled epoch %d", currentEpoch, params.BeaconConfig().ElectraForkEpoch), http.StatusBadRequest)
+			return
+		}
+		var atts []*eth.SingleAttestation
+		atts, decodeFailures, err = decodeSingleAttestations(r)
+		if err != nil {
+			writeAttestationDecodeError(w, err)
+			return
+		}
+		if len(atts) == 0 && len(decodeFailures) == 0 {
+			httputil.HandleError(w, "no data submitted", http.StatusBadRequest)
+			return
+		}
+		attFailures, failedBroadcasts, err = s.handleAttestationsPostElectra(ctx, atts)
 	} else {
-		attFailures, failedBroadcasts, err = s.handleAttestations(ctx, req.Data)
+		if slots.ToEpoch(s.TimeFetcher.CurrentSlot()) >= params.BeaconConfig().ElectraForkEpoch {
+			httputil.HandleError(w, "old attestation format, only electra attestations should be sent", http.StatusBadRequest)
+			return
+		}
+		var atts []*eth.Attestation
+		atts, decodeFailures, err = decodeAttestationsJSON(r.Body)
+		if err != nil {
+			writeAttestationDecodeError(w, err)
+			return
+		}
+		if len(atts) == 0 && len(decodeFailures) == 0 {
+			httputil.HandleError(w, "no data submitted", http.StatusBadRequest)
+			return
+		}
+		attFailures, failedBroadcasts, err = s.handleAttestations(ctx, atts)
 	}
 	if err != nil {
 		httputil.HandleError(w, fmt.Sprintf("Failed to handle attestations: %v", err), http.StatusBadRequest)
 		return
 	}
+	attFailures = append(decodeFailures, attFailures...)
 
 	if len(attFailures) > 0 {
 		failuresErr := &server.IndexedErrorContainer{
@@ -191,34 +208,94 @@ func (s *Server) SubmitAttestationsV2(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) handleAttestationsPostElectra(
-	ctx context.Context,
-	data json.RawMessage,
-) (attFailures []*server.IndexedError, failedBroadcasts []*server.IndexedError, err error) {
-	var sourceAttestations []*structs.SingleAttestation
-	currentEpoch := slots.ToEpoch(s.TimeFetcher.CurrentSlot())
-	if currentEpoch < params.BeaconConfig().ElectraForkEpoch {
-		return nil, nil, errors.Errorf("electra attestations have not been enabled, current epoch %d enabled epoch %d", currentEpoch, params.BeaconConfig().ElectraForkEpoch)
+// writeAttestationDecodeError maps a request-body decode error to an HTTP response.
+func writeAttestationDecodeError(w http.ResponseWriter, err error) {
+	if errors.Is(err, io.EOF) {
+		httputil.HandleError(w, "No data submitted", http.StatusBadRequest)
+		return
 	}
+	httputil.HandleError(w, "Could not decode request body: "+err.Error(), http.StatusBadRequest)
+}
 
-	if err = json.Unmarshal(data, &sourceAttestations); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to unmarshal attestation")
+// decodeSingleAttestations decodes Electra+ attestations from a JSON or SSZ request body.
+func decodeSingleAttestations(r *http.Request) ([]*eth.SingleAttestation, []*server.IndexedError, error) {
+	if httputil.IsRequestSsz(r) {
+		return decodeSingleAttestationsSSZ(r.Body)
 	}
+	return decodeSingleAttestationsJSON(r.Body)
+}
 
-	if len(sourceAttestations) == 0 {
-		return nil, nil, errors.New("no data submitted")
+// decodeSingleAttestationsJSON decodes a JSON array of SingleAttestation.
+func decodeSingleAttestationsJSON(body io.Reader) ([]*eth.SingleAttestation, []*server.IndexedError, error) {
+	var src []*structs.SingleAttestation
+	if err := json.NewDecoder(body).Decode(&src); err != nil {
+		return nil, nil, err
 	}
-
-	var validAttestations []*eth.SingleAttestation
-	for i, sourceAtt := range sourceAttestations {
-		att, err := sourceAtt.ToConsensus()
+	atts := make([]*eth.SingleAttestation, 0, len(src))
+	var failures []*server.IndexedError
+	for i, item := range src {
+		att, err := item.ToConsensus()
 		if err != nil {
-			attFailures = append(attFailures, &server.IndexedError{
-				Index:   i,
-				Message: "Could not convert request attestation to consensus attestation: " + err.Error(),
-			})
+			failures = append(failures, &server.IndexedError{Index: i, Message: "Could not convert request attestation to consensus attestation: " + err.Error()})
 			continue
 		}
+		atts = append(atts, att)
+	}
+	return atts, failures, nil
+}
+
+// decodeSingleAttestationsSSZ decodes an SSZ list of fixed-size SingleAttestation.
+func decodeSingleAttestationsSSZ(body io.Reader) ([]*eth.SingleAttestation, []*server.IndexedError, error) {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "could not read request body")
+	}
+	if len(b) == 0 {
+		return nil, nil, io.EOF
+	}
+	sszSize := (&eth.SingleAttestation{}).SizeSSZ()
+	if len(b)%sszSize != 0 {
+		return nil, nil, errors.New("invalid SSZ single attestation list size")
+	}
+	n := len(b) / sszSize
+	atts := make([]*eth.SingleAttestation, 0, n)
+	var failures []*server.IndexedError
+	for i := range n {
+		att := &eth.SingleAttestation{}
+		if err := att.UnmarshalSSZ(b[i*sszSize : (i+1)*sszSize]); err != nil {
+			failures = append(failures, &server.IndexedError{Index: i, Message: "Could not decode SSZ message: " + err.Error()})
+			continue
+		}
+		atts = append(atts, att)
+	}
+	return atts, failures, nil
+}
+
+// decodeAttestationsJSON decodes a JSON array of pre-Electra Attestation.
+func decodeAttestationsJSON(body io.Reader) ([]*eth.Attestation, []*server.IndexedError, error) {
+	var src []*structs.Attestation
+	if err := json.NewDecoder(body).Decode(&src); err != nil {
+		return nil, nil, err
+	}
+	atts := make([]*eth.Attestation, 0, len(src))
+	var failures []*server.IndexedError
+	for i, item := range src {
+		att, err := item.ToConsensus()
+		if err != nil {
+			failures = append(failures, &server.IndexedError{Index: i, Message: "Could not convert request attestation to consensus attestation: " + err.Error()})
+			continue
+		}
+		atts = append(atts, att)
+	}
+	return atts, failures, nil
+}
+
+func (s *Server) handleAttestationsPostElectra(
+	ctx context.Context,
+	atts []*eth.SingleAttestation,
+) (attFailures []*server.IndexedError, failedBroadcasts []*server.IndexedError, err error) {
+	var validAttestations []*eth.SingleAttestation
+	for i, att := range atts {
 		if _, err = bls.SignatureFromBytes(att.Signature); err != nil {
 			attFailures = append(attFailures, &server.IndexedError{
 				Index:   i,
@@ -349,32 +426,10 @@ func (s *Server) handleAttestationsPostElectra(
 
 func (s *Server) handleAttestations(
 	ctx context.Context,
-	data json.RawMessage,
+	atts []*eth.Attestation,
 ) (attFailures []*server.IndexedError, failedBroadcasts []*server.IndexedError, err error) {
-	var sourceAttestations []*structs.Attestation
-
-	if slots.ToEpoch(s.TimeFetcher.CurrentSlot()) >= params.BeaconConfig().ElectraForkEpoch {
-		return nil, nil, errors.New("old attestation format, only electra attestations should be sent")
-	}
-
-	if err = json.Unmarshal(data, &sourceAttestations); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to unmarshal attestation")
-	}
-
-	if len(sourceAttestations) == 0 {
-		return nil, nil, errors.New("no data submitted")
-	}
-
 	var validAttestations []*eth.Attestation
-	for i, sourceAtt := range sourceAttestations {
-		att, err := sourceAtt.ToConsensus()
-		if err != nil {
-			attFailures = append(attFailures, &server.IndexedError{
-				Index:   i,
-				Message: "Could not convert request attestation to consensus attestation: " + err.Error(),
-			})
-			continue
-		}
+	for i, att := range atts {
 		if _, err = bls.SignatureFromBytes(att.Signature); err != nil {
 			attFailures = append(attFailures, &server.IndexedError{
 				Index:   i,

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -810,6 +810,59 @@ func TestSubmitAttestationsV2(t *testing.T) {
 				return s.AttestationsPool.UnaggregatedAttestationCount() == 1
 			}, time.Second, 10*time.Millisecond, "Expected 1 attestation in pool")
 		})
+		t.Run("ssz", func(t *testing.T) {
+			broadcaster := &p2pMock.MockBroadcaster{}
+			s.Broadcaster = broadcaster
+			s.AttestationsPool = attestations.NewPool()
+
+			blockRoot := hexutil.MustDecode("0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2")
+			sourceRoot := bytesutil.PadTo([]byte("sourceroot1"), 32)
+			data0 := &ethpbv1alpha1.AttestationData{
+				BeaconBlockRoot: blockRoot,
+				Source:          &ethpbv1alpha1.Checkpoint{Epoch: 0, Root: sourceRoot},
+				Target:          &ethpbv1alpha1.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("targetroot1"), 32)},
+			}
+			data1 := &ethpbv1alpha1.AttestationData{
+				BeaconBlockRoot: blockRoot,
+				Source:          &ethpbv1alpha1.Checkpoint{Epoch: 0, Root: sourceRoot},
+				Target:          &ethpbv1alpha1.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("targetroot2"), 32)},
+			}
+			var sszBody []byte
+			for _, a := range []*structs.SingleAttestation{
+				signedSingleAttElectra(t, bs.Fork(), bs.GenesisValidatorsRoot(), keys[0], 0, data0),
+				signedSingleAttElectra(t, bs.Fork(), bs.GenesisValidatorsRoot(), keys[1], 1, data1),
+			} {
+				att, err := a.ToConsensus()
+				require.NoError(t, err)
+				b, err := att.MarshalSSZ()
+				require.NoError(t, err)
+				sszBody = append(sszBody, b...)
+			}
+			request := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader(sszBody))
+			request.Header.Set(api.VersionHeader, version.String(version.Electra))
+			request.Header.Set("Content-Type", api.OctetStreamMediaType)
+			writer := httptest.NewRecorder()
+			writer.Body = &bytes.Buffer{}
+
+			s.SubmitAttestationsV2(writer, request)
+			assert.Equal(t, http.StatusOK, writer.Code)
+			assert.Equal(t, true, broadcaster.BroadcastCalled.Load())
+			assert.Equal(t, 2, broadcaster.NumAttestations())
+			require.Eventually(t, func() bool {
+				return s.AttestationsPool.UnaggregatedAttestationCount() == 2
+			}, time.Second, 10*time.Millisecond, "Expected 2 attestations in pool")
+		})
+		t.Run("ssz invalid size", func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader([]byte{0x01, 0x02, 0x03}))
+			request.Header.Set(api.VersionHeader, version.String(version.Electra))
+			request.Header.Set("Content-Type", api.OctetStreamMediaType)
+			writer := httptest.NewRecorder()
+			writer.Body = &bytes.Buffer{}
+
+			s.SubmitAttestationsV2(writer, request)
+			assert.Equal(t, http.StatusBadRequest, writer.Code)
+			assert.Equal(t, true, strings.Contains(writer.Body.String(), "invalid SSZ single attestation list size"))
+		})
 		t.Run("invalid signature not added to pool", func(t *testing.T) {
 			broadcaster := &p2pMock.MockBroadcaster{}
 			s.Broadcaster = broadcaster

--- a/changelog/syjn99_ssz-submit-pool-attestations.md
+++ b/changelog/syjn99_ssz-submit-pool-attestations.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support SSZ-encoded request bodies (`Content-Type: application/octet-stream`) for the `POST /eth/v2/beacon/pool/attestations` endpoint (Electra and later).


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Add `application/octet-stream` decoding to `POST /eth/v2/beacon/pool/attestations` for Electra+ (fixed-size `SingleAttestation` list), matching the block-submission SSZ convention. See [beacon-APIs](https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolAttestationsV2).

Pre-Electra keeps the JSON path, as pre-Electra Attestation is variable-length container thus the list of Attestation is variable-length, which makes our code much harder to navigate. This PR presumes that we only cares post-Electra.

**Which issue(s) does this PR fix?**

N/A - but related to #17183.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
