### PR TITLE
sync: wait briefly for attested block availability

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "attestation_block_waiter.go",
         "batch_verifier.go",
         "block_batcher.go",
         "context.go",
@@ -181,6 +182,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "attestation_block_waiter_test.go",
         "batch_verifier_test.go",
         "blobs_test.go",
         "block_batcher_test.go",

--- a/beacon-chain/sync/attestation_block_waiter.go
+++ b/beacon-chain/sync/attestation_block_waiter.go
@@ -1,0 +1,222 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+const (
+	attestationBlockWaitTimeout   = 600 * time.Millisecond
+	maxConcurrentBlockWaiters     = 128
+	maxConcurrentWaitersPerPeer   = 32
+	maxConcurrentWaitersPerRoot   = 64
+	attestationBlockEventChanSize = 16
+)
+
+// attestationBlockWaiter coordinates bounded waits for attested block and state availability.
+type attestationBlockWaiter struct {
+	mu             sync.Mutex
+	waiters        map[[32]byte]*attestationBlockRootWait
+	waitersByPeer  map[peer.ID]int
+	nextID         uint64
+	count          int
+	timeout        time.Duration
+	maxWaiters     int
+	maxWaitersPeer int
+	maxWaitersRoot int
+}
+
+type attestationBlockRootWait struct {
+	ready chan struct{}
+	peers map[uint64]peer.ID
+}
+
+func newAttestationBlockWaiter(
+	timeout time.Duration,
+	maxWaiters int,
+	maxWaitersPeer int,
+	maxWaitersRoot int,
+) *attestationBlockWaiter {
+	return &attestationBlockWaiter{
+		waiters:        make(map[[32]byte]*attestationBlockRootWait),
+		waitersByPeer:  make(map[peer.ID]int),
+		timeout:        timeout,
+		maxWaiters:     maxWaiters,
+		maxWaitersPeer: maxWaitersPeer,
+		maxWaitersRoot: maxWaitersRoot,
+	}
+}
+
+// wait checks readiness, registers within bounded budgets, waits for a block event, and rechecks readiness before returning.
+func (w *attestationBlockWaiter) wait(
+	ctx context.Context,
+	peerID peer.ID,
+	root [32]byte,
+	available func() bool,
+) bool {
+	if available() {
+		return true
+	}
+
+	id, ready, ok := w.register(peerID, root)
+	if !ok {
+		attestationBlockWaitTotal.WithLabelValues("capacity").Inc()
+		return false
+	}
+	defer w.unregister(peerID, root, id)
+
+	start := time.Now()
+	outcome := "canceled"
+	defer func() {
+		attestationBlockWaitTotal.WithLabelValues(outcome).Inc()
+		attestationBlockWaitDuration.Observe(float64(time.Since(start).Milliseconds()))
+	}()
+
+	// Recheck after registration to avoid missing availability between the first check and registration.
+	if available() {
+		outcome = "ready"
+		return true
+	}
+
+	timer := time.NewTimer(w.timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ready:
+			ready = nil
+			// A block event is only a wake-up hint; readiness still requires both block and state.
+			if available() {
+				outcome = "ready"
+				return true
+			}
+		case <-timer.C:
+			if available() {
+				outcome = "ready"
+				return true
+			}
+			outcome = "timeout"
+			return false
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
+
+// register shares one readiness channel per root and enforces global, per-peer, and per-root limits.
+func (w *attestationBlockWaiter) register(peerID peer.ID, root [32]byte) (uint64, <-chan struct{}, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	rootWait := w.waiters[root]
+	rootCount := 0
+	if rootWait != nil {
+		rootCount = len(rootWait.peers)
+	}
+	if w.count >= w.maxWaiters ||
+		w.waitersByPeer[peerID] >= w.maxWaitersPeer ||
+		rootCount >= w.maxWaitersRoot {
+		return 0, nil, false
+	}
+
+	id := w.nextID
+	w.nextID++
+	if rootWait == nil {
+		rootWait = &attestationBlockRootWait{
+			ready: make(chan struct{}),
+			peers: make(map[uint64]peer.ID),
+		}
+		w.waiters[root] = rootWait
+	}
+	rootWait.peers[id] = peerID
+	w.waitersByPeer[peerID]++
+	w.count++
+	return id, rootWait.ready, true
+}
+
+func (w *attestationBlockWaiter) unregister(peerID peer.ID, root [32]byte, id uint64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	rootWait, ok := w.waiters[root]
+	if !ok {
+		return
+	}
+	if _, ok := rootWait.peers[id]; !ok {
+		return
+	}
+	delete(rootWait.peers, id)
+	if len(rootWait.peers) == 0 {
+		delete(w.waiters, root)
+	}
+	w.waitersByPeer[peerID]--
+	if w.waitersByPeer[peerID] == 0 {
+		delete(w.waitersByPeer, peerID)
+	}
+	w.count--
+}
+
+// notify wakes all validators waiting for the processed block root.
+func (w *attestationBlockWaiter) notify(root [32]byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	rootWait, ok := w.waiters[root]
+	if !ok {
+		return
+	}
+	delete(w.waiters, root)
+	close(rootWait.ready)
+	for _, peerID := range rootWait.peers {
+		w.waitersByPeer[peerID]--
+		if w.waitersByPeer[peerID] == 0 {
+			delete(w.waitersByPeer, peerID)
+		}
+		w.count--
+	}
+}
+
+// waitForAttestationBlock returns false on timeout, cancellation, or capacity exhaustion so callers can preserve pending storage and ValidationIgnore.
+func (s *Service) waitForAttestationBlock(ctx context.Context, peerID peer.ID, root [32]byte) bool {
+	if s.attestationBlockWaiter == nil {
+		return s.hasBlockAndState(ctx, root)
+	}
+	return s.attestationBlockWaiter.wait(ctx, peerID, root, func() bool {
+		return s.hasBlockAndState(ctx, root)
+	})
+}
+
+// startAttestationBlockWaiter forwards processed block roots to waiting gossip validators.
+func (s *Service) startAttestationBlockWaiter() {
+	if s.attestationBlockWaiter == nil || s.cfg.stateNotifier == nil {
+		return
+	}
+
+	events := make(chan *feed.Event, attestationBlockEventChanSize)
+	sub := s.cfg.stateNotifier.StateFeed().Subscribe(events)
+	go func() {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case event := <-events:
+				if event == nil || event.Type != statefeed.BlockProcessed {
+					continue
+				}
+				data, ok := event.Data.(*statefeed.BlockProcessedData)
+				if !ok || data == nil {
+					continue
+				}
+				s.attestationBlockWaiter.notify(data.BlockRoot)
+			case <-sub.Err():
+				return
+			case <-s.ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/beacon-chain/sync/attestation_block_waiter_test.go
+++ b/beacon-chain/sync/attestation_block_waiter_test.go
@@ -1,0 +1,191 @@
+package sync
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func TestAttestationBlockWaiterAvailable(t *testing.T) {
+	waiter := newAttestationBlockWaiter(time.Second, 1, 1, 1)
+	available := atomic.Bool{}
+	available.Store(true)
+
+	require.Equal(t, true, waiter.wait(t.Context(), "peer", [32]byte{1}, func() bool {
+		return available.Load()
+	}))
+	require.Equal(t, 0, waiter.count)
+}
+
+func TestAttestationBlockWaiterNotify(t *testing.T) {
+	waiter := newAttestationBlockWaiter(time.Second, 1, 1, 1)
+	root := [32]byte{1}
+	available := atomic.Bool{}
+	result := make(chan bool, 1)
+
+	go func() {
+		result <- waiter.wait(t.Context(), "peer", root, func() bool {
+			return available.Load()
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		waiter.mu.Lock()
+		defer waiter.mu.Unlock()
+		return waiter.count == 1
+	}, time.Second, time.Millisecond)
+
+	available.Store(true)
+	waiter.notify(root)
+	require.Equal(t, true, <-result)
+	require.Equal(t, 0, waiter.count)
+}
+
+func TestAttestationBlockWaiterTimeout(t *testing.T) {
+	waiter := newAttestationBlockWaiter(time.Millisecond, 1, 1, 1)
+
+	require.Equal(t, false, waiter.wait(t.Context(), "peer", [32]byte{1}, func() bool {
+		return false
+	}))
+	require.Equal(t, 0, waiter.count)
+}
+
+func TestAttestationBlockWaiterCancellation(t *testing.T) {
+	waiter := newAttestationBlockWaiter(time.Second, 1, 1, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.Equal(t, false, waiter.wait(ctx, "peer", [32]byte{1}, func() bool {
+		return false
+	}))
+	require.Equal(t, 0, waiter.count)
+}
+
+func TestAttestationBlockWaiterSharesRootNotification(t *testing.T) {
+	waiter := newAttestationBlockWaiter(time.Second, 2, 1, 2)
+	root := [32]byte{1}
+
+	_, first, registered := waiter.register("peer-1", root)
+	require.Equal(t, true, registered)
+	_, second, registered := waiter.register("peer-2", root)
+	require.Equal(t, true, registered)
+	require.Equal(t, first, second)
+
+	waiter.notify(root)
+	select {
+	case <-first:
+	default:
+		t.Fatal("shared root notification was not closed")
+	}
+	require.Equal(t, 0, waiter.count)
+}
+
+func TestServiceStartAttestationBlockWaiter(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	notifier := mock.NewSimpleStateNotifier()
+	waiter := newAttestationBlockWaiter(time.Second, 1, 1, 1)
+	service := &Service{
+		ctx: ctx,
+		cfg: &config{
+			stateNotifier: notifier,
+		},
+		attestationBlockWaiter: waiter,
+	}
+	service.startAttestationBlockWaiter()
+
+	root := [32]byte{1}
+	_, ready, registered := waiter.register("peer", root)
+	require.Equal(t, true, registered)
+	notifier.StateFeed().Send(&feed.Event{
+		Type: statefeed.BlockProcessed,
+		Data: &statefeed.BlockProcessedData{
+			BlockRoot: root,
+		},
+	})
+
+	select {
+	case <-ready:
+	case <-time.After(time.Second):
+		t.Fatal("block processed event did not notify attestation waiter")
+	}
+	require.Equal(t, 0, waiter.count)
+}
+
+func TestAttestationBlockWaiterLimits(t *testing.T) {
+	tests := []struct {
+		name             string
+		maxWaiters       int
+		maxWaitersPeer   int
+		maxWaitersRoot   int
+		firstPeer        peer.ID
+		firstRoot        [32]byte
+		secondPeer       peer.ID
+		secondRoot       [32]byte
+		secondRegistered bool
+	}{
+		{
+			name:             "global",
+			maxWaiters:       1,
+			maxWaitersPeer:   2,
+			maxWaitersRoot:   2,
+			firstPeer:        "peer-1",
+			firstRoot:        [32]byte{1},
+			secondPeer:       "peer-2",
+			secondRoot:       [32]byte{2},
+			secondRegistered: false,
+		},
+		{
+			name:             "per peer",
+			maxWaiters:       2,
+			maxWaitersPeer:   1,
+			maxWaitersRoot:   2,
+			firstPeer:        "peer-1",
+			firstRoot:        [32]byte{1},
+			secondPeer:       "peer-1",
+			secondRoot:       [32]byte{2},
+			secondRegistered: false,
+		},
+		{
+			name:             "per root",
+			maxWaiters:       2,
+			maxWaitersPeer:   2,
+			maxWaitersRoot:   1,
+			firstPeer:        "peer-1",
+			firstRoot:        [32]byte{1},
+			secondPeer:       "peer-2",
+			secondRoot:       [32]byte{1},
+			secondRegistered: false,
+		},
+		{
+			name:             "different peers",
+			maxWaiters:       2,
+			maxWaitersPeer:   1,
+			maxWaitersRoot:   1,
+			firstPeer:        "peer-1",
+			firstRoot:        [32]byte{1},
+			secondPeer:       "peer-2",
+			secondRoot:       [32]byte{2},
+			secondRegistered: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			waiter := newAttestationBlockWaiter(time.Second, test.maxWaiters, test.maxWaitersPeer, test.maxWaitersRoot)
+			_, _, registered := waiter.register(test.firstPeer, test.firstRoot)
+			require.Equal(t, true, registered)
+
+			_, _, registered = waiter.register(test.secondPeer, test.secondRoot)
+			require.Equal(t, test.secondRegistered, registered)
+		})
+	}
+}

--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -125,6 +125,20 @@ var (
 		Name: "gossip_attestation_bad_signature_batch_total",
 		Help: "Increased when a gossip attestation has a bad signature batch",
 	})
+	attestationBlockWaitTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gossip_attestation_block_wait_total",
+			Help: "Count of attestation block availability waits by outcome.",
+		},
+		[]string{"outcome"},
+	)
+	attestationBlockWaitDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "gossip_attestation_block_wait_milliseconds",
+			Help:    "Time spent waiting for an attestation's referenced block and state.",
+			Buckets: []float64{10, 25, 50, 100, 200, 400, 600},
+		},
+	)
 
 	// Attestation and block gossip verification performance.
 	aggregateAttestationVerificationGossipSummary = promauto.NewSummary(

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -213,6 +213,7 @@ type Service struct {
 	selfBuildSigFailSlot                 primitives.Slot
 	pendingPayloadAttestations           map[[32]byte][]*ethpb.PayloadAttestationMessage
 	pendingPayloadAttestationLock        sync.RWMutex
+	attestationBlockWaiter               *attestationBlockWaiter
 }
 
 // NewService initializes new regular sync service.
@@ -233,6 +234,12 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 		proposerPreferencesCache:   cache.NewProposerPreferencesCache(),
 		pendingPayloadEnvelopes:    make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
 		pendingPayloadAttestations: make(map[[32]byte][]*ethpb.PayloadAttestationMessage),
+		attestationBlockWaiter: newAttestationBlockWaiter(
+			attestationBlockWaitTimeout,
+			maxConcurrentBlockWaiters,
+			maxConcurrentWaitersPerPeer,
+			maxConcurrentWaitersPerRoot,
+		),
 	}
 
 	for _, opt := range opts {
@@ -317,6 +324,7 @@ func (s *Service) Start() {
 	s.newExecutionPayloadEnvelopeVerifier = newPayloadVerifierFromInitializer(v)
 
 	go s.verifierRoutine()
+	s.startAttestationBlockWaiter()
 
 	if broadcaster := s.cfg.p2p.PartialColumnBroadcaster(); broadcaster != nil {
 		go broadcaster.Start(&partialColumnCallbacks{service: s})

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -29,6 +29,7 @@ import (
 
 // validateAggregateAndProof verifies the aggregated signature and the selection proof is valid before forwarding to the
 // network and downstream services.
+// It may briefly wait when the referenced block and state are the only missing dependencies.
 func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, msg *pubsub.Message) (pubsub.ValidationResult, error) {
 	receivedTime := prysmTime.Now()
 	if pid == s.cfg.p2p.PeerID() {
@@ -126,13 +127,19 @@ func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 		}
 	}
 
-	// Verify the block being voted on is in the beacon chain.
-	// If not, store this attestation in the map of pending attestations.
-	if !s.validateBlockInAttestation(ctx, m) {
+	validationRes, err := s.validateAggregatedAttPreBlock(ctx, m)
+	if validationRes != pubsub.ValidationAccept {
+		return validationRes, err
+	}
+
+	blockRoot := bytesutil.ToBytes32(data.BeaconBlockRoot)
+	// After non-block checks pass, wait briefly or preserve the pending plus ValidationIgnore fallback.
+	if !s.waitForAttestationBlock(ctx, pid, blockRoot) {
+		s.savePendingAggregate(m)
 		return pubsub.ValidationIgnore, nil
 	}
 
-	validationRes, err := s.validateAggregatedAtt(ctx, m)
+	validationRes, err = s.validateAggregatedAttPostBlock(ctx, m)
 	if validationRes != pubsub.ValidationAccept {
 		return validationRes, err
 	}
@@ -152,26 +159,21 @@ func (s *Service) validateAggregatedAtt(ctx context.Context, signed ethpb.Signed
 	ctx, span := trace.StartSpan(ctx, "sync.validateAggregatedAtt")
 	defer span.End()
 
+	result, err := s.validateAggregatedAttPreBlock(ctx, signed)
+	if result != pubsub.ValidationAccept {
+		return result, err
+	}
+	return s.validateAggregatedAttPostBlock(ctx, signed)
+}
+
+func (s *Service) validateAggregatedAttPreBlock(ctx context.Context, signed ethpb.SignedAggregateAttAndProof) (pubsub.ValidationResult, error) {
+	ctx, span := trace.StartSpan(ctx, "sync.validateAggregatedAttPreBlock")
+	defer span.End()
+
 	aggregateAndProof := signed.AggregateAttestationAndProof()
 	aggregatorIndex := aggregateAndProof.GetAggregatorIndex()
 	aggregate := aggregateAndProof.AggregateVal()
 	data := aggregate.GetData()
-
-	// Verify attestation target root is consistent with the head root.
-	// This verification is not in the spec, however we guard against it as it opens us up
-	// to weird edge cases during verification. The attestation technically could be used to add value to a block,
-	// but it's invalid in the spirit of the protocol. Here we choose safety over profit.
-	if err := s.cfg.chain.VerifyLmdFfgConsistency(ctx, aggregate); err != nil {
-		tracing.AnnotateError(span, err)
-		attBadLmdConsistencyCount.Inc()
-		return pubsub.ValidationReject, err
-	}
-
-	// Verify current finalized checkpoint is an ancestor of the block defined by the attestation's beacon block root.
-	if !s.cfg.chain.InForkchoice(bytesutil.ToBytes32(data.BeaconBlockRoot)) {
-		tracing.AnnotateError(span, blockchain.ErrNotDescendantOfFinalized)
-		return pubsub.ValidationIgnore, blockchain.ErrNotDescendantOfFinalized
-	}
 
 	bs, err := s.cfg.chain.AttestationTargetState(ctx, data.Target)
 	if err != nil {
@@ -240,6 +242,27 @@ func (s *Service) validateAggregatedAtt(ctx context.Context, signed ethpb.Signed
 	set.Join(selectionSigSet).Join(aggregatorSigSet).Join(attSigSet)
 
 	return s.validateWithBatchVerifier(ctx, "aggregate", set)
+}
+
+func (s *Service) validateAggregatedAttPostBlock(ctx context.Context, signed ethpb.SignedAggregateAttAndProof) (pubsub.ValidationResult, error) {
+	ctx, span := trace.StartSpan(ctx, "sync.validateAggregatedAttPostBlock")
+	defer span.End()
+
+	aggregate := signed.AggregateAttestationAndProof().AggregateVal()
+
+	// This is stricter than the gossip spec and guards against inconsistent LMD and FFG votes.
+	if err := s.cfg.chain.VerifyLmdFfgConsistency(ctx, aggregate); err != nil {
+		tracing.AnnotateError(span, err)
+		attBadLmdConsistencyCount.Inc()
+		return pubsub.ValidationReject, err
+	}
+
+	blockRoot := bytesutil.ToBytes32(aggregate.GetData().BeaconBlockRoot)
+	if !s.cfg.chain.InForkchoice(blockRoot) {
+		tracing.AnnotateError(span, blockchain.ErrNotDescendantOfFinalized)
+		return pubsub.ValidationIgnore, blockchain.ErrNotDescendantOfFinalized
+	}
+	return pubsub.ValidationAccept, nil
 }
 
 // validateBlocksInAttestation checks if the block being voted on is in the beaconDB.

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -36,6 +36,7 @@ import (
 // - The attestation is unaggregated -- that is, it has exactly one participating validator (len(get_attesting_indices(state, attestation.data, attestation.aggregation_bits)) == 1).
 // - attestation.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot).
 // - The signature of attestation is valid.
+// - Validation may briefly wait when the referenced block and state are the only missing dependencies.
 func (s *Service) validateCommitteeIndexBeaconAttestation(
 	ctx context.Context,
 	pid peer.ID,
@@ -117,25 +118,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		}
 	}
 
-	// Verify the block being voted and the processed state is in beaconDB and the block has passed validation if it's in the beaconDB.
 	blockRoot := bytesutil.ToBytes32(data.BeaconBlockRoot)
-	if !s.hasBlockAndState(ctx, blockRoot) {
-		// Block not yet available - save attestation to pending queue for later processing
-		// when the block arrives. Return ValidationIgnore so gossip doesn't potentially penalize the peer.
-		s.savePendingAtt(att)
-		return pubsub.ValidationIgnore, nil
-	}
-	// Block exists - verify it's in forkchoice (i.e., it's a descendant of the finalized checkpoint)
-	if !s.cfg.chain.InForkchoice(blockRoot) {
-		tracing.AnnotateError(span, blockchain.ErrNotDescendantOfFinalized)
-		return pubsub.ValidationIgnore, blockchain.ErrNotDescendantOfFinalized
-	}
-	if err = s.cfg.chain.VerifyLmdFfgConsistency(ctx, att); err != nil {
-		tracing.AnnotateError(span, err)
-		attBadLmdConsistencyCount.Inc()
-		return pubsub.ValidationReject, wrapAttestationError(err, att)
-	}
-
 	preState, err := s.cfg.chain.AttestationTargetState(ctx, data.Target)
 	if err != nil {
 		tracing.AnnotateError(span, err)
@@ -191,6 +174,21 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	validationRes, err = s.validateUnaggregatedAttWithState(ctx, attForValidation, preState)
 	if validationRes != pubsub.ValidationAccept {
 		return validationRes, wrapAttestationError(err, att)
+	}
+
+	// After non-block checks pass, wait briefly or preserve the pending plus ValidationIgnore fallback.
+	if !s.waitForAttestationBlock(ctx, pid, blockRoot) {
+		s.savePendingAtt(att)
+		return pubsub.ValidationIgnore, nil
+	}
+	if !s.cfg.chain.InForkchoice(blockRoot) {
+		tracing.AnnotateError(span, blockchain.ErrNotDescendantOfFinalized)
+		return pubsub.ValidationIgnore, blockchain.ErrNotDescendantOfFinalized
+	}
+	if err = s.cfg.chain.VerifyLmdFfgConsistency(ctx, att); err != nil {
+		tracing.AnnotateError(span, err)
+		attBadLmdConsistencyCount.Inc()
+		return pubsub.ValidationReject, wrapAttestationError(err, att)
 	}
 
 	if s.slasherEnabled {

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -19,6 +19,7 @@ import (
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -307,6 +308,114 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestService_validateCommitteeIndexBeaconAttestationWaitsForBlock(t *testing.T) {
+	p := p2ptest.NewTestP2P(t)
+	db := dbtest.SetupDB(t)
+	chain := &mockChain.ChainService{
+		Genesis:          time.Now().Add(-time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+		ValidatorsRoot:   [32]byte{'A'},
+		ValidAttestation: true,
+		DB:               db,
+		Optimistic:       true,
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	s := &Service{
+		ctx: ctx,
+		cfg: &config{
+			initialSync:         &mockSync.Sync{IsSyncing: false},
+			p2p:                 p,
+			beaconDB:            db,
+			chain:               chain,
+			clock:               startup.NewClock(chain.Genesis, chain.ValidatorsRoot),
+			attestationNotifier: (&mockChain.ChainService{}).OperationNotifier(),
+		},
+		blkRootToPendingAtts:             make(map[[32]byte][]any),
+		seenUnAggregatedAttestationCache: lruwrpr.New(10),
+		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+		attestationBlockWaiter:           newAttestationBlockWaiter(time.Second, 1, 1, 1),
+	}
+	s.initCaches()
+	go s.verifierRoutine()
+
+	block := util.NewBeaconBlock()
+	block.Block.Slot = 1
+	blockRoot, err := block.Block.HashTreeRoot()
+	require.NoError(t, err)
+	wrappedBlock, err := consensusblocks.NewSignedBeaconBlock(block)
+	require.NoError(t, err)
+
+	savedState, keys := util.DeterministicGenesisState(t, 64)
+	require.NoError(t, savedState.SetSlot(1))
+	chain.State = savedState
+	chain.FinalizedCheckPoint = &ethpb.Checkpoint{
+		Root:  blockRoot[:],
+		Epoch: 0,
+	}
+
+	att := &ethpb.Attestation{
+		AggregationBits: bitfield.Bitlist{0b101},
+		Data: &ethpb.AttestationData{
+			BeaconBlockRoot: blockRoot[:],
+			CommitteeIndex:  0,
+			Slot:            1,
+			Target: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  blockRoot[:],
+			},
+			Source: &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
+		},
+	}
+	committee, err := helpers.BeaconCommitteeFromState(t.Context(), savedState, att.Data.Slot, att.Data.CommitteeIndex)
+	require.NoError(t, err)
+	domain, err := signing.Domain(
+		savedState.Fork(),
+		att.Data.Target.Epoch,
+		params.BeaconConfig().DomainBeaconAttester,
+		savedState.GenesisValidatorsRoot(),
+	)
+	require.NoError(t, err)
+	attRoot, err := signing.ComputeSigningRoot(att.Data, domain)
+	require.NoError(t, err)
+	att.Signature = keys[committee[0]].Sign(attRoot[:]).Marshal()
+
+	digest, err := s.currentForkDigest()
+	require.NoError(t, err)
+	topic := fmt.Sprintf("/eth2/%x/beacon_attestation_1", digest) + p.Encoding().ProtocolSuffix()
+	buf := new(bytes.Buffer)
+	_, err = p.Encoding().EncodeGossip(buf, att)
+	require.NoError(t, err)
+	msg := &pubsub.Message{
+		Message: &pubsubpb.Message{
+			Data:  buf.Bytes(),
+			Topic: &topic,
+		},
+	}
+
+	saved := make(chan error, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		if err := db.SaveBlock(ctx, wrappedBlock); err != nil {
+			saved <- err
+			return
+		}
+		if err := db.SaveState(ctx, savedState, blockRoot); err != nil {
+			saved <- err
+			return
+		}
+		s.attestationBlockWaiter.notify(blockRoot)
+		saved <- nil
+	}()
+
+	result, err := s.validateCommitteeIndexBeaconAttestation(ctx, "peer", msg)
+	require.NoError(t, <-saved)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, result)
+	require.Equal(t, true, msg.ValidatorData != nil)
+	require.Equal(t, 0, len(s.blkRootToPendingAtts))
 }
 
 func TestService_validateCommitteeIndexBeaconAttestationElectra(t *testing.T) {

--- a/changelog/zhaochonghe_attestation_block_gossip_grace.md
+++ b/changelog/zhaochonghe_attestation_block_gossip_grace.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Preserve gossip propagation for attestations that arrive shortly before their referenced beacon block.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR adds a short, bounded grace period for otherwise-valid gossip
attestations whose referenced beacon block and state are not yet available
locally.

Previously, Prysm immediately stored these attestations in the pending queue
and returned `pubsub.ValidationIgnore`. Once the block arrived, re-publishing
the same attestation could be suppressed by GossipSub's seen-message cache.

After all non-block-dependent validation succeeds, Prysm now waits for block
and state availability for up to 600ms. If they become available, the remaining
fork-choice and LMD/FFG checks run in the original gossip validation call,
allowing it to return `pubsub.ValidationAccept`.

On timeout, cancellation, or waiter-capacity exhaustion, the existing pending
queue and `pubsub.ValidationIgnore` behavior is preserved.

Additional background, measurements, and analysis are available in #17233.

Overall, the waiter is event-driven, keyed by `beacon_block_root`, and uses one shared
readiness channel per root. The initial internal limits are:

- 600ms timeout;
- 128 concurrent messages globally;
- 32 concurrent messages per peer;
- 64 concurrent messages per block root.

No CLI parameters or GossipSub seen-message TTL behavior are changed.

**Metrics**

- `gossip_attestation_block_wait_total{outcome}`
- `gossip_attestation_block_wait_milliseconds`

**Which issue(s) does this PR fix?**

Fixes #17233

**Testing**

- shared notification by block root;
- block arrival during validation;
- timeout and context cancellation;
- global, per-peer, and per-root limits;
- successful original-validator `ValidationAccept`;
- successful wait does not add the attestation to the pending queue.

```text
//beacon-chain/sync:go_default_test PASSED
make build PASSED