### PR TITLE
Remove fcuArgsNonCanonicalBlock

### DIFF
--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -66,11 +66,7 @@ func (s *Service) sendFCU(cfg *postBlockProcessConfig) {
 		s.updateCachesPostBlockProcessing(cfg)
 		s.ForkChoicer().Lock()
 	}
-	fcuArgs, err := s.getFCUArgs(cfg)
-	if err != nil {
-		log.WithError(err).Error("Could not get forkchoice update argument")
-		return
-	}
+	fcuArgs := s.getFCUArgs(cfg)
 	// If head has not been updated and attributes are nil, we can skip the FCU.
 	if !s.isNewHead(cfg.headRoot, true) && (fcuArgs.attributes == nil || fcuArgs.attributes.IsEmpty()) {
 		return

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -38,7 +38,7 @@ func (s *Service) CurrentSlot() primitives.Slot {
 	return slots.CurrentSlot(s.genesisTime)
 }
 
-// getFCUArgs returns the arguments to call forkchoice update.
+// getFCUArgs returns the arguments to call forkchoice update
 // this function is only called pre-gloas hence we pass in full to getPayloadAttribute
 func (s *Service) getFCUArgs(cfg *postBlockProcessConfig) *fcuConfig {
 	fcuArgs := &fcuConfig{

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -38,28 +38,17 @@ func (s *Service) CurrentSlot() primitives.Slot {
 	return slots.CurrentSlot(s.genesisTime)
 }
 
-// getFCUArgs returns the arguments to call forkchoice update
+// getFCUArgs returns the arguments to call forkchoice update.
 // this function is only called pre-gloas hence we pass in full to getPayloadAttribute
-func (s *Service) getFCUArgs(cfg *postBlockProcessConfig) (*fcuConfig, error) {
-	fcuArgs, err := s.getFCUArgsEarlyBlock(cfg)
-	if err != nil {
-		return nil, err
+func (s *Service) getFCUArgs(cfg *postBlockProcessConfig) *fcuConfig {
+	fcuArgs := &fcuConfig{
+		headState:     cfg.postState,
+		headBlock:     cfg.roblock,
+		headRoot:      cfg.headRoot,
+		proposingSlot: s.CurrentSlot() + 1,
 	}
-
 	fcuArgs.attributes = s.getPayloadAttribute(cfg.ctx, fcuArgs.headState, fcuArgs.proposingSlot, cfg.headRoot[:], true)
-	return fcuArgs, nil
-}
-
-func (s *Service) getFCUArgsEarlyBlock(cfg *postBlockProcessConfig) (*fcuConfig, error) {
-	if cfg.roblock.Root() == cfg.headRoot {
-		return &fcuConfig{
-			headState:     cfg.postState,
-			headBlock:     cfg.roblock,
-			headRoot:      cfg.headRoot,
-			proposingSlot: s.CurrentSlot() + 1,
-		}, nil
-	}
-	return s.fcuArgsNonCanonicalBlock(cfg)
+	return fcuArgs
 }
 
 // logNonCanonicalBlockReceived prints a message informing that the received
@@ -86,21 +75,6 @@ func (s *Service) logNonCanonicalBlockReceived(blockRoot [32]byte, headRoot [32]
 		fields["headFullWeight"] = headFull
 	}
 	log.WithFields(fields).Debug("Head block is not the received block")
-}
-
-// fcuArgsNonCanonicalBlock returns the arguments to the FCU call when the
-// incoming block is non-canonical, that is, based on the head root.
-func (s *Service) fcuArgsNonCanonicalBlock(cfg *postBlockProcessConfig) (*fcuConfig, error) {
-	headState, headBlock, err := s.getStateAndBlock(cfg.ctx, cfg.headRoot)
-	if err != nil {
-		return nil, err
-	}
-	return &fcuConfig{
-		headState:     headState,
-		headBlock:     headBlock,
-		headRoot:      cfg.headRoot,
-		proposingSlot: s.CurrentSlot() + 1,
-	}, nil
 }
 
 // sendStateFeedOnBlock sends an event that a new block has been synced

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2414,17 +2414,12 @@ func Test_getFCUArgs(t *testing.T) {
 		ctx:            ctx,
 		roblock:        roblock,
 		postState:      st,
+		headRoot:       roblock.Root(),
 		isValidPayload: true,
 	}
-	// error branch
-	_, err = s.getFCUArgs(cfg)
-	require.ErrorContains(t, "block does not exist", err)
-
-	// canonical branch
-	cfg.headRoot = cfg.roblock.Root()
-	fcuArgs, err := s.getFCUArgs(cfg)
-	require.NoError(t, err)
+	fcuArgs := s.getFCUArgs(cfg)
 	require.Equal(t, cfg.roblock.Root(), fcuArgs.headRoot)
+	require.Equal(t, cfg.postState, fcuArgs.headState)
 }
 
 func TestRollbackBlock(t *testing.T) {

--- a/changelog/akronim26_remove-dead-path.md
+++ b/changelog/akronim26_remove-dead-path.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed the unreachable `fcuArgsNonCanonicalBlock` path from post-block processing.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

`getFCUArgsEarlyBlock` fallback to `fcuArgsNonCanonicalBlock` when the incoming block is not the head. But the fallback is unreachable (dead code) because the case of incoming block not being the head is already ruled out in `postBlockProcess`.

**Which issue(s) does this PR fix?**

Fixes #16867

**Other notes for review**

**Acknowledgements**

- [X] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [X] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [X] I have added a description with sufficient context for reviewers to understand this PR.
- [X] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
