### PR TITLE
Fix incompatibilities between `--beacon-db-pruning` and `--enable-state-diff`.

### DIFF
--- a/beacon-chain/db/kv/genesis.go
+++ b/beacon-chain/db/kv/genesis.go
@@ -111,6 +111,15 @@ func (s *Store) EnsureEmbeddedGenesis(ctx context.Context) error {
 		return fmt.Errorf("could not read the origin checkpoint block root: %w", err)
 	}
 
+	anchoredAfterGenesis, err := s.stateDiffAnchoredAfterGenesis()
+	if err != nil {
+		return fmt.Errorf("state diff anchored after genesis: %w", err)
+	}
+
+	if anchoredAfterGenesis {
+		return nil
+	}
+
 	gs, err := s.GenesisState(ctx)
 	if err != nil {
 		return err

--- a/beacon-chain/db/kv/genesis.go
+++ b/beacon-chain/db/kv/genesis.go
@@ -104,6 +104,13 @@ func (s *Store) EnsureEmbeddedGenesis(ctx context.Context) error {
 	if gb != nil && !gb.IsNil() {
 		return nil
 	}
+
+	if _, err := s.OriginCheckpointBlockRoot(ctx); err == nil {
+		return nil
+	} else if !errors.Is(err, ErrNotFoundOriginBlockRoot) {
+		return fmt.Errorf("could not read the origin checkpoint block root: %w", err)
+	}
+
 	gs, err := s.GenesisState(ctx)
 	if err != nil {
 		return err

--- a/beacon-chain/db/kv/state_diff_helpers.go
+++ b/beacon-chain/db/kv/state_diff_helpers.go
@@ -262,6 +262,26 @@ func (s *Store) hasStateDiffOffset() (bool, error) {
 	return hasOffset, err
 }
 
+// stateDiffAnchoredAfterGenesis returns true if the state-diff tree is anchored on a slot after
+// genesis (which only happens on a database synced from a checkpoint).
+func (s *Store) stateDiffAnchoredAfterGenesis() (bool, error) {
+	hasOffset, err := s.hasStateDiffOffset()
+	if err != nil {
+		return false, fmt.Errorf("has state diff offset: %w", err)
+	}
+
+	if !hasOffset {
+		return false, nil
+	}
+
+	offset, err := s.loadOffset()
+	if err != nil {
+		return false, fmt.Errorf("load offset: %w", err)
+	}
+
+	return offset != 0, nil
+}
+
 // initializeStateDiff sets up the state-diff schema for a new database.
 // This should be called during checkpoint sync or genesis sync.
 func (s *Store) initializeStateDiff(slot primitives.Slot, initialState state.ReadOnlyBeaconState) error {

--- a/beacon-chain/db/kv/state_diff_test.go
+++ b/beacon-chain/db/kv/state_diff_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/genesis"
 	"github.com/OffchainLabs/prysm/v7/math"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
@@ -897,6 +898,77 @@ func TestStateDiff_AnchorCache(t *testing.T) {
 			for i := 1; i < len(exponents)-1; i++ {
 				require.IsNil(t, db.stateDiffCache.getAnchor(i))
 			}
+		})
+	}
+}
+
+func TestStateDiff_EnsureEmbeddedGenesisKeepsCheckpointSyncedTree(t *testing.T) {
+	testCases := []struct {
+		name             string
+		hasOriginBlkRoot bool
+	}{
+		{
+			name:             "origin checkpoint block root available",
+			hasOriginBlkRoot: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCfg := features.InitWithReset(&features.Flags{EnableStateDiff: true})
+			defer resetCfg()
+
+			setDefaultStateDiffExponents()
+
+			// The genesis state is globally available from the embedded or provider genesis, even for a node
+			// that was synced from a checkpoint and has no genesis data in its database.
+			genesisState, err := util.NewBeaconStateFulu()
+			require.NoError(t, err)
+			genesis.StoreStateDuringTest(t, genesisState)
+
+			db := setupDB(t)
+
+			// A checkpoint-synced node anchors the tree at the origin state's slot, but never stores a
+			// genesis block.
+			const offset = primitives.Slot(14689088)
+			originState, _ := createState(t, offset, version.Fulu)
+			require.NoError(t, db.initializeStateDiff(offset, originState))
+
+			if tc.hasOriginBlkRoot {
+				require.NoError(t, db.SaveOriginCheckpointBlockRoot(t.Context(), [32]byte{1}))
+			} else {
+				_, err := db.OriginCheckpointBlockRoot(t.Context())
+				require.ErrorIs(t, err, ErrNotFoundOriginBlockRoot)
+			}
+
+			// A few epochs worth of diffs accumulate on top of the anchor.
+			for slot := offset + 32; slot <= offset+128; slot += 32 {
+				st, _ := createState(t, slot, version.Fulu)
+				require.NoError(t, db.saveStateByDiff(t.Context(), st))
+			}
+
+			// This runs on every restart, and must leave a checkpoint-synced database alone.
+			require.NoError(t, db.EnsureEmbeddedGenesis(t.Context()))
+
+			gb, err := db.GenesisBlock(t.Context())
+			require.NoError(t, err)
+			require.IsNil(t, gb)
+
+			// The tree must still be anchored where the origin put it, and still be readable.
+			require.Equal(t, uint64(offset), db.getOffset())
+
+			st, err := db.stateByDiff(t.Context(), offset+128)
+			require.NoError(t, err)
+			require.Equal(t, offset+128, st.Slot())
+
+			// And the database must still open on the next restart.
+			storedOffset, err := db.loadOffset()
+			require.NoError(t, err)
+			require.Equal(t, uint64(offset), storedOffset)
+
+			cache, err := populateStateDiffCacheFromDB(db, storedOffset)
+			require.NoError(t, err)
+			require.NoError(t, validateStateDiffCache(t.Context(), db, cache))
 		})
 	}
 }

--- a/beacon-chain/db/kv/state_diff_test.go
+++ b/beacon-chain/db/kv/state_diff_test.go
@@ -911,6 +911,12 @@ func TestStateDiff_EnsureEmbeddedGenesisKeepsCheckpointSyncedTree(t *testing.T) 
 			name:             "origin checkpoint block root available",
 			hasOriginBlkRoot: true,
 		},
+		{
+			// Pruning ran long enough to delete the origin block, and with it the origin checkpoint
+			// block root. Only the anchor is left to tell that this database was not synced from genesis.
+			name:             "origin checkpoint block root pruned",
+			hasOriginBlkRoot: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/changelog/manu_fix-state-diff-genesis-reanchor.md
+++ b/changelog/manu_fix-state-diff-genesis-reanchor.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a checkpoint-synced beacon node using `--enable-state-diff` and `--beacon-db-pruning` failing to restart with `state-diff database corrupted`.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR has two commits.
1. The first commit fixes https://github.com/OffchainLabs/prysm/issues/17148
2. The second commit fixes a bug hidden by https://github.com/OffchainLabs/prysm/issues/17148: If, after https://github.com/OffchainLabs/prysm/issues/17148 is fixed, a beacon node both using `--beacon-db-pruning` and 
`--enable-state-diff` is rebooted after the checkpoint block is itself pruned (so, after ~5 months), then the node cannot restart.

**Which issue(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/17148

**Other notes for review**
Please read commit by commit, with commit message.

**How to test**
To reproduce the bug fixed by the first commit:
1. Run the node from a fresh DB with the `--beacon-db-pruning` and `--enable-state-diff` flags
2. Wait for the first pruning action to run (up to one epoch after the sync)
3. Reboot the node

To reproduce the bug fixed by the second commit:
1. Checkout to the first commit (else, the bug fixed by the fixed by the first commit will hit first)
2. Run the node from a fresh DB with the `--beacon-db-pruning` and `--enable-state-diff` flags
3. Wait for `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (~5 months)
4. Reboot the node

Note: If you are in a hurry, you can cherry pick 9af4973fd970f09e02e1c7d72c9303270627848f, then start the node with `--pruner-retention-epochs=3` and then wait only for 3 epochs before rebooting

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
