### PR TITLE
VC: Implement `ValidatorBalances` natively in the beacon API chain client

### DIFF
--- a/changelog/syjn99_rest-validator-balances-parity.md
+++ b/changelog/syjn99_rest-validator-balances-parity.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Implement `ValidatorBalances` in the validator client's beacon API chain client using the standard `/eth/v1/beacon/states/{state_id}/validators` endpoint instead of falling back to gRPC.

--- a/validator/client/beacon-api/beacon_api_beacon_chain_client.go
+++ b/validator/client/beacon-api/beacon_api_beacon_chain_client.go
@@ -147,12 +147,122 @@ func (c beaconApiChainClient) ChainHead(ctx context.Context, _ *empty.Empty) (*e
 }
 
 func (c beaconApiChainClient) ValidatorBalances(ctx context.Context, in *ethpb.ListValidatorBalancesRequest) (*ethpb.ValidatorBalances, error) {
-	if c.fallbackClient != nil {
-		return c.fallbackClient.ValidatorBalances(ctx, in)
+	pageSize := in.PageSize
+
+	// We follow the gRPC behavior here, which returns a maximum of 250 results when pageSize == 0
+	if pageSize == 0 {
+		pageSize = 250
 	}
 
-	// TODO: Implement me
-	return nil, errors.New("beaconApiChainClient.ValidatorBalances is not implemented. To use a fallback client, pass a fallback client as the last argument of NewBeaconApiChainClientWithFallback.")
+	var pageToken uint64
+	var err error
+
+	if in.PageToken != "" {
+		if pageToken, err = strconv.ParseUint(in.PageToken, 10, 64); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse page token `%s`", in.PageToken)
+		}
+	}
+
+	pubkeys := make([]string, len(in.PublicKeys))
+	for idx, pubkey := range in.PublicKeys {
+		pubkeys[idx] = hexutil.Encode(pubkey)
+	}
+
+	var stateValidators *structs.GetValidatorsResponse
+	var epoch primitives.Epoch
+
+	switch queryFilter := in.QueryFilter.(type) {
+	case *ethpb.ListValidatorBalancesRequest_Epoch:
+		slot, err := slots.EpochStart(queryFilter.Epoch)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get first slot for epoch `%d`", queryFilter.Epoch)
+		}
+		if stateValidators, err = c.stateValidatorsProvider.StateValidatorsForSlot(ctx, slot, pubkeys, in.Indices, nil); err != nil {
+			return nil, errors.Wrapf(err, "failed to get state validators for slot `%d`", slot)
+		}
+		epoch = slots.ToEpoch(slot)
+	case *ethpb.ListValidatorBalancesRequest_Genesis:
+		if stateValidators, err = c.stateValidatorsProvider.StateValidatorsForSlot(ctx, 0, pubkeys, in.Indices, nil); err != nil {
+			return nil, errors.Wrap(err, "failed to get genesis state validators")
+		}
+		epoch = 0
+	case nil:
+		if stateValidators, err = c.stateValidatorsProvider.StateValidatorsForHead(ctx, pubkeys, in.Indices, nil); err != nil {
+			return nil, errors.Wrap(err, "failed to get head state validators")
+		}
+
+		blockHeader, err := c.headBlockHeaders(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get head block headers")
+		}
+
+		slot, err := strconv.ParseUint(blockHeader.Data.Header.Message.Slot, 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse header slot `%s`", blockHeader.Data.Header.Message.Slot)
+		}
+
+		epoch = slots.ToEpoch(primitives.Slot(slot))
+	default:
+		return nil, errors.Errorf("unsupported query filter type `%v`", reflect.TypeOf(queryFilter))
+	}
+
+	if stateValidators.Data == nil {
+		return nil, errors.New("state validators data is nil")
+	}
+
+	start := min(pageToken*uint64(pageSize), uint64(len(stateValidators.Data)))
+
+	end := min(start+uint64(pageSize), uint64(len(stateValidators.Data)))
+
+	// Balances are returned in the order the beacon node reports them, as in `Validators`.
+	balances := make([]*ethpb.ValidatorBalances_Balance, end-start)
+	for idx := start; idx < end; idx++ {
+		stateValidator := stateValidators.Data[idx]
+
+		if stateValidator.Validator == nil {
+			return nil, errors.Errorf("state validator at index `%d` is nil", idx)
+		}
+
+		pubkey, err := hexutil.Decode(stateValidator.Validator.Pubkey)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to decode validator pubkey `%s`", stateValidator.Validator.Pubkey)
+		}
+
+		validatorIndex, err := strconv.ParseUint(stateValidator.Index, 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse validator index `%s`", stateValidator.Index)
+		}
+
+		balance, err := strconv.ParseUint(stateValidator.Balance, 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse validator balance `%s`", stateValidator.Balance)
+		}
+
+		// The gRPC implementation reports the `ethpb.ValidatorStatus` enum name, so map the beacon API status onto it.
+		status, ok := beaconAPITogRPCValidatorStatus[stateValidator.Status]
+		if !ok {
+			status = ethpb.ValidatorStatus_UNKNOWN_STATUS
+		}
+
+		balances[idx-start] = &ethpb.ValidatorBalances_Balance{
+			PublicKey: pubkey,
+			Index:     primitives.ValidatorIndex(validatorIndex),
+			Balance:   balance,
+			Status:    status.String(),
+		}
+	}
+
+	var nextPageToken string
+	if end < uint64(len(stateValidators.Data)) {
+		nextPageToken = strconv.FormatUint(pageToken+1, 10)
+	}
+
+	return &ethpb.ValidatorBalances{
+		Epoch:         epoch,
+		Balances:      balances,
+		NextPageToken: nextPageToken,
+		TotalSize:     int32(len(stateValidators.Data)),
+	}, nil
 }
 
 func (c beaconApiChainClient) Validators(ctx context.Context, in *ethpb.ListValidatorsRequest) (*ethpb.Validators, error) {

--- a/validator/client/beacon-api/beacon_api_beacon_chain_client_test.go
+++ b/validator/client/beacon-api/beacon_api_beacon_chain_client_test.go
@@ -579,6 +579,419 @@ func TestListValidators(t *testing.T) {
 	})
 }
 
+func TestListValidatorBalances(t *testing.T) {
+	const blockHeaderEndpoint = "/eth/v1/beacon/headers/head"
+
+	t.Run("invalid token", func(t *testing.T) {
+		ctx := t.Context()
+
+		beaconChainClient := beaconApiChainClient{}
+		_, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+			PageToken: "foo",
+		})
+		assert.ErrorContains(t, "failed to parse page token `foo`", err)
+	})
+
+	t.Run("query filter epoch overflow", func(t *testing.T) {
+		ctx := t.Context()
+
+		beaconChainClient := beaconApiChainClient{}
+		_, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+			QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{
+				Epoch: math.MaxUint64,
+			},
+		})
+		assert.ErrorContains(t, fmt.Sprintf("failed to get first slot for epoch `%d`", uint64(math.MaxUint64)), err)
+	})
+
+	t.Run("fails to get validators for epoch filter", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := t.Context()
+
+		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
+		stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nil,
+			errors.New("foo error"),
+		)
+
+		beaconChainClient := beaconApiChainClient{stateValidatorsProvider: stateValidatorsProvider}
+		_, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+			QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{
+				Epoch: 0,
+			},
+		})
+		assert.ErrorContains(t, "failed to get state validators for slot `0`: foo error", err)
+	})
+
+	t.Run("fails to get validators for genesis filter", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := t.Context()
+
+		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
+		stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nil,
+			errors.New("bar error"),
+		)
+
+		beaconChainClient := beaconApiChainClient{stateValidatorsProvider: stateValidatorsProvider}
+		_, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+			QueryFilter: &ethpb.ListValidatorBalancesRequest_Genesis{},
+		})
+		assert.ErrorContains(t, "failed to get genesis state validators: bar error", err)
+	})
+
+	t.Run("fails to get validators for nil filter", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := t.Context()
+
+		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
+		stateValidatorsProvider.EXPECT().StateValidatorsForHead(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nil,
+			errors.New("foo error"),
+		)
+
+		beaconChainClient := beaconApiChainClient{stateValidatorsProvider: stateValidatorsProvider}
+		_, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+			QueryFilter: nil,
+		})
+		assert.ErrorContains(t, "failed to get head state validators: foo error", err)
+	})
+
+	t.Run("fails to get latest block header for nil filter", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := t.Context()
+
+		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
+		stateValidatorsProvider.EXPECT().StateValidatorsForHead(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nil,
+			nil,
+		)
+
+		handler := mock.NewMockHandler(ctrl)
+		handler.EXPECT().Get(gomock.Any(), blockHeaderEndpoint, gomock.Any()).Return(errors.New("bar error"))
+
+		beaconChainClient := beaconApiChainClient{
+			stateValidatorsProvider: stateValidatorsProvider,
+			handler:                 handler,
+		}
+		_, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+			QueryFilter: nil,
+		})
+		assert.ErrorContains(t, "bar error", err)
+	})
+
+	t.Run("fails to read state validators response", func(t *testing.T) {
+		generateValidStateValidatorsResponse := func() *structs.GetValidatorsResponse {
+			return &structs.GetValidatorsResponse{
+				Data: []*structs.ValidatorContainer{
+					{
+						Index:   "1",
+						Balance: "2",
+						Status:  "active_ongoing",
+						Validator: &structs.Validator{
+							Pubkey: hexutil.Encode([]byte{3}),
+						},
+					},
+				},
+			}
+		}
+
+		testCases := []struct {
+			name                            string
+			generateStateValidatorsResponse func() *structs.GetValidatorsResponse
+			expectedError                   string
+		}{
+			{
+				name: "nil validator",
+				generateStateValidatorsResponse: func() *structs.GetValidatorsResponse {
+					validatorsResponse := generateValidStateValidatorsResponse()
+					validatorsResponse.Data[0].Validator = nil
+					return validatorsResponse
+				},
+				expectedError: "state validator at index `0` is nil",
+			},
+			{
+				name: "invalid pubkey",
+				generateStateValidatorsResponse: func() *structs.GetValidatorsResponse {
+					validatorsResponse := generateValidStateValidatorsResponse()
+					validatorsResponse.Data[0].Validator.Pubkey = "foo"
+					return validatorsResponse
+				},
+				expectedError: "failed to decode validator pubkey `foo`",
+			},
+			{
+				name: "invalid validator index",
+				generateStateValidatorsResponse: func() *structs.GetValidatorsResponse {
+					validatorsResponse := generateValidStateValidatorsResponse()
+					validatorsResponse.Data[0].Index = "bar"
+					return validatorsResponse
+				},
+				expectedError: "failed to parse validator index `bar`",
+			},
+			{
+				name: "invalid balance",
+				generateStateValidatorsResponse: func() *structs.GetValidatorsResponse {
+					validatorsResponse := generateValidStateValidatorsResponse()
+					validatorsResponse.Data[0].Balance = "foo"
+					return validatorsResponse
+				},
+				expectedError: "failed to parse validator balance `foo`",
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ctx := t.Context()
+
+				stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
+				stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					testCase.generateStateValidatorsResponse(),
+					nil,
+				)
+
+				beaconChainClient := beaconApiChainClient{stateValidatorsProvider: stateValidatorsProvider}
+				_, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+					QueryFilter: &ethpb.ListValidatorBalancesRequest_Genesis{},
+				})
+				assert.ErrorContains(t, testCase.expectedError, err)
+			})
+		}
+	})
+
+	t.Run("correctly returns the expected balances", func(t *testing.T) {
+		generateValidStateValidatorsResponse := func() *structs.GetValidatorsResponse {
+			return &structs.GetValidatorsResponse{
+				Data: []*structs.ValidatorContainer{
+					{
+						Index:   "1",
+						Balance: "2",
+						Status:  "active_ongoing",
+						Validator: &structs.Validator{
+							Pubkey: hexutil.Encode([]byte{3}),
+						},
+					},
+					{
+						Index:   "4",
+						Balance: "5",
+						Status:  "withdrawal_done",
+						Validator: &structs.Validator{
+							Pubkey: hexutil.Encode([]byte{6}),
+						},
+					},
+					{
+						Index:   "7",
+						Balance: "8",
+						Status:  "foo",
+						Validator: &structs.Validator{
+							Pubkey: hexutil.Encode([]byte{9}),
+						},
+					},
+				},
+			}
+		}
+
+		testCases := []struct {
+			name                                string
+			generateJsonStateValidatorsResponse func() *structs.GetValidatorsResponse
+			generateProtoBalancesResponse       func() *ethpb.ValidatorBalances
+			pageSize                            int32
+			pageToken                           string
+		}{
+			{
+				name: "page size 0",
+				generateJsonStateValidatorsResponse: func() *structs.GetValidatorsResponse {
+					validValidatorsResponse := generateValidStateValidatorsResponse()
+
+					// Generate more than 250 validators, but expect only 250 to be returned
+					validators := make([]*structs.ValidatorContainer, 267)
+					for idx := range validators {
+						validators[idx] = validValidatorsResponse.Data[0]
+					}
+
+					return &structs.GetValidatorsResponse{Data: validators}
+				},
+				generateProtoBalancesResponse: func() *ethpb.ValidatorBalances {
+					balances := make([]*ethpb.ValidatorBalances_Balance, 250)
+					for idx := range balances {
+						balances[idx] = &ethpb.ValidatorBalances_Balance{
+							PublicKey: []byte{3},
+							Index:     1,
+							Balance:   2,
+							Status:    "ACTIVE",
+						}
+					}
+
+					return &ethpb.ValidatorBalances{
+						Balances:      balances,
+						TotalSize:     267,
+						Epoch:         0,
+						NextPageToken: "1",
+					}
+				},
+				pageSize:  0,
+				pageToken: "",
+			},
+			{
+				name:                                "pageSize==2 and pageToken==0",
+				generateJsonStateValidatorsResponse: generateValidStateValidatorsResponse,
+				generateProtoBalancesResponse: func() *ethpb.ValidatorBalances {
+					return &ethpb.ValidatorBalances{
+						Balances: []*ethpb.ValidatorBalances_Balance{
+							{
+								PublicKey: []byte{3},
+								Index:     1,
+								Balance:   2,
+								Status:    "ACTIVE",
+							},
+							{
+								PublicKey: []byte{6},
+								Index:     4,
+								Balance:   5,
+								Status:    "EXITED",
+							},
+						},
+						TotalSize:     3,
+						Epoch:         0,
+						NextPageToken: "1",
+					}
+				},
+				pageSize:  2,
+				pageToken: "0",
+			},
+			{
+				name:                                "pageSize==2 and pageToken==1 with unknown status",
+				generateJsonStateValidatorsResponse: generateValidStateValidatorsResponse,
+				generateProtoBalancesResponse: func() *ethpb.ValidatorBalances {
+					return &ethpb.ValidatorBalances{
+						Balances: []*ethpb.ValidatorBalances_Balance{
+							{
+								PublicKey: []byte{9},
+								Index:     7,
+								Balance:   8,
+								Status:    "UNKNOWN_STATUS",
+							},
+						},
+						TotalSize:     3,
+						Epoch:         0,
+						NextPageToken: "",
+					}
+				},
+				pageSize:  2,
+				pageToken: "1",
+			},
+			{
+				name:                                "pageSize==2 and pageToken==2",
+				generateJsonStateValidatorsResponse: generateValidStateValidatorsResponse,
+				generateProtoBalancesResponse: func() *ethpb.ValidatorBalances {
+					return &ethpb.ValidatorBalances{
+						Balances:      []*ethpb.ValidatorBalances_Balance{},
+						TotalSize:     3,
+						Epoch:         0,
+						NextPageToken: "",
+					}
+				},
+				pageSize:  2,
+				pageToken: "2",
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ctx := t.Context()
+
+				stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
+				stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), primitives.Slot(0), make([]string, 0), []primitives.ValidatorIndex{}, nil).Return(
+					testCase.generateJsonStateValidatorsResponse(),
+					nil,
+				)
+
+				beaconChainClient := beaconApiChainClient{stateValidatorsProvider: stateValidatorsProvider}
+				balances, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+					QueryFilter: &ethpb.ListValidatorBalancesRequest_Genesis{},
+					PublicKeys:  [][]byte{},
+					Indices:     []primitives.ValidatorIndex{},
+					PageSize:    testCase.pageSize,
+					PageToken:   testCase.pageToken,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, balances)
+
+				assert.DeepEqual(t, testCase.generateProtoBalancesResponse(), balances)
+			})
+		}
+	})
+
+	t.Run("correctly returns balances for the head epoch", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := t.Context()
+
+		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
+		stateValidatorsProvider.EXPECT().StateValidatorsForHead(gomock.Any(), []string{hexutil.Encode([]byte{3})}, nil, nil).Return(
+			&structs.GetValidatorsResponse{
+				Data: []*structs.ValidatorContainer{
+					{
+						Index:   "1",
+						Balance: "2",
+						Status:  "active_exiting",
+						Validator: &structs.Validator{
+							Pubkey: hexutil.Encode([]byte{3}),
+						},
+					},
+				},
+			},
+			nil,
+		)
+
+		headSlot, err := slots.EpochStart(3)
+		require.NoError(t, err)
+
+		handler := mock.NewMockHandler(ctrl)
+		handler.EXPECT().Get(gomock.Any(), blockHeaderEndpoint, gomock.Any()).Return(nil).SetArg(
+			2,
+			structs.GetBlockHeaderResponse{
+				Data: &structs.SignedBeaconBlockHeaderContainer{
+					Header: &structs.SignedBeaconBlockHeader{
+						Message: &structs.BeaconBlockHeader{
+							Slot: strconv.FormatUint(uint64(headSlot), 10),
+						},
+					},
+				},
+			},
+		)
+
+		beaconChainClient := beaconApiChainClient{
+			stateValidatorsProvider: stateValidatorsProvider,
+			handler:                 handler,
+		}
+		balances, err := beaconChainClient.ValidatorBalances(ctx, &ethpb.ListValidatorBalancesRequest{
+			PublicKeys: [][]byte{{3}},
+		})
+		require.NoError(t, err)
+		assert.DeepEqual(t, &ethpb.ValidatorBalances{
+			Epoch: 3,
+			Balances: []*ethpb.ValidatorBalances_Balance{
+				{
+					PublicKey: []byte{3},
+					Index:     1,
+					Balance:   2,
+					Status:    "EXITING",
+				},
+			},
+			TotalSize:     1,
+			NextPageToken: "",
+		}, balances)
+	})
+}
+
 func TestGetChainHead(t *testing.T) {
 	const finalityCheckpointsEndpoint = "/eth/v1/beacon/states/head/finality_checkpoints"
 	const headBlockHeadersEndpoint = "/eth/v1/beacon/headers/head"


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Replaces the gRPC fallback with the standard `/eth/v1/beacon/states/{state_id}/validators` endpoint, mirroring the existing `Validators` implementation: same query filter handling, default page size of 250, and client-side numeric page tokens. Validator status strings are mapped onto the gRPC ValidatorStatus enum names so callers see the same values as the gRPC server.

**Which issue(s) does this PR fix?**

N/A - but will help #15346 

**Other notes for review**

Do we still maintain web UI?

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
