### PR TITLE
Look up payload availability at the parent block's slot

### DIFF
--- a/beacon-chain/core/altair/attestation.go
+++ b/beacon-chain/core/altair/attestation.go
@@ -22,10 +22,27 @@ import (
 
 // ProcessAttestationsNoVerifySignature applies processing operations to a block's inner attestation
 // records. The only difference would be that the attestation signature would not be verified.
+//
+// Callers inside Gloas block processing must use ProcessAttestationsNoVerifySignatureWithParentSlot instead.
 func ProcessAttestationsNoVerifySignature(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	b interfaces.ReadOnlyBeaconBlock,
+) (state.BeaconState, error) {
+	parentSlot, err := gloas.ParentSlotFromBid(beaconState)
+	if err != nil {
+		return nil, err
+	}
+	return ProcessAttestationsNoVerifySignatureWithParentSlot(ctx, beaconState, b, parentSlot)
+}
+
+// ProcessAttestationsNoVerifySignatureWithParentSlot takes the parent block's slot explicitly, for
+// Gloas block processing where the bid in state has already been replaced by the current block's.
+func ProcessAttestationsNoVerifySignatureWithParentSlot(
+	ctx context.Context,
+	beaconState state.BeaconState,
+	b interfaces.ReadOnlyBeaconBlock,
+	parentSlot primitives.Slot,
 ) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "altair.ProcessAttestationsNoVerifySignature")
 	defer span.End()
@@ -42,7 +59,7 @@ func ProcessAttestationsNoVerifySignature(
 		return nil, err
 	}
 	for idx, att := range body.Attestations() {
-		beaconState, err = ProcessAttestationNoVerifySignature(ctx, beaconState, att, totalBalance)
+		beaconState, err = ProcessAttestationNoVerifySignature(ctx, beaconState, att, totalBalance, parentSlot)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not verify attestation at index %d in block", idx)
 		}
@@ -57,6 +74,7 @@ func ProcessAttestationNoVerifySignature(
 	beaconState state.BeaconState,
 	att ethpb.Att,
 	totalBalance uint64,
+	parentSlot primitives.Slot,
 ) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "altair.ProcessAttestationNoVerifySignature")
 	defer span.End()
@@ -69,7 +87,7 @@ func ProcessAttestationNoVerifySignature(
 	if err != nil {
 		return nil, fmt.Errorf("att slot %d can't be greater than state slot %d", att.GetData().Slot, beaconState.Slot())
 	}
-	participatedFlags, err := AttestationParticipationFlagIndices(beaconState, att.GetData(), delay)
+	participatedFlags, err := AttestationParticipationFlagIndices(beaconState, att.GetData(), delay, parentSlot)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +298,7 @@ func RewardProposer(ctx context.Context, beaconState state.BeaconState, proposer
 //	    participation_flag_indices.append(TIMELY_HEAD_FLAG_INDEX)
 //
 //	return participation_flag_indices
-func AttestationParticipationFlagIndices(beaconState state.ReadOnlyBeaconState, data *ethpb.AttestationData, delay primitives.Slot) (map[uint8]bool, error) {
+func AttestationParticipationFlagIndices(beaconState state.ReadOnlyBeaconState, data *ethpb.AttestationData, delay primitives.Slot, parentSlot primitives.Slot) (map[uint8]bool, error) {
 	currEpoch := time.CurrentEpoch(beaconState)
 	var justifiedCheckpt *ethpb.Checkpoint
 	if data.Target.Epoch == currEpoch {
@@ -319,6 +337,7 @@ func AttestationParticipationFlagIndices(beaconState state.ReadOnlyBeaconState, 
 		beaconState,
 		beaconBlockRoot,
 		data.Slot,
+		parentSlot,
 		uint64(data.CommitteeIndex),
 	)
 	if err != nil {

--- a/beacon-chain/core/altair/attestation_test.go
+++ b/beacon-chain/core/altair/attestation_test.go
@@ -315,7 +315,7 @@ func TestProcessAttestationNoVerify_SourceTargetHead(t *testing.T) {
 
 	b, err := helpers.TotalActiveBalance(t.Context(), beaconState)
 	require.NoError(t, err)
-	beaconState, err = altair.ProcessAttestationNoVerifySignature(t.Context(), beaconState, att, b)
+	beaconState, err = altair.ProcessAttestationNoVerifySignature(t.Context(), beaconState, att, b, 0)
 	require.NoError(t, err)
 
 	p, err := beaconState.CurrentEpochParticipation()
@@ -689,6 +689,7 @@ func TestAttestationParticipationFlagIndices(t *testing.T) {
 		inputState           state.BeaconState
 		inputData            *ethpb.AttestationData
 		inputDelay           primitives.Slot
+		inputParentSlot      primitives.Slot
 		participationIndices map[uint8]bool
 	}{
 		{
@@ -820,7 +821,36 @@ func TestAttestationParticipationFlagIndices(t *testing.T) {
 					Root:  bytes.Repeat([]byte{0xAA}, 32),
 				},
 			},
-			inputDelay: 1,
+			inputDelay:      1,
+			inputParentSlot: 3,
+			participationIndices: map[uint8]bool{
+				sourceFlagIndex: true,
+				targetFlagIndex: true,
+				headFlagIndex:   true,
+			},
+		},
+		{
+			name: "gloas skipped data slot uses parent slot availability",
+			inputState: func() state.BeaconState {
+				stateSlot := primitives.Slot(5)
+				slot := primitives.Slot(4)
+				targetRoot := bytes.Repeat([]byte{0xAA}, 32)
+				headRoot := bytes.Repeat([]byte{0xBB}, 32)
+				// Slot 4 was skipped so it inherits slot 3's root, and slot 3 is where the revealed payload is recorded.
+				return buildGloasStateForFlags(t, stateSlot, slot, targetRoot, headRoot, headRoot, 1, 3)
+			}(),
+			inputData: &ethpb.AttestationData{
+				Slot:            4,
+				CommitteeIndex:  1,
+				BeaconBlockRoot: bytes.Repeat([]byte{0xBB}, 32),
+				Source:          &ethpb.Checkpoint{Root: bytes.Repeat([]byte{0xDD}, 32)},
+				Target: &ethpb.Checkpoint{
+					Epoch: 0,
+					Root:  bytes.Repeat([]byte{0xAA}, 32),
+				},
+			},
+			inputDelay:      1,
+			inputParentSlot: 3,
 			participationIndices: map[uint8]bool{
 				sourceFlagIndex: true,
 				targetFlagIndex: true,
@@ -829,7 +859,7 @@ func TestAttestationParticipationFlagIndices(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		flagIndices, err := altair.AttestationParticipationFlagIndices(test.inputState, test.inputData, test.inputDelay)
+		flagIndices, err := altair.AttestationParticipationFlagIndices(test.inputState, test.inputData, test.inputDelay, test.inputParentSlot)
 		if test.participationIndices == nil {
 			require.ErrorContains(t, "committee index", err)
 			continue

--- a/beacon-chain/core/altair/upgrade.go
+++ b/beacon-chain/core/altair/upgrade.go
@@ -154,7 +154,8 @@ func TranslateParticipation(ctx context.Context, state state.BeaconState, atts [
 	}
 
 	for _, att := range atts {
-		participatedFlags, err := AttestationParticipationFlagIndices(state, att.Data, att.InclusionDelay)
+		// The parent slot is unused, the phase0 state being upgraded has no payload availability.
+		participatedFlags, err := AttestationParticipationFlagIndices(state, att.Data, att.InclusionDelay, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/beacon-chain/core/electra/BUILD.bazel
+++ b/beacon-chain/core/electra/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/epoch/precompute:go_default_library",
+        "//beacon-chain/core/gloas:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/signing:go_default_library",
         "//beacon-chain/core/time:go_default_library",

--- a/beacon-chain/core/electra/attestation.go
+++ b/beacon-chain/core/electra/attestation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/altair"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/time"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
@@ -33,7 +34,12 @@ func GetProposerRewardNumerator(
 		return 0, fmt.Errorf("attestation slot %d exceeds state slot %d", data.Slot, st.Slot())
 	}
 
-	flags, err := altair.AttestationParticipationFlagIndices(st, data, delay)
+	parentSlot, err := gloas.ParentSlotFromBid(st)
+	if err != nil {
+		return 0, err
+	}
+
+	flags, err := altair.AttestationParticipationFlagIndices(st, data, delay, parentSlot)
 	if err != nil {
 		return 0, err
 	}

--- a/beacon-chain/core/gloas/attestation.go
+++ b/beacon-chain/core/gloas/attestation.go
@@ -20,20 +20,21 @@ import (
 //	    assert data.index == 0
 //	    payload_matches = True
 //	else:
-//	    slot_index = data.slot % SLOTS_PER_HISTORICAL_ROOT
+//	    slot_index = parent_slot % SLOTS_PER_HISTORICAL_ROOT
 //	    payload_index = state.execution_payload_availability[slot_index]
 //	    payload_matches = data.index == payload_index
 func MatchingPayload(
 	beaconState state.ReadOnlyBeaconState,
 	beaconBlockRoot [32]byte,
-	slot primitives.Slot,
+	dataSlot primitives.Slot,
+	parentSlot primitives.Slot,
 	committeeIndex uint64,
 ) (bool, error) {
 	if beaconState.Version() < version.Gloas {
 		return true, nil
 	}
 
-	sameSlot, err := beaconState.IsAttestationSameSlot(beaconBlockRoot, slot)
+	sameSlot, err := beaconState.IsAttestationSameSlot(beaconBlockRoot, dataSlot)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get same slot attestation status")
 	}
@@ -44,9 +45,27 @@ func MatchingPayload(
 		return true, nil
 	}
 
-	executionPayloadAvail, err := beaconState.ExecutionPayloadAvailability(slot)
+	// The attested block is the parent whenever the head flag can apply, so its availability bit lives at parentSlot, not at a skipped dataSlot.
+	executionPayloadAvail, err := beaconState.ExecutionPayloadAvailability(parentSlot)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get execution payload availability status")
 	}
 	return executionPayloadAvail == committeeIndex, nil
+}
+
+// ParentSlotFromBid returns the parent block's slot from the bid cached in state.
+// Not valid inside block processing, ProcessExecutionPayloadBid replaces the bid with the current block's.
+func ParentSlotFromBid(beaconState state.ReadOnlyBeaconState) (primitives.Slot, error) {
+	if beaconState.Version() < version.Gloas {
+		return 0, nil
+	}
+
+	bid, err := beaconState.LatestExecutionPayloadBid()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get latest execution payload bid")
+	}
+	if bid == nil {
+		return 0, nil
+	}
+	return bid.Slot(), nil
 }

--- a/beacon-chain/core/gloas/attestation_test.go
+++ b/beacon-chain/core/gloas/attestation_test.go
@@ -31,12 +31,43 @@ func buildStateWithBlockRoots(t *testing.T, stateSlot primitives.Slot, roots map
 	return state.(*state_native.BeaconState)
 }
 
+func buildStateWithAvailability(t *testing.T, stateSlot primitives.Slot, roots map[primitives.Slot][]byte, availableSlots ...primitives.Slot) *state_native.BeaconState {
+	t.Helper()
+
+	cfg := params.BeaconConfig()
+	blockRoots := make([][]byte, cfg.SlotsPerHistoricalRoot)
+	for slot, root := range roots {
+		blockRoots[slot%cfg.SlotsPerHistoricalRoot] = root
+	}
+
+	availability := make([]byte, cfg.SlotsPerHistoricalRoot/8)
+	for _, slot := range availableSlots {
+		idx := uint64(slot % cfg.SlotsPerHistoricalRoot)
+		availability[idx/8] |= byte(1 << (idx % 8))
+	}
+
+	stIface, err := state_native.InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+		Slot:                         stateSlot,
+		BlockRoots:                   blockRoots,
+		ExecutionPayloadAvailability: availability,
+		Fork: &ethpb.Fork{
+			CurrentVersion:  bytes.Repeat([]byte{0x66}, 4),
+			PreviousVersion: bytes.Repeat([]byte{0x66}, 4),
+			Epoch:           0,
+		},
+	})
+	require.NoError(t, err)
+	st := stIface.(*state_native.BeaconState)
+	require.Equal(t, version.Gloas, st.Version())
+	return st
+}
+
 func TestMatchingPayload(t *testing.T) {
 	t.Run("pre-gloas always true", func(t *testing.T) {
 		stIface, err := state_native.InitializeFromProtoElectra(&ethpb.BeaconStateElectra{})
 		require.NoError(t, err)
 
-		ok, err := MatchingPayload(stIface, [32]byte{}, 0, 123)
+		ok, err := MatchingPayload(stIface, [32]byte{}, 0, 0, 123)
 		require.NoError(t, err)
 		require.Equal(t, true, ok)
 	})
@@ -51,7 +82,7 @@ func TestMatchingPayload(t *testing.T) {
 		var rootArr [32]byte
 		copy(rootArr[:], root)
 
-		ok, err := MatchingPayload(state, rootArr, 4, 1)
+		ok, err := MatchingPayload(state, rootArr, 4, 3, 1)
 		require.ErrorContains(t, "committee index", err)
 		require.Equal(t, false, ok)
 	})
@@ -66,45 +97,71 @@ func TestMatchingPayload(t *testing.T) {
 		var rootArr [32]byte
 		copy(rootArr[:], root)
 
-		ok, err := MatchingPayload(state, rootArr, 4, 0)
+		ok, err := MatchingPayload(state, rootArr, 4, 3, 0)
 		require.NoError(t, err)
 		require.Equal(t, true, ok)
 	})
 
-	t.Run("non same slot checks payload availability", func(t *testing.T) {
-		cfg := params.BeaconConfig()
-		root := bytes.Repeat([]byte{0xAA}, 32)
-		blockRoots := make([][]byte, cfg.SlotsPerHistoricalRoot)
-		blockRoots[4%cfg.SlotsPerHistoricalRoot] = bytes.Repeat([]byte{0xCC}, 32)
-		blockRoots[3%cfg.SlotsPerHistoricalRoot] = bytes.Repeat([]byte{0xBB}, 32)
+	roots := map[primitives.Slot][]byte{
+		4: bytes.Repeat([]byte{0xCC}, 32),
+		3: bytes.Repeat([]byte{0xBB}, 32),
+	}
+	var attestedRoot [32]byte
+	copy(attestedRoot[:], bytes.Repeat([]byte{0xAA}, 32))
 
-		availability := make([]byte, cfg.SlotsPerHistoricalRoot/8)
-		slotIndex := uint64(4)
-		availability[slotIndex/8] = byte(1 << (slotIndex % 8))
+	t.Run("non same slot checks availability at the parent slot", func(t *testing.T) {
+		// Slot 4 was skipped, the attested block at slot 3 revealed its payload.
+		st := buildStateWithAvailability(t, 6, roots, 3)
 
-		stIface, err := state_native.InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
-			Slot:                         6,
-			BlockRoots:                   blockRoots,
-			ExecutionPayloadAvailability: availability,
-			Fork: &ethpb.Fork{
-				CurrentVersion:  bytes.Repeat([]byte{0x66}, 4),
-				PreviousVersion: bytes.Repeat([]byte{0x66}, 4),
-				Epoch:           0,
-			},
-		})
-		require.NoError(t, err)
-		state := stIface.(*state_native.BeaconState)
-		require.Equal(t, version.Gloas, state.Version())
-
-		var rootArr [32]byte
-		copy(rootArr[:], root)
-
-		ok, err := MatchingPayload(state, rootArr, 4, 1)
+		ok, err := MatchingPayload(st, attestedRoot, 4, 3, 1)
 		require.NoError(t, err)
 		require.Equal(t, true, ok)
 
-		ok, err = MatchingPayload(state, rootArr, 4, 0)
+		ok, err = MatchingPayload(st, attestedRoot, 4, 3, 0)
 		require.NoError(t, err)
 		require.Equal(t, false, ok)
+	})
+
+	t.Run("non same slot ignores availability at the data slot", func(t *testing.T) {
+		// Only the skipped slot 4 is marked available, the attested block at slot 3 withheld its payload.
+		st := buildStateWithAvailability(t, 6, roots, 4)
+
+		ok, err := MatchingPayload(st, attestedRoot, 4, 3, 1)
+		require.NoError(t, err)
+		require.Equal(t, false, ok)
+
+		ok, err = MatchingPayload(st, attestedRoot, 4, 3, 0)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+}
+
+func TestParentSlotFromBid(t *testing.T) {
+	t.Run("pre-gloas returns zero", func(t *testing.T) {
+		st, err := state_native.InitializeFromProtoElectra(&ethpb.BeaconStateElectra{})
+		require.NoError(t, err)
+
+		parentSlot, err := ParentSlotFromBid(st)
+		require.NoError(t, err)
+		require.Equal(t, primitives.Slot(0), parentSlot)
+	})
+
+	t.Run("returns the cached bid slot", func(t *testing.T) {
+		st, err := state_native.InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+			Slot: 6,
+			LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
+				Slot:            3,
+				ParentBlockHash: make([]byte, 32),
+				ParentBlockRoot: make([]byte, 32),
+				BlockHash:       make([]byte, 32),
+				PrevRandao:      make([]byte, 32),
+				FeeRecipient:    make([]byte, 20),
+			},
+		})
+		require.NoError(t, err)
+
+		parentSlot, err := ParentSlotFromBid(st)
+		require.NoError(t, err)
+		require.Equal(t, primitives.Slot(3), parentSlot)
 	})
 }

--- a/beacon-chain/core/transition/gloas.go
+++ b/beacon-chain/core/transition/gloas.go
@@ -3,6 +3,7 @@ package transition
 import (
 	"context"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/altair"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/blocks"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/electra"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/epoch/precompute"
@@ -44,7 +45,7 @@ import (
 //	    # [New in Gloas:EIP7732]
 //	    for_ops(body.payload_attestations, process_payload_attestation)
 //	</spec>
-func gloasOperations(ctx context.Context, st state.BeaconState, block interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
+func gloasOperations(ctx context.Context, st state.BeaconState, block interfaces.ReadOnlyBeaconBlock, parentSlot primitives.Slot) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.gloasOperations")
 	defer span.End()
 
@@ -69,7 +70,7 @@ func gloasOperations(ctx context.Context, st state.BeaconState, block interfaces
 	if err != nil {
 		return nil, errors.Wrap(ErrProcessAttesterSlashingsFailed, err.Error())
 	}
-	st, err = electra.ProcessAttestationsNoVerifySignature(ctx, st, block)
+	st, err = altair.ProcessAttestationsNoVerifySignatureWithParentSlot(ctx, st, block, parentSlot)
 	if err != nil {
 		return nil, errors.Wrap(ErrProcessAttestationsFailed, err.Error())
 	}

--- a/beacon-chain/core/transition/gloas_operations_test.go
+++ b/beacon-chain/core/transition/gloas_operations_test.go
@@ -33,7 +33,7 @@ func TestGloasOperations_HappyPath(t *testing.T) {
 	// A plain Electra state is fine here because we exercise zero operations.
 	blk := newGloasBlock(t, emptyGloasBody())
 
-	_, err := transition.GloasOperations(context.Background(), st, blk)
+	_, err := transition.GloasOperations(context.Background(), st, blk, 0)
 	require.NoError(t, err)
 }
 
@@ -226,7 +226,7 @@ func TestGloasOperations_ProcessingErrors(t *testing.T) {
 
 			gloasBlk := newGloasBlock(t, body)
 
-			_, err := transition.GloasOperations(ctx, st, gloasBlk)
+			_, err := transition.GloasOperations(ctx, st, gloasBlk, 0)
 			require.NotNil(t, err, "expected an error but got nil")
 			require.ErrorContains(t, tc.errSubstr, err)
 			require.Equal(t, true, errors.Is(err, tc.errSentinel))

--- a/beacon-chain/core/transition/transition_fuzz_test.go
+++ b/beacon-chain/core/transition/transition_fuzz_test.go
@@ -113,7 +113,7 @@ func TestFuzzprocessOperationsNoVerify_1000(t *testing.T) {
 		}
 		wb, err := blocks.NewBeaconBlock(bb)
 		require.NoError(t, err)
-		s, err := ProcessOperationsNoVerifyAttsSigs(ctx, state, wb)
+		s, err := ProcessOperationsNoVerifyAttsSigs(ctx, state, wb, 0)
 		if err != nil && s != nil {
 			t.Fatalf("state should be nil on err. found: %v on error: %v for block body: %v", s, err, bb)
 		}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -346,7 +347,8 @@ func ProcessBlockNoVerifyAnySig(
 func ProcessOperationsNoVerifyAttsSigs(
 	ctx context.Context,
 	state state.BeaconState,
-	beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
+	beaconBlock interfaces.ReadOnlyBeaconBlock,
+	parentSlot primitives.Slot) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessOperationsNoVerifyAttsSigs")
 	defer span.End()
 	if beaconBlock == nil || beaconBlock.IsNil() {
@@ -359,7 +361,7 @@ func ProcessOperationsNoVerifyAttsSigs(
 
 	blockVersion := beaconBlock.Version()
 	if blockVersion >= version.Gloas {
-		state, err := gloasOperations(ctx, state, beaconBlock)
+		state, err := gloasOperations(ctx, state, beaconBlock, parentSlot)
 		if err != nil {
 			return nil, fmt.Errorf("gloas operations: %w", err)
 		}
@@ -437,6 +439,7 @@ func ProcessBlockForStateRoot(
 		return nil, errors.Wrap(err, "could not process block header")
 	}
 
+	var parentSlot primitives.Slot
 	if state.Version() >= version.Gloas {
 		// <spec fn="process_block" fork="gloas" hash="7d98b5a3">
 		// def process_block(state: BeaconState, block: BeaconBlock) -> None:
@@ -457,6 +460,11 @@ func ProcessBlockForStateRoot(
 		// </spec>
 		if err := gloas.ProcessWithdrawals(state); err != nil {
 			return nil, errors.Wrap(ErrProcessWithdrawalsFailed, err.Error())
+		}
+		// Read before the bid is replaced by this block's, process_attestation needs the parent's slot.
+		parentSlot, err = gloas.ParentSlotFromBid(state)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get parent slot from bid")
 		}
 		if err := gloas.ProcessExecutionPayloadBid(state, blk); err != nil {
 			return nil, errors.Wrap(err, "could not process execution payload bid")
@@ -496,7 +504,7 @@ func ProcessBlockForStateRoot(
 		return nil, errors.Wrap(ErrProcessEth1DataFailed, err.Error())
 	}
 
-	state, err = ProcessOperationsNoVerifyAttsSigs(ctx, state, signed.Block())
+	state, err = ProcessOperationsNoVerifyAttsSigs(ctx, state, signed.Block(), parentSlot)
 	if err != nil {
 		tracing.AnnotateError(span, err)
 		return nil, errors.Wrap(err, "could not process block operation")

--- a/beacon-chain/core/transition/transition_no_verify_sig_test.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig_test.go
@@ -170,7 +170,7 @@ func TestProcessOperationsNoVerifyAttsSigs_OK(t *testing.T) {
 	require.NoError(t, err)
 	beaconState, err = transition.ProcessSlots(t.Context(), beaconState, wsb.Block().Slot())
 	require.NoError(t, err)
-	_, err = transition.ProcessOperationsNoVerifyAttsSigs(t.Context(), beaconState, wsb.Block())
+	_, err = transition.ProcessOperationsNoVerifyAttsSigs(t.Context(), beaconState, wsb.Block(), 0)
 	require.NoError(t, err)
 }
 
@@ -180,7 +180,7 @@ func TestProcessOperationsNoVerifyAttsSigsBellatrix_OK(t *testing.T) {
 	require.NoError(t, err)
 	beaconState, err = transition.ProcessSlots(t.Context(), beaconState, wsb.Block().Slot())
 	require.NoError(t, err)
-	_, err = transition.ProcessOperationsNoVerifyAttsSigs(t.Context(), beaconState, wsb.Block())
+	_, err = transition.ProcessOperationsNoVerifyAttsSigs(t.Context(), beaconState, wsb.Block(), 0)
 	require.NoError(t, err)
 }
 
@@ -190,7 +190,7 @@ func TestProcessOperationsNoVerifyAttsSigsCapella_OK(t *testing.T) {
 	require.NoError(t, err)
 	beaconState, err = transition.ProcessSlots(t.Context(), beaconState, wsb.Block().Slot())
 	require.NoError(t, err)
-	_, err = transition.ProcessOperationsNoVerifyAttsSigs(t.Context(), beaconState, wsb.Block())
+	_, err = transition.ProcessOperationsNoVerifyAttsSigs(t.Context(), beaconState, wsb.Block(), 0)
 	require.NoError(t, err)
 }
 

--- a/changelog/terence_att-payload-availability-parent-slot.md
+++ b/changelog/terence_att-payload-availability-parent-slot.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Gloas: look up payload availability at the parent block's slot so attestations to skipped slots can earn the timely head flag.


### PR DESCRIPTION
Implements https://github.com/ethereum/consensus-specs/pull/5473.

- Gloas payload matching read execution_payload_availability at data.slot, which is not the attested block's slot when slots are skipped, so attestations to a skipped slot with data.index == 1 never earned the timely head flag
- The parent slot is captured before process_execution_payload_bid overwrites the bid and passed down to process_attestation
- Callers outside block processing derive the parent slot from the bid still cached in state