### PR TITLE
Fix a not always reproducible deadlock at the very end of the backfill.

### DIFF
--- a/beacon-chain/sync/backfill/pool.go
+++ b/beacon-chain/sync/backfill/pool.go
@@ -49,6 +49,7 @@ type p2pBatchWorkerPool struct {
 	fromRouter     chan batch
 	shutdownErr    chan error
 	endSeq         []batch
+	outstanding    int // number of batches handed to the router that have not come back yet
 	ctx            context.Context
 	cancel         func()
 	earliest       primitives.Slot // earliest is the earliest slot a worker is processing
@@ -96,16 +97,23 @@ func (p *p2pBatchWorkerPool) todo(b batch) {
 		p.endSeq = append(p.endSeq, b)
 		return
 	}
+	p.outstanding += 1
 	p.toRouter <- b
 }
 
 func (p *p2pBatchWorkerPool) complete() (batch, error) {
-	if len(p.endSeq) == p.maxBatches {
+	if len(p.endSeq) > 0 && p.outstanding == 0 {
 		return p.endSeq[0], errEndSequence
 	}
 
 	select {
 	case b := <-p.fromRouter:
+		if p.outstanding > 0 {
+			p.outstanding -= 1
+			return b, nil
+		}
+
+		log.WithFields(b.logFields()).Error("Backfill pool received a batch it did not dispatch. This should never happen.")
 		return b, nil
 	case err := <-p.shutdownErr:
 		return batch{}, errors.Wrap(err, "fatal error from backfill worker pool")
@@ -188,7 +196,7 @@ func (p *p2pBatchWorkerPool) processTodo(todo []batch, pa PeerAssigner, busy map
 	for i, b := range todo {
 		needs := p.needs()
 		if b.expired(needs) {
-			p.endSeq = append(p.endSeq, b.withState(batchEndSequence))
+			p.fromRouter <- b.withState(batchEndSequence)
 			continue
 		}
 		excludePeers := busy

--- a/beacon-chain/sync/backfill/service_test.go
+++ b/beacon-chain/sync/backfill/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/proto/dbval"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -96,6 +97,104 @@ func TestServiceInit(t *testing.T) {
 		require.Equal(t, batchEndSequence, todo[i].state)
 	}
 }
+
+func TestServiceReportsCompletion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*300)
+	defer cancel()
+
+	db := &mockBackfillDB{}
+	store, err := NewUpdater(ctx, db)
+	require.NoError(t, err)
+
+	const (
+		nWorkers = 5
+		nBatches = nWorkers - 3
+	)
+
+	batchSize := uint64(4)
+	high := 1 + batchSize*uint64(nBatches) // extra 1 because upper bound is exclusive
+
+	originRoot := [32]byte{}
+	origin, err := util.NewBeaconState()
+	require.NoError(t, err)
+
+	db.states = map[[32]byte]state.BeaconState{originRoot: origin}
+	store.bs = &dbval.BackfillStatus{
+		LowSlot:    high,
+		OriginRoot: originRoot[:],
+	}
+
+	clockSynchronizer := startup.NewClockSynchronizer()
+	clock := startup.NewClock(time.Now(), [32]byte{}, startup.WithSlotAsNow(primitives.Slot(high)+1))
+	require.NoError(t, clockSynchronizer.SetClock(clock))
+
+	p2pt := p2ptest.NewTestP2P(t)
+	blobStorage := filesystem.NewEphemeralBlobStorage(t)
+	dataColumnStorage := filesystem.NewEphemeralDataColumnStorage(t)
+	syncNeedsWaiter := func() (das.SyncNeeds, error) {
+		return das.NewSyncNeeds(clock.CurrentSlot, nil, primitives.Epoch(0))
+	}
+
+	service, err := NewService(
+		ctx, store, blobStorage, dataColumnStorage, clockSynchronizer, p2pt, &mockAssigner{},
+		WithBatchSize(batchSize), WithWorkerCount(nWorkers), WithEnableBackfill(true), WithVerifierWaiter(&mockInitalizerWaiter{}), WithSyncNeedsWaiter(syncNeedsWaiter),
+	)
+	require.NoError(t, err)
+
+	// The importer is stubbed out, so a single block is enough to keep batches out of the
+	// "batch with no results" error path.
+	blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
+	require.NoError(t, err)
+
+	rob, err := blocks.NewROBlock(blk)
+	require.NoError(t, err)
+
+	needs, err := syncNeedsWaiter()
+	require.NoError(t, err)
+
+	service.pool = &stubRoutedPool{
+		p2pBatchWorkerPool: newP2PBatchWorkerPool(p2pt, nWorkers, needs.Currently),
+		blocks:             verifiedROBlocks{rob},
+	}
+
+	service.batchImporter = func(context.Context, primitives.Slot, batch, *Store) (*dbval.BackfillStatus, error) {
+		return &dbval.BackfillStatus{}, nil
+	}
+	go service.Start()
+
+	done := make(chan error, 1)
+	go func() { done <- service.WaitForCompletion() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("backfill reached the end of the sequence but never reported completion")
+	}
+}
+
+// stubRoutedPool exercises the real pool bookkeeping in todo() and complete(), standing in for the
+// p2p worker fleet with a router that hands every batch straight back as importable.
+type stubRoutedPool struct {
+	*p2pBatchWorkerPool
+	blocks verifiedROBlocks
+}
+
+func (p *stubRoutedPool) spawn(ctx context.Context, _ int, _ PeerAssigner, _ *workerCfg) {
+	p.ctx, p.cancel = context.WithCancel(ctx)
+	go func() {
+		for {
+			select {
+			case b := <-p.toRouter:
+				b.blocks = p.blocks
+				p.fromRouter <- b.withState(batchImportable)
+			case <-p.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+var _ batchWorkerPool = &stubRoutedPool{}
 
 func testReadN(ctx context.Context, t *testing.T, c chan batch, n int, into []batch) []batch {
 	for range n {

--- a/changelog/manu_backfill-completion-deadlock.md
+++ b/changelog/manu_backfill-completion-deadlock.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Backfill: fix a deadlock where a node that backfilled all the way down to its retention window would hang instead of reporting completion.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Sometimes, at the end of the backfill process, we get:
```
[2026-07-30 19:50:17.37] DEBUG backfill: Imported batch batchId=13828288:13828320 batchesRemaining=10 begin=13828288 blobPid= blockPid=16Uiu2HAmJYCRKjdfVqYNqUEPqjmX1HNKGsJ4VdNRPeJC9XjPYrN7 busyPid=16Uiu2HAmJYCRKjdfVqYNqUEPqjmX1HNKGsJ4VdNRPeJC9XjPYrN7 colPid= end=13828320 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:15.807447205 +0000 UTC m=+32635.201330993 seq=2 state=importable
[2026-07-30 19:50:17.85] DEBUG backfill: Imported batch batchId=13828256:13828288 batchesRemaining=9 begin=13828256 blobPid= blockPid=16Uiu2HAmL7DsdduKsUNdSCxh9NrP2vssrmYrkDSapg5JkmqgJF5A busyPid=16Uiu2HAmL7DsdduKsUNdSCxh9NrP2vssrmYrkDSapg5JkmqgJF5A colPid= end=13828288 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:16.722343682 +0000 UTC m=+32636.116227470 seq=2 state=importable
[2026-07-30 19:50:18.15] DEBUG backfill: Imported batch batchId=13828224:13828256 batchesRemaining=8 begin=13828224 blobPid= blockPid=16Uiu2HAkxtZ7BRTzCqvYMDNsaJzGLm4JNUGvvtBVteK8zAri7LNm busyPid=16Uiu2HAkxtZ7BRTzCqvYMDNsaJzGLm4JNUGvvtBVteK8zAri7LNm colPid= end=13828256 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:17.376384833 +0000 UTC m=+32636.770268621 seq=2 state=importable
[2026-07-30 19:50:19.19] DEBUG backfill: Imported batch batchId=13828192:13828224 batchesRemaining=7 begin=13828192 blobPid= blockPid=16Uiu2HAmUxASPUjQBwEjfqjeDkjdRWguHamHQSZ2EiJrDfepSpba busyPid=16Uiu2HAmUxASPUjQBwEjfqjeDkjdRWguHamHQSZ2EiJrDfepSpba colPid= end=13828224 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:17.854756233 +0000 UTC m=+32637.248640021 seq=2 state=importable
[2026-07-30 19:50:19.32] DEBUG backfill: Imported batch batchId=13828160:13828192 batchesRemaining=6 begin=13828160 blobPid= blockPid=16Uiu2HAm9gK8x5hF37TvKRUMnK1rv5U1XUd1zFwVfFjFaxMKWvDZ busyPid=16Uiu2HAm9gK8x5hF37TvKRUMnK1rv5U1XUd1zFwVfFjFaxMKWvDZ colPid= end=13828192 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:18.153061934 +0000 UTC m=+32637.546945722 seq=2 state=importable
[2026-07-30 19:50:19.92] DEBUG backfill: Imported batch batchId=13828128:13828160 batchesRemaining=5 begin=13828128 blobPid= blockPid=16Uiu2HAkxtZ7BRTzCqvYMDNsaJzGLm4JNUGvvtBVteK8zAri7LNm busyPid=16Uiu2HAkxtZ7BRTzCqvYMDNsaJzGLm4JNUGvvtBVteK8zAri7LNm colPid= end=13828160 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:19.190329447 +0000 UTC m=+32638.584213235 seq=2 state=importable
[2026-07-30 19:50:20.62] DEBUG backfill: Imported batch batchId=13828096:13828128 batchesRemaining=4 begin=13828096 blobPid= blockPid=16Uiu2HAmJYCRKjdfVqYNqUEPqjmX1HNKGsJ4VdNRPeJC9XjPYrN7 busyPid=16Uiu2HAmJYCRKjdfVqYNqUEPqjmX1HNKGsJ4VdNRPeJC9XjPYrN7 colPid= end=13828128 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:19.325958443 +0000 UTC m=+32638.719842191 seq=2 state=importable
[2026-07-30 19:50:20.94] DEBUG backfill: Imported batch batchId=13828064:13828096 batchesRemaining=3 begin=13828064 blobPid= blockPid=16Uiu2HAmEEFin6991smQ4vXGkrHRpB5yXZu2b7GD8jF95nY7RdB8 busyPid=16Uiu2HAmEEFin6991smQ4vXGkrHRpB5yXZu2b7GD8jF95nY7RdB8 colPid= end=13828096 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:19.926218225 +0000 UTC m=+32639.320102013 seq=2 state=importable
[2026-07-30 19:50:21.76] DEBUG backfill: Imported batch batchId=13828032:13828064 batchesRemaining=2 begin=13828032 blobPid= blockPid=16Uiu2HAm9gK8x5hF37TvKRUMnK1rv5U1XUd1zFwVfFjFaxMKWvDZ busyPid=16Uiu2HAm9gK8x5hF37TvKRUMnK1rv5U1XUd1zFwVfFjFaxMKWvDZ colPid= end=13828064 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:20.620430126 +0000 UTC m=+32640.014313914 seq=2 state=importable
[2026-07-30 19:50:22.40] DEBUG backfill: Waiting for descendent batch to complete
[2026-07-30 19:50:22.61] DEBUG backfill: Imported batch batchId=13828000:13828032 batchesRemaining=1 begin=13828000 blobPid= blockPid=16Uiu2HAmMCcBUnUpBaazfD2pYabyPsAh9GYVHyb4exzvPz1MCzQe busyPid=16Uiu2HAmMCcBUnUpBaazfD2pYabyPsAh9GYVHyb4exzvPz1MCzQe colPid= end=13828032 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:20.943216978 +0000 UTC m=+32640.337100766 seq=2 state=importable
[2026-07-30 19:50:22.69] DEBUG backfill: Batch outside retention window batchId=13827981:13827981 begin=13827981 blockPid= busyPid= end=13827981 retentionStartSlot=13827981 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=0001-01-01 00:00:00 +0000 UTC seq=0 state=end_sequence
[2026-07-30 19:50:22.69] DEBUG backfill: Imported batch batchId=13827981:13828000 batchesRemaining=0 begin=13827981 blobPid= blockPid=16Uiu2HAmEEFin6991smQ4vXGkrHRpB5yXZu2b7GD8jF95nY7RdB8 busyPid=16Uiu2HAmEEFin6991smQ4vXGkrHRpB5yXZu2b7GD8jF95nY7RdB8 colPid= end=13828000 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-30 19:50:21.766186127 +0000 UTC m=+32641.160069915 seq=2 state=importable

[No more backfill log]
```

- We never see the `Backfill is complete` log
- The backfill process never really ends even if, technically, all the blocks to backfill are backfilled (`batchesRemaining=0`)
- The DB pruning process, which wait for the backfill to end, never starts.

Restarting the node is a workaround.

This issue does not happen 100% of the time.

This pull request has 2 commits:
1. The first commit only introduce a new (failing) unit test, reproducing deterministically the deadlock process.
2. The second commit fixes the issue.

All details explanations are in the commit messages.

A correct backfill termination should look like:
```
[2026-07-31 09:55:20.27] DEBUG backfill: Validation failed batchId=13832206:13832224 begin=13832206 blockPid=16Uiu2HAmBnZmaGre71139RXA2zUkJ4C36PZcfcKhPp5UGgfbLhg9 busyPid=16Uiu2HAmBnZmaGre71139RXA2zUkJ4C36PZcfcKhPp5UGgfbLhg9 end=13832224 error=no blocks to verify in batch retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-31 09:55:20.262870769 +0000 UTC m=+46364.245270372 seq=1 state=sequenced
[2026-07-31 09:55:20.27] DEBUG backfill: Sleeping for retry backoff delay batchId=13832206:13832224 begin=13832206 blockPid= busyPid=16Uiu2HAmQs5CGRvPCN9TvxXit7aWg6Lv37c2DBf7okLfj9u1s7HH end=13832224 retries=1 retryAfter=2026-07-31 09:55:21.274184318 +0000 UTC m=+46365.256583961 scheduled=2026-07-31 09:55:20.27607181 +0000 UTC m=+46364.258471413 seq=3 state=sequenced untilRetry=997.999428ms
[2026-07-31 09:55:21.54] DEBUG backfill: Waiting for descendent batch to complete
[2026-07-31 09:55:22.35] DEBUG backfill: Imported batch batchId=13832224:13832256 batchesRemaining=1 begin=13832224 blobPid= blockPid=16Uiu2HAkvkioAXvB4xDeDWugpvfXe7vrjYKvEiNxPhSF4HkuCtHp busyPid=16Uiu2HAkvkioAXvB4xDeDWugpvfXe7vrjYKvEiNxPhSF4HkuCtHp colPid= end=13832256 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=2026-07-31 09:55:20.262869849 +0000 UTC m=+46364.245269492 seq=2 state=importable
[2026-07-31 09:55:22.44] DEBUG backfill: Batch outside retention window batchId=13832206:13832206 begin=13832206 blockPid= busyPid= end=13832206 retentionStartSlot=13832206 retries=0 retryAfter=0001-01-01 00:00:00 +0000 UTC scheduled=0001-01-01 00:00:00 +0000 UTC seq=0 state=end_sequence
[2026-07-31 09:55:22.44] DEBUG backfill: Imported batch batchId=13832206:13832224 batchesRemaining=0 begin=13832206 blobPid= blockPid=16Uiu2HAmQs5CGRvPCN9TvxXit7aWg6Lv37c2DBf7okLfj9u1s7HH busyPid=16Uiu2HAmQs5CGRvPCN9TvxXit7aWg6Lv37c2DBf7okLfj9u1s7HH colPid= end=13832224 retries=1 retryAfter=2026-07-31 09:55:21.274184318 +0000 UTC m=+46365.256583961 scheduled=2026-07-31 09:55:20.27607181 +0000 UTC m=+46364.258471413 seq=4 state=importable
[2026-07-31 09:55:22.44]  INFO backfill: Backfill is complete backfillSlot=13832206
[2026-07-31 09:55:22.44]  INFO backfill: Marked as complete
[2026-07-31 09:55:22.44]  INFO backfill: Service is shutting down
[2026-07-31 09:55:22.44]  INFO backfill: Worker exiting after context canceled backfillWorker=1
[2026-07-31 09:55:22.44]  INFO backfill: Worker exiting after context canceled backfillWorker=0
[2026-07-31 09:55:22.44]  INFO backfill: p2pBatchWorkerPool context canceled, shutting down error=context canceled
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
