### PR TITLE
Log the underlying error in the "genesis provider failed" warning

### DIFF
--- a/changelog/satushh_genesis-provider-log-error.md
+++ b/changelog/satushh_genesis-provider-log-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Include the underlying error in the `genesis provider failed` warning log, so failures such as a misconfigured checkpoint sync URL are visible instead of surfacing later as a generic `genesis state has not been initialized` error.

--- a/genesis/initialize.go
+++ b/genesis/initialize.go
@@ -38,7 +38,7 @@ func initializeFromProviders(ctx context.Context, dir string, providers ...Provi
 	for _, get := range providers {
 		gs, err := get.Genesis(ctx)
 		if err != nil {
-			log.WithField("provider", fmt.Sprintf("%T", get)).Warn("genesis provider failed")
+			log.WithError(err).WithField("provider", fmt.Sprintf("%T", get)).Warn("genesis provider failed")
 			continue
 		}
 		gd, err := newGenesisData(gs, dir)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Include the dropped provider error in the "genesis provider failed" warning log, so failures like a misconfigured checkpoint sync URL are visible instead of only surfacing later as a generic "genesis state has not been initialized" error.