### PR TITLE
Advertise the current head to the execution client during Gloas initial-sync

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -217,7 +217,9 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b interfaces.ReadOnlySignedB
 		go func() {
 			if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, parentHash, nil); err != nil {
 				log.WithError(err).Error("Could not notify forkchoice update after batch import")
+				return
 			}
+			log.WithField("blockHash", fmt.Sprintf("%#x", bytesutil.Trunc(parentHash[:]))).Debug("Notified forkchoice update after batch import")
 		}()
 	}
 	return nil

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -182,9 +182,50 @@ type versionAndHeader struct {
 	header  interfaces.ExecutionData
 }
 
-func (s *Service) onBlockBatch(ctx context.Context, blks []consensusblocks.ROBlock, envelopes []interfaces.ROSignedExecutionPayloadEnvelope, avs das.AvailabilityChecker) error {
+// fcuHeadOnBatchFailure sends a plain forkchoice update for the current head
+// payload, using the same head derivation as the batch-end update in
+// saveHeadNoDB. It runs after a failed batch import so a syncing node keeps
+// supplying its execution client with a head target, and is limited to once
+// per slot.
+func (s *Service) fcuHeadOnBatchFailure(ctx context.Context) {
+	currentSlot := uint64(s.CurrentSlot())
+	last := s.lastBatchFailureFCUSlot.Load()
+	if currentSlot <= last || !s.lastBatchFailureFCUSlot.CompareAndSwap(last, currentSlot) {
+		return
+	}
+	headBlock, err := s.HeadBlock(ctx)
+	if err != nil || consensusblocks.BeaconBlockIsNil(headBlock) != nil || headBlock.Version() < version.Gloas {
+		return
+	}
+	sbid, err := headBlock.Block().Body().SignedExecutionPayloadBid()
+	if err != nil || sbid == nil || sbid.Message == nil || len(sbid.Message.ParentBlockHash) != 32 {
+		return
+	}
+	parentHash := bytesutil.ToBytes32(sbid.Message.ParentBlockHash)
+	go func() {
+		if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, parentHash, nil); err != nil {
+			log.WithError(err).Debug("Could not notify forkchoice update after failed batch import")
+		}
+	}()
+}
+
+func (s *Service) onBlockBatch(ctx context.Context, blks []consensusblocks.ROBlock, envelopes []interfaces.ROSignedExecutionPayloadEnvelope, avs das.AvailabilityChecker) (err error) {
 	ctx, span := trace.StartSpan(ctx, "blockChain.onBlockBatch")
 	defer span.End()
+
+	// A failed batch sends no forkchoice update at all: the batch-end update
+	// in saveHeadNoDB only runs when the whole batch imports. When batches
+	// keep failing (e.g. unavailable sidecars during non-finality) the
+	// execution client hears nothing for as long as the failures last, and a
+	// lagging execution client never receives a sync target. Re-advertise the
+	// current head payload in that case. The head is already in forkchoice,
+	// so the engine is never told about anything the beacon node does not
+	// stand behind.
+	defer func() {
+		if err != nil {
+			s.fcuHeadOnBatchFailure(ctx)
+		}
+	}()
 
 	if len(blks) == 0 {
 		return errors.New("no blocks provided")

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -196,11 +196,26 @@ func (s *Service) setHeadFull(root [32]byte) interfaces.ReadOnlySignedBeaconBloc
 }
 
 func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROExecutionPayloadEnvelope, st state.BeaconState) error {
-	if !s.inRegularSync() {
-		return nil
-	}
 	root := envelope.BeaconBlockRoot()
 	if headRoot, _ := s.HeadRootAndFull(); headRoot != root {
+		return nil
+	}
+	if !s.inRegularSync() {
+		// The envelope belongs to the current head block and was inserted
+		// into forkchoice before this call: notify the engine of the new
+		// head payload so the execution client can follow the chain while
+		// the beacon node is itself still syncing. Payload attributes are
+		// only computed in regular sync.
+		payload, err := envelope.Execution()
+		if err != nil {
+			return errors.Wrap(err, "could not get execution payload from envelope")
+		}
+		blockHash := bytesutil.ToBytes32(payload.BlockHash())
+		go func() {
+			if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, nil); err != nil {
+				log.WithError(err).Debug("Could not notify forkchoice update while syncing")
+			}
+		}()
 		return nil
 	}
 	proposingSlot := s.CurrentSlot() + 1

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/async/event"
@@ -69,6 +70,7 @@ type Service struct {
 	syncCommitteeHeadState         *cache.SyncCommitteeHeadStateCache
 	payloadArrivals                *payloadArrivals
 	goroutineCounter               *goroutineCounter
+	lastBatchFailureFCUSlot        atomic.Uint64
 }
 
 // config options for the service.

--- a/changelog/qu0b_gloas-initialsync-fcu.md
+++ b/changelog/qu0b_gloas-initialsync-fcu.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Keep the execution client supplied with a forkchoice target during Gloas initial-sync: re-advertise the current head payload (already in forkchoice) when a batch import fails, and notify the head payload from the gossip envelope path while syncing.


### PR DESCRIPTION
Reworked follow-up to #17273 (closed) — the objection there was correct and this PR is redesigned around it: **only heads that are already in forkchoice are ever advertised to the engine.** The earlier version FCU'd payloads from a failed (unimported) batch, which could put the EL ahead of the CL and roll its head backwards later; that mechanism is gone.

## Problem

While a Gloas node is not in regular sync and its batches keep failing, it sends **no** `forkchoiceUpdated` at all — the batch-end FCU in `saveHeadNoDB` only runs when the whole batch imports, and the gossip envelope path returns before notifying the engine. An execution client that is itself behind (rewound after a crash, or full-syncing behind a checkpoint-synced beacon) then never receives any sync target. Observed on glamsterdam-devnet-7: 285 `newPayload` calls and zero FCUs over ~3 hours of persistent late-batch failures; the EL stayed pinned the whole time. Fixing why batches fail is the root-cause work, but even then a starved EL has nothing to work with until the first fully successful batch.

## Change

- **After a failed batch import** (`onBlockBatch`): re-send a plain FCU for the **current head payload** — the identical derivation `saveHeadNoDB` uses after successful batches — rate-limited to once per slot. Nothing new is asserted; the engine just re-hears where the CL actually is.
- **Gossip envelope path while syncing** (`postPayloadTasks`): if the imported envelope belongs to the current head block (it is inserted into forkchoice before this call), notify the engine of the head payload. Payload attributes remain regular-sync-only.
- Log successful batch-end FCUs at debug so their absence is observable.

No FCU is added on any success path, so steady-state latency is unchanged.

## Testing

Full `beacon-chain/blockchain` package green with `-tags develop`. (As noted on #17273, `head_test.go` on the current branch head has a pre-existing unrelated compile error — `notifyNewHeadEvent` now takes `[32]byte` but four test call sites pass `[]byte`; patched locally only to run the suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6buHMiS3KiNHcnpUx32FU