### PR TITLE
Add attestation_ready SSE event

### DIFF
--- a/api/server/structs/endpoints_events.go
+++ b/api/server/structs/endpoints_events.go
@@ -42,6 +42,12 @@ type BlockGossipEvent struct {
 	Block string `json:"block"`
 }
 
+type AttestationReadyEvent struct {
+	Slot                string `json:"slot"`
+	BeaconBlockRoot     string `json:"beacon_block_root"`
+	ExecutionOptimistic bool   `json:"execution_optimistic"`
+}
+
 type DataColumnGossipEvent struct {
 	Slot           string   `json:"slot"`
 	Index          string   `json:"index"`

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -118,6 +118,7 @@ go_test(
     name = "go_default_test",
     size = "medium",
     srcs = [
+        "attestation_ready_test.go",
         "blockchain_test.go",
         "chain_info_norace_test.go",
         "chain_info_test.go",

--- a/beacon-chain/blockchain/attestation_ready_test.go
+++ b/beacon-chain/blockchain/attestation_ready_test.go
@@ -1,0 +1,90 @@
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
+	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
+)
+
+func TestSendAttestationReadyOnBlock(t *testing.T) {
+	setup := func(t *testing.T, slotOffset primitives.Slot) (*Service, *postBlockProcessConfig, chan *feed.Event) {
+		s, _ := minimalTestService(t)
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = s.CurrentSlot() - slotOffset
+		signed, err := blocks.NewSignedBeaconBlock(blk)
+		require.NoError(t, err)
+		roblock, err := blocks.NewROBlockWithRoot(signed, [32]byte{'b'})
+		require.NoError(t, err)
+		events := make(chan *feed.Event, 10)
+		sub := s.cfg.StateNotifier.StateFeed().Subscribe(events)
+		t.Cleanup(sub.Unsubscribe)
+		return s, &postBlockProcessConfig{ctx: t.Context(), roblock: roblock}, events
+	}
+
+	drain := func(events chan *feed.Event) *statefeed.AttestationReadyData {
+		for {
+			select {
+			case e := <-events:
+				if e.Type == statefeed.AttestationReady {
+					d, ok := e.Data.(*statefeed.AttestationReadyData)
+					if ok {
+						return d
+					}
+				}
+			default:
+				return nil
+			}
+		}
+	}
+
+	t.Run("head block for current slot fires", func(t *testing.T) {
+		s, cfg, events := setup(t, 0)
+		cfg.headRoot = cfg.roblock.Root()
+		s.cfg.ForkChoiceStore.Lock()
+		s.sendAttestationReadyOnBlock(cfg)
+		s.cfg.ForkChoiceStore.Unlock()
+		got := drain(events)
+		require.NotNil(t, got)
+		require.Equal(t, cfg.roblock.Root(), got.BeaconBlockRoot)
+		require.Equal(t, cfg.roblock.Block().Slot(), got.Slot)
+	})
+
+	t.Run("old slot block does not fire", func(t *testing.T) {
+		s, cfg, events := setup(t, 1)
+		cfg.headRoot = cfg.roblock.Root()
+		s.cfg.ForkChoiceStore.Lock()
+		s.sendAttestationReadyOnBlock(cfg)
+		s.cfg.ForkChoiceStore.Unlock()
+		require.IsNil(t, drain(events))
+	})
+
+	t.Run("non-head block does not fire when not finalizing", func(t *testing.T) {
+		s, cfg, events := setup(t, 0)
+		cfg.headRoot = [32]byte{'p'}
+		s.cfg.ForkChoiceStore.Lock()
+		s.sendAttestationReadyOnBlock(cfg)
+		s.cfg.ForkChoiceStore.Unlock()
+		require.IsNil(t, drain(events))
+	})
+
+	t.Run("non-head block fires with head root when finalizing", func(t *testing.T) {
+		s, cfg, events := setup(t, 0)
+		cfg.headRoot = [32]byte{'p'}
+		s.cfg.ForkChoiceStore.Lock()
+		require.NoError(t, s.cfg.ForkChoiceStore.UpdateFinalizedCheckpoint(&forkchoicetypes.Checkpoint{
+			Epoch: slots.ToEpoch(s.CurrentSlot()) - 2,
+		}))
+		s.sendAttestationReadyOnBlock(cfg)
+		s.cfg.ForkChoiceStore.Unlock()
+		got := drain(events)
+		require.NotNil(t, got)
+		require.Equal(t, [32]byte{'p'}, got.BeaconBlockRoot)
+	})
+}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -106,6 +106,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	newBlockHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 	if cfg.headRoot != cfg.roblock.Root() {
 		s.logNonCanonicalBlockReceived(cfg.roblock.Root(), cfg.headRoot)
+		s.sendAttestationReadyOnBlock(cfg)
 		return nil
 	}
 	if cfg.roblock.Version() < version.Gloas {
@@ -113,6 +114,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	} else {
 		s.saveHeadIfNeeded(ctx, cfg)
 	}
+	s.sendAttestationReadyOnBlock(cfg)
 	// Pre-Fulu the caches are updated when computing the payload attributes
 	if cfg.postState.Version() >= version.Fulu {
 		go func() {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -137,6 +137,36 @@ func (s *Service) sendStateFeedOnBlock(cfg *postBlockProcessConfig) {
 	})
 }
 
+func (s *Service) sendAttestationReadyOnBlock(cfg *postBlockProcessConfig) {
+	slot := cfg.roblock.Block().Slot()
+	if slot != s.CurrentSlot() {
+		return
+	}
+	isHead := cfg.headRoot == cfg.roblock.Root()
+	if !isHead && !s.isFinalizing() {
+		return
+	}
+	optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(cfg.headRoot)
+	if err != nil {
+		log.WithError(err).Debug("Could not check if head is optimistic")
+		optimistic = true
+	}
+	s.cfg.StateNotifier.StateFeed().Send(&feed.Event{
+		Type: statefeed.AttestationReady,
+		Data: &statefeed.AttestationReadyData{
+			Slot:                slot,
+			BeaconBlockRoot:     cfg.headRoot,
+			ExecutionOptimistic: optimistic,
+		},
+	})
+}
+
+// Caller must hold the forkchoice lock.
+func (s *Service) isFinalizing() bool {
+	finalized := s.cfg.ForkChoiceStore.FinalizedCheckpoint()
+	return finalized.Epoch+2 >= slots.ToEpoch(s.CurrentSlot())
+}
+
 // processLightClientUpdates saves the light client data in lcStore, when feature flag is enabled.
 func (s *Service) processLightClientUpdates(cfg *postBlockProcessConfig) {
 	attestedRoot := cfg.roblock.Block().ParentRoot()

--- a/beacon-chain/core/feed/state/events.go
+++ b/beacon-chain/core/feed/state/events.go
@@ -39,6 +39,8 @@ const (
 	ExecutionPayloadAvailable
 	// ExecutionPayloadProcessed is sent after a payload envelope has been processed.
 	ExecutionPayloadProcessed
+	// AttestationReady is sent when it is safe to attest for the current slot without waiting for the attestation deadline.
+	AttestationReady
 )
 
 // BlockProcessedData is the data sent with BlockProcessed events.
@@ -57,6 +59,16 @@ type BlockProcessedData struct {
 	Verified bool
 	// Optimistic is true if the block is optimistic.
 	Optimistic bool
+}
+
+// AttestationReadyData is the data sent with AttestationReady events.
+type AttestationReadyData struct {
+	// Slot to attest for.
+	Slot primitives.Slot
+	// BeaconBlockRoot is the fork choice head root to vote for.
+	BeaconBlockRoot [32]byte
+	// ExecutionOptimistic is true if the head is optimistic.
+	ExecutionOptimistic bool
 }
 
 // ChainStartedData is the data sent with ChainStarted events.

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -93,6 +93,8 @@ const (
 	PayloadAttestationMessageTopic = "payload_attestation_message"
 	// ProposerPreferencesTopic represents a new signed proposer preferences event topic.
 	ProposerPreferencesTopic = "proposer_preferences"
+	// AttestationReadyTopic represents the event topic fired when it is safe to attest for the current slot.
+	AttestationReadyTopic = "attestation_ready"
 )
 
 var (
@@ -141,6 +143,7 @@ var stateFeedEventTopics = map[feed.EventType]string{
 	statefeed.LightClientOptimisticUpdate: LightClientOptimisticUpdateTopic,
 	statefeed.Reorg:                       ChainReorgTopic,
 	statefeed.BlockProcessed:              BlockTopic,
+	statefeed.AttestationReady:            AttestationReadyTopic,
 	statefeed.PayloadAttributes:           PayloadAttributesTopic,
 	statefeed.ExecutionPayloadAvailable:   ExecutionPayloadAvailableTopic,
 	statefeed.ExecutionPayloadProcessed:   ExecutionPayloadTopic,
@@ -494,6 +497,8 @@ func topicForEvent(event *feed.Event) string {
 		return ChainReorgTopic
 	case *statefeed.BlockProcessedData:
 		return BlockTopic
+	case *statefeed.AttestationReadyData:
+		return AttestationReadyTopic
 	case payloadattribute.EventData:
 		return PayloadAttributesTopic
 	case *operation.DataColumnReceivedData:
@@ -685,6 +690,14 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 				ExecutionOptimistic: v.Optimistic,
 			}
 			return jsonMarshalReader(eventName, blk)
+		}, nil
+	case *statefeed.AttestationReadyData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, &structs.AttestationReadyEvent{
+				Slot:                fmt.Sprintf("%d", v.Slot),
+				BeaconBlockRoot:     hexutil.Encode(v.BeaconBlockRoot[:]),
+				ExecutionOptimistic: v.ExecutionOptimistic,
+			})
 		}, nil
 	case *operation.PayloadAttestationMessageReceivedData:
 		return func() io.Reader {

--- a/changelog/terence_attestation-ready-event.md
+++ b/changelog/terence_attestation-ready-event.md
@@ -1,0 +1,3 @@
+### Added
+
+- `attestation_ready` SSE event, fired when a current-slot block is processed and it is safe to attest without waiting for the attestation deadline.


### PR DESCRIPTION
- New `attestation_ready` SSE event: fired when a current-slot block is processed and it is either the head, or not the head while the chain is finalizing, so a VC can attest immediately instead of waiting for the attestation deadline.
- Carries `slot`, `beacon_block_root` (the fork choice head to vote for), and `execution_optimistic`.
- Emitted after the head update on the canonical path, and on the non-canonical path only when finalizing.
- Validator client consumption is stacked on top in #17243.