### PR TITLE
Remove unused reference counter from validator map handler

### DIFF
--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -1015,7 +1015,7 @@ func (b *BeaconState) Copy() state.BeaconState {
 		rebuildTrie:      make(map[types.FieldIndex]bool, fieldCount),
 		stateFieldLeaves: make(map[types.FieldIndex]*fieldtrie.FieldTrie, len(fieldMap)),
 
-		// Share the reference to validator index map.
+		// Shared and mutated in place, lookups are bounded by each state's validator count.
 		valMapHandler: b.valMapHandler,
 
 		builderIdxMap: maps.Clone(b.builderIdxMap),
@@ -1053,9 +1053,6 @@ func (b *BeaconState) Copy() state.BeaconState {
 		ref.AddRef()
 		dst.sharedFieldReferences[field] = ref
 	}
-
-	// Increment ref for validator map
-	b.valMapHandler.AddRef()
 
 	for i := range b.dirtyFields {
 		dst.dirtyFields[i] = true

--- a/beacon-chain/state/stateutil/validator_map_handler.go
+++ b/beacon-chain/state/stateutil/validator_map_handler.go
@@ -9,11 +9,9 @@ import (
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 )
 
-// ValidatorMapHandler is a container to hold the map and a reference tracker for how many
-// states shared this.
+// ValidatorMapHandler holds the pubkey to index map shared by every state copied from a common ancestor.
 type ValidatorMapHandler struct {
 	valIdxMap map[[fieldparams.BLSPubkeyLength]byte]primitives.ValidatorIndex
-	mapRef    *Reference
 	*sync.RWMutex
 }
 
@@ -21,19 +19,13 @@ type ValidatorMapHandler struct {
 func NewValMapHandler(vals []*ethpb.Validator) *ValidatorMapHandler {
 	return &ValidatorMapHandler{
 		valIdxMap: coreutils.ValidatorIndexMap(vals),
-		mapRef:    &Reference{refs: 1},
 		RWMutex:   new(sync.RWMutex),
 	}
 }
 
-// AddRef copies the whole map and returns a map handler with the copied map.
-func (v *ValidatorMapHandler) AddRef() {
-	v.mapRef.AddRef()
-}
-
 // IsNil returns true if the underlying validator index map is nil.
 func (v *ValidatorMapHandler) IsNil() bool {
-	return v.mapRef == nil || v.valIdxMap == nil
+	return v == nil || v.valIdxMap == nil
 }
 
 // Get the validator index using the corresponding public key.

--- a/changelog/terence_remove-valmap-refcount.md
+++ b/changelog/terence_remove-valmap-refcount.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed the unused reference counter on the validator pubkey to index map.


### PR DESCRIPTION
The refcount on the validator pubkey to index map is never read, `Refs()` and `MinusRef()` have no callers on it and `finalizerCleanup` never decrements it. It has been dead since #8860 removed the copy-on-append and #13954 removed the `Copy()` method.