### PR TITLE
Send forkchoice updates to the execution client during Gloas initial-sync

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -217,7 +217,9 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b interfaces.ReadOnlySignedB
 		go func() {
 			if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, parentHash, nil); err != nil {
 				log.WithError(err).Error("Could not notify forkchoice update after batch import")
+				return
 			}
+			log.WithField("blockHash", fmt.Sprintf("%#x", bytesutil.Trunc(parentHash[:]))).Debug("Notified forkchoice update after batch import")
 		}()
 	}
 	return nil

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -364,11 +364,29 @@ func (s *Service) notifyEngineAndSaveData(
 	postVersionAndHeaders []*versionAndHeader,
 	jCheckpoints []*ethpb.Checkpoint,
 	fCheckpoints []*ethpb.Checkpoint,
-) ([]*forkchoicetypes.BlockAndCheckpoints, bool, error) {
+) (pendingNodes []*forkchoicetypes.BlockAndCheckpoints, isValidPayload bool, err error) {
 	span := trace.FromContext(ctx)
-	pendingNodes := make([]*forkchoicetypes.BlockAndCheckpoints, len(blks))
-	var isValidPayload bool
-	var err error
+	pendingNodes = make([]*forkchoicetypes.BlockAndCheckpoints, len(blks))
+
+	// If the batch fails after some payloads were already delivered to the
+	// execution client, still point the engine at the most recent imported
+	// payload. Without this, a node whose batches keep failing mid-way (e.g.
+	// unavailable sidecars during non-finality) never sends any forkchoice
+	// update: the execution client cannot start syncing and its head stays
+	// pinned to a stale block. Fully successful batches send the forkchoice
+	// update in saveHeadNoDB instead.
+	var lastPayloadHash [32]byte
+	defer func() {
+		if err == nil || lastPayloadHash == ([32]byte{}) {
+			return
+		}
+		hash := lastPayloadHash
+		go func() {
+			if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, hash, nil); err != nil {
+				log.WithError(err).Debug("Could not notify forkchoice update after partial batch import")
+			}
+		}()
+	}()
 
 	envMap := make(map[[32]byte]int, len(envelopes))
 	for i, e := range envelopes {
@@ -410,6 +428,9 @@ func (s *Service) notifyEngineAndSaveData(
 				isValidPayload, err = s.notifyNewEnvelopeFromBlock(ctx, b, env)
 				if err != nil {
 					return nil, false, errors.Wrap(err, "could not notify new envelope from block")
+				}
+				if payload, perr := env.Execution(); perr == nil {
+					lastPayloadHash = bytesutil.ToBytes32(payload.BlockHash())
 				}
 				args.HasPayload = true
 			}

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -197,6 +197,20 @@ func (s *Service) setHeadFull(root [32]byte) interfaces.ReadOnlySignedBeaconBloc
 
 func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROExecutionPayloadEnvelope, st state.BeaconState) error {
 	if !s.inRegularSync() {
+		// Still notify the engine of the new head payload so the execution
+		// client can follow the chain (or start syncing toward it) while the
+		// beacon node is itself still syncing. Payload attributes are only
+		// computed in regular sync.
+		payload, err := envelope.Execution()
+		if err != nil {
+			return errors.Wrap(err, "could not get execution payload from envelope")
+		}
+		blockHash := bytesutil.ToBytes32(payload.BlockHash())
+		go func() {
+			if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, nil); err != nil {
+				log.WithError(err).Debug("Could not notify forkchoice update while syncing")
+			}
+		}()
 		return nil
 	}
 	root := envelope.BeaconBlockRoot()

--- a/changelog/qu0b_gloas-initialsync-fcu.md
+++ b/changelog/qu0b_gloas-initialsync-fcu.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Send forkchoice updates to the execution client during Gloas initial-sync: notify the last imported payload when a batch fails partway, and send a plain forkchoice update from the gossip envelope path while syncing.


### PR DESCRIPTION
## What

A Gloas beacon node that is not in regular sync never sends `engine_forkchoiceUpdated`. Payloads are delivered via `newPayload`, but the engine is never told where the head is: `postPayloadTasks` returns early when not in regular sync, and batch processing only notifies on a fully successful batch (`saveHeadNoDB`). This PR adds two minimal FCU paths, both plain (attribute-less):

- **Partial batch failure** (`notifyEngineAndSaveData`): if a batch fails after some payloads were already delivered to the execution client, still point the engine at the most recent imported payload.
- **Gossip envelope while syncing** (`postPayloadTasks`): notify the engine of the envelope's payload so the execution client can follow the chain (or start syncing toward it) while the beacon node is itself still syncing. Payload attributes remain regular-sync-only.

## Why

Without any FCU the execution client cannot start syncing and its head stays pinned to a stale block — the CL then starves it indefinitely. Observed in production on glamsterdam-devnet-7 (2026-07-23): a syncing prysm node delivered 285 `newPayload` calls with **zero** FCUs; its paired EL sat frozen for hours, and the node could not recover from its initial-sync wedge without operator action. The failing-batch case is exactly the state a node is stuck in during non-finality (unavailable sidecars/envelopes), i.e. precisely when the EL most needs to be pointed at the chain.

## Testing

Full `beacon-chain/blockchain` package green with `-tags develop`.

Note: `head_test.go` on the current branch head has a pre-existing compile error unrelated to this PR (`notifyNewHeadEvent` now takes `[32]byte` but 4 test call sites still pass `[]byte`) — I patched those lines locally only to be able to run the suite, and left them out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6buHMiS3KiNHcnpUx32FU