### PR TITLE
VC: Implement validator REST `Peers` and drop its gRPC fallback

### DIFF
--- a/changelog/syjn99_rest-peers-parity.md
+++ b/changelog/syjn99_rest-peers-parity.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Implement the validator client's `Peers` node method natively with `GET /eth/v1/node/peers`, removing its gRPC fallback.

--- a/validator/client/beacon-api/beacon_api_node_client.go
+++ b/validator/client/beacon-api/beacon_api_node_client.go
@@ -2,8 +2,10 @@ package beacon_api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/api/rest"
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
@@ -20,7 +22,6 @@ var (
 )
 
 type beaconApiNodeClient struct {
-	fallbackClient  iface.NodeClient
 	handler         rest.Handler
 	genesisProvider GenesisProvider
 }
@@ -94,13 +95,38 @@ func (c *beaconApiNodeClient) Version(ctx context.Context, _ *empty.Empty) (*eth
 	}, nil
 }
 
-func (c *beaconApiNodeClient) Peers(ctx context.Context, in *empty.Empty) (*ethpb.Peers, error) {
-	if c.fallbackClient != nil {
-		return c.fallbackClient.Peers(ctx, in)
+func (c *beaconApiNodeClient) Peers(ctx context.Context, _ *empty.Empty) (*ethpb.Peers, error) {
+	var peersResponse structs.GetPeersResponse
+	if err := c.handler.Get(ctx, "/eth/v1/node/peers", &peersResponse); err != nil {
+		return nil, err
 	}
 
-	// TODO: Implement me
-	return nil, errors.New("beaconApiNodeClient.Peers is not implemented. To use a fallback client, pass a fallback client as the last argument of NewBeaconApiNodeClientWithFallback.")
+	peers := make([]*ethpb.Peer, len(peersResponse.Data))
+	for i, p := range peersResponse.Data {
+		if p == nil {
+			return nil, fmt.Errorf("peer at index %d is nil", i)
+		}
+
+		// The beacon API spells the enums in lower case, the proto enums in upper case.
+		direction, ok := ethpb.PeerDirection_value[strings.ToUpper(p.Direction)]
+		if !ok {
+			return nil, fmt.Errorf("unknown peer direction `%s`", p.Direction)
+		}
+		state, ok := ethpb.ConnectionState_value[strings.ToUpper(p.State)]
+		if !ok {
+			return nil, fmt.Errorf("unknown connection state `%s`", p.State)
+		}
+
+		peers[i] = &ethpb.Peer{
+			Address:         p.LastSeenP2PAddress,
+			Direction:       ethpb.PeerDirection(direction),
+			ConnectionState: ethpb.ConnectionState(state),
+			PeerId:          p.PeerId,
+			Enr:             p.Enr,
+		}
+	}
+
+	return &ethpb.Peers{Peers: peers}, nil
 }
 
 // IsReady returns true only if the node is fully synced (200 OK).
@@ -116,12 +142,10 @@ func (c *beaconApiNodeClient) IsReady(ctx context.Context) bool {
 	return statusCode == http.StatusOK
 }
 
-func NewNodeClientWithFallback(provider rest.RestConnectionProvider, fallbackClient iface.NodeClient) iface.NodeClient {
+func NewNodeClient(provider rest.RestConnectionProvider) iface.NodeClient {
 	handler := provider.Handler()
-	b := &beaconApiNodeClient{
+	return &beaconApiNodeClient{
 		handler:         handler,
-		fallbackClient:  fallbackClient,
 		genesisProvider: &beaconApiGenesisProvider{handler: handler},
 	}
-	return b
 }

--- a/validator/client/beacon-api/beacon_api_node_client_test.go
+++ b/validator/client/beacon-api/beacon_api_node_client_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/validator/client/beacon-api/mock"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"go.uber.org/mock/gomock"
@@ -284,6 +285,116 @@ func TestGetVersion(t *testing.T) {
 				assert.ErrorContains(t, testCase.expectedError, err)
 			} else {
 				assert.DeepEqual(t, testCase.expectedResponse, version)
+			}
+		})
+	}
+}
+
+func TestGetPeers(t *testing.T) {
+	const peersEndpoint = "/eth/v1/node/peers"
+
+	testCases := []struct {
+		name                 string
+		restEndpointResponse structs.GetPeersResponse
+		restEndpointError    error
+		expectedResponse     *ethpb.Peers
+		expectedError        string
+	}{
+		{
+			name:              "fails to query REST endpoint",
+			restEndpointError: errors.New("foo error"),
+			expectedError:     "foo error",
+		},
+		{
+			name:                 "returns no peers",
+			restEndpointResponse: structs.GetPeersResponse{Data: []*structs.Peer{}},
+			expectedResponse:     &ethpb.Peers{Peers: []*ethpb.Peer{}},
+		},
+		{
+			name:                 "returns nil peer",
+			restEndpointResponse: structs.GetPeersResponse{Data: []*structs.Peer{nil}},
+			expectedError:        "peer at index 0 is nil",
+		},
+		{
+			name: "returns unknown direction",
+			restEndpointResponse: structs.GetPeersResponse{Data: []*structs.Peer{{
+				Direction: "sideways",
+				State:     "connected",
+			}}},
+			expectedError: "unknown peer direction `sideways`",
+		},
+		{
+			name: "returns unknown state",
+			restEndpointResponse: structs.GetPeersResponse{Data: []*structs.Peer{{
+				Direction: "inbound",
+				State:     "napping",
+			}}},
+			expectedError: "unknown connection state `napping`",
+		},
+		{
+			name: "returns peers",
+			restEndpointResponse: structs.GetPeersResponse{Data: []*structs.Peer{
+				{
+					PeerId:             "peer1",
+					Enr:                "enr1",
+					LastSeenP2PAddress: "address1",
+					State:              "connected",
+					Direction:          "inbound",
+				},
+				{
+					PeerId:             "peer2",
+					Enr:                "enr2",
+					LastSeenP2PAddress: "address2",
+					State:              "DISCONNECTING",
+					Direction:          "OutBound",
+				},
+			}},
+			expectedResponse: &ethpb.Peers{Peers: []*ethpb.Peer{
+				{
+					PeerId:          "peer1",
+					Enr:             "enr1",
+					Address:         "address1",
+					ConnectionState: ethpb.ConnectionState_CONNECTED,
+					Direction:       ethpb.PeerDirection_INBOUND,
+				},
+				{
+					PeerId:          "peer2",
+					Enr:             "enr2",
+					Address:         "address2",
+					ConnectionState: ethpb.ConnectionState_DISCONNECTING,
+					Direction:       ethpb.PeerDirection_OUTBOUND,
+				},
+			}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ctx := t.Context()
+
+			var peersResponse structs.GetPeersResponse
+			handler := mock.NewMockHandler(ctrl)
+			handler.EXPECT().Get(
+				gomock.Any(),
+				peersEndpoint,
+				&peersResponse,
+			).Return(
+				testCase.restEndpointError,
+			).SetArg(
+				2,
+				testCase.restEndpointResponse,
+			)
+
+			nodeClient := &beaconApiNodeClient{handler: handler}
+			peers, err := nodeClient.Peers(ctx, &emptypb.Empty{})
+
+			if testCase.expectedResponse == nil {
+				assert.ErrorContains(t, testCase.expectedError, err)
+			} else {
+				require.NoError(t, err)
+				assert.DeepEqual(t, testCase.expectedResponse, peers)
 			}
 		})
 	}

--- a/validator/client/factory.go
+++ b/validator/client/factory.go
@@ -9,12 +9,10 @@ import (
 )
 
 func NewNodeClient(validatorConn *validatorHelpers.NodeConnection) iface.NodeClient {
-	grpcClient := grpcApi.NewNodeClient(validatorConn)
 	if features.Get().EnableBeaconRESTApi && validatorConn.GetRestConnectionProvider() != nil {
-		restProvider := validatorConn.GetRestConnectionProvider()
-		return beaconApi.NewNodeClientWithFallback(restProvider, grpcClient)
+		return beaconApi.NewNodeClient(validatorConn.GetRestConnectionProvider())
 	}
-	return grpcClient
+	return grpcApi.NewNodeClient(validatorConn)
 }
 
 func NewChainClient(validatorConn *validatorHelpers.NodeConnection) iface.ChainClient {


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

`beaconApiNodeClient.Peers` now calls `GET /eth/v1/node/peers` directly, mapping each entry onto `ethpb.Peer` with case-insensitive parsing of the `direction` and `state` enums. With no caller left needing gRPC, the `fallbackClient` field and `NewNodeClientWithFallback` are gone; the factory builds a plain REST node client.

**Which issue(s) does this PR fix?**

N/A - but will definitely help #15346 

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
