### PR TITLE
VC: Remove unused `FeeRecipientByPubKey` method

### DIFF
--- a/changelog/syjn99_rest-delete-fee-recipient.md
+++ b/changelog/syjn99_rest-delete-fee-recipient.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Remove the unused `FeeRecipientByPubKey` method from the validator client. The proposer flow pushes fee recipients to the beacon node via `PrepareBeaconProposer` and never pulls them back, so the method had no callers. The beacon node's `GetFeeRecipientByPubKey` gRPC endpoint is unchanged.

--- a/changelog/syjn99_rest-delete-fee-recipient.md
+++ b/changelog/syjn99_rest-delete-fee-recipient.md
@@ -1,3 +1,3 @@
-### Removed
+### Ignored
 
 - Remove the unused `FeeRecipientByPubKey` method from the validator client. The proposer flow pushes fee recipients to the beacon node via `PrepareBeaconProposer` and never pulls them back, so the method had no callers. The beacon node's `GetFeeRecipientByPubKey` gRPC endpoint is unchanged.

--- a/testing/validator-mock/validator_client_mock.go
+++ b/testing/validator-mock/validator_client_mock.go
@@ -207,21 +207,6 @@ func (mr *MockValidatorClientMockRecorder) EventStreamIsRunning() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventStreamIsRunning", reflect.TypeOf((*MockValidatorClient)(nil).EventStreamIsRunning))
 }
 
-// FeeRecipientByPubKey mocks base method.
-func (m *MockValidatorClient) FeeRecipientByPubKey(ctx context.Context, in *eth.FeeRecipientByPubKeyRequest) (*eth.FeeRecipientByPubKeyResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FeeRecipientByPubKey", ctx, in)
-	ret0, _ := ret[0].(*eth.FeeRecipientByPubKeyResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FeeRecipientByPubKey indicates an expected call of FeeRecipientByPubKey.
-func (mr *MockValidatorClientMockRecorder) FeeRecipientByPubKey(ctx, in any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FeeRecipientByPubKey", reflect.TypeOf((*MockValidatorClient)(nil).FeeRecipientByPubKey), ctx, in)
-}
-
 // GetExecutionPayloadEnvelope mocks base method.
 func (m *MockValidatorClient) GetExecutionPayloadEnvelope(ctx context.Context, slot primitives.Slot, beaconBlockRoot [32]byte) (*eth.ExecutionPayloadEnvelope, error) {
 	m.ctrl.T.Helper()

--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -139,10 +139,6 @@ func (c *beaconApiValidatorClient) BeaconBlock(ctx context.Context, in *ethpb.Bl
 	})
 }
 
-func (c *beaconApiValidatorClient) FeeRecipientByPubKey(_ context.Context, _ *ethpb.FeeRecipientByPubKeyRequest) (*ethpb.FeeRecipientByPubKeyResponse, error) {
-	return nil, nil
-}
-
 func (c *beaconApiValidatorClient) SyncCommitteeContribution(ctx context.Context, in *ethpb.SyncCommitteeContributionRequest) (*ethpb.SyncCommitteeContribution, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon-api.SyncCommitteeContribution")
 	defer span.End()

--- a/validator/client/beacon-api/beacon_api_validator_client_test.go
+++ b/validator/client/beacon-api/beacon_api_validator_client_test.go
@@ -95,16 +95,6 @@ func TestBeaconApiValidatorClient_GetAttestationDataError(t *testing.T) {
 	assert.DeepEqual(t, expectedResp, resp)
 }
 
-func TestBeaconApiValidatorClient_GetFeeRecipientByPubKey(t *testing.T) {
-	ctx := t.Context()
-	validatorClient := beaconApiValidatorClient{}
-	var expected *ethpb.FeeRecipientByPubKeyResponse = nil
-
-	resp, err := validatorClient.FeeRecipientByPubKey(ctx, nil)
-	require.NoError(t, err)
-	require.Equal(t, expected, resp)
-}
-
 func TestBeaconApiValidatorClient_DomainDataValid(t *testing.T) {
 	const genesisValidatorRoot = "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
 	epoch := params.BeaconConfig().AltairForkEpoch

--- a/validator/client/grpc-api/grpc_validator_client.go
+++ b/validator/client/grpc-api/grpc_validator_client.go
@@ -228,10 +228,6 @@ func (c *grpcValidatorClient) BeaconBlock(ctx context.Context, in *ethpb.BlockRe
 	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Gloas{Gloas: gc.Block}}, nil
 }
 
-func (c *grpcValidatorClient) FeeRecipientByPubKey(ctx context.Context, in *ethpb.FeeRecipientByPubKeyRequest) (*ethpb.FeeRecipientByPubKeyResponse, error) {
-	return c.getClient().GetFeeRecipientByPubKey(ctx, in)
-}
-
 func (c *grpcValidatorClient) SyncCommitteeContribution(ctx context.Context, in *ethpb.SyncCommitteeContributionRequest) (*ethpb.SyncCommitteeContribution, error) {
 	return c.getClient().GetSyncCommitteeContribution(ctx, in)
 }

--- a/validator/client/iface/validator_client.go
+++ b/validator/client/iface/validator_client.go
@@ -137,7 +137,6 @@ type ValidatorClient interface {
 	BeaconBlock(ctx context.Context, in *ethpb.BlockRequest) (*ethpb.GenericBeaconBlock, error)
 	ProposeBeaconBlock(ctx context.Context, in *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error)
 	PrepareBeaconProposer(ctx context.Context, in *ethpb.PrepareBeaconProposerRequest) (*empty.Empty, error)
-	FeeRecipientByPubKey(ctx context.Context, in *ethpb.FeeRecipientByPubKeyRequest) (*ethpb.FeeRecipientByPubKeyResponse, error)
 	AttestationData(ctx context.Context, in *ethpb.AttestationDataRequest) (*ethpb.AttestationData, error)
 	ProposeAttestation(ctx context.Context, in *ethpb.Attestation) (*ethpb.AttestResponse, error)
 	ProposeAttestationElectra(ctx context.Context, in *ethpb.SingleAttestation) (*ethpb.AttestResponse, error)

--- a/validator/rpc/handlers_keymanager_test.go
+++ b/validator/rpc/handlers_keymanager_test.go
@@ -991,11 +991,6 @@ func TestServer_SetGasLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err2)
 
-	type beaconResp struct {
-		resp  *eth.FeeRecipientByPubKeyResponse
-		error error
-	}
-
 	type want struct {
 		pubkey   []byte
 		gaslimit uint64
@@ -1007,7 +1002,6 @@ func TestServer_SetGasLimit(t *testing.T) {
 		newGasLimit      uint64
 		proposerSettings *proposer.Settings
 		w                []*want
-		beaconReturn     *beaconResp
 		wantErr          string
 	}{
 		{
@@ -1129,13 +1123,6 @@ func TestServer_SetGasLimit(t *testing.T) {
 					validatorService:          vs,
 					beaconNodeValidatorClient: beaconClient,
 					db:                        validatorDB,
-				}
-
-				if tt.beaconReturn != nil {
-					beaconClient.EXPECT().FeeRecipientByPubKey(
-						gomock.Any(),
-						gomock.Any(),
-					).Return(tt.beaconReturn.resp, tt.beaconReturn.error)
 				}
 
 				request := &SetGasLimitRequest{
@@ -1654,10 +1641,9 @@ func TestServer_ListFeeRecipientByPubkey(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		args   *proposer.Settings
-		want   *want
-		cached *eth.FeeRecipientByPubKeyResponse
+		name string
+		args *proposer.Settings
+		want *want
 	}{
 		{
 			name: "ProposerSettings.ProposeConfig.FeeRecipientConfig defined for pubkey (and ProposerSettings.DefaultConfig.FeeRecipientConfig defined)",
@@ -1782,17 +1768,12 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 		valEthAddress     string
 		defaultEthaddress string
 	}
-	type beaconResp struct {
-		resp  *eth.FeeRecipientByPubKeyResponse
-		error error
-	}
 	tests := []struct {
 		name             string
 		args             string
 		proposerSettings *proposer.Settings
 		want             *want
 		wantErr          bool
-		beaconReturn     *beaconResp
 	}{
 		{
 			name:             "ProposerSetting is nil",
@@ -1802,10 +1783,6 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 				valEthAddress: "0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9",
 			},
 			wantErr: false,
-			beaconReturn: &beaconResp{
-				resp:  nil,
-				error: nil,
-			},
 		},
 		{
 			name: "ProposerSetting.ProposeConfig is nil",
@@ -1817,10 +1794,6 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 				valEthAddress: "0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9",
 			},
 			wantErr: false,
-			beaconReturn: &beaconResp{
-				resp:  nil,
-				error: nil,
-			},
 		},
 		{
 			name: "ProposerSetting.ProposeConfig is nil AND ProposerSetting.Defaultconfig is defined",
@@ -1833,10 +1806,6 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 				valEthAddress: "0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9",
 			},
 			wantErr: false,
-			beaconReturn: &beaconResp{
-				resp:  nil,
-				error: nil,
-			},
 		},
 		{
 			name: "ProposerSetting.ProposeConfig is defined for pubkey",
@@ -1850,10 +1819,6 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 				valEthAddress: "0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9",
 			},
 			wantErr: false,
-			beaconReturn: &beaconResp{
-				resp:  nil,
-				error: nil,
-			},
 		},
 		{
 			name: "ProposerSetting.ProposeConfig not defined for pubkey",
@@ -1865,10 +1830,6 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 				valEthAddress: "0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9",
 			},
 			wantErr: false,
-			beaconReturn: &beaconResp{
-				resp:  nil,
-				error: nil,
-			},
 		},
 		{
 			name: "ProposerSetting.ProposeConfig is nil for pubkey",
@@ -1882,10 +1843,6 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 				valEthAddress: "0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9",
 			},
 			wantErr: false,
-			beaconReturn: &beaconResp{
-				resp:  nil,
-				error: nil,
-			},
 		},
 		{
 			name: "ProposerSetting.ProposeConfig is nil for pubkey AND DefaultConfig is not nil",
@@ -1900,10 +1857,6 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 				valEthAddress: "0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9",
 			},
 			wantErr: false,
-			beaconReturn: &beaconResp{
-				resp:  nil,
-				error: nil,
-			},
 		},
 	}
 	for _, isSlashingProtectionMinimal := range [...]bool{false, true} {


### PR DESCRIPTION
**What type of PR is this?**

> Other: Cleanup

**What does this PR do? Why is it needed?**

The beacon node's GetFeeRecipientByPubKey endpoint and the proto definitions stay until the whole gRPC service is removed.

The proposer flow pushes fee recipients to the beacon node via PrepareBeaconProposer and never pulls them back, so this method had zero callers. Drop the interface declaration, the beacon-api stub (which returned nil, nil), the grpc-api implementation, the generated mock, and the dead test scaffolding that fed it.


**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
