### PR TITLE
Only accept gossip bids compatible with the head view

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -101,6 +101,7 @@ type HeadFetcher interface {
 	HeadPublicKeyToValidatorIndex(pubKey [fieldparams.BLSPubkeyLength]byte) (primitives.ValidatorIndex, bool)
 	HeadValidatorIndexToPublicKey(ctx context.Context, index primitives.ValidatorIndex) ([fieldparams.BLSPubkeyLength]byte, error)
 	ChainHeads() ([][32]byte, []primitives.Slot)
+	IsBidCompatibleWithHead(interfaces.ROExecutionPayloadBid) bool
 	DependentRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	HeadSyncCommitteeFetcher

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -15,11 +15,44 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	payloadattribute "github.com/OffchainLabs/prysm/v7/consensus-types/payload-attribute"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
+
+func (s *Service) IsBidCompatibleWithHead(bid interfaces.ROExecutionPayloadBid) bool {
+	s.headLock.RLock()
+	if s.head == nil || s.head.block == nil || s.head.block.Block() == nil || s.head.state == nil {
+		s.headLock.RUnlock()
+		return false
+	}
+	headRoot := s.head.root
+	headBlock := s.head.block.Block()
+	headState := s.head.state
+	s.headLock.RUnlock()
+
+	headBid, err := headBlock.Body().SignedExecutionPayloadBid()
+	if err != nil || headBid.Message == nil {
+		log.WithError(err).Debug("Could not get head bid to check bid compatibility")
+		return false
+	}
+
+	buildsOnParentBlock := bid.ParentBlockRoot() == headBlock.ParentRoot()
+	buildsOnParentPayload := bid.ParentBlockHash() == bytesutil.ToBytes32(headBid.Message.ParentBlockHash)
+	if buildsOnParentBlock && buildsOnParentPayload {
+		return true
+	}
+	if bid.ParentBlockRoot() != headRoot {
+		return false
+	}
+	buildsOnHeadPayload := bid.ParentBlockHash() == bytesutil.ToBytes32(headBid.Message.BlockHash)
+	if buildFull, _ := s.shouldBuildOnFull(headState, headRoot, bid.Slot()); buildFull {
+		return buildsOnHeadPayload
+	}
+	return buildsOnParentPayload
+}
 
 func (s *Service) waitUntilEpoch(target primitives.Epoch, secondsPerSlot uint64) error {
 	if slots.ToEpoch(s.CurrentSlot()) >= target {

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -15,6 +15,7 @@ import (
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	payloadattribute "github.com/OffchainLabs/prysm/v7/consensus-types/payload-attribute"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -669,6 +670,78 @@ func TestShouldBuildOnFull(t *testing.T) {
 		setTestPTCVotes(service, root, true, false)
 		assertBuild(t, service, root, blockSlot+1, true, false, "arrived late, betting on empty")
 	})
+}
+
+func testROBid(t *testing.T, slot primitives.Slot, parentRoot, parentHash [32]byte) interfaces.ROExecutionPayloadBid {
+	t.Helper()
+	signed := util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			Slot:            slot,
+			ParentBlockRoot: parentRoot[:],
+			ParentBlockHash: parentHash[:],
+		},
+	})
+	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signed)
+	require.NoError(t, err)
+	bid, err := wrapped.Bid()
+	require.NoError(t, err)
+	return bid
+}
+
+func TestIsBidCompatibleWithHead(t *testing.T) {
+	headParentRoot := bytesutil.ToBytes32([]byte("head-parent-root"))
+	headRoot := bytesutil.ToBytes32([]byte("compat-head-root"))
+	headBlockHash := bytesutil.ToBytes32([]byte("compat-head-hash"))
+	headParentHash := bytesutil.ToBytes32([]byte("compat-parent-hash"))
+	headSlot := primitives.Slot(1)
+
+	setup := func(t *testing.T) *Service {
+		service, _ := setupGloasService(t, &mockExecution.EngineClient{})
+		base, blk := testGloasState(t, headSlot, headParentRoot, headBlockHash)
+		blk.Block.Body.SignedExecutionPayloadBid.Message.ParentBlockHash = headParentHash[:]
+		insertGloasBlock(t, service, base, blk, headRoot)
+		st, err := state_native.InitializeFromProtoUnsafeGloas(base)
+		require.NoError(t, err)
+		signed, err := blocks.NewSignedBeaconBlock(blk)
+		require.NoError(t, err)
+		service.head = &head{root: headRoot, block: signed, state: st, slot: headSlot}
+		return service
+	}
+
+	t.Run("no head", func(t *testing.T) {
+		service, _ := setupGloasService(t, &mockExecution.EngineClient{})
+		require.Equal(t, false, service.IsBidCompatibleWithHead(testROBid(t, headSlot+1, headRoot, headBlockHash)))
+	})
+
+	t.Run("builds on head parent block and payload", func(t *testing.T) {
+		service := setup(t)
+		require.Equal(t, true, service.IsBidCompatibleWithHead(testROBid(t, headSlot+1, headParentRoot, headParentHash)))
+	})
+
+	t.Run("builds on head parent block with wrong payload", func(t *testing.T) {
+		service := setup(t)
+		other := bytesutil.ToBytes32([]byte("other-hash"))
+		require.Equal(t, false, service.IsBidCompatibleWithHead(testROBid(t, headSlot+1, headParentRoot, other)))
+	})
+
+	t.Run("unknown parent root", func(t *testing.T) {
+		service := setup(t)
+		other := bytesutil.ToBytes32([]byte("other-root"))
+		require.Equal(t, false, service.IsBidCompatibleWithHead(testROBid(t, headSlot+1, other, headParentHash)))
+	})
+
+	t.Run("builds on head full payload when full expected", func(t *testing.T) {
+		service := setup(t)
+		require.Equal(t, true, service.IsBidCompatibleWithHead(testROBid(t, headSlot+1, headRoot, headBlockHash)))
+		require.Equal(t, false, service.IsBidCompatibleWithHead(testROBid(t, headSlot+1, headRoot, headParentHash)))
+	})
+
+	t.Run("builds on head empty variant when forkchoice prefers empty", func(t *testing.T) {
+		service := setup(t)
+		require.Equal(t, true, service.IsBidCompatibleWithHead(testROBid(t, headSlot+2, headRoot, headParentHash)))
+		require.Equal(t, false, service.IsBidCompatibleWithHead(testROBid(t, headSlot+2, headRoot, headBlockHash)))
+	})
+
 }
 
 func TestSetHeadFull(t *testing.T) {

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -41,6 +41,7 @@ type ChainService struct {
 	Full                        bool
 	ValidAttestation            bool
 	Optimistic                  bool
+	BidCompatibleWithHead       bool
 	ValidatorsRoot              [32]byte
 	OptimisticCheckRootReceived [32]byte
 	SyncingRoot                 [32]byte
@@ -625,6 +626,11 @@ func (s *ChainService) InForkchoice(root [32]byte) bool {
 		return s.ForkchoiceRoots[root]
 	}
 	return !s.NotFinalized
+}
+
+// IsBidCompatibleWithHead mocks the same method in the chain service.
+func (s *ChainService) IsBidCompatibleWithHead(_ interfaces.ROExecutionPayloadBid) bool {
+	return s.BidCompatibleWithHead
 }
 
 // BlockHash mocks the execution payload block hash lookup for a beacon block root.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
@@ -48,6 +48,9 @@ func (v *fakeBidVerifier) VerifyParentBlockRootSeen(fn func([32]byte) bool) erro
 	v.rootSeenFn = fn
 	return v.rootSeenErr
 }
+func (v *fakeBidVerifier) VerifyBidCompatibleWithHead(func(interfaces.ROExecutionPayloadBid) bool) error {
+	return nil
+}
 func (v *fakeBidVerifier) VerifyBidSlotHigherThanParent(primitives.Slot) error { return nil }
 func (v *fakeBidVerifier) VerifyParentBlockHash(fn func([32]byte, [32]byte) bool) error {
 	v.hasPayloadFn = fn

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -58,10 +58,10 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 		return pubsub.ValidationIgnore, err
 	}
 
-	// [IGNORE] this is the first signed bid seen with a valid signature from the given builder for this slot.
+	// [IGNORE] this is the first signed bid seen with a valid signature from the given builder for the tuple (bid.slot, bid.parent_block_hash, bid.parent_block_root).
 	// Cache is populated only after VerifySignature below; a hit here implies a valid-sig bid was already seen.
-	builderKey := executionPayloadBidBuilderKey(bid.Slot(), bid.BuilderIndex())
-	if s.hasSeenExecutionPayloadBidBuilder(builderKey) {
+	tupleKey := executionPayloadBidTupleKey(bid)
+	if s.hasSeenExecutionPayloadBid(tupleKey) {
 		return pubsub.ValidationIgnore, nil
 	}
 
@@ -112,7 +112,7 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifySignature(st); err != nil {
 		return pubsub.ValidationReject, err
 	}
-	s.setSeenExecutionPayloadBidBuilder(bid.Slot(), builderKey)
+	s.setSeenExecutionPayloadBid(bid.Slot(), tupleKey)
 	// [IGNORE] this bid is the highest value bid seen for the tuple (bid.slot, bid.parent_block_hash, bid.parent_block_root).
 	if !s.isHighestExecutionPayloadBid(bid) {
 		return pubsub.ValidationIgnore, nil
@@ -133,8 +133,8 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyGasLimitTargetCompatible(parentGasLimit, pref.TargetGasLimit); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	// [IGNORE] bid.parent_block_root is the hash tree root of a known beacon block in fork choice.
-	if err := v.VerifyParentBlockRootSeen(s.cfg.chain.InForkchoice); err != nil {
+	// [IGNORE] the bid is compatible with the current head branch, i.e. is_bid_compatible_with_head(store, bid) returns True.
+	if err := v.VerifyBidCompatibleWithHead(s.cfg.chain.IsBidCompatibleWithHead); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 	// [REJECT] bid.slot is greater than the slot of the block with root bid.parent_block_root.
@@ -165,17 +165,20 @@ func (s *Service) executionPayloadBidSubscriber(_ context.Context, msg proto.Mes
 	return nil
 }
 
-func executionPayloadBidBuilderKey(slot primitives.Slot, builderIndex primitives.BuilderIndex) string {
-	b := append(bytesutil.Bytes32(uint64(slot)), bytesutil.Bytes32(uint64(builderIndex))...)
-	return string(b)
+func executionPayloadBidTupleKey(bid interfaces.ROExecutionPayloadBid) string {
+	parentHash := bid.ParentBlockHash()
+	parentRoot := bid.ParentBlockRoot()
+	b := append(bytesutil.Bytes32(uint64(bid.Slot())), bytesutil.Bytes32(uint64(bid.BuilderIndex()))...)
+	b = append(b, parentHash[:]...)
+	return string(append(b, parentRoot[:]...))
 }
 
-func (s *Service) hasSeenExecutionPayloadBidBuilder(key string) bool {
+func (s *Service) hasSeenExecutionPayloadBid(key string) bool {
 	_, seen := s.seenExecutionPayloadBidCache.Get(key)
 	return seen
 }
 
-func (s *Service) setSeenExecutionPayloadBidBuilder(slot primitives.Slot, key string) {
+func (s *Service) setSeenExecutionPayloadBid(slot primitives.Slot, key string) {
 	s.seenExecutionPayloadBidCache.Add(slot, key, true)
 }
 

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -43,24 +43,41 @@ func TestValidateExecutionPayloadBidGossip_InvalidTopic(t *testing.T) {
 	require.Equal(t, pubsub.ValidationReject, result)
 }
 
-func TestValidateExecutionPayloadBidGossip_AlreadySeenBuilder(t *testing.T) {
+func TestValidateExecutionPayloadBidGossip_AlreadySeenTuple(t *testing.T) {
 	ctx := context.Background()
 	s, msg, signedBid := setupExecutionPayloadBidService(t)
 	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
 
-	key := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	s.setSeenExecutionPayloadBidBuilder(signedBid.Message.Slot, key)
+	key := executionPayloadBidTupleKey(mustBid(t, signedBid))
+	s.setSeenExecutionPayloadBid(signedBid.Message.Slot, key)
 	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
 	require.NoError(t, err)
 	require.Equal(t, pubsub.ValidationIgnore, result)
+}
+
+func TestValidateExecutionPayloadBidGossip_SameBuilderDifferentParentAccepted(t *testing.T) {
+	ctx := context.Background()
+	s, msg, signedBid := setupExecutionPayloadBidService(t)
+	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+
+	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, result)
+
+	other := proto.Clone(signedBid).(*ethpb.SignedExecutionPayloadBid)
+	other.Message.ParentBlockHash = bytesutil.PadTo([]byte{0x09}, 32)
+	msg = executionPayloadBidToPubsub(t, s, s.cfg.p2p, other)
+	result, err = s.validateExecutionPayloadBidGossip(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, result)
 }
 
 // Dedup must short-circuit before every later check; duplicates pay only the cache lookup.
 func TestValidateExecutionPayloadBidGossip_DedupShortCircuitsAllLaterChecks(t *testing.T) {
 	ctx := context.Background()
 	s, msg, signedBid := setupExecutionPayloadBidService(t)
-	key := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	s.setSeenExecutionPayloadBidBuilder(signedBid.Message.Slot, key)
+	key := executionPayloadBidTupleKey(mustBid(t, signedBid))
+	s.setSeenExecutionPayloadBid(signedBid.Message.Slot, key)
 	// Every subsequent verifier method would Reject/Ignore if it ran; the cache hit must skip them all.
 	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
 		errCurrentOrNextSlot:    errors.New("slot"),
@@ -134,8 +151,8 @@ func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name:      "parent root unknown",
-			verifier:  mockExecutionPayloadBidVerifier{errParentBlockRootSeen: errors.New("unknown root")},
+			name:      "bid not compatible with head",
+			verifier:  mockExecutionPayloadBidVerifier{errBidCompatibleWithHead: errors.New("incompatible branch")},
 			result:    pubsub.ValidationIgnore,
 			wantError: true,
 		},
@@ -214,11 +231,10 @@ func TestValidateExecutionPayloadBidGossip_LowerOrEqualBidIgnored(t *testing.T) 
 	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
 	require.NoError(t, err)
 	require.Equal(t, pubsub.ValidationIgnore, result)
-	builderKey := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	require.Equal(t, true, s.hasSeenExecutionPayloadBidBuilder(builderKey))
+	require.Equal(t, true, s.hasSeenExecutionPayloadBid(executionPayloadBidTupleKey(mustBid(t, signedBid))))
 }
 
-func TestValidateExecutionPayloadBidGossip_LowerBidIgnoredStillMarksBuilderSeen(t *testing.T) {
+func TestValidateExecutionPayloadBidGossip_LowerBidIgnoredStillMarksTupleSeen(t *testing.T) {
 	ctx := context.Background()
 	s, msg, signedBid := setupExecutionPayloadBidService(t)
 	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
@@ -231,7 +247,7 @@ func TestValidateExecutionPayloadBidGossip_LowerBidIgnoredStillMarksBuilderSeen(
 	require.NoError(t, err)
 	require.Equal(t, pubsub.ValidationIgnore, result)
 
-	// If the lower valid bid did not mark the builder as seen, the same bid would
+	// If the lower valid bid did not mark the tuple as seen, the same bid would
 	// be accepted once the highest-bid cache is cleared.
 	s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
 	msg = executionPayloadBidToPubsub(t, s, s.cfg.p2p, signedBid)
@@ -268,8 +284,7 @@ func TestValidateExecutionPayloadBidGossip_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, pubsub.ValidationAccept, result)
 
-	builderKey := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
-	require.Equal(t, true, s.hasSeenExecutionPayloadBidBuilder(builderKey))
+	require.Equal(t, true, s.hasSeenExecutionPayloadBid(executionPayloadBidTupleKey(mustBid(t, signedBid))))
 	got, ok := msg.ValidatorData.(*ethpb.SignedExecutionPayloadBid)
 	require.Equal(t, true, ok)
 	require.DeepEqual(t, signedBid, got)
@@ -401,20 +416,21 @@ func TestExecutionPayloadBidSubscriber_NilMessage(t *testing.T) {
 }
 
 type mockExecutionPayloadBidVerifier struct {
-	errCurrentOrNextSlot    error
-	errSlotMatches          error
-	errBuilderActive        error
-	errBuilderVersion       error
-	errExecutionPayment     error
-	errFeeRecipientMismatch error
-	errBlobKzgCommitments   error
-	errPrevRandao           error
-	errGasLimitIncompatible error
-	errParentBlockRootSeen  error
-	errSlotHigherThanParent error
-	errParentBlockHash      error
-	errBuilderCanCoverBid   error
-	errSignature            error
+	errCurrentOrNextSlot     error
+	errSlotMatches           error
+	errBuilderActive         error
+	errBuilderVersion        error
+	errExecutionPayment      error
+	errFeeRecipientMismatch  error
+	errBlobKzgCommitments    error
+	errPrevRandao            error
+	errGasLimitIncompatible  error
+	errParentBlockRootSeen   error
+	errBidCompatibleWithHead error
+	errSlotHigherThanParent  error
+	errParentBlockHash       error
+	errBuilderCanCoverBid    error
+	errSignature             error
 }
 
 var _ verification.ExecutionPayloadBidVerifier = &mockExecutionPayloadBidVerifier{}
@@ -457,6 +473,10 @@ func (m *mockExecutionPayloadBidVerifier) VerifyGasLimitTargetCompatible(uint64,
 
 func (m *mockExecutionPayloadBidVerifier) VerifyParentBlockRootSeen(func([32]byte) bool) error {
 	return m.errParentBlockRootSeen
+}
+
+func (m *mockExecutionPayloadBidVerifier) VerifyBidCompatibleWithHead(func(interfaces.ROExecutionPayloadBid) bool) error {
+	return m.errBidCompatibleWithHead
 }
 
 func (m *mockExecutionPayloadBidVerifier) VerifyBidSlotHigherThanParent(primitives.Slot) error {

--- a/beacon-chain/verification/execution_payload_bid.go
+++ b/beacon-chain/verification/execution_payload_bid.go
@@ -23,7 +23,7 @@ var ExecutionPayloadBidGossipRequirements = []Requirement{
 	RequireBidFeeRecipientMatches,
 	RequireBidBlobKzgCommitmentsLimit,
 	RequireBidPrevRandaoValid,
-	RequireBidParentBlockRootSeen,
+	RequireBidCompatibleWithHead,
 	RequireBidSlotHigherThanParent,
 	RequireBidParentBlockHashValid,
 	RequireBidGasLimitCompatible,
@@ -62,6 +62,7 @@ var (
 	ErrBidPrevRandaoMismatch        = errors.New("bid prev randao does not match state randao mix")
 	ErrBidGasLimitIncompatible      = errors.New("bid gas limit is incompatible with parent and target")
 	ErrBidParentBlockRootNotSeen    = errors.New("parent block root not seen")
+	ErrBidNotCompatibleWithHead     = errors.New("bid is not compatible with the head branch")
 	ErrBidSlotNotHigherThanParent   = errors.New("bid slot is not higher than parent block slot")
 	ErrBidParentBlockHashMismatch   = errors.New("parent block hash does not match forkchoice")
 	ErrBidBuilderCannotCover        = errors.New("builder cannot cover bid")
@@ -269,6 +270,19 @@ func (v *BidVerifier) VerifyParentBlockRootSeen(parentSeen func([32]byte) bool) 
 		return nil
 	}
 	return fmt.Errorf("%w: root=%#x", ErrBidParentBlockRootNotSeen, root)
+}
+
+func (v *BidVerifier) VerifyBidCompatibleWithHead(compatible func(interfaces.ROExecutionPayloadBid) bool) (err error) {
+	defer v.record(RequireBidCompatibleWithHead, &err)
+
+	bid, err := v.b.Bid()
+	if err != nil {
+		return errors.Wrap(err, "failed to get bid")
+	}
+	if compatible != nil && compatible(bid) {
+		return nil
+	}
+	return fmt.Errorf("%w: root=%#x hash=%#x", ErrBidNotCompatibleWithHead, bid.ParentBlockRoot(), bid.ParentBlockHash())
 }
 
 // VerifyBidSlotHigherThanParent verifies the bid slot is greater than the slot of its parent block.

--- a/beacon-chain/verification/execution_payload_bid_test.go
+++ b/beacon-chain/verification/execution_payload_bid_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -136,6 +137,23 @@ func TestBidVerifier_VerifyParentBlockRootSeen(t *testing.T) {
 
 	verifier = &BidVerifier{results: newResults(RequireBidParentBlockRootSeen), b: wrapped}
 	require.ErrorIs(t, verifier.VerifyParentBlockRootSeen(func([32]byte) bool { return false }), ErrBidParentBlockRootNotSeen)
+}
+
+func TestBidVerifier_VerifyBidCompatibleWithHead(t *testing.T) {
+	signed := testSignedExecutionPayloadBid(t, 1)
+	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signed)
+	require.NoError(t, err)
+
+	verifier := &BidVerifier{results: newResults(RequireBidCompatibleWithHead), b: wrapped}
+	require.NoError(t, verifier.VerifyBidCompatibleWithHead(func(bid interfaces.ROExecutionPayloadBid) bool {
+		return bid.ParentBlockRoot() == [32]byte(signed.Message.ParentBlockRoot)
+	}))
+
+	verifier = &BidVerifier{results: newResults(RequireBidCompatibleWithHead), b: wrapped}
+	require.ErrorIs(t, verifier.VerifyBidCompatibleWithHead(func(interfaces.ROExecutionPayloadBid) bool { return false }), ErrBidNotCompatibleWithHead)
+
+	verifier = &BidVerifier{results: newResults(RequireBidCompatibleWithHead), b: wrapped}
+	require.ErrorIs(t, verifier.VerifyBidCompatibleWithHead(nil), ErrBidNotCompatibleWithHead)
 }
 
 func TestBidVerifier_VerifyBidSlotMatches(t *testing.T) {

--- a/beacon-chain/verification/interface.go
+++ b/beacon-chain/verification/interface.go
@@ -109,6 +109,7 @@ type ExecutionPayloadBidVerifier interface {
 	VerifyBlobKzgCommitmentsLimit() error
 	VerifyPrevRandao(state.ReadOnlyBeaconState) error
 	VerifyParentBlockRootSeen(func([32]byte) bool) error
+	VerifyBidCompatibleWithHead(func(interfaces.ROExecutionPayloadBid) bool) error
 	VerifyBidSlotHigherThanParent(parentSlot primitives.Slot) error
 	VerifyParentBlockHash(func([32]byte, [32]byte) bool) error
 	VerifyGasLimitTargetCompatible(parentGasLimit, targetGasLimit uint64) error

--- a/beacon-chain/verification/requirements.go
+++ b/beacon-chain/verification/requirements.go
@@ -54,6 +54,7 @@ const (
 	RequireBidBuilderCanCover
 	RequireBidSignatureValid
 	RequireBidSlotMatches
+	RequireBidCompatibleWithHead
 
 	// Signed proposer preferences specific.
 	RequireProposerPreferencesCurrentOrNextEpoch

--- a/changelog/terence_bid-compatible-with-head.md
+++ b/changelog/terence_bid-compatible-with-head.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Allow builders to bid on multiple branches, deduplicate bids per `(slot, parent_block_hash, parent_block_root)` and only accept bids compatible with the head view.


### PR DESCRIPTION
- Dedup bids per builder on the tuple (slot, parent_block_hash, parent_block_root) instead of per slot
- Replace the known-parent-root gossip check with is_bid_compatible_with_head, accepting only bids that build on the head block (full or empty variant per should_build_on_full) or on the head's parent block
- Spec reference: https://github.com/ethereum/consensus-specs/pull/5497