### PR TITLE
Kurtosis+E2E: Add sync and checkpoint-sync tests

### DIFF
--- a/changelog/syjn99_kurtosis-e2e-sync.md
+++ b/changelog/syjn99_kurtosis-e2e-sync.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Add Kurtosis-backed P2P sync and checkpoint sync E2E tests.

--- a/testing/endtoend/kurtosis/BUILD.bazel
+++ b/testing/endtoend/kurtosis/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "assertoor_playbook.go",
         "assertoor_types.go",
         "helper.go",
+        "starlark.go",
         "wrapper.go",
     ],
     embedsrcs = [
@@ -30,6 +31,10 @@ go_library(
         "playbooks/validators-sync-participation.yaml",
         "playbooks/voluntary-exits.yaml",
         "playbooks/withdrawals.yaml",
+
+        # Playbooks for late-joining nodes
+        "playbooks/beacon-chain-sync.yaml",
+        "playbooks/checkpoint-sync.yaml",
     ],
     importpath = "github.com/OffchainLabs/prysm/v7/testing/endtoend/kurtosis",
     visibility = ["//visibility:public"],

--- a/testing/endtoend/kurtosis/playbooks/beacon-chain-sync.yaml
+++ b/testing/endtoend/kurtosis/playbooks/beacon-chain-sync.yaml
@@ -1,0 +1,30 @@
+# Verify that a late-joining beacon node syncs the chain from genesis over P2P.
+
+# Replaces this legacy E2E test and its evaluators (testBeaconChainSync):
+# - FinishedSyncing (for the late node)
+# - AllNodesHaveSameHead
+
+id: beacon-chain-sync
+name: "Late beacon node syncs from genesis"
+timeout: 60m
+
+config:
+  # NOTE: This assumes the late-joining node is the 3rd participant in Kurtosis network config file.
+  syncNodePattern: "^3-geth-prysm$"
+
+tasks:
+  - name: check_clients_are_healthy
+    title: "Wait for the late beacon node to start and report healthy"
+    timeout: 50m
+    configVars:
+      clientPattern: "syncNodePattern"
+    config:
+      minClientCount: 1
+
+  - name: check_consensus_sync_status
+    title: "Late beacon node is synced and following the chain head"
+    timeout: 50m
+    configVars:
+      clientPattern: "syncNodePattern"
+    config:
+      waitForChainProgression: true

--- a/testing/endtoend/kurtosis/playbooks/checkpoint-sync.yaml
+++ b/testing/endtoend/kurtosis/playbooks/checkpoint-sync.yaml
@@ -1,0 +1,31 @@
+# Verify a late-joining beacon node syncs via CHECKPOINT sync — from a finalized
+# state served by the checkpointz service, not from genesis.
+
+# Replaces this legacy E2E test (testCheckpointSync).
+
+id: checkpoint-sync
+name: "Late beacon node syncs from a finalized checkpoint"
+timeout: 60m
+
+config:
+  # NOTE: This assumes the late-joining node (w. checkpoint) is the 4th participant in Kurtosis network config file.
+  syncNodePattern: "^4-geth-prysm$"
+
+tasks:
+  # Gate on the node first: this fails loudly if it never starts or the pattern
+  # matches nothing, instead of the sync check passing vacuously.
+  - name: check_clients_are_healthy
+    title: "Wait for the checkpoint-sync node to start and report healthy"
+    timeout: 50m
+    configVars:
+      clientPattern: "syncNodePattern"
+    config:
+      minClientCount: 1
+
+  - name: check_consensus_sync_status
+    title: "Checkpoint-sync node is synced and following the chain head"
+    timeout: 50m
+    configVars:
+      clientPattern: "syncNodePattern"
+    config:
+      waitForChainProgression: true

--- a/testing/endtoend/kurtosis/playbooks/network-health-monitor.yaml
+++ b/testing/endtoend/kurtosis/playbooks/network-health-monitor.yaml
@@ -94,6 +94,10 @@ tasks:
             timeout: 60m
             config:
               maxForkDistance: 2
+              # NOTE: This is intentional because of late-joining nodes.
+              # If we DO NOT allow for 1 extra fork group, the monitoring test fails
+              # because the late-joining nodes will still report their head as zero root.
+              maxForkCount: 1
               continueOnPass: true
 
           - name: check_consensus_reorgs

--- a/testing/endtoend/kurtosis/starlark.go
+++ b/testing/endtoend/kurtosis/starlark.go
@@ -1,0 +1,26 @@
+package kurtosis
+
+import (
+	"fmt"
+
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/starlark_run_config"
+)
+
+// runStarlarkScript runs the given Starlark script in the enclave,
+// returning an error if the script fails to run or if it returns a non-zero exit code.
+func (kw *KurtosisWrapper) runStarlarkScript(script string) error {
+	res, err := kw.enclaveCtx.RunStarlarkScriptBlocking(kw.ctx, script, starlark_run_config.NewRunStarlarkConfig())
+	if err != nil {
+		return err
+	}
+	if res.InterpretationError != nil {
+		return fmt.Errorf("starlark interpretation error: %v", res.InterpretationError)
+	}
+	if len(res.ValidationErrors) > 0 {
+		return fmt.Errorf("starlark validation errors: %v", res.ValidationErrors)
+	}
+	if res.ExecutionError != nil {
+		return fmt.Errorf("starlark execution error: %v", res.ExecutionError)
+	}
+	return nil
+}

--- a/testing/endtoend/kurtosis/wrapper.go
+++ b/testing/endtoend/kurtosis/wrapper.go
@@ -113,6 +113,64 @@ func (kw *KurtosisWrapper) RunPackageWithNetworkConfig(packageId string, network
 	return nil
 }
 
+// StartService starts a previously-stopped service (e.g. a skip_start beacon
+// node) by running a one-line Starlark script in the enclave.
+func (kw *KurtosisWrapper) StartService(name string) error {
+	if kw.enclaveCtx == nil {
+		return fmt.Errorf("enclave context is nil")
+	}
+	script := fmt.Sprintf("def run(plan):\n    plan.start_service(%q)\n", name)
+	err := kw.runStarlarkScript(script)
+	if err != nil {
+		return fmt.Errorf("failed to start service %q: %w", name, err)
+	}
+	return nil
+}
+
+// ServiceAction surfaces orchestration actions (start/stop) for services in the enclave.
+type ServiceAction string
+
+const (
+	ServiceStart ServiceAction = "start"
+)
+
+// ScheduleServiceAction applies the given action to the services after delay.
+func (kw *KurtosisWrapper) ScheduleServiceAction(delay time.Duration, action ServiceAction, services ...string) {
+	kw.t.Logf("Will %s services %v after %s", action, services, delay)
+
+	done := make(chan error, len(services))
+	go func() {
+		select {
+		case <-kw.ctx.Done():
+			return // run ended before the services were due to change state
+		case <-time.After(delay):
+		}
+		for _, name := range services {
+			kw.t.Logf("%s service %q", action, name)
+
+			switch action {
+			case ServiceStart:
+				done <- kw.StartService(name)
+			default:
+				done <- fmt.Errorf("unknown Kurtosis service action %q", action)
+			}
+		}
+	}()
+
+	kw.t.Cleanup(func() {
+		// Non-blocking: report any action that actually ran and failed.
+		for range services {
+			select {
+			case err := <-done:
+				if err != nil {
+					kw.t.Errorf("Failed to %s service: %v", action, err)
+				}
+			default:
+			}
+		}
+	})
+}
+
 // prysmCLServices returns all Prysm beacon (CL) service contexts in the enclave
 // keyed by name, plus their names sorted ("cl-<i>-prysm-<el>").
 func (kw *KurtosisWrapper) prysmCLServices() (map[services.ServiceName]*services.ServiceContext, []string, error) {
@@ -124,9 +182,12 @@ func (kw *KurtosisWrapper) prysmCLServices() (map[services.ServiceName]*services
 
 	// Prysm beacon nodes are the CL services: "cl-<i>-prysm-<el>".
 	var names []string
-	for name := range all {
+	for name, sc := range all {
 		n := string(name)
 		if strings.HasPrefix(n, "cl-") && strings.Contains(n, "prysm") {
+			if isStoppedService(sc) {
+				continue
+			}
 			names = append(names, n)
 		}
 	}
@@ -135,6 +196,27 @@ func (kw *KurtosisWrapper) prysmCLServices() (map[services.ServiceName]*services
 		return nil, nil, fmt.Errorf("no prysm CL beacon services found in enclave %q", kw.enclaveName)
 	}
 	return all, names, nil
+}
+
+// StoppedPrysmCLName returns the name of the stopped Prysm beacon (CL) service in the enclave, which is the skip_start sync node.
+func (kw *KurtosisWrapper) StoppedPrysmCLName() ([]string, error) {
+	all, err := kw.enclaveCtx.GetServiceContexts(map[string]bool{})
+	if err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+	var stopped []string
+	for name, sc := range all {
+		n := string(name)
+		if strings.HasPrefix(n, "cl-") && strings.Contains(n, "prysm") && isStoppedService(sc) {
+			stopped = append(stopped, n)
+		}
+	}
+
+	// NOTE: One for sync node, other for checkpoint sync node.
+	if len(stopped) > 2 {
+		return nil, fmt.Errorf("expected at most two stopped prysm CL nodes, found %v", stopped)
+	}
+	return stopped, nil
 }
 
 // NewBeaconRESTEndpoints discovers the published Beacon REST ("http") port of
@@ -168,4 +250,10 @@ func (kw *KurtosisWrapper) NewAssertoorEndpoint() (string, error) {
 		return "", fmt.Errorf("assertoor service has no published http port")
 	}
 	return fmt.Sprintf("http://127.0.0.1:%d", httpPort.GetNumber()), nil // lint:ignore uintcast -- a uint16 port never exceeds int.
+}
+
+// isStoppedService returns true if the service has no published ports, which
+// is how we identify the skip_start sync node in the enclave.
+func isStoppedService(sc *services.ServiceContext) bool {
+	return len(sc.GetPublicPorts()) == 0
 }

--- a/testing/endtoend/kurtosis_e2e_helper.go
+++ b/testing/endtoend/kurtosis_e2e_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,6 +21,16 @@ import (
 const (
 	// ETHEREUM_PACKAGE is the identifier of the ethereum-package Starlark package used in these tests.
 	ETHEREUM_PACKAGE = "github.com/ethpandaops/ethereum-package"
+
+	// DEFAULT_LATE_SYNC_NODE_DELAY is how long after genesis the skip_start sync nodes are
+	// started, so the chain has advanced and finalized.
+	DEFAULT_LATE_SYNC_NODE_DELAY = 6 * time.Minute
+
+	// SYNC_NODE_SERVICE is the skip_start node for the P2P (genesis) sync test.
+	SYNC_NODE_SERVICE = "cl-3-prysm-geth"
+
+	// CHECKPOINT_SYNC_NODE_SERVICE is the skip_start node for the checkpoint sync test.
+	CHECKPOINT_SYNC_NODE_SERVICE = "cl-4-prysm-geth"
 
 	BEACON_CHAIN_IMAGE_TARGET = "cmd/beacon-chain/oci_image_tarball_e2e/tarball.tar"
 	VALIDATOR_IMAGE_TARGET    = "cmd/validator/oci_image_tarball_e2e/tarball.tar"
@@ -38,14 +49,20 @@ const (
 
 // KurtosisTestSuites defines a suite of end-to-end tests to run against a Kurtosis enclave.
 type KurtosisTestSuites struct {
-	enclaveName string
-	configPath  string
-	epochsToRun uint64
+	enclaveName       string
+	configPath        string
+	epochsToRun       uint64
+	runSyncTest       bool
+	lateSyncNodeDelay time.Duration
 }
 
 func (k *KurtosisTestSuites) Run(t *testing.T) {
 	// Note: Subtests can be run in parallel as they use separate enclaves.
 	t.Parallel()
+
+	if k.runSyncTest && k.lateSyncNodeDelay <= 0 {
+		k.lateSyncNodeDelay = DEFAULT_LATE_SYNC_NODE_DELAY
+	}
 
 	ctx := t.Context()
 
@@ -94,7 +111,24 @@ func (k *KurtosisTestSuites) Run(t *testing.T) {
 	require.NoError(t, kw.RegisterPlaybooks(ctx, map[string]any{
 		"epochsToRun": k.epochsToRun,
 	}), "Failed to register Assertoor playbooks")
+
+	k.scheduleServiceEvents(t, kw, genesisTime)
+
 	require.NoError(t, kw.WaitForAssertoor(ctx, deadline), "Assertoor checks failed")
+}
+
+func (k *KurtosisTestSuites) scheduleServiceEvents(t *testing.T, kw *kurtosis.KurtosisWrapper, genesisTime time.Time) {
+	if k.runSyncTest {
+		// Resume late-joining beacon node for normal sync and checkpoint sync test.
+		stoppedNodes, err := kw.StoppedPrysmCLName()
+		require.NoError(t, err, "Failed to locate the skip_start sync node")
+		require.Equal(t, 2, len(stoppedNodes))
+		require.Equal(t, true, slices.Contains(stoppedNodes, SYNC_NODE_SERVICE), "Expected stopped nodes to contain %s", SYNC_NODE_SERVICE)
+		require.Equal(t, true, slices.Contains(stoppedNodes, CHECKPOINT_SYNC_NODE_SERVICE), "Expected stopped nodes to contain %s", CHECKPOINT_SYNC_NODE_SERVICE)
+
+		delay := time.Until(genesisTime.Add(k.lateSyncNodeDelay))
+		kw.ScheduleServiceAction(delay, kurtosis.ServiceStart, SYNC_NODE_SERVICE, CHECKPOINT_SYNC_NODE_SERVICE)
+	}
 }
 
 // waitForNodeReady blocks until the beacon node reports healthy (200 from

--- a/testing/endtoend/minimal_kurtosis_e2e_test.go
+++ b/testing/endtoend/minimal_kurtosis_e2e_test.go
@@ -14,6 +14,7 @@ func TestEndToEnd_Kurtosis_MinimalConfig(t *testing.T) {
 			enclaveName: "minimal",
 			configPath:  "testing/endtoend/network-config/minimal.yaml",
 			epochsToRun: 15,
+			runSyncTest: true,
 		},
 	}
 

--- a/testing/endtoend/network-config/minimal.yaml
+++ b/testing/endtoend/network-config/minimal.yaml
@@ -20,6 +20,26 @@ participants:
       "/config": "graffiti.yaml"
     count: 2
 
+  # Late-joining beacon node for the P2P normal sync test.
+  # Asserted by beacon-chain-sync.yaml.
+  - el_type: geth
+    cl_type: prysm
+    cl_image: "gcr.io/offchainlabs/prysm/beacon-chain:latest"
+    validator_count: 0
+    skip_start: true
+    count: 1
+
+  # Late-joining beacon node for the checkpoint sync test: syncs from a finalized
+  # checkpoint (served by the checkpointz additional service) instead of genesis.
+  # Asserted by checkpoint-sync.yaml.
+  - el_type: geth
+    cl_type: prysm
+    cl_image: "gcr.io/offchainlabs/prysm/beacon-chain:latest"
+    validator_count: 0
+    skip_start: true
+    checkpoint_sync_enabled: true
+    count: 1
+
 extra_files:
   graffiti.yaml: |
     default: "Rice"
@@ -67,6 +87,7 @@ additional_services:
   - assertoor
   - dora
   - spamoor
+  - checkpointz
 
 spamoor_params:
   image: "ethpandaops/spamoor:master"


### PR DESCRIPTION
> [!NOTE]
> This PR will be rebased after #17239 and #17240 are merged.

**What type of PR is this?**

> Other: E2E test

**What does this PR do? Why is it needed?**

This PR adds on Kurtosis-backed E2E tests whether late-joining beacon node can be synced with other participants, so basically replaces `testBeaconChainSync` and `testCheckpointSync` in legacy E2E tests. Mechanism:

1. Add third, fourth nodes in Kurtosis configuration, but set `skip_start` as `true`. (See the diff of `minimal.yaml`) `skip_start` pauses BN services right after the initialization, so each node got stuck as CL is not working.
2. After `lateSyncNodeDelay` (default: 6 minutes)., resume each nodes by running Starlark script (`plan.start_service`).
3. `beacon-chain-sync.yaml` checks whether `cl-3-geth-prysm` node is synced (full sync, receive blocks from genesis), and `checkpoint-sync.yaml` checks whether `cl-4-geth-prysm` node is synced (checkpoint sync, bootstrap s from the checkpoint that `checkpointz` service provides).

**Which issue(s) does this PR fix?**

Part of **Phase 2: Parity with "minimal" test suites**
- #15320

**Other notes for review**

How to run a test:

```
bazel test //testing/endtoend:go_minimal_kurtosis_test \
      --nocache_test_results --test_output=streamed
```

Verifed that this isn't flaky by running multiple times locally.

As #17239 mentioned, with this PR we expect same assertion level with `TestEndToEnd_MinimalConfig`. So I believe it is **safe** to replace it but we should set up Kurtosis things in our CI pipeline, so this PR deliberately retains the legacy E2E test.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
