### PR TITLE
`getHeader`: Allow a user defined timeout value with the `--builder-header-timeout` flag

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -88,6 +89,31 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
+
+	return nil
+}
+
+func configureBuilderHeaderTimeout(cliCtx *cli.Context) error {
+	if !cliCtx.IsSet(flags.BuilderHeaderTimeout.Name) {
+		return nil
+	}
+
+	timeout := cliCtx.Duration(flags.BuilderHeaderTimeout.Name)
+	if timeout <= 0 {
+		return fmt.Errorf("--%s must be greater than 0, got %s", flags.BuilderHeaderTimeout.Name, timeout)
+	}
+
+	c := params.BeaconConfig().Copy()
+	c.BuilderHeaderTimeout = timeout
+
+	if err := params.SetActive(c); err != nil {
+		return fmt.Errorf("set active: %w", err)
+	}
+
+	log.WithFields(logrus.Fields{
+		"timeout": timeout,
+		"default": params.BuilderProposalDelayTolerance,
+	}).Warning("Overriding the builder API `getHeader` timeout. A too high value may cause the node to miss blocks. Use with caution")
 
 	return nil
 }

--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -113,7 +113,7 @@ func configureBuilderHeaderTimeout(cliCtx *cli.Context) error {
 	log.WithFields(logrus.Fields{
 		"timeout": timeout,
 		"default": params.BuilderProposalDelayTolerance,
-	}).Warning("Overriding the builder API `getHeader` timeout. A too high value may cause the node to miss blocks. Use with caution")
+	}).Warning("Overriding the builder API `getHeader` timeout. A too high value may cause the node to miss blocks. Only effective up to the Fulu fork. Use with caution")
 
 	return nil
 }

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
@@ -37,6 +38,55 @@ func TestConfigureHistoricalSlasher(t *testing.T) {
 			params.BeaconConfig().SlotsPerArchivedPoint,
 			int(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().MaxAttestations))),
 	)
+}
+
+func TestConfigureBuilderHeaderTimeout(t *testing.T) {
+	newCliCtx := func(t *testing.T, timeout string) *cli.Context {
+		set := flag.NewFlagSet("test", 0)
+		set.Duration(flags.BuilderHeaderTimeout.Name, flags.BuilderHeaderTimeout.Value, "")
+		if timeout != "" {
+			require.NoError(t, set.Set(flags.BuilderHeaderTimeout.Name, timeout))
+		}
+		return cli.NewContext(&cli.App{}, set, nil)
+	}
+
+	t.Run("leaves the config untouched when unset", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		hook := logTest.NewGlobal()
+		c := params.BeaconConfig().Copy()
+		c.BuilderHeaderTimeout = 1234 * time.Millisecond
+		require.NoError(t, params.SetActive(c))
+
+		require.NoError(t, configureBuilderHeaderTimeout(newCliCtx(t, "")))
+
+		assert.Equal(t, 1234*time.Millisecond, params.BeaconConfig().BuilderHeaderTimeout)
+		assert.LogsDoNotContain(t, hook, "Overriding the builder API `getHeader` timeout")
+	})
+
+	for _, timeout := range []string{"0s", "-1ms"} {
+		t.Run("rejects "+timeout, func(t *testing.T) {
+			params.SetupTestConfigCleanup(t)
+
+			err := configureBuilderHeaderTimeout(newCliCtx(t, timeout))
+
+			require.ErrorContains(t, fmt.Sprintf("--builder-header-timeout must be greater than 0, got %s", timeout), err)
+			assert.Equal(t, params.BuilderProposalDelayTolerance, params.BeaconConfig().BuilderHeaderTimeout)
+		})
+	}
+
+	// Any positive value is accepted: there is no upper bound, and no relay endpoint is required.
+	t.Run("nominal", func(t *testing.T) {
+		const timeout = "2500ms"
+		params.SetupTestConfigCleanup(t)
+		hook := logTest.NewGlobal()
+
+		require.NoError(t, configureBuilderHeaderTimeout(newCliCtx(t, timeout)))
+
+		expected, err := time.ParseDuration(timeout)
+		require.NoError(t, err)
+		assert.Equal(t, expected, params.BeaconConfig().BuilderHeaderTimeout)
+		assert.LogsContain(t, hook, "Overriding the builder API `getHeader` timeout")
+	})
 }
 
 func TestConfigureSlotsPerArchivedPoint(t *testing.T) {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -317,6 +317,10 @@ func configureBeacon(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "could not configure builder circuit breaker")
 	}
 
+	if err := configureBuilderHeaderTimeout(cliCtx); err != nil {
+		return errors.Wrap(err, "could not configure builder header timeout")
+	}
+
 	if err := configureSlotsPerArchivedPoint(cliCtx); err != nil {
 		return errors.Wrap(err, "could not configure slots per archived point")
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -46,9 +46,6 @@ var (
 // can be used as a constant to avoid recomputing this value in every call.
 var emptyTransactionsRoot = [32]byte{127, 254, 36, 30, 166, 1, 135, 253, 176, 24, 123, 250, 34, 222, 53, 209, 249, 190, 215, 171, 6, 29, 148, 1, 253, 71, 227, 74, 84, 251, 237, 225}
 
-// blockBuilderTimeout is the maximum amount of time allowed for a block builder to respond to a
-// block request. This value is known as `BUILDER_PROPOSAL_DELAY_TOLERANCE` in builder spec.
-const blockBuilderTimeout = 1 * time.Second
 const gasLimitAdjustmentFactor = 1024
 
 // Sets the execution data for the block. Execution data can come from local EL client or remote builder depends on validator registration and circuit breaker conditions.
@@ -208,7 +205,7 @@ func (vs *Server) getPayloadHeaderFromBuilder(
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, blockBuilderTimeout)
+	ctx, cancel := context.WithTimeout(ctx, params.BeaconConfig().BuilderHeaderTimeout)
 	defer cancel()
 
 	signedBid, err := vs.BlockBuilder.GetHeader(ctx, slot, bytesutil.ToBytes32(h.BlockHash()), pk)

--- a/changelog/nalepae_builder-header-timeout.md
+++ b/changelog/nalepae_builder-header-timeout.md
@@ -1,0 +1,3 @@
+### Added
+
+- `--builder-header-timeout`: makes the builder `getHeader` timeout (`BUILDER_PROPOSAL_DELAY_TOLERANCE`, previously hardcoded to 1s) configurable. Must be greater than 0.

--- a/changelog/nalepae_builder-header-timeout.md
+++ b/changelog/nalepae_builder-header-timeout.md
@@ -1,3 +1,3 @@
 ### Added
 
-- `--builder-header-timeout`: makes the builder `getHeader` timeout (`BUILDER_PROPOSAL_DELAY_TOLERANCE`, previously hardcoded to 1s) configurable. Must be greater than 0.
+- `--builder-header-timeout`: makes the builder `getHeader` timeout (`BUILDER_PROPOSAL_DELAY_TOLERANCE`, previously hardcoded to 1s) configurable. Must be greater than 0. Only effective up to the Fulu fork. 

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -82,7 +82,7 @@ var (
 	// before giving up and using the locally built block.
 	BuilderHeaderTimeout = &cli.DurationFlag{
 		Name:  "builder-header-timeout",
-		Usage: "Timeout to use when fetching a block header from the builder API, as a duration (e.g. 1s, 2s, 2500ms). Must be greater than 0",
+		Usage: "Timeout to use when fetching a block header from the builder API, as a duration (e.g. 1s, 2s, 2500ms). Must be greater than 0. Only effective up to the Fulu fork.",
 		Value: params.BeaconConfig().BuilderHeaderTimeout,
 	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -78,6 +78,13 @@ var (
 			" and the beacon will revert to local building.",
 		Value: 0,
 	}
+	// BuilderHeaderTimeout bounds how long the beacon node waits for a builder relay `getHeader` response
+	// before giving up and using the locally built block.
+	BuilderHeaderTimeout = &cli.DurationFlag{
+		Name:  "builder-header-timeout",
+		Usage: "Timeout to use when fetching a block header from the builder API, as a duration (e.g. 1s, 2s, 2500ms). Must be greater than 0",
+		Value: params.BeaconConfig().BuilderHeaderTimeout,
+	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer
 	ExecutionEngineEndpoint = &cli.StringFlag{
 		Name:  "execution-endpoint",

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -87,6 +87,7 @@ var appFlags = []cli.Flag{
 	flags.LocalBlockValueBoost,
 	flags.MinBuilderBid,
 	flags.MinBuilderDiff,
+	flags.BuilderHeaderTimeout,
 	flags.BeaconDBPruning,
 	flags.PrunerRetentionEpochs,
 	flags.DisableBuilderSSZ,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -144,6 +144,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.MevRelayEndpoint,
 			flags.MinBuilderBid,
 			flags.MinBuilderDiff,
+			flags.BuilderHeaderTimeout,
 			flags.SuggestedFeeRecipient,
 			flags.DisableBuilderSSZ,
 		},

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -21,6 +21,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// BUILDER_PROPOSAL_DELAY_TOLERANCE
+// https://github.com/ethereum/builder-specs/blob/main/specs/bellatrix/validator.md#constants
+const BuilderProposalDelayTolerance = 1 * time.Second
+
 // BeaconChainConfig contains constant configs for node to participate in beacon chain.
 type BeaconChainConfig struct {
 	// Constants (non-configurable)
@@ -267,6 +271,7 @@ type BeaconChainConfig struct {
 	LocalBlockValueBoost             uint64          // LocalBlockValueBoost is the value boost for local block construction. This is used to prioritize local block construction over relay/builder block construction.
 	MinBuilderBid                    uint64          // MinBuilderBid is the minimum value that the builder's block can have to be considered by this node.
 	MinBuilderDiff                   uint64          // MinBuilderDiff is the minimum value above the local block value that the builder has to bid to be considered by this node
+	BuilderHeaderTimeout             time.Duration   // BuilderHeaderTimeout is how long to wait for a builder relay `getHeader` response before falling back to local block building. Known as `BUILDER_PROPOSAL_DELAY_TOLERANCE` in the builder spec.
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue uint64 // ExecutionEngineTimeoutValue defines the seconds to wait before timing out engine endpoints with execution payload execution semantics (newPayload, forkchoiceUpdated).
 

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -303,6 +303,8 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
+	// Builder `getHeader` timeout.
+	BuilderHeaderTimeout: BuilderProposalDelayTolerance,
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core
 


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
Currently, when the beacon node requests a header from a builder via the [getHeader](https://ethereum.github.io/builder-specs/#/Builder/getHeader) beacon API endpoint, the timeout is fixed, by the specification, at 1 second: [BUILDER_PROPOSAL_DELAY_TOLERANCE](https://github.com/ethereum/builder-specs/blob/main/specs/bellatrix/validator.md#constants).

This pull request allows the user to define a custom value with the `--builder-header-timeout` flag.

The beacon node still sends the `getHeader` request as early as it does today: the flag only widens the window for the response to arrive. Deliberately shifting the request later in the slot is left to the builder middleware.

Example with [Commit boost](https://commit-boost.github.io/commit-boost-client/):
```toml
[pbs]
timeout_get_header_ms = 950     # per-request timeout to the relay
late_in_slot_time_ms  = 2000    # hard deadline in the slot: past this, skip relays -> local build

[[relays]]
id  = "example-relay"
url = "http://0xa1ce...@abc.xyz"
enable_timing_games     = true   # master switch (no effect unless one of the two below is set)
target_first_request_ms = 200    # the delay: time-in-slot at which the first getHeader is sent
frequency_get_header_ms = 300    # resend interval afterwards
```

This PR is an alternative take of:
- https://github.com/OffchainLabs/prysm/pull/17224, 

which actively delays, in the validator client, the moment the `getHeader` request is triggered.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
