### PR TITLE
Reorg late blocks even on slot 31

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/reorg_late_blocks.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/reorg_late_blocks.go
@@ -46,10 +46,6 @@ func (f *ForkChoice) ShouldOverrideFCU() (override bool) {
 		return
 	}
 
-	// Do not reorg on epoch boundaries
-	if (consensusHead.slot+1)%params.BeaconConfig().SlotsPerEpoch == 0 {
-		return
-	}
 	head := f.store.choosePayloadContent(consensusHead)
 	// Only reorg blocks that arrive late
 	early, err := head.arrivedEarly(f.store.genesisTime)
@@ -114,10 +110,6 @@ func (f *ForkChoice) GetProposerHead() [32]byte {
 	// Only reorg blocks from the previous slot.
 	currentSlot := slots.CurrentSlot(f.store.genesisTime)
 	if consensusHead.slot+1 != currentSlot {
-		return consensusHead.root
-	}
-	// Do not reorg on epoch boundaries
-	if (consensusHead.slot+1)%params.BeaconConfig().SlotsPerEpoch == 0 {
 		return consensusHead.root
 	}
 	// Only reorg blocks that arrive late

--- a/beacon-chain/forkchoice/doubly-linked-tree/reorg_late_blocks_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/reorg_late_blocks_test.go
@@ -50,14 +50,6 @@ func TestForkChoice_ShouldOverrideFCU(t *testing.T) {
 		require.Equal(t, false, f.ShouldOverrideFCU())
 		driftGenesisTime(f, 2, orphanLateBlockFirstThreshold+time.Second)
 	})
-	t.Run("head is from epoch boundary", func(t *testing.T) {
-		saved := f.store.headNode.slot
-		driftGenesisTime(f, params.BeaconConfig().SlotsPerEpoch-1, 0)
-		f.store.headNode.slot = params.BeaconConfig().SlotsPerEpoch - 1
-		require.Equal(t, false, f.ShouldOverrideFCU())
-		driftGenesisTime(f, 2, orphanLateBlockFirstThreshold+time.Second)
-		f.store.headNode.slot = saved
-	})
 	t.Run("head is early", func(t *testing.T) {
 		fn := f.store.fullNodeByRoot[f.store.headNode.root]
 		saved := fn.timestamp
@@ -151,14 +143,6 @@ func TestForkChoice_GetProposerHead(t *testing.T) {
 		require.Equal(t, childRoot, f.GetProposerHead())
 		driftGenesisTime(f, 3, 1*time.Second)
 	})
-	t.Run("head is from epoch boundary", func(t *testing.T) {
-		saved := f.store.headNode.slot
-		driftGenesisTime(f, params.BeaconConfig().SlotsPerEpoch, 0)
-		f.store.headNode.slot = params.BeaconConfig().SlotsPerEpoch - 1
-		require.Equal(t, childRoot, f.GetProposerHead())
-		driftGenesisTime(f, 3, 1*time.Second)
-		f.store.headNode.slot = saved
-	})
 	t.Run("head is early", func(t *testing.T) {
 		fn := f.store.fullNodeByRoot[f.store.headNode.root]
 		saved := fn.timestamp
@@ -197,4 +181,83 @@ func TestForkChoice_GetProposerHead(t *testing.T) {
 		f.store.headNode.weight = f.store.committeeWeight
 		require.Equal(t, childRoot, f.GetProposerHead())
 	})
+}
+
+// Regression test: a weak, late head whose next slot lands on an epoch boundary
+// must still be reorgeable. Reorgs used to be skipped on epoch boundaries.
+func TestForkChoice_ShouldOverrideFCU_EpochBoundary(t *testing.T) {
+	f := setup(0, 0)
+	numValidators := uint64(640)
+	f.justifiedBalances = make([]uint64, numValidators)
+	for i := range f.justifiedBalances {
+		f.justifiedBalances[i] = uint64(10)
+		f.store.committeeWeight += uint64(10)
+	}
+	f.store.committeeWeight /= uint64(params.BeaconConfig().SlotsPerEpoch)
+	ctx := t.Context()
+
+	parentSlot := params.BeaconConfig().SlotsPerEpoch - 2 // 30
+	headSlot := params.BeaconConfig().SlotsPerEpoch - 1   // 31; headSlot+1 == 32 is an epoch boundary
+	driftGenesisTime(f, parentSlot, 0)
+	st, parent, err := prepareForkchoiceState(ctx, parentSlot, [32]byte{'a'}, [32]byte{}, [32]byte{'A'}, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, parent))
+	attesters := make([]uint64, numValidators-64)
+	for i := range attesters {
+		attesters[i] = uint64(i + 64)
+	}
+	f.ProcessAttestation(ctx, attesters, parent.Root(), parentSlot, true)
+
+	orphanLateBlockFirstThreshold := time.Duration(params.BeaconConfig().SecondsPerSlot/params.BeaconConfig().IntervalsPerSlot) * time.Second
+	driftGenesisTime(f, headSlot, orphanLateBlockFirstThreshold+time.Second)
+	st, head, err := prepareForkchoiceState(ctx, headSlot, [32]byte{'b'}, [32]byte{'a'}, [32]byte{'B'}, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, head))
+	headRoot, err := f.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, head.Root(), headRoot)
+
+	require.Equal(t, true, f.ShouldOverrideFCU())
+}
+
+// Regression test: GetProposerHead must orphan a weak, late head even when the
+// proposing slot is an epoch boundary.
+func TestForkChoice_GetProposerHead_EpochBoundary(t *testing.T) {
+	f := setup(0, 0)
+	numValidators := uint64(640)
+	f.justifiedBalances = make([]uint64, numValidators)
+	for i := range f.justifiedBalances {
+		f.justifiedBalances[i] = uint64(10)
+		f.store.committeeWeight += uint64(10)
+	}
+	f.store.committeeWeight /= uint64(params.BeaconConfig().SlotsPerEpoch)
+	ctx := t.Context()
+
+	parentSlot := params.BeaconConfig().SlotsPerEpoch - 2 // 30
+	headSlot := params.BeaconConfig().SlotsPerEpoch - 1   // 31; headSlot+1 == 32 is an epoch boundary
+	parentRoot := [32]byte{'a'}
+	driftGenesisTime(f, parentSlot, 0)
+	st, parent, err := prepareForkchoiceState(ctx, parentSlot, parentRoot, [32]byte{}, [32]byte{'A'}, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, parent))
+	attesters := make([]uint64, numValidators-64)
+	for i := range attesters {
+		attesters[i] = uint64(i + 64)
+	}
+	f.ProcessAttestation(ctx, attesters, parent.Root(), parentSlot, true)
+
+	driftGenesisTime(f, headSlot+1, 1*time.Second)
+	childRoot := [32]byte{'b'}
+	st, head, err := prepareForkchoiceState(ctx, headSlot, childRoot, parentRoot, [32]byte{'B'}, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, head))
+	headRoot, err := f.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, head.Root(), headRoot)
+
+	orphanLateBlockFirstThreshold := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().AttestationDueBPS)
+	fn := f.store.fullNodeByRoot[f.store.headNode.root]
+	fn.timestamp = fn.timestamp.Add(-1 * (params.BeaconConfig().SlotDuration() - orphanLateBlockFirstThreshold))
+
+	require.Equal(t, parentRoot, f.GetProposerHead())
 }

--- a/changelog/potuz_reorg_slot_31.md
+++ b/changelog/potuz_reorg_slot_31.md
@@ -1,0 +1,2 @@
+### Changed
+- Reorg weak late blocks even on slot 31. 


### PR DESCRIPTION
The lookahead solved the shuffling stability problem on Fulu

This PR also adds a regression test and fixes the tests that were incorrectly passing before this PR, in fact the epoch boundary clause was not tested. 