### PR TITLE
Fix validator monitor dropping aggregated performance logs

### DIFF
--- a/beacon-chain/monitor/process_block.go
+++ b/beacon-chain/monitor/process_block.go
@@ -148,11 +148,11 @@ func (s *Service) logAggregatedPerformance() {
 
 	for idx, p := range s.aggregatedPerformance {
 		if p.totalAttestedCount == 0 || p.totalRequestedCount == 0 || p.startBalance == 0 {
-			break
+			continue
 		}
 		l, ok := s.latestPerformance[idx]
 		if !ok {
-			break
+			continue
 		}
 		percentAtt := float64(p.totalAttestedCount) / float64(p.totalRequestedCount)
 		percentBal := float64(l.balance-p.startBalance) / float64(p.startBalance)

--- a/changelog/manu_fix-monitor-aggregated-performance-break.md
+++ b/changelog/manu_fix-monitor-aggregated-performance-break.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Validator monitor: use `continue` instead of `break` when skipping validators with no recorded performance, so a single validator without data no longer suppresses the "Aggregated performance since launch" log for all other monitored validators.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this commit, `logAggregatedPerformance` ranged over a map and used `break` to skip validators with no recorded data, so a randomized iteration order aborted the loop at the first empty entry.
A single tracked validator without included attestations made each 5-epoch report log an arbitrary subset of monitored validators, sometimes none. Use `continue` instead.

Also fixes the `TestLogAggregatedPerformance flake`, which passed only when the one populated fixture entry was visited first.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
