### PR TITLE
VC: Remove unused `ValidatorParticipation` and `ValidatorQueue` from validator `ChainClient`

### DIFF
--- a/changelog/syjn99_rest-delete-participation-queue.md
+++ b/changelog/syjn99_rest-delete-participation-queue.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Remove the unused `ValidatorParticipation` and `ValidatorQueue` methods from the validator's `ChainClient` interface and its gRPC/REST implementations. The beacon node keeps serving both endpoints for external consumers.

--- a/testing/validator-mock/chain_client_mock.go
+++ b/testing/validator-mock/chain_client_mock.go
@@ -72,21 +72,6 @@ func (mr *MockChainClientMockRecorder) ValidatorBalances(ctx, in any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorBalances", reflect.TypeOf((*MockChainClient)(nil).ValidatorBalances), ctx, in)
 }
 
-// ValidatorParticipation mocks base method.
-func (m *MockChainClient) ValidatorParticipation(ctx context.Context, in *eth.GetValidatorParticipationRequest) (*eth.ValidatorParticipationResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidatorParticipation", ctx, in)
-	ret0, _ := ret[0].(*eth.ValidatorParticipationResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ValidatorParticipation indicates an expected call of ValidatorParticipation.
-func (mr *MockChainClientMockRecorder) ValidatorParticipation(ctx, in any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorParticipation", reflect.TypeOf((*MockChainClient)(nil).ValidatorParticipation), ctx, in)
-}
-
 // ValidatorPerformance mocks base method.
 func (m *MockChainClient) ValidatorPerformance(arg0 context.Context, arg1 *eth.ValidatorPerformanceRequest) (*eth.ValidatorPerformanceResponse, error) {
 	m.ctrl.T.Helper()
@@ -100,21 +85,6 @@ func (m *MockChainClient) ValidatorPerformance(arg0 context.Context, arg1 *eth.V
 func (mr *MockChainClientMockRecorder) ValidatorPerformance(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorPerformance", reflect.TypeOf((*MockChainClient)(nil).ValidatorPerformance), arg0, arg1)
-}
-
-// ValidatorQueue mocks base method.
-func (m *MockChainClient) ValidatorQueue(ctx context.Context, in *empty.Empty) (*eth.ValidatorQueue, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidatorQueue", ctx, in)
-	ret0, _ := ret[0].(*eth.ValidatorQueue)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ValidatorQueue indicates an expected call of ValidatorQueue.
-func (mr *MockChainClientMockRecorder) ValidatorQueue(ctx, in any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorQueue", reflect.TypeOf((*MockChainClient)(nil).ValidatorQueue), ctx, in)
 }
 
 // Validators mocks base method.

--- a/validator/client/beacon-api/beacon_api_beacon_chain_client.go
+++ b/validator/client/beacon-api/beacon_api_beacon_chain_client.go
@@ -304,15 +304,6 @@ func (c beaconApiChainClient) Validators(ctx context.Context, in *ethpb.ListVali
 	}, nil
 }
 
-func (c beaconApiChainClient) ValidatorQueue(ctx context.Context, in *empty.Empty) (*ethpb.ValidatorQueue, error) {
-	if c.fallbackClient != nil {
-		return c.fallbackClient.ValidatorQueue(ctx, in)
-	}
-
-	// TODO: Implement me
-	return nil, errors.New("beaconApiChainClient.ValidatorQueue is not implemented. To use a fallback client, pass a fallback client as the last argument of NewBeaconApiChainClientWithFallback.")
-}
-
 func (c beaconApiChainClient) ValidatorPerformance(ctx context.Context, in *ethpb.ValidatorPerformanceRequest) (*ethpb.ValidatorPerformanceResponse, error) {
 	// Note: ValidatorPerformance is only supported on Prysm nodes,
 	// So we should check whether the node is Prysm by node version.
@@ -353,15 +344,6 @@ func (c beaconApiChainClient) ValidatorPerformance(ctx context.Context, in *ethp
 		PublicKeys:                    resp.PublicKeys,
 		InactivityScores:              resp.InactivityScores,
 	}, nil
-}
-
-func (c beaconApiChainClient) ValidatorParticipation(ctx context.Context, in *ethpb.GetValidatorParticipationRequest) (*ethpb.ValidatorParticipationResponse, error) {
-	if c.fallbackClient != nil {
-		return c.fallbackClient.ValidatorParticipation(ctx, in)
-	}
-
-	// TODO: Implement me
-	return nil, errors.New("beaconApiChainClient.ValidatorParticipation is not implemented. To use a fallback client, pass a fallback client as the last argument of NewBeaconApiChainClientWithFallback.")
 }
 
 func NewBeaconApiChainClientWithFallback(provider rest.RestConnectionProvider, fallbackClient iface.ChainClient) iface.ChainClient {

--- a/validator/client/grpc-api/grpc_beacon_chain_client.go
+++ b/validator/client/grpc-api/grpc_beacon_chain_client.go
@@ -25,16 +25,8 @@ func (c *grpcChainClient) Validators(ctx context.Context, in *ethpb.ListValidato
 	return c.getClient().ListValidators(ctx, in)
 }
 
-func (c *grpcChainClient) ValidatorQueue(ctx context.Context, in *empty.Empty) (*ethpb.ValidatorQueue, error) {
-	return c.getClient().GetValidatorQueue(ctx, in)
-}
-
 func (c *grpcChainClient) ValidatorPerformance(ctx context.Context, in *ethpb.ValidatorPerformanceRequest) (*ethpb.ValidatorPerformanceResponse, error) {
 	return c.getClient().GetValidatorPerformance(ctx, in)
-}
-
-func (c *grpcChainClient) ValidatorParticipation(ctx context.Context, in *ethpb.GetValidatorParticipationRequest) (*ethpb.ValidatorParticipationResponse, error) {
-	return c.getClient().GetValidatorParticipation(ctx, in)
 }
 
 // NewGrpcChainClient creates a new gRPC chain client that supports

--- a/validator/client/iface/chain_client.go
+++ b/validator/client/iface/chain_client.go
@@ -14,7 +14,5 @@ type ChainClient interface {
 	ChainHead(ctx context.Context, in *empty.Empty) (*ethpb.ChainHead, error)
 	ValidatorBalances(ctx context.Context, in *ethpb.ListValidatorBalancesRequest) (*ethpb.ValidatorBalances, error)
 	Validators(ctx context.Context, in *ethpb.ListValidatorsRequest) (*ethpb.Validators, error)
-	ValidatorQueue(ctx context.Context, in *empty.Empty) (*ethpb.ValidatorQueue, error)
-	ValidatorParticipation(ctx context.Context, in *ethpb.GetValidatorParticipationRequest) (*ethpb.ValidatorParticipationResponse, error)
 	ValidatorPerformance(context.Context, *ethpb.ValidatorPerformanceRequest) (*ethpb.ValidatorPerformanceResponse, error)
 }


### PR DESCRIPTION
**What type of PR is this?**

> Other: Cleanup

**What does this PR do? Why is it needed?**

Neither method had a caller anywhere in `validator/` — the only references were the gRPC-fallback delegation lines themselves. Drop them from the `iface.ChainClient` interface, the gRPC and beacon-API implementations, and the generated mock.

The beacon node keeps serving both endpoints for external consumers.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
