### PR TITLE
Filter sync committee contributions by the aggregator's own voted root

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee.go
@@ -80,9 +80,9 @@ func (vs *Server) GetSyncCommitteeContribution(
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get sync subcommittee messages: %v", err)
 	}
-	headRoot, err := vs.HeadFetcher.HeadRoot(ctx)
+	root, err := vs.aggregatorSyncMessageRoot(ctx, req.PublicKey, msgs)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head root: %v", err)
+		return nil, status.Errorf(codes.Internal, "Could not get aggregator sync message root: %v", err)
 	}
 	sig, aggregatedBits, err := vs.CoreService.AggregatedSigAndAggregationBits(
 		ctx,
@@ -90,20 +90,32 @@ func (vs *Server) GetSyncCommitteeContribution(
 			Msgs:      msgs,
 			Slot:      req.Slot,
 			SubnetId:  req.SubnetId,
-			BlockRoot: headRoot,
+			BlockRoot: root,
 		})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get contribution data: %v", err)
 	}
 	contribution := &ethpb.SyncCommitteeContribution{
 		Slot:              req.Slot,
-		BlockRoot:         headRoot,
+		BlockRoot:         root,
 		SubcommitteeIndex: req.SubnetId,
 		AggregationBits:   aggregatedBits,
 		Signature:         sig,
 	}
 
 	return contribution, nil
+}
+
+func (vs *Server) aggregatorSyncMessageRoot(ctx context.Context, pubkey []byte, msgs []*ethpb.SyncCommitteeMessage) ([]byte, error) {
+	index, exists := vs.HeadFetcher.HeadPublicKeyToValidatorIndex(bytesutil.ToBytes48(pubkey))
+	if exists {
+		for _, msg := range msgs {
+			if msg.ValidatorIndex == index {
+				return msg.BlockRoot, nil
+			}
+		}
+	}
+	return vs.HeadFetcher.HeadRoot(ctx)
 }
 
 // Deprecated: The gRPC API will remain the default and fully supported through v8 (expected in 2026) but will be eventually removed in favor of REST API.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -143,6 +144,54 @@ func TestGetSyncCommitteeContribution_FiltersDuplicates(t *testing.T) {
 			PublicKey: val.PublicKey,
 			SubnetId:  1})
 	require.NoError(t, err)
+	assert.DeepEqual(t, sig, contr.Signature)
+}
+
+func TestGetSyncCommitteeContribution_UsesAggregatorRootNotHead(t *testing.T) {
+	votedRoot := bytesutil.PadTo([]byte("A"), 32)
+	lateBlockRoot := bytesutil.PadTo([]byte("B"), 32)
+
+	st, _ := util.DeterministicGenesisStateAltair(t, 10)
+	syncCommitteePool := synccommittee.NewStore()
+	headFetcher := &mock.ChainService{
+		State:                st,
+		SyncCommitteeIndices: []primitives.CommitteeIndex{10},
+		Root:                 lateBlockRoot,
+	}
+	server := &Server{
+		CoreService: &core.Service{
+			SyncCommitteePool: syncCommitteePool,
+			HeadFetcher:       headFetcher,
+			P2P:               &mockp2p.MockBroadcaster{},
+		},
+		SyncCommitteePool: syncCommitteePool,
+		HeadFetcher:       headFetcher,
+		P2P:               &mockp2p.MockBroadcaster{},
+		TimeFetcher:       &mock.ChainService{Genesis: time.Now()},
+	}
+
+	secKey, err := bls.RandKey()
+	require.NoError(t, err)
+	sig := secKey.Sign([]byte{'A'}).Marshal()
+	_, err = server.SubmitSyncMessage(t.Context(), &ethpb.SyncCommitteeMessage{
+		Slot:           1,
+		ValidatorIndex: 0,
+		BlockRoot:      votedRoot,
+		Signature:      sig,
+	})
+	require.NoError(t, err)
+
+	val, err := st.ValidatorAtIndex(0)
+	require.NoError(t, err)
+	contr, err := server.GetSyncCommitteeContribution(t.Context(),
+		&ethpb.SyncCommitteeContributionRequest{
+			Slot:      1,
+			PublicKey: val.PublicKey,
+			SubnetId:  1})
+	require.NoError(t, err)
+
+	assert.DeepEqual(t, votedRoot, contr.BlockRoot)
+	assert.Equal(t, uint64(1), contr.AggregationBits.Count())
 	assert.DeepEqual(t, sig, contr.Signature)
 }
 

--- a/changelog/terence_sync-contribution-aggregator-root.md
+++ b/changelog/terence_sync-contribution-aggregator-root.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Sync committee aggregators now filter pool messages by the root they voted for instead of current head.


### PR DESCRIPTION
- `GetSyncCommitteeContribution` filtered pool messages by `HeadFetcher.HeadRoot()` read at aggregation time, but the messages were signed against head at the sync message deadline earlier in the slot.
- Edge case: a block arriving after the sync message deadline moves head between those two moments, so every pooled message carries the parent root while the filter asks for the new block root, matching nothing and producing an empty contribution.
- Now uses the root from the aggregator's own message in the pool, falling back to head when that message is absent. Identical to current behavior