### PR TITLE
Drop the unused error return from the beacon-chain sync `currentForkDigest` helper and its callers

### DIFF
--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -310,10 +310,7 @@ func (s *Service) updateMetrics() {
 		return
 	}
 	// We update the dynamic subnet topics.
-	digest, err := s.currentForkDigest()
-	if err != nil {
-		log.WithError(err).Debugf("Could not compute fork digest")
-	}
+	digest := s.currentForkDigest()
 	indices := aggregatorSubnetIndices(s.cfg.clock.CurrentSlot())
 	syncIndices := cache.SyncSubnetIDs.GetAllSubnets(slots.ToEpoch(s.cfg.clock.CurrentSlot()))
 	attTopic := p2p.GossipTypeMapping[reflect.TypeFor[*pb.Attestation]()]

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -415,8 +415,7 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAttElectra_VerifyAlreadySeen
 	buf := new(bytes.Buffer)
 	_, err = p1.Encoding().EncodeGossip(buf, att)
 	require.NoError(t, err)
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic := fmt.Sprintf("/eth2/%x/beacon_attestation_1", digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -143,10 +143,7 @@ func (s *Service) sendRPCStatusRequest(ctx context.Context, peer peer.ID) error 
 		return errors.Wrap(err, "chain head root")
 	}
 
-	forkDigest, err := s.currentForkDigest()
-	if err != nil {
-		return errors.Wrap(err, "current fork digest")
-	}
+	forkDigest := s.currentForkDigest()
 
 	// Compute the current epoch.
 	currentSlot := s.cfg.clock.CurrentSlot()
@@ -308,10 +305,7 @@ func (s *Service) respondWithStatus(ctx context.Context, stream network.Stream) 
 		return errors.Wrap(err, "chain head root")
 	}
 
-	forkDigest, err := s.currentForkDigest()
-	if err != nil {
-		return errors.Wrap(err, "current fork digest")
-	}
+	forkDigest := s.currentForkDigest()
 
 	cp := s.cfg.chain.FinalizedCheckpt()
 	status, err := s.buildStatusFromStream(ctx, stream, forkDigest, cp.Root, cp.Epoch, headRoot)
@@ -433,10 +427,7 @@ func (s *Service) validateStatusMessage(ctx context.Context, genericMsg any) err
 		return errors.Wrap(p2ptypes.ErrInvalidRequest, "head slot too far in the future")
 	}
 
-	forkDigest, err := s.currentForkDigest()
-	if err != nil {
-		return err
-	}
+	forkDigest := s.currentForkDigest()
 	if !bytes.Equal(forkDigest[:], msg.ForkDigest) {
 		return fmt.Errorf("mismatch fork digest: expected %#x, got %#x: %w", forkDigest[:], msg.ForkDigest, p2ptypes.ErrWrongForkDigestVersion)
 	}

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -161,8 +161,7 @@ func TestStatusRPCHandler_ConnectsOnGenesis(t *testing.T) {
 
 	stream1, err := p1.BHost.NewStream(ctx, p2.BHost.ID(), pcl)
 	require.NoError(t, err)
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
+	digest := r.currentForkDigest()
 
 	err = r.statusRPCHandler(ctx, &ethpb.Status{ForkDigest: digest[:], FinalizedRoot: params.BeaconConfig().ZeroHash[:]}, stream1)
 	assert.NoError(t, err)
@@ -230,8 +229,7 @@ func TestStatusRPCHandler_ReturnsHelloMessage(t *testing.T) {
 		},
 		rateLimiter: newRateLimiter(p1),
 	}
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
+	digest := r.currentForkDigest()
 
 	// Setup streams
 	pcl := protocol.ID(p2p.RPCStatusTopicV1)
@@ -337,8 +335,7 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	clock := startup.NewClockSynchronizer()
 	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
 	r.verifierWaiter = verification.NewInitializerWaiter(clock, chain.ForkChoiceStore, r.cfg.stateGen, chain)
-	p1.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
+	p1.Digest = r.currentForkDigest()
 
 	chain2 := &mock.ChainService{
 		FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
@@ -360,8 +357,7 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	require.NoError(t, clock.SetClock(startup.NewClock(time.Now(), [32]byte{})))
 	r2.verifierWaiter = verification.NewInitializerWaiter(clock, chain2.ForkChoiceStore, r2.cfg.stateGen, chain2)
 
-	p2.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
+	p2.Digest = r.currentForkDigest()
 
 	go r.Start()
 
@@ -466,8 +462,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 				out := &ethpb.Status{}
 				require.NoError(t, service.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
 
-				digest, err := service.currentForkDigest()
-				require.NoError(t, err)
+				digest := service.currentForkDigest()
 
 				expected := &ethpb.Status{
 					ForkDigest:     digest[:],
@@ -481,7 +476,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 					t.Errorf("Did not receive expected message. Got %+v wanted %+v", out, expected)
 				}
 
-				err = service.respondWithStatus(ctx, stream)
+				err := service.respondWithStatus(ctx, stream)
 				require.NoError(t, err)
 			},
 		},
@@ -493,8 +488,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 				out := &ethpb.StatusV2{}
 				assert.NoError(t, service.cfg.p2p.Encoding().DecodeWithMaxLength(stream, out))
 
-				digest, err := service.currentForkDigest()
-				assert.NoError(t, err)
+				digest := service.currentForkDigest()
 
 				expected := &ethpb.StatusV2{
 					ForkDigest:            digest[:],
@@ -509,7 +503,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 					t.Errorf("Did not receive expected message. Got %+v wanted %+v", out, expected)
 				}
 
-				err = service.respondWithStatus(ctx, stream)
+				err := service.respondWithStatus(ctx, stream)
 				require.NoError(t, err)
 			},
 		},
@@ -1043,8 +1037,7 @@ func TestStatusRPC_ValidGenesisMessage(t *testing.T) {
 		},
 		ctx: ctx,
 	}
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
+	digest := r.currentForkDigest()
 	// There should be no error for a status message
 	// with a genesis checkpoint.
 	err = r.validateStatusMessage(r.ctx, &ethpb.Status{
@@ -1076,8 +1069,7 @@ func TestStatusRPC_RejectsFutureHeadSlot(t *testing.T) {
 		},
 		ctx: ctx,
 	}
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
+	digest := r.currentForkDigest()
 
 	status := func(headSlot primitives.Slot) *ethpb.Status {
 		return &ethpb.Status{

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -154,9 +154,7 @@ func TestSyncHandlers_WaitTillSynced(t *testing.T) {
 	r.waitForChainStart()
 	require.Equal(t, true, r.chainStarted.Load(), "Did not receive chain start event.")
 
-	var err error
-	p2p.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
+	p2p.Digest = r.currentForkDigest()
 
 	syncCompleteCh := make(chan bool)
 	go func() {
@@ -225,9 +223,7 @@ func TestSyncService_StopCleanly(t *testing.T) {
 	require.NoError(t, gs.SetClock(startup.NewClock(time.Now(), vr)))
 	r.waitForChainStart()
 
-	var err error
-	p2p.Digest, err = r.currentForkDigest()
-	require.NoError(t, err)
+	p2p.Digest = r.currentForkDigest()
 
 	// Wait for chainstart and topics to be registered
 	require.Eventually(t, func() bool {

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -533,11 +533,7 @@ func (s *Service) wrapAndReportValidation(topic string, v wrappedVal) (string, p
 			log.WithField("topic", topic).Errorf("Invalid topic format of pubsub topic: %v", err)
 			return pubsub.ValidationIgnore
 		}
-		currDigest, err := s.currentForkDigest()
-		if err != nil {
-			log.WithField("topic", topic).Errorf("Unable to retrieve fork data: %v", err)
-			return pubsub.ValidationIgnore
-		}
+		currDigest := s.currentForkDigest()
 		if currDigest != retDigest {
 			// Only proposer preferences are accepted from the next epoch's fork
 			// digest, allowing them to arrive before a fork activates.
@@ -820,11 +816,7 @@ func (s *Service) filterNeededPeers(pids []peer.ID) []peer.ID {
 		return pids
 	}
 
-	digest, err := s.currentForkDigest()
-	if err != nil {
-		log.WithError(err).Error("Could not compute fork digest")
-		return pids
-	}
+	digest := s.currentForkDigest()
 
 	wantedSubnets := make(map[uint64]bool)
 	for subnet := range s.persistentAndAggregatorSubnetIndices(currentSlot) {
@@ -903,8 +895,8 @@ func (*Service) addDigestAndIndexToTopic(topic string, digest [4]byte, idx uint6
 	return fmt.Sprintf(topic, digest, idx)
 }
 
-func (s *Service) currentForkDigest() ([4]byte, error) {
-	return params.ForkDigest(s.cfg.clock.CurrentEpoch()), nil
+func (s *Service) currentForkDigest() [4]byte {
+	return params.ForkDigest(s.cfg.clock.CurrentEpoch())
 }
 
 // computeAllNeededSubnets computes the subnets we want to join

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -370,12 +370,9 @@ func (s *Service) publishPartialColumns(ctx context.Context, indices map[uint64]
 		return nil
 	}
 
-	digest, err := s.currentForkDigest()
-	if err != nil {
-		return errors.Wrap(err, "current fork digest")
-	}
+	digest := s.currentForkDigest()
 
-	err = partialBroadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
+	err := partialBroadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
 		for i := range uint64(len(partialColumns)) {
 			if !indices[i] {
 				continue

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -51,23 +51,19 @@ func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) e
 			// re-publish the full column on the partial column extension as we don't send full columns to peers
 			// who have explicitly requested for partial columns. This method is idempotent so this is fine.
 			if broadcaster := s.cfg.p2p.PartialColumnBroadcaster(); broadcaster != nil {
-				digest, err := s.currentForkDigest()
-				if err != nil {
-					log.Error("Failed to get current fork digest")
-				} else {
-					err := broadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
-						subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index())
-						topic := fmt.Sprintf(p2p.DataColumnSubnetTopicFormat, digest, subnet) + s.cfg.p2p.Encoding().ProtocolSuffix()
-						partialColumn, err := blocks.NewPartialDataColumnFromVerifiedRODataColumn(sidecar)
-						if err != nil {
-							log.WithError(err).Error("Failed to create partial data column from verified RO data column")
-							return
-						}
-						yield(topic, partialColumn)
-					})
+				digest := s.currentForkDigest()
+				err := broadcaster.Publish(ctx, func(yield func(string, blocks.PartialDataColumn) bool) {
+					subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index())
+					topic := fmt.Sprintf(p2p.DataColumnSubnetTopicFormat, digest, subnet) + s.cfg.p2p.Encoding().ProtocolSuffix()
+					partialColumn, err := blocks.NewPartialDataColumnFromVerifiedRODataColumn(sidecar)
 					if err != nil {
-						log.WithError(err).Error("Failed to publish partial column on getting data column sidecar")
+						log.WithError(err).Error("Failed to create partial data column from verified RO data column")
+						return
 					}
+					yield(topic, partialColumn)
+				})
+				if err != nil {
+					log.WithError(err).Error("Failed to publish partial column on getting data column sidecar")
 				}
 			}
 		}

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -608,8 +608,7 @@ func TestFilterSubnetPeers(t *testing.T) {
 	markInitSyncComplete(t, &r)
 	// Empty cache at the end of the test.
 	defer cache.SubnetIDs.EmptyAllCaches()
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	defaultTopic := "/eth2/%x/beacon_attestation_%d" + r.cfg.p2p.Encoding().ProtocolSuffix()
 	subnet10 := r.addDigestAndIndexToTopic(defaultTopic, digest, 10)
 	cache.SubnetIDs.AddAggregatorSubnetID(currSlot, 10)
@@ -617,7 +616,7 @@ func TestFilterSubnetPeers(t *testing.T) {
 	subnet20 := r.addDigestAndIndexToTopic(defaultTopic, digest, 20)
 	cache.SubnetIDs.AddAttesterSubnetID(currSlot, 20)
 
-	_, err = tracer.JoinAndWatchTopic(t.Context(), subnet10, p)
+	_, err := tracer.JoinAndWatchTopic(t.Context(), subnet10, p)
 	require.NoError(t, err)
 	_, err = tracer.JoinAndWatchTopic(t.Context(), subnet20, p)
 	require.NoError(t, err)

--- a/beacon-chain/sync/sync_fuzz_test.go
+++ b/beacon-chain/sync/sync_fuzz_test.go
@@ -21,7 +21,6 @@ import (
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
-	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -80,8 +79,7 @@ func FuzzValidateBeaconBlockPubSub_Phase0(f *testing.F) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(f, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(f, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 
 	f.Add("junk", []byte("junk"), buf.Bytes(), []byte(topic))
@@ -164,8 +162,7 @@ func FuzzValidateBeaconBlockPubSub_Altair(f *testing.F) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(f, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(f, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 
 	f.Add("junk", []byte("junk"), buf.Bytes(), []byte(topic))
@@ -248,8 +245,7 @@ func FuzzValidateBeaconBlockPubSub_Bellatrix(f *testing.F) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(f, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(f, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 
 	f.Add("junk", []byte("junk"), buf.Bytes(), []byte(topic))

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -486,8 +486,7 @@ func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	msg := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -589,8 +588,7 @@ func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedAggregateAttestationAndProof]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	msg := &pubsub.Message{
 		Message: &pubsubpb.Message{

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -99,8 +99,7 @@ func TestValidateAttesterSlashing_ValidSlashing(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	msg := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -144,8 +143,7 @@ func TestValidateAttesterSlashing_ValidOldSlashing(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	msg := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -189,8 +187,7 @@ func TestValidateAttesterSlashing_InvalidSlashing_WithdrawableEpoch(t *testing.T
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	msg := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -238,11 +235,10 @@ func TestValidateAttesterSlashing_CanFilter(t *testing.T) {
 
 	// The below attestations should be filtered hence bad signature is ok.
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.AttesterSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	buf := new(bytes.Buffer)
-	_, err = p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
+	_, err := p.Encoding().EncodeGossip(buf, &ethpb.AttesterSlashing{
 		Attestation_1: util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
 			AttestingIndices: []uint64{3},
 		}),

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -63,8 +63,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 	invalidRoot := [32]byte{'A', 'B', 'C', 'D'}
 	s.setBadBlock(ctx, invalidRoot)
 
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 
 	blk := util.NewBeaconBlock()
 	blk.Block.Slot = 1
@@ -344,8 +343,7 @@ func TestService_validateCommitteeIndexBeaconAttestationElectra(t *testing.T) {
 	s.initCaches()
 	go s.verifierRoutine()
 
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 
 	blk := util.NewBeaconBlock()
 	blk.Block.Slot = s.cfg.clock.CurrentSlot()

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -109,8 +109,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -187,8 +186,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature_DownscoresPeer(t *testing.T)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -254,8 +252,7 @@ func TestValidateBeaconBlockPubSub_OutOfRangeProposerIndex(t *testing.T) {
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic := r.addDigestToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()], digest)
 	m := &pubsub.Message{Message: &pubsubpb.Message{Data: buf.Bytes(), Topic: &topic}}
 
@@ -299,8 +296,7 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -374,8 +370,7 @@ func TestValidateBeaconBlockPubSub_CanRecoverStateSummary(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -456,8 +451,7 @@ func TestValidateBeaconBlockPubSub_IsInCache(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -538,8 +532,7 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -623,8 +616,7 @@ func TestValidateBeaconBlockPubSub_WithLookahead(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -707,8 +699,7 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -824,8 +815,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -886,8 +876,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -975,8 +964,7 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msgClone)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -1141,8 +1129,7 @@ func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -1219,8 +1206,7 @@ func TestValidateBeaconBlockPubSub_InvalidParentBlock(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -1324,8 +1310,7 @@ func TestValidateBeaconBlockPubSub_InsertValidPendingBlock(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -1420,8 +1405,7 @@ func TestValidateBeaconBlockPubSub_RequestsUnknownParentBlock(t *testing.T) {
 	_, err = p1.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	require.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -1510,8 +1494,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromBadParent(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, msg)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedBeaconBlock]()]
-	digest, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	digest := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, digest)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{

--- a/beacon-chain/sync/validate_blob_test.go
+++ b/beacon-chain/sync/validate_blob_test.go
@@ -68,8 +68,7 @@ func TestValidateBlob_InvalidMessageType(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.SignedBeaconBlock]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic = s.addDigestToTopic(topic, digest)
 	result, err := s.validateBlob(ctx, "", &pubsub.Message{
 		Message: &pb.Message{
@@ -127,8 +126,7 @@ func TestValidateBlob_AlreadySeenInCache(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
 
 	s.setSeenBlobIndex(sc.Slot(), sc.SignedBlockHeader.Header.ProposerIndex, 0)
@@ -157,8 +155,7 @@ func TestValidateBlob_InvalidTopicIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic = s.addDigestAndIndexToTopic(topic, digest, 1) + p.Encoding().ProtocolSuffix()
 	result, err := s.validateBlob(ctx, "", &pubsub.Message{
 		Message: &pb.Message{
@@ -272,8 +269,7 @@ func TestValidateBlob_ErrorPathsWithMock(t *testing.T) {
 			require.NoError(t, err)
 
 			topic := p2p.GossipTypeMapping[reflect.TypeFor[*eth.BlobSidecar]()]
-			digest, err := s.currentForkDigest()
-			require.NoError(t, err)
+			digest := s.currentForkDigest()
 			topic = s.addDigestAndIndexToTopic(topic, digest, 0) + p.Encoding().ProtocolSuffix()
 			result, err := s.validateBlob(ctx, "", &pubsub.Message{
 				Message: &pb.Message{

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -103,8 +103,7 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		require.NoError(t, err)
 
 		topic := p2p.GossipTypeMapping[reflect.TypeOf(msg)]
-		digest, err := service.currentForkDigest()
-		require.NoError(t, err)
+		digest := service.currentForkDigest()
 
 		subnet := peerdas.ComputeSubnetForDataColumnSidecar(columnIndex)
 		topic = service.addDigestAndIndexToTopic(topic, digest, subnet)
@@ -219,8 +218,7 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		roDataColumn, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
 		require.NoError(t, err)
 
-		digest, err := service.currentForkDigest()
-		require.NoError(t, err)
+		digest := service.currentForkDigest()
 		topic := service.addDigestAndIndexToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.DataColumnSidecarGloas]()], digest, peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index))
 		msg := &pubsub.Message{Message: &pb.Message{Topic: &topic}}
 
@@ -251,8 +249,7 @@ func TestValidateDataColumnGloas(t *testing.T) {
 
 		roDataColumn, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
 		require.NoError(t, err)
-		digest, err := service.currentForkDigest()
-		require.NoError(t, err)
+		digest := service.currentForkDigest()
 		topic := service.addDigestAndIndexToTopic(p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.DataColumnSidecarGloas]()], digest, peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index))
 		msg := &pubsub.Message{Message: &pb.Message{Topic: &topic}}
 

--- a/beacon-chain/sync/validate_data_column_test.go
+++ b/beacon-chain/sync/validate_data_column_test.go
@@ -85,8 +85,7 @@ func TestValidateDataColumn(t *testing.T) {
 		require.NoError(t, err)
 
 		topic := p2p.GossipTypeMapping[reflect.TypeOf(msg)]
-		digest, err := service.currentForkDigest()
-		require.NoError(t, err)
+		digest := service.currentForkDigest()
 
 		if dc, ok := msg.(*ethpb.DataColumnSidecar); ok {
 			subnet := peerdas.ComputeSubnetForDataColumnSidecar(dc.Index)

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -548,8 +548,7 @@ func executionPayloadBidToPubsub(t *testing.T, s *Service, p p2p.P2P, bid *ethpb
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedExecutionPayloadBid]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic = s.addDigestToTopic(topic, digest)
 
 	return &pubsub.Message{

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -391,8 +391,7 @@ func envelopeToPubsub(t *testing.T, s *Service, p p2p.P2P, env *ethpb.SignedExec
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedExecutionPayloadEnvelope]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic = s.addDigestToTopic(topic, digest)
 
 	return &pubsub.Message{

--- a/beacon-chain/sync/validate_light_client_test.go
+++ b/beacon-chain/sync/validate_light_client_test.go
@@ -134,8 +134,7 @@ func TestValidateLightClientOptimisticUpdate(t *testing.T) {
 				require.NoError(t, err)
 
 				topic := p2p.LightClientOptimisticUpdateTopicFormat
-				digest, err := s.currentForkDigest()
-				require.NoError(t, err)
+				digest := s.currentForkDigest()
 				topic = s.addDigestToTopic(topic, digest)
 
 				r, err := s.validateLightClientOptimisticUpdate(ctx, "", &pubsub.Message{
@@ -265,8 +264,7 @@ func TestValidateLightClientFinalityUpdate(t *testing.T) {
 				require.NoError(t, err)
 
 				topic := p2p.LightClientFinalityUpdateTopicFormat
-				digest, err := s.currentForkDigest()
-				require.NoError(t, err)
+				digest := s.currentForkDigest()
 				topic = s.addDigestToTopic(topic, digest)
 
 				r, err := s.validateLightClientFinalityUpdate(ctx, "", &pubsub.Message{

--- a/beacon-chain/sync/validate_payload_attestation_test.go
+++ b/beacon-chain/sync/validate_payload_attestation_test.go
@@ -39,8 +39,7 @@ func TestValidatePayloadAttestationMessage_IncorrectTopic(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestation]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic = s.addDigestToTopic(topic, digest)
 
 	result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
@@ -112,8 +111,7 @@ func TestValidatePayloadAttestationMessage_ErrorPathsWithMock(t *testing.T) {
 			require.NoError(t, err)
 
 			topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
-			digest, err := s.currentForkDigest()
-			require.NoError(t, err)
+			digest := s.currentForkDigest()
 			topic = s.addDigestToTopic(topic, digest)
 
 			result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{
@@ -147,8 +145,7 @@ func TestValidatePayloadAttestationMessage_Accept(t *testing.T) {
 	require.NoError(t, err)
 
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.PayloadAttestationMessage]()]
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic = s.addDigestToTopic(topic, digest)
 
 	result, err := s.validatePayloadAttestation(ctx, "", &pubsub.Message{

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -130,8 +130,7 @@ func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
 	_, err := p.Encoding().EncodeGossip(buf, slashing)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{
@@ -173,8 +172,7 @@ func TestValidateProposerSlashing_ValidOldSlashing(t *testing.T) {
 	_, err = p.Encoding().EncodeGossip(buf, slashing)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.ProposerSlashing]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{

--- a/beacon-chain/sync/validate_signed_proposer_preferences_test.go
+++ b/beacon-chain/sync/validate_signed_proposer_preferences_test.go
@@ -316,8 +316,7 @@ func signedProposerPreferencesToPubsub(t *testing.T, s *Service, p p2p.P2P, pref
 	buf := new(bytes.Buffer)
 	_, err := p.Encoding().EncodeGossip(buf, preferences)
 	require.NoError(t, err)
-	digest, err := s.currentForkDigest()
-	require.NoError(t, err)
+	digest := s.currentForkDigest()
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedProposerPreferences]()]
 	topic = s.addDigestToTopic(topic, digest)
 	return &pubsub.Message{

--- a/beacon-chain/sync/validate_sync_committee_message.go
+++ b/beacon-chain/sync/validate_sync_committee_message.go
@@ -178,11 +178,7 @@ func (s *Service) rejectIncorrectSyncCommittee(
 		_, span := trace.StartSpan(ctx, "sync.rejectIncorrectSyncCommittee")
 		defer span.End()
 		isValid := false
-		digest, err := s.currentForkDigest()
-		if err != nil {
-			tracing.AnnotateError(span, err)
-			return pubsub.ValidationIgnore, err
-		}
+		digest := s.currentForkDigest()
 
 		format := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SyncCommitteeMessage]()]
 		// Validate that the validator is in the correct committee.

--- a/beacon-chain/sync/validate_sync_committee_message_test.go
+++ b/beacon-chain/sync/validate_sync_committee_message_test.go
@@ -526,8 +526,7 @@ func TestService_rejectIncorrectSyncCommittee(t *testing.T) {
 			setupTopic: func(s *Service) string {
 				format := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SyncCommitteeMessage]()]
 
-				digest, err := s.currentForkDigest()
-				require.NoError(t, err)
+				digest := s.currentForkDigest()
 				prefix := fmt.Sprintf(format, digest, 0 /* validator index 0 */)
 				return prefix + s.cfg.p2p.Encoding().ProtocolSuffix()
 			},

--- a/beacon-chain/sync/validate_voluntary_exit_test.go
+++ b/beacon-chain/sync/validate_voluntary_exit_test.go
@@ -102,8 +102,7 @@ func TestValidateVoluntaryExit_ValidExit(t *testing.T) {
 	_, err := p.Encoding().EncodeGossip(buf, exit)
 	require.NoError(t, err)
 	topic := p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.SignedVoluntaryExit]()]
-	d, err := r.currentForkDigest()
-	assert.NoError(t, err)
+	d := r.currentForkDigest()
 	topic = r.addDigestToTopic(topic, d)
 	m := &pubsub.Message{
 		Message: &pubsubpb.Message{

--- a/changelog/syjn99_fork-digest-infallible.md
+++ b/changelog/syjn99_fork-digest-infallible.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Drop the unused error return from the beacon-chain sync `currentForkDigest` helper and its callers.


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

From https://github.com/OffchainLabs/prysm/pull/15490, `currentForkDigest` never returns non-nil `err`. This PR changes `currentForkDigest` signature only to return the digest, and fixes the caller side by removing error handling parts.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
