### PR TITLE
Gloas builder circuit breaker: single builder tracking

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "builder_circuit_breaker.go",
         "chain_info.go",
         "chain_info_forkchoice.go",
         "currently_syncing_block.go",
@@ -119,6 +120,7 @@ go_test(
     size = "medium",
     srcs = [
         "blockchain_test.go",
+        "builder_circuit_breaker_test.go",
         "chain_info_norace_test.go",
         "chain_info_test.go",
         "checktags_test.go",

--- a/beacon-chain/blockchain/builder_circuit_breaker.go
+++ b/beacon-chain/blockchain/builder_circuit_breaker.go
@@ -1,0 +1,69 @@
+package blockchain
+
+import (
+	"fmt"
+
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
+	"github.com/sirupsen/logrus"
+)
+
+// The caller MUST hold the forkchoice write lock.
+func (s *Service) checkBuilderPayloadFailure(blk interfaces.ReadOnlyBeaconBlock) {
+	cb := s.cfg.BuilderCircuitBreaker
+	if cb == nil || blk.Version() < version.Gloas {
+		return
+	}
+	fc := s.cfg.ForkChoiceStore
+	parentRoot := blk.ParentRoot()
+
+	if fc.HasFullNode(parentRoot) {
+		return
+	}
+	parentSlot, err := fc.Slot(parentRoot)
+	if err != nil {
+		return
+	}
+	if parentSlot+1 != blk.Slot() {
+		return
+	}
+	builderIndex, err := fc.BuilderIndex(parentRoot)
+	if err != nil {
+		return
+	}
+	if builderIndex == params.BeaconConfig().BuilderIndexSelfBuild {
+		return
+	}
+	weight, err := fc.ConsensusNodeWeight(parentRoot)
+	if err != nil {
+		return
+	}
+	committeeWeight := fc.CommitteeWeight()
+	if committeeWeight == 0 {
+		return
+	}
+	if weight*100 <= committeeWeight*params.BeaconConfig().BuilderFailureWeightThreshold {
+		return
+	}
+
+	epoch := slots.ToEpoch(blk.Slot())
+	if cb.RecordFailure(builderIndex, parentRoot, epoch) {
+		builderPayloadFailuresTotal.Inc()
+		log.WithFields(logrus.Fields{
+			"builderIndex": builderIndex,
+			"parentRoot":   fmt.Sprintf("%#x", parentRoot),
+			"parentSlot":   parentSlot,
+		}).Warn("Builder failed to reveal payload, blacklisting it")
+	}
+	cb.Prune(epoch)
+	builderBlacklistedCount.Set(float64(cb.BlacklistedCount(epoch)))
+	if cb.SelfBuildOnly(epoch) {
+		builderSelfBuildOnly.Set(1)
+		log.WithField("blacklistedBuilders", cb.BlacklistedCount(epoch)).
+			Warn("Builder circuit breaker tripped, falling back to self-building")
+	} else {
+		builderSelfBuildOnly.Set(0)
+	}
+}

--- a/beacon-chain/blockchain/builder_circuit_breaker_test.go
+++ b/beacon-chain/blockchain/builder_circuit_breaker_test.go
@@ -1,0 +1,186 @@
+package blockchain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	mockExecution "github.com/OffchainLabs/prysm/v7/beacon-chain/execution/testing"
+	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
+	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+)
+
+// gloasBlockWithBid builds a Gloas block committing to blockHash and extending parentBlockHash.
+func gloasBlockWithBid(
+	t *testing.T,
+	slot primitives.Slot,
+	parentRoot [32]byte,
+	blockHash, parentBlockHash [32]byte,
+	builderIndex primitives.BuilderIndex,
+) *ethpb.SignedBeaconBlockGloas {
+	t.Helper()
+	bid := util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			BlockHash:       blockHash[:],
+			ParentBlockHash: parentBlockHash[:],
+			BuilderIndex:    builderIndex,
+		},
+	})
+	return util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{SignedExecutionPayloadBid: bid},
+		},
+	})
+}
+
+// setupBuilderFailureTest inserts a Gloas parent block whose bid names builderIndex, gives the
+// parent enough attestation weight to clear the threshold, and returns the service plus the
+// parent root.
+func setupBuilderFailureTest(
+	t *testing.T,
+	builderIndex primitives.BuilderIndex,
+	balances []uint64,
+) (*Service, [32]byte, [32]byte) {
+	t.Helper()
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	require.NoError(t, params.SetActive(cfg))
+
+	cb := cache.NewBuilderCircuitBreaker(nil)
+	service, tr := setupGloasService(t, &mockExecution.EngineClient{})
+	require.NoError(t, WithBuilderCircuitBreaker(cb)(service))
+	service.cfg.ForkChoiceStore.SetBalancesByRooter(
+		func(context.Context, [32]byte) ([]uint64, error) { return balances, nil })
+
+	parentHash := bytesutil.ToBytes32([]byte("parenthash"))
+	parentRoot := bytesutil.ToBytes32([]byte("parentroot"))
+	base, _ := testGloasState(t, 1, params.BeaconConfig().ZeroHash, parentHash)
+	parentBlk := gloasBlockWithBid(t, 1, params.BeaconConfig().ZeroHash, parentHash, [32]byte{}, builderIndex)
+	insertGloasBlock(t, service, base, parentBlk, parentRoot)
+
+	// One attestation for the parent. UpdateJustifiedCheckpoint pulls the balances in, then Head
+	// folds them into the node weights.
+	service.cfg.ForkChoiceStore.ProcessAttestation(tr.ctx, []uint64{0}, parentRoot, 1, false)
+	require.NoError(t, service.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(
+		tr.ctx, &forkchoicetypes.Checkpoint{Epoch: 0, Root: parentRoot}))
+	_, err := service.cfg.ForkChoiceStore.Head(tr.ctx)
+	require.NoError(t, err)
+
+	return service, parentRoot, parentHash
+}
+
+// childOnEmpty returns a block extending the parent's empty payload.
+func childOnEmpty(t *testing.T, parentRoot [32]byte, slot primitives.Slot, hash byte) interfaces.ReadOnlyBeaconBlock {
+	t.Helper()
+	blk := gloasBlockWithBid(t, slot, parentRoot, bytesutil.ToBytes32([]byte{hash}), [32]byte{}, 3)
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	return signed.Block()
+}
+
+func TestCheckBuilderPayloadFailure_BlacklistsBuilder(t *testing.T) {
+	service, parentRoot, _ := setupBuilderFailureTest(t, 5, []uint64{100})
+
+	service.checkBuilderPayloadFailure(childOnEmpty(t, parentRoot, 2, 1))
+	require.Equal(t, true, service.cfg.BuilderCircuitBreaker.Blacklisted(5, 0))
+}
+
+func TestCheckBuilderPayloadFailure_IdempotentPerParent(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderCriticalFailures = 2
+	cfg.BuilderBlacklistPeriod = 1
+	cfg.BuilderCriticalBlacklistPeriod = 256
+	require.NoError(t, params.SetActive(cfg))
+
+	service, parentRoot, _ := setupBuilderFailureTest(t, 5, []uint64{100})
+
+	// Two children extending the same empty parent must only count as one failure, so the
+	// builder gets the short ban rather than the critical one.
+	service.checkBuilderPayloadFailure(childOnEmpty(t, parentRoot, 2, 1))
+	service.checkBuilderPayloadFailure(childOnEmpty(t, parentRoot, 2, 2))
+	require.Equal(t, true, service.cfg.BuilderCircuitBreaker.Blacklisted(5, 0))
+	require.Equal(t, false, service.cfg.BuilderCircuitBreaker.Blacklisted(5, 1))
+}
+
+func TestCheckBuilderPayloadFailure_NotBlacklistedWhenPayloadPresent(t *testing.T) {
+	service, parentRoot, parentHash := setupBuilderFailureTest(t, 5, []uint64{100})
+
+	// The payload did arrive, so a child on empty is a payload reorg attempt, not a failure.
+	env, err := blocks.WrappedROExecutionPayloadEnvelope(
+		testSignedEnvelope(t, parentRoot, 1, parentHash[:]).Message)
+	require.NoError(t, err)
+	require.NoError(t, service.InsertPayload(env))
+
+	service.checkBuilderPayloadFailure(childOnEmpty(t, parentRoot, 2, 1))
+	require.Equal(t, false, service.cfg.BuilderCircuitBreaker.Blacklisted(5, 0))
+}
+
+func TestCheckBuilderPayloadFailure_NotBlacklistedBelowWeightThreshold(t *testing.T) {
+	// 100 validators of 100 each: committee weight is 312, a single attestation is far below 60%.
+	balances := make([]uint64, 100)
+	for i := range balances {
+		balances[i] = 100
+	}
+	service, parentRoot, _ := setupBuilderFailureTest(t, 5, balances)
+
+	service.checkBuilderPayloadFailure(childOnEmpty(t, parentRoot, 2, 1))
+	require.Equal(t, false, service.cfg.BuilderCircuitBreaker.Blacklisted(5, 0))
+}
+
+func TestCheckBuilderPayloadFailure_NotBlacklistedAcrossSkippedSlot(t *testing.T) {
+	service, parentRoot, _ := setupBuilderFailureTest(t, 5, []uint64{100})
+
+	// Parent is at slot 1, so a child at slot 3 leaves a skipped slot in between.
+	service.checkBuilderPayloadFailure(childOnEmpty(t, parentRoot, 3, 1))
+	require.Equal(t, false, service.cfg.BuilderCircuitBreaker.Blacklisted(5, 0))
+}
+
+func TestCheckBuilderPayloadFailure_NotBlacklistedForSelfBuild(t *testing.T) {
+	selfBuild := params.BeaconConfig().BuilderIndexSelfBuild
+	service, parentRoot, _ := setupBuilderFailureTest(t, selfBuild, []uint64{100})
+
+	service.checkBuilderPayloadFailure(childOnEmpty(t, parentRoot, 2, 1))
+	require.Equal(t, false, service.cfg.BuilderCircuitBreaker.Blacklisted(selfBuild, 0))
+}
+
+// checkBuilderPayloadFailure has no builds-on-full check because forkchoice cannot hold such a
+// block while the parent's payload is missing: insert resolves the child to the parent's full node
+// and rejects it when that node is absent. If this ever stops holding, the circuit breaker would
+// start blacklisting builders whose payload was actually delivered.
+func TestInsertRejectsBuildsOnFullChildWithoutPayload(t *testing.T) {
+	service, parentRoot, parentHash := setupBuilderFailureTest(t, 5, []uint64{100})
+	require.Equal(t, false, service.cfg.ForkChoiceStore.HasFullNode(parentRoot))
+
+	childHash := bytesutil.ToBytes32([]byte("childhash"))
+	base, _ := testGloasState(t, 2, parentRoot, childHash)
+	st, err := state_native.InitializeFromProtoUnsafeGloas(base)
+	require.NoError(t, err)
+	// The child commits to the parent's own block hash, so it claims to build on full.
+	blk := gloasBlockWithBid(t, 2, parentRoot, childHash, parentHash, 3)
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	roblock, err := blocks.NewROBlockWithRoot(signed, bytesutil.ToBytes32([]byte("child")))
+	require.NoError(t, err)
+
+	require.ErrorContains(t, "invalid parent root", service.InsertNode(t.Context(), st, roblock))
+}
+
+func TestCheckBuilderPayloadFailure_NoBreakerConfigured(t *testing.T) {
+	service, _ := setupGloasService(t, &mockExecution.EngineClient{})
+	require.Equal(t, true, service.cfg.BuilderCircuitBreaker == nil)
+	// Must not panic.
+	service.checkBuilderPayloadFailure(childOnEmpty(t, [32]byte{1}, 2, 1))
+}

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -257,6 +257,18 @@ var (
 		Name: "beacon_late_payload_task_triggered_total",
 		Help: "Count the number of times late payload tasks fired.",
 	})
+	builderPayloadFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "builder_payload_failures_total",
+		Help: "Count of builders blacklisted for failing to reveal a payload.",
+	})
+	builderBlacklistedCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "builder_blacklisted_count",
+		Help: "Number of builders currently blacklisted by the circuit breaker.",
+	})
+	builderSelfBuildOnly = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "builder_self_build_only",
+		Help: "1 when the builder circuit breaker forces self-building, 0 otherwise.",
+	})
 	goroutineCountGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "beacon_goroutine_count",
 		Help: "Goroutine count sampled once per slot.",

--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -97,6 +97,14 @@ func WithProposerPreferencesCache(c *cache.ProposerPreferencesCache) Option {
 	}
 }
 
+// WithBuilderCircuitBreaker sets the tracker of builders that failed to reveal their payload.
+func WithBuilderCircuitBreaker(c *cache.BuilderCircuitBreaker) Option {
+	return func(s *Service) error {
+		s.cfg.BuilderCircuitBreaker = c
+		return nil
+	}
+}
+
 // WithSubscribedValidatorsCache sets the cache of validator indices attached
 // to this BN, populated from beacon_committee_subscriptions.
 func WithSubscribedValidatorsCache(c *cache.SubscribedValidatorsCache) Option {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -104,6 +104,9 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 		log.WithError(err).Warn("Could not update head")
 	}
 	newBlockHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
+	// Weights are fresh here: the block's attestations were just fed to forkchoice and Head
+	// recomputed them. A block that lost the head race is still valid evidence about its parent.
+	s.checkBuilderPayloadFailure(cfg.roblock.Block())
 	if cfg.headRoot != cfg.roblock.Root() {
 		s.logNonCanonicalBlockReceived(cfg.roblock.Root(), cfg.headRoot)
 		return nil

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -153,6 +153,9 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 		s.cfg.ForkChoiceStore.Unlock()
 	}
 
+	// A revealed payload clears any recorded failure for this builder.
+	s.cfg.BuilderCircuitBreaker.RecordSuccess(envelope.BuilderIndex())
+
 	if err := s.postPayloadTasks(ctx, envelope, blockState); err != nil {
 		return err
 	}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -80,6 +80,7 @@ type config struct {
 	PayloadIDCache            *cache.PayloadIDCache
 	ProposerPreferencesCache  *cache.ProposerPreferencesCache
 	SubscribedValidatorsCache *cache.SubscribedValidatorsCache
+	BuilderCircuitBreaker     *cache.BuilderCircuitBreaker
 	AttestationCache          *cache.AttestationCache
 	AttestationDataCache      *cache.AttestationDataCache
 	AttPool                   attestations.Pool

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "attestation.go",
         "attestation_data.go",
         "balance_cache_key.go",
+        "builder_circuit_breaker.go",
         "checkpoint_state.go",
         "committee.go",
         "committee_disabled.go",  # keep
@@ -75,6 +76,7 @@ go_test(
         "active_balance_test.go",
         "attestation_data_test.go",
         "attestation_test.go",
+        "builder_circuit_breaker_test.go",
         "cache_test.go",
         "checkpoint_state_test.go",
         "committee_fuzz_test.go",

--- a/beacon-chain/cache/builder_circuit_breaker.go
+++ b/beacon-chain/cache/builder_circuit_breaker.go
@@ -1,0 +1,171 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+)
+
+// builderFailure tracks consecutive payload delivery failures for a single builder index.
+type builderFailure struct {
+	failed              uint64
+	blacklistUntilEpoch primitives.Epoch
+	backOffEpoch        primitives.Epoch // epoch at which `failed` resets to zero
+}
+
+// BuilderCircuitBreaker tracks builders that won an auction but failed to reveal the payload,
+// and blacklists them so their bids are neither propagated nor used for block production.
+//
+// It is written by the blockchain service on block import and read by the sync and validator
+// services, so all methods take the epoch to evaluate against rather than depending on a clock.
+type BuilderCircuitBreaker struct {
+	lock     sync.RWMutex
+	failures map[primitives.BuilderIndex]*builderFailure
+	denied   map[primitives.BuilderIndex]bool
+	recorded map[[32]byte]primitives.Epoch // parent roots whose failure was already recorded, and when
+}
+
+// NewBuilderCircuitBreaker initializes a circuit breaker with an operator supplied denylist of
+// permanently blacklisted builder indices.
+func NewBuilderCircuitBreaker(denylist []primitives.BuilderIndex) *BuilderCircuitBreaker {
+	denied := make(map[primitives.BuilderIndex]bool, len(denylist))
+	for _, idx := range denylist {
+		denied[idx] = true
+	}
+	return &BuilderCircuitBreaker{
+		failures: make(map[primitives.BuilderIndex]*builderFailure),
+		denied:   denied,
+		recorded: make(map[[32]byte]primitives.Epoch),
+	}
+}
+
+// RecordFailure records a missing payload for parentRoot against the given builder and reports
+// whether the builder is blacklisted as a result. Repeated calls for the same parentRoot are ignored, since
+// several children can build on the same empty parent.
+func (c *BuilderCircuitBreaker) RecordFailure(
+	idx primitives.BuilderIndex,
+	parentRoot [32]byte,
+	epoch primitives.Epoch,
+) bool {
+	if c == nil {
+		return false
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if _, ok := c.recorded[parentRoot]; ok {
+		return false
+	}
+	c.recorded[parentRoot] = epoch
+
+	cfg := params.BeaconConfig()
+	f, ok := c.failures[idx]
+	if !ok {
+		f = &builderFailure{}
+		c.failures[idx] = f
+	} else if epoch >= f.backOffEpoch {
+		f.failed = 0
+	}
+	f.failed++
+	f.backOffEpoch = epoch + cfg.BuilderFailureBackOffPeriod
+
+	if f.failed <= cfg.BuilderAllowedFailures {
+		return c.blacklistedAtEpoch(idx, epoch)
+	}
+	period := cfg.BuilderBlacklistPeriod
+	if f.failed >= cfg.BuilderCriticalFailures {
+		period = cfg.BuilderCriticalBlacklistPeriod
+	}
+	if until := epoch + period; until > f.blacklistUntilEpoch {
+		f.blacklistUntilEpoch = until
+	}
+	return true
+}
+
+// RecordSuccess clears a builder's failure record after it reveals a valid payload.
+// The operator denylist is not affected.
+func (c *BuilderCircuitBreaker) RecordSuccess(idx primitives.BuilderIndex) {
+	if c == nil {
+		return
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.failures, idx)
+}
+
+// Blacklisted reports whether the builder's bids must be ignored at the given epoch.
+func (c *BuilderCircuitBreaker) Blacklisted(idx primitives.BuilderIndex, epoch primitives.Epoch) bool {
+	if c == nil {
+		return false
+	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.blacklistedAtEpoch(idx, epoch)
+}
+
+// SelfBuildOnly reports whether enough builders are concurrently blacklisted that the node should
+// stop taking foreign bids altogether. The operator denylist is excluded: it expresses operator
+// intent, not a signal about the health of the payload market.
+func (c *BuilderCircuitBreaker) SelfBuildOnly(epoch primitives.Epoch) bool {
+	if c == nil {
+		return false
+	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	var count uint64
+	for _, f := range c.failures {
+		if f.blacklistUntilEpoch > epoch {
+			count++
+		}
+	}
+	return count >= params.BeaconConfig().BuilderCriticalFailedBuilders
+}
+
+// BlacklistedCount returns the number of builders currently blacklisted by failure tracking.
+func (c *BuilderCircuitBreaker) BlacklistedCount(epoch primitives.Epoch) uint64 {
+	if c == nil {
+		return 0
+	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	var count uint64
+	for _, f := range c.failures {
+		if f.blacklistUntilEpoch > epoch {
+			count++
+		}
+	}
+	return count
+}
+
+// Prune drops records whose blacklist and back off periods have both elapsed, along with recorded
+// roots that can no longer be revisited.
+func (c *BuilderCircuitBreaker) Prune(epoch primitives.Epoch) {
+	if c == nil {
+		return
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for idx, f := range c.failures {
+		if f.blacklistUntilEpoch <= epoch && epoch >= f.backOffEpoch {
+			delete(c.failures, idx)
+		}
+	}
+	for root, at := range c.recorded {
+		if epoch > at+1 {
+			delete(c.recorded, root)
+		}
+	}
+}
+
+// blacklistedAtEpoch requires the caller to hold the lock.
+func (c *BuilderCircuitBreaker) blacklistedAtEpoch(idx primitives.BuilderIndex, epoch primitives.Epoch) bool {
+	if c.denied[idx] {
+		return true
+	}
+	f, ok := c.failures[idx]
+	return ok && f.blacklistUntilEpoch > epoch
+}

--- a/beacon-chain/cache/builder_circuit_breaker_test.go
+++ b/beacon-chain/cache/builder_circuit_breaker_test.go
@@ -1,0 +1,216 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func root(b byte) [32]byte {
+	var r [32]byte
+	r[0] = b
+	return r
+}
+
+func TestBuilderCircuitBreaker_NilSafe(t *testing.T) {
+	var c *BuilderCircuitBreaker
+	require.Equal(t, false, c.Blacklisted(1, 0))
+	require.Equal(t, false, c.RecordFailure(1, root(1), 0))
+	require.Equal(t, false, c.SelfBuildOnly(0))
+	require.Equal(t, uint64(0), c.BlacklistedCount(0))
+	c.RecordSuccess(1)
+	c.Prune(0)
+}
+
+func TestBuilderCircuitBreaker_Denylist(t *testing.T) {
+	c := NewBuilderCircuitBreaker([]primitives.BuilderIndex{7, 9})
+	require.Equal(t, true, c.Blacklisted(7, 0))
+	require.Equal(t, true, c.Blacklisted(9, 1000))
+	require.Equal(t, false, c.Blacklisted(8, 0))
+
+	// A success cannot lift an operator denylist entry.
+	c.RecordSuccess(7)
+	require.Equal(t, true, c.Blacklisted(7, 0))
+
+	// The denylist is operator intent, not a systemic signal.
+	require.Equal(t, uint64(0), c.BlacklistedCount(0))
+}
+
+func TestBuilderCircuitBreaker_AllowedFailures(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 1
+	cfg.BuilderCriticalFailures = 3
+	cfg.BuilderBlacklistPeriod = 2
+	cfg.BuilderFailureBackOffPeriod = 5
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker(nil)
+
+	// First failure is within tolerance.
+	require.Equal(t, false, c.RecordFailure(1, root(1), 10))
+	require.Equal(t, false, c.Blacklisted(1, 10))
+
+	// Second failure exceeds AllowedFailures.
+	require.Equal(t, true, c.RecordFailure(1, root(2), 10))
+	require.Equal(t, true, c.Blacklisted(1, 10))
+	require.Equal(t, true, c.Blacklisted(1, 11))
+	// blacklistUntilEpoch is 12, so the ban has lifted at 12.
+	require.Equal(t, false, c.Blacklisted(1, 12))
+}
+
+func TestBuilderCircuitBreaker_CriticalFailuresBanLonger(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderCriticalFailures = 2
+	cfg.BuilderBlacklistPeriod = 1
+	cfg.BuilderCriticalBlacklistPeriod = 256
+	cfg.BuilderFailureBackOffPeriod = 5
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker(nil)
+	require.Equal(t, true, c.RecordFailure(1, root(1), 10))
+	require.Equal(t, false, c.Blacklisted(1, 11)) // short ban expired
+
+	// A second failure within the back off window escalates to the critical ban.
+	require.Equal(t, true, c.RecordFailure(1, root(2), 12))
+	require.Equal(t, true, c.Blacklisted(1, 200))
+	require.Equal(t, true, c.Blacklisted(1, 267))
+	require.Equal(t, false, c.Blacklisted(1, 268))
+}
+
+// A builder is whitelisted again at blacklistUntilEpoch while its failure counter lives on until
+// backOffEpoch, so a repeat offense in between escalates instead of starting over.
+func TestBuilderCircuitBreaker_WhitelistedBeforeCounterResets(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderCriticalFailures = 2
+	cfg.BuilderBlacklistPeriod = 1      // ban lifts at epoch 6
+	cfg.BuilderFailureBackOffPeriod = 3 // counter resets at epoch 8
+	cfg.BuilderCriticalBlacklistPeriod = 256
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker(nil)
+	require.Equal(t, true, c.RecordFailure(1, root(1), 5))
+	require.Equal(t, true, c.Blacklisted(1, 5))
+	require.Equal(t, false, c.Blacklisted(1, 6))
+
+	// Pruning while the back off window is open must not drop the counter.
+	c.Prune(6)
+	c.lock.RLock()
+	require.Equal(t, uint64(1), c.failures[1].failed)
+	c.lock.RUnlock()
+
+	// Still inside the window, so this is the second offense and earns the long ban.
+	require.Equal(t, true, c.RecordFailure(1, root(2), 7))
+	require.Equal(t, true, c.Blacklisted(1, 100))
+	require.Equal(t, true, c.Blacklisted(1, 262))
+	require.Equal(t, false, c.Blacklisted(1, 263))
+}
+
+func TestBuilderCircuitBreaker_BackOffResetsCounter(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderCriticalFailures = 2
+	cfg.BuilderBlacklistPeriod = 1
+	cfg.BuilderCriticalBlacklistPeriod = 256
+	cfg.BuilderFailureBackOffPeriod = 5
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker(nil)
+	require.Equal(t, true, c.RecordFailure(1, root(1), 10))
+
+	// Failing again after the back off period is a first offense again, so only a short ban.
+	require.Equal(t, true, c.RecordFailure(1, root(2), 20))
+	require.Equal(t, true, c.Blacklisted(1, 20))
+	require.Equal(t, false, c.Blacklisted(1, 21))
+}
+
+func TestBuilderCircuitBreaker_RecordSuccessClearsBan(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderCriticalFailures = 2
+	cfg.BuilderCriticalBlacklistPeriod = 256
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker(nil)
+	require.Equal(t, true, c.RecordFailure(1, root(1), 10))
+	require.Equal(t, true, c.RecordFailure(1, root(2), 10))
+	require.Equal(t, true, c.Blacklisted(1, 100))
+
+	c.RecordSuccess(1)
+	require.Equal(t, false, c.Blacklisted(1, 100))
+	require.Equal(t, uint64(0), c.BlacklistedCount(100))
+}
+
+func TestBuilderCircuitBreaker_IdempotentPerRoot(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderCriticalFailures = 2
+	cfg.BuilderBlacklistPeriod = 1
+	cfg.BuilderCriticalBlacklistPeriod = 256
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker(nil)
+	r := root(1)
+	require.Equal(t, true, c.RecordFailure(1, r, 10))
+	// Two children building on the same empty parent must not escalate to a critical ban.
+	require.Equal(t, false, c.RecordFailure(1, r, 10))
+	require.Equal(t, false, c.Blacklisted(1, 11))
+}
+
+func TestBuilderCircuitBreaker_SelfBuildOnlyThreshold(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderBlacklistPeriod = 10
+	cfg.BuilderCriticalFailedBuilders = 3
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker([]primitives.BuilderIndex{99})
+	require.Equal(t, false, c.SelfBuildOnly(0))
+
+	for i := 0; i < 2; i++ {
+		require.Equal(t, true, c.RecordFailure(primitives.BuilderIndex(i), root(byte(i)), 0))
+	}
+	require.Equal(t, false, c.SelfBuildOnly(0))
+
+	require.Equal(t, true, c.RecordFailure(2, root(2), 0))
+	require.Equal(t, uint64(3), c.BlacklistedCount(0))
+	require.Equal(t, true, c.SelfBuildOnly(0))
+
+	// Bans expire and the breaker re-opens.
+	require.Equal(t, false, c.SelfBuildOnly(10))
+}
+
+func TestBuilderCircuitBreaker_Prune(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BuilderAllowedFailures = 0
+	cfg.BuilderBlacklistPeriod = 1
+	cfg.BuilderFailureBackOffPeriod = 2
+	require.NoError(t, params.SetActive(cfg))
+
+	c := NewBuilderCircuitBreaker(nil)
+	require.Equal(t, true, c.RecordFailure(1, root(1), 10))
+
+	// Still inside the back off window, the record must survive so a repeat offense escalates.
+	c.Prune(11)
+	c.lock.RLock()
+	require.Equal(t, 1, len(c.failures))
+	require.Equal(t, 1, len(c.recorded))
+	c.lock.RUnlock()
+
+	c.Prune(13)
+	c.lock.RLock()
+	require.Equal(t, 0, len(c.failures))
+	require.Equal(t, 0, len(c.recorded))
+	c.lock.RUnlock()
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -750,6 +750,11 @@ func (f *ForkChoice) ConsensusNodeWeight(root [32]byte) (uint64, error) {
 	return n.node.weight, nil
 }
 
+// CommitteeWeight returns the total active balance per slot, as last computed at the justified checkpoint.
+func (f *ForkChoice) CommitteeWeight() uint64 {
+	return f.store.committeeWeight
+}
+
 // PayloadWeights returns the empty and full payload node weights for the given root.
 func (f *ForkChoice) PayloadWeights(root [32]byte) (emptyWeight, fullWeight uint64, err error) {
 	en, ok := f.store.emptyNodeByRoot[root]

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -41,7 +41,7 @@ func (f *ForkChoice) CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool) 
 	return pn.node.root, pn.full
 }
 
-func (s *Store) resolveParentPayloadStatus(block interfaces.ReadOnlyBeaconBlock, parent **PayloadNode, blockHash *[32]byte) error {
+func (s *Store) resolveParentPayloadStatus(block interfaces.ReadOnlyBeaconBlock, parent **PayloadNode, blockHash *[32]byte, builderIndex *primitives.BuilderIndex) error {
 	sb, err := block.Body().SignedExecutionPayloadBid()
 	if err != nil {
 		return err
@@ -55,6 +55,7 @@ func (s *Store) resolveParentPayloadStatus(block interfaces.ReadOnlyBeaconBlock,
 		return errors.Wrap(err, "failed to get bid from wrapped bid")
 	}
 	*blockHash = bid.BlockHash()
+	*builderIndex = bid.BuilderIndex()
 	parentRoot := block.ParentRoot()
 	*parent = s.emptyNodeByRoot[parentRoot]
 	if *parent == nil {
@@ -626,6 +627,15 @@ func (f *ForkChoice) ParentHash(root [32]byte) [32]byte {
 		return [32]byte{}
 	}
 	return f.store.parentHash(en)
+}
+
+// BuilderIndex returns the builder index committed in the given block's bid.
+func (f *ForkChoice) BuilderIndex(root [32]byte) (primitives.BuilderIndex, error) {
+	en := f.store.emptyNodeByRoot[root]
+	if en == nil || en.node == nil {
+		return 0, errors.Wrap(ErrNilNode, "could not get builder index for root")
+	}
+	return en.node.builderIndex, nil
 }
 
 // BlockHash returns the hash committed in the given block

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -360,6 +360,45 @@ func TestBlockHash_ReturnsBlockHash(t *testing.T) {
 	assert.Equal(t, blockHash, got)
 }
 
+func TestBuilderIndex(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+
+	root := indexToHash(1)
+	st, roblock, err := prepareGloasForkchoiceState(ctx, 1, root, params.BeaconConfig().ZeroHash, indexToHash(100), params.BeaconConfig().ZeroHash, 0, 0)
+	require.NoError(t, err)
+	// Rebuild the block with a non-default builder index.
+	blk := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot: 1,
+			Body: &ethpb.BeaconBlockBodyGloas{
+				SignedExecutionPayloadBid: util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
+					Message: &ethpb.ExecutionPayloadBid{BuilderIndex: 42},
+				}),
+			},
+		},
+	})
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	roblock, err = blocks.NewROBlockWithRoot(signed, root)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	got, err := f.BuilderIndex(root)
+	require.NoError(t, err)
+	assert.Equal(t, primitives.BuilderIndex(42), got)
+
+	_, err = f.BuilderIndex(indexToHash(999))
+	require.ErrorContains(t, ErrNilNode.Error(), err)
+}
+
+func TestCommitteeWeight(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	assert.Equal(t, uint64(0), f.CommitteeWeight())
+	f.store.committeeWeight = 320
+	assert.Equal(t, uint64(320), f.CommitteeWeight())
+}
+
 func TestBlockHash_UnknownRoot(t *testing.T) {
 	f := setupGloas(t, 0, 0)
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -87,8 +87,9 @@ func (s *Store) insert(ctx context.Context,
 	var parent *PayloadNode
 	blockHash := &[32]byte{}
 	var gasLimit uint64
+	var builderIndex primitives.BuilderIndex
 	if block.Version() >= version.Gloas {
-		if err := s.resolveParentPayloadStatus(block, &parent, blockHash); err != nil {
+		if err := s.resolveParentPayloadStatus(block, &parent, blockHash, &builderIndex); err != nil {
 			return nil, err
 		}
 	} else {
@@ -112,6 +113,7 @@ func (s *Store) insert(ctx context.Context,
 	n := &Node{
 		slot:                        slot,
 		proposerIndex:               block.ProposerIndex(),
+		builderIndex:                builderIndex,
 		root:                        root,
 		parent:                      parent,
 		justifiedEpoch:              justifiedEpoch,

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -54,6 +54,7 @@ type Store struct {
 type Node struct {
 	slot                        primitives.Slot              // slot of the block converted to the node.
 	proposerIndex               primitives.ValidatorIndex    // proposer index of the block.
+	builderIndex                primitives.BuilderIndex      // builder index committed in the block's bid (Gloas only).
 	root                        [fieldparams.RootLength]byte // root of the block converted to the node.
 	blockHash                   [fieldparams.RootLength]byte // payloadHash of the block converted to the node.
 	parent                      *PayloadNode                 // parent index of this node.

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -95,6 +95,8 @@ type FastGetter interface {
 	UnrealizedJustifiedPayloadBlockHash() [32]byte
 	Weight(root [32]byte) (uint64, error)
 	ConsensusNodeWeight(root [32]byte) (uint64, error)
+	CommitteeWeight() uint64
+	BuilderIndex(root [32]byte) (primitives.BuilderIndex, error)
 	PayloadWeights(root [32]byte) (emptyWeight, fullWeight uint64, err error)
 	HasPayloadBlockHash(root, blockHash [32]byte) bool
 	PTCVotedEarlyAndAvailable(root [32]byte) bool

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -170,6 +170,20 @@ func (ro *ROForkChoice) ConsensusNodeWeight(root [32]byte) (uint64, error) {
 	return ro.getter.ConsensusNodeWeight(root)
 }
 
+// CommitteeWeight delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) CommitteeWeight() uint64 {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.CommitteeWeight()
+}
+
+// BuilderIndex delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) BuilderIndex(root [32]byte) (primitives.BuilderIndex, error) {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.BuilderIndex(root)
+}
+
 // PayloadWeights delegates to the underlying forkchoice call, under a lock.
 func (ro *ROForkChoice) PayloadWeights(root [32]byte) (uint64, uint64, error) {
 	ro.l.RLock()

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -37,6 +37,8 @@ const (
 	receivedBlocksLastEpochCalled
 	weightCalled
 	consensusNodeWeightCalled
+	committeeWeightCalled
+	builderIndexCalled
 	isOptimisticCalled
 	shouldOverrideFCUCalled
 	slotCalled
@@ -162,6 +164,16 @@ func TestROLocking(t *testing.T) {
 			name: "consensusNodeWeightCalled",
 			call: consensusNodeWeightCalled,
 			cb:   func(g FastGetter) { _, err := g.ConsensusNodeWeight([32]byte{}); _discard(t, err) },
+		},
+		{
+			name: "committeeWeightCalled",
+			call: committeeWeightCalled,
+			cb:   func(g FastGetter) { g.CommitteeWeight() },
+		},
+		{
+			name: "builderIndexCalled",
+			call: builderIndexCalled,
+			cb:   func(g FastGetter) { _, err := g.BuilderIndex([32]byte{}); _discard(t, err) },
 		},
 		{
 			name: "isOptimisticCalled",
@@ -342,6 +354,16 @@ func (ro *mockROForkchoice) Weight(_ [32]byte) (uint64, error) {
 
 func (ro *mockROForkchoice) ConsensusNodeWeight(_ [32]byte) (uint64, error) {
 	ro.calls = append(ro.calls, consensusNodeWeightCalled)
+	return 0, nil
+}
+
+func (ro *mockROForkchoice) CommitteeWeight() uint64 {
+	ro.calls = append(ro.calls, committeeWeightCalled)
+	return 0
+}
+
+func (ro *mockROForkchoice) BuilderIndex(_ [32]byte) (primitives.BuilderIndex, error) {
+	ro.calls = append(ro.calls, builderIndexCalled)
 	return 0, nil
 }
 

--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -2,6 +2,8 @@ package node
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
@@ -9,6 +11,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
 
@@ -50,6 +53,20 @@ func configureHistoricalSlasher(cliCtx *cli.Context) error {
 		)
 	}
 	return nil
+}
+
+// builderIndexDenylist parses the operator supplied list of permanently blacklisted builder indices.
+func builderIndexDenylist(cliCtx *cli.Context) ([]primitives.BuilderIndex, error) {
+	raw := cliCtx.StringSlice(flags.BuilderIndexDenylist.Name)
+	indices := make([]primitives.BuilderIndex, 0, len(raw))
+	for _, entry := range raw {
+		idx, err := strconv.ParseUint(strings.TrimSpace(entry), 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid builder index %q in --%s", entry, flags.BuilderIndexDenylist.Name)
+		}
+		indices = append(indices, primitives.BuilderIndex(idx))
+	}
+	return indices, nil
 }
 
 func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -107,6 +107,7 @@ type BeaconNode struct {
 	depositCache              cache.DepositCache
 	proposerPreferencesCache  *cache.ProposerPreferencesCache
 	subscribedValidatorsCache *cache.SubscribedValidatorsCache
+	builderCircuitBreaker     *cache.BuilderCircuitBreaker
 	payloadIDCache            *cache.PayloadIDCache
 	executionPayloadCache     *cache.ExecutionPayloadEnvelopeCache
 	stateFeed                 *event.Feed
@@ -154,6 +155,11 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, optFuncs []func(*cli.Co
 	}
 	ctx := cliCtx.Context
 
+	builderDenylist, err := builderIndexDenylist(cliCtx)
+	if err != nil {
+		return nil, err
+	}
+
 	beacon := &BeaconNode{
 		cliCtx:                    cliCtx,
 		ctx:                       ctx,
@@ -173,6 +179,7 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, optFuncs []func(*cli.Co
 		blsToExecPool:             blstoexec.NewPool(),
 		proposerPreferencesCache:  cache.NewProposerPreferencesCache(),
 		subscribedValidatorsCache: cache.NewSubscribedValidatorsCache(),
+		builderCircuitBreaker:     cache.NewBuilderCircuitBreaker(builderDenylist),
 		payloadIDCache:            cache.NewPayloadIDCache(),
 		executionPayloadCache:     cache.NewExecutionPayloadEnvelopeCache(),
 		slasherBlockHeadersFeed:   new(event.Feed),
@@ -780,6 +787,7 @@ func (b *BeaconNode) registerBlockchainService(fc forkchoice.ForkChoicer, gs *st
 		blockchain.WithDataColumnStorage(b.DataColumnStorage),
 		blockchain.WithProposerPreferencesCache(b.proposerPreferencesCache),
 		blockchain.WithSubscribedValidatorsCache(b.subscribedValidatorsCache),
+		blockchain.WithBuilderCircuitBreaker(b.builderCircuitBreaker),
 		blockchain.WithPayloadIDCache(b.payloadIDCache),
 		blockchain.WithSyncChecker(b.syncChecker),
 		blockchain.WithSlasherEnabled(b.slasherEnabled),
@@ -880,6 +888,7 @@ func (b *BeaconNode) registerSyncService(initialSyncComplete chan struct{}, bFil
 		regularsync.WithAvailableBlocker(bFillStore),
 		regularsync.WithProposerPreferencesCache(b.proposerPreferencesCache),
 		regularsync.WithSubscribedValidatorsCache(b.subscribedValidatorsCache),
+		regularsync.WithBuilderCircuitBreaker(b.builderCircuitBreaker),
 		regularsync.WithSlasherEnabled(b.slasherEnabled),
 		regularsync.WithLightClientStore(b.lcStore),
 		regularsync.WithBatchVerifierLimit(b.cliCtx.Int(flags.BatchVerifierLimit.Name)),
@@ -1042,6 +1051,7 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		DataColumnStorage:                b.DataColumnStorage,
 		ProposerPreferencesCache:         b.proposerPreferencesCache,
 		SubscribedValidatorsCache:        b.subscribedValidatorsCache,
+		BuilderCircuitBreaker:            b.builderCircuitBreaker,
 		HighestBidCache:                  regularSyncService.HighestExecutionPayloadBidCache(),
 		PayloadIDCache:                   b.payloadIDCache,
 		ExecutionPayloadEnvelopeCache:    b.executionPayloadCache,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -21,6 +21,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/io/logs"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -172,8 +173,13 @@ func (vs *Server) getBuilderExecutionPayloadBid(ctx context.Context, head state.
 		bestValue primitives.Gwei
 	)
 	bidLog := make([]string, 0, len(bids))
+	epoch := slots.ToEpoch(q.slot)
 	for _, pb := range bids {
 		if pb.Bid == nil {
+			continue
+		}
+		if vs.BuilderCircuitBreaker.Blacklisted(pb.Bid.Message.BuilderIndex, epoch) {
+			bidLog = append(bidLog, fmt.Sprintf("%s(builder=%d discarded: blacklisted)", logs.MaskCredentialsLogging(pb.BuilderURL), pb.Bid.Message.BuilderIndex))
 			continue
 		}
 		if err := vs.validateBuilderBid(head, pb.Bid, q); err != nil {
@@ -298,6 +304,8 @@ func (vs *Server) submitBlockToBuilder(block interfaces.ReadOnlySignedBeaconBloc
 }
 
 // setP2PBidFallback uses a cached P2P bid when the local EL self-build is unavailable.
+// The circuit breaker is deliberately not consulted here: with no local payload at all, a block
+// carrying a possibly-undelivered bid still beats missing the slot outright.
 func (vs *Server) setP2PBidFallback(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, parentFull bool) error {
 	if vs.HighestBidCache == nil {
 		return errors.New("highest bid cache is nil")
@@ -326,6 +334,10 @@ func (vs *Server) cachedP2PBid(sBlk interfaces.SignedBeaconBlock, local *consens
 	copy(parentHash[:], local.ExecutionData.ParentHash())
 	cached, ok := vs.HighestBidCache.Get(sBlk.Block().Slot(), parentHash, sBlk.Block().ParentRoot())
 	if !ok {
+		return nil
+	}
+	// The bid may have been cached before the builder was blacklisted.
+	if vs.BuilderCircuitBreaker.Blacklisted(cached.Message.BuilderIndex, slots.ToEpoch(sBlk.Block().Slot())) {
 		return nil
 	}
 	return cached

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
@@ -9,6 +9,7 @@ import (
 
 	beaconbuilder "github.com/OffchainLabs/prysm/v7/beacon-chain/builder"
 	builderTest "github.com/OffchainLabs/prysm/v7/beacon-chain/builder/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -311,6 +312,28 @@ func TestGetBuilderExecutionPayloadBid(t *testing.T) {
 		got, _ := vs.getBuilderExecutionPayloadBid(t.Context(), head, query(auths))
 		require.NotNil(t, got)
 		require.Equal(t, primitives.BuilderIndex(1), got.Message.BuilderIndex)
+	})
+
+	t.Run("discards blacklisted builders", func(t *testing.T) {
+		vs := &Server{
+			BlockBuilder:                   &builderTest.MockBuilderService{PayloadBids: []beaconbuilder.PayloadBid{bid(1, 500), bid(2, 1500)}},
+			NewExecutionPayloadBidVerifier: passAll,
+			BuilderCircuitBreaker:          cache.NewBuilderCircuitBreaker([]primitives.BuilderIndex{2}),
+		}
+		got, _ := vs.getBuilderExecutionPayloadBid(t.Context(), head, query(auths))
+		require.NotNil(t, got)
+		require.Equal(t, primitives.BuilderIndex(1), got.Message.BuilderIndex)
+	})
+
+	t.Run("nil when all blacklisted", func(t *testing.T) {
+		vs := &Server{
+			BlockBuilder:                   &builderTest.MockBuilderService{PayloadBids: []beaconbuilder.PayloadBid{bid(1, 500)}},
+			NewExecutionPayloadBidVerifier: passAll,
+			BuilderCircuitBreaker:          cache.NewBuilderCircuitBreaker([]primitives.BuilderIndex{1}),
+		}
+		got, url := vs.getBuilderExecutionPayloadBid(t.Context(), head, query(auths))
+		require.IsNil(t, got)
+		require.Equal(t, "", url)
 	})
 
 	t.Run("nil when all invalid", func(t *testing.T) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_test.go
@@ -229,6 +229,75 @@ func TestSetExecutionPayloadBid_PrefersP2PBid(t *testing.T) {
 	require.Equal(t, primitives.Gwei(500), signedBid.Message.ExecutionPayment)
 }
 
+// A cached P2P bid from a blacklisted builder must be ignored, even though it outbids the local
+// payload: bids can be cached before the ban lands.
+func TestSetExecutionPayloadBid_IgnoresBlacklistedP2PBid(t *testing.T) {
+	parentHash := [32]byte{10, 20, 30}
+	parentRoot := [32]byte{1, 2, 3}
+	slot := primitives.Slot(100)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	payload := &enginev1.ExecutionPayloadDeneb{
+		ParentHash:    parentHash[:],
+		FeeRecipient:  make([]byte, 20),
+		StateRoot:     make([]byte, 32),
+		ReceiptsRoot:  make([]byte, 32),
+		LogsBloom:     make([]byte, 256),
+		PrevRandao:    make([]byte, 32),
+		BaseFeePerGas: make([]byte, 32),
+		BlockHash:     make([]byte, 32),
+		ExtraData:     make([]byte, 0),
+	}
+	ed, err := consensusblocks.WrappedExecutionPayloadDeneb(payload)
+	require.NoError(t, err)
+	local := &consensusblocks.GetPayloadResponse{
+		ExecutionData:          ed,
+		Bid:                    big.NewInt(0),
+		BlobsBundler:           &enginev1.BlobsBundle{},
+		ExecutionRequestsGloas: &enginev1.ExecutionRequestsGloas{},
+	}
+
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	bidCache.SetIfHigher(&ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			Slot:                  slot,
+			ParentBlockHash:       parentHash[:],
+			ParentBlockRoot:       parentRoot[:],
+			BlockHash:             make([]byte, 32),
+			BuilderIndex:          5,
+			Value:                 1000,
+			ExecutionPayment:      500,
+			FeeRecipient:          make([]byte, 20),
+			GasLimit:              30_000_000,
+			PrevRandao:            make([]byte, 32),
+			BlobKzgCommitments:    [][]byte{},
+			ExecutionRequestsRoot: make([]byte, 32),
+		},
+		Signature: make([]byte, 96),
+	})
+
+	vs := &Server{
+		HighestBidCache:       bidCache,
+		BuilderCircuitBreaker: cache.NewBuilderCircuitBreaker([]primitives.BuilderIndex{5}),
+	}
+
+	src, err := vs.setExecutionPayloadBid(t.Context(), sBlk, local, nil, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, bidSourceSelfBuild, src)
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.Equal(t, params.BeaconConfig().BuilderIndexSelfBuild, signedBid.Message.BuilderIndex)
+}
+
 func TestSetExecutionPayloadBid_PrefersLocalWhenHigherValue(t *testing.T) {
 	parentHash := [32]byte{10, 20, 30}
 	parentRoot := [32]byte{1, 2, 3}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -42,7 +43,10 @@ func (vs *Server) buildBlockGloas(ctx context.Context, sBlk interfaces.SignedBea
 			return nil, status.Errorf(codes.Internal, "Could not get local payload and no P2P bid fallback: %v", fbErr)
 		}
 	} else {
-		selfBuildOnly := local.OverrideBuilder || skipBuilder
+		// The circuit breaker gate is applied here rather than at bid selection so the builder-API
+		// round trip is skipped too.
+		epoch := slots.ToEpoch(sBlk.Block().Slot())
+		selfBuildOnly := local.OverrideBuilder || skipBuilder || vs.BuilderCircuitBreaker.SelfBuildOnly(epoch)
 		var builderBid *ethpb.SignedExecutionPayloadBid
 		var builderURL string
 		var maxExecutionPayment uint64

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
@@ -40,6 +40,11 @@ func (vs *Server) SubmitSignedExecutionPayloadBid(
 			"execution payload bids are not supported before Gloas fork (slot %d)", req.Message.Slot)
 	}
 
+	// Do not broadcast a bid this node would itself ignore on gossip.
+	if vs.BuilderCircuitBreaker.Blacklisted(req.Message.BuilderIndex, slots.ToEpoch(req.Message.Slot)) {
+		return nil, status.Errorf(codes.FailedPrecondition, "builder %d is blacklisted by the circuit breaker", req.Message.BuilderIndex)
+	}
+
 	if err := vs.validateSubmittedBid(ctx, req); err != nil {
 		return nil, err
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	ProposerPreferencesCache         *cache.ProposerPreferencesCache
 	SubscribedValidatorsCache        *cache.SubscribedValidatorsCache
 	HighestBidCache                  *cache.HighestExecutionPayloadBidCache
+	BuilderCircuitBreaker            *cache.BuilderCircuitBreaker
 	ExecutionPayloadEnvelopeCache    *cache.ExecutionPayloadEnvelopeCache
 	HeadFetcher                      blockchain.HeadFetcher
 	ForkFetcher                      blockchain.ForkFetcher

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -132,6 +132,7 @@ type Config struct {
 	ProposerPreferencesCache         *cache.ProposerPreferencesCache
 	SubscribedValidatorsCache        *cache.SubscribedValidatorsCache
 	HighestBidCache                  *cache.HighestExecutionPayloadBidCache
+	BuilderCircuitBreaker            *cache.BuilderCircuitBreaker
 	PayloadIDCache                   *cache.PayloadIDCache
 	ExecutionPayloadEnvelopeCache    *cache.ExecutionPayloadEnvelopeCache
 	LCStore                          *lightClient.Store
@@ -272,6 +273,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		ProposerPreferencesCache:         s.cfg.ProposerPreferencesCache,
 		SubscribedValidatorsCache:        s.cfg.SubscribedValidatorsCache,
 		HighestBidCache:                  s.cfg.HighestBidCache,
+		BuilderCircuitBreaker:            s.cfg.BuilderCircuitBreaker,
 		PayloadIDCache:                   s.cfg.PayloadIDCache,
 		ExecutionPayloadEnvelopeCache:    s.cfg.ExecutionPayloadEnvelopeCache,
 		AttestationStateFetcher:          s.cfg.AttestationReceiver,

--- a/beacon-chain/sync/options.go
+++ b/beacon-chain/sync/options.go
@@ -214,6 +214,14 @@ func WithProposerPreferencesCache(c *cache.ProposerPreferencesCache) Option {
 	}
 }
 
+// WithBuilderCircuitBreaker sets the tracker used to ignore bids from blacklisted builders.
+func WithBuilderCircuitBreaker(c *cache.BuilderCircuitBreaker) Option {
+	return func(s *Service) error {
+		s.builderCircuitBreaker = c
+		return nil
+	}
+}
+
 func WithSubscribedValidatorsCache(c *cache.SubscribedValidatorsCache) Option {
 	return func(s *Service) error {
 		s.subscribedValidatorsCache = c

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -204,6 +204,7 @@ type Service struct {
 	payloadAttestationCache              *cache.PayloadAttestationCache
 	proposerPreferencesCache             *cache.ProposerPreferencesCache
 	subscribedValidatorsCache            *cache.SubscribedValidatorsCache
+	builderCircuitBreaker                *cache.BuilderCircuitBreaker
 	digestActions                        perDigestSet
 	subscriptionSpawner                  func(func()) // see Service.spawn for details
 	newExecutionPayloadEnvelopeVerifier  verification.NewExecutionPayloadEnvelopeVerifier

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -58,6 +58,11 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 		return pubsub.ValidationIgnore, err
 	}
 
+	// [IGNORE] local policy: this builder is blacklisted by the circuit breaker.
+	if s.builderCircuitBreaker.Blacklisted(bid.BuilderIndex(), slots.ToEpoch(bid.Slot())) {
+		return pubsub.ValidationIgnore, nil
+	}
+
 	// [IGNORE] this is the first signed bid seen with a valid signature from the given builder for this slot.
 	// Cache is populated only after VerifySignature below; a hit here implies a valid-sig bid was already seen.
 	builderKey := executionPayloadBidBuilderKey(bid.Slot(), bid.BuilderIndex())

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -275,6 +275,45 @@ func TestValidateExecutionPayloadBidGossip_HappyPath(t *testing.T) {
 	require.DeepEqual(t, signedBid, got)
 }
 
+// A blacklisted builder must be ignored before any verification runs, and must not be cached.
+func TestValidateExecutionPayloadBidGossip_BlacklistedBuilderIgnored(t *testing.T) {
+	ctx := context.Background()
+	s, msg, signedBid := setupExecutionPayloadBidService(t)
+	s.builderCircuitBreaker = cache.NewBuilderCircuitBreaker(
+		[]primitives.BuilderIndex{signedBid.Message.BuilderIndex})
+	// Every verifier method would reject if reached.
+	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{
+		errCurrentOrNextSlot: errors.New("slot"),
+		errBuilderActive:     errors.New("builder"),
+		errSignature:         errors.New("sig"),
+	})
+
+	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+
+	builderKey := executionPayloadBidBuilderKey(signedBid.Message.Slot, signedBid.Message.BuilderIndex)
+	require.Equal(t, false, s.hasSeenExecutionPayloadBidBuilder(builderKey))
+	_, cached := s.highestExecutionPayloadBidCache.Get(
+		signedBid.Message.Slot,
+		bytesutil.ToBytes32(signedBid.Message.ParentBlockHash),
+		bytesutil.ToBytes32(signedBid.Message.ParentBlockRoot))
+	require.Equal(t, false, cached)
+}
+
+// A bid from a builder that is not blacklisted is unaffected by the circuit breaker.
+func TestValidateExecutionPayloadBidGossip_OtherBuilderNotBlacklisted(t *testing.T) {
+	ctx := context.Background()
+	s, msg, signedBid := setupExecutionPayloadBidService(t)
+	s.builderCircuitBreaker = cache.NewBuilderCircuitBreaker(
+		[]primitives.BuilderIndex{signedBid.Message.BuilderIndex + 1})
+	s.newExecutionPayloadBidVerifier = testNewExecutionPayloadBidVerifier(mockExecutionPayloadBidVerifier{})
+
+	result, err := s.validateExecutionPayloadBidGossip(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, result)
+}
+
 func TestValidateExecutionPayloadBidGossip_NextSlotStateMissIgnored(t *testing.T) {
 	ctx := context.Background()
 	s, msg, _ := setupExecutionPayloadBidService(t)

--- a/changelog/potuz_gloas-builder-circuit-breaker.md
+++ b/changelog/potuz_gloas-builder-circuit-breaker.md
@@ -1,0 +1,3 @@
+### Added
+
+- Gloas builder circuit breaker: blacklist builders that win an auction but never reveal the payload.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -54,6 +54,12 @@ var (
 		Usage:       "Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window",
 		DefaultText: fmt.Sprintf("%d", params.BeaconConfig().MaxBuilderEpochMissedSlots),
 	}
+	// BuilderIndexDenylist permanently blacklists the given Gloas builder indices.
+	BuilderIndexDenylist = &cli.StringSliceFlag{
+		Name: "builder-index-denylist",
+		Usage: "Comma separated list of Gloas builder indices whose bids this node will always ignore. Builder indices are " +
+			"reused when a builder exits, so keep this list up to date or restrict it to builders you never intend to use.",
+	}
 	// LocalBlockValueBoost sets a percentage boost for local block construction while using a custom builder.
 	LocalBlockValueBoost = &cli.Uint64Flag{
 		Name: "local-block-value-boost",

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -82,6 +82,7 @@ var appFlags = []cli.Flag{
 	flags.TerminalBlockHashActivationEpochOverride,
 	flags.MevRelayEndpoint,
 	flags.MaxBuilderEpochMissedSlots,
+	flags.BuilderIndexDenylist,
 	flags.MaxBuilderConsecutiveMissedSlots,
 	flags.EngineEndpointTimeoutSeconds,
 	flags.LocalBlockValueBoost,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -141,6 +141,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.LocalBlockValueBoost,
 			flags.MaxBuilderConsecutiveMissedSlots,
 			flags.MaxBuilderEpochMissedSlots,
+			flags.BuilderIndexDenylist,
 			flags.MevRelayEndpoint,
 			flags.MinBuilderBid,
 			flags.MinBuilderDiff,

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -267,6 +267,16 @@ type BeaconChainConfig struct {
 	LocalBlockValueBoost             uint64          // LocalBlockValueBoost is the value boost for local block construction. This is used to prioritize local block construction over relay/builder block construction.
 	MinBuilderBid                    uint64          // MinBuilderBid is the minimum value that the builder's block can have to be considered by this node.
 	MinBuilderDiff                   uint64          // MinBuilderDiff is the minimum value above the local block value that the builder has to bid to be considered by this node
+
+	// Gloas builder circuit breaker. These are local policy, not spec values.
+	BuilderAllowedFailures         uint64           // BuilderAllowedFailures is how many payload delivery failures a builder is allowed before being blacklisted.
+	BuilderCriticalFailures        uint64           // BuilderCriticalFailures is the failure count at which a builder is blacklisted for BuilderCriticalBlacklistPeriod.
+	BuilderBlacklistPeriod         primitives.Epoch // BuilderBlacklistPeriod is how many epochs a builder stays blacklisted on its first offense.
+	BuilderCriticalBlacklistPeriod primitives.Epoch // BuilderCriticalBlacklistPeriod is how many epochs a builder stays blacklisted once it reaches BuilderCriticalFailures.
+	BuilderFailureBackOffPeriod    primitives.Epoch // BuilderFailureBackOffPeriod is how many epochs without a failure reset a builder's failure counter.
+	BuilderCriticalFailedBuilders  uint64           // BuilderCriticalFailedBuilders is how many concurrently blacklisted builders force a fallback to self-building.
+	BuilderFailureWeightThreshold  uint64           // BuilderFailureWeightThreshold is the percentage of committee weight a block needs before its missing payload is charged to the builder.
+
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue uint64 // ExecutionEngineTimeoutValue defines the seconds to wait before timing out engine endpoints with execution payload execution semantics (newPayload, forkchoiceUpdated).
 

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -303,6 +303,16 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
+
+	// Gloas builder circuit breaker
+	BuilderAllowedFailures:         0,
+	BuilderCriticalFailures:        2,
+	BuilderBlacklistPeriod:         1,
+	BuilderCriticalBlacklistPeriod: 256,
+	BuilderFailureBackOffPeriod:    5,
+	BuilderCriticalFailedBuilders:  7,
+	BuilderFailureWeightThreshold:  60,
+
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core
 


### PR DESCRIPTION
Track builders that win an auction but never reveal the payload, and blacklist them so their bids are neither propagated nor used for block production. This is purely a local ban; the builder's actual payment is settled by the builder payment flow and is unaffected by any of this.

A failure is recorded on block import, in postBlockProcess right after forkchoice recomputes Head: the incoming block extends the parent's empty payload, no full node exists for the parent, and the parent's consensus weight exceeds 60% of committee weight. That is the first moment the parent's slot attestations reach forkchoice, and the write lock is already held. Recording is idempotent per parent root so several children on the same empty parent count once. A revealed envelope clears the record.

Blacklisted builders are ignored on gossip, skipped when selecting builder-API and cached P2P bids, and once enough are banned at the same time the node falls back to self-building. setP2PBidFallback is left unfiltered on purpose: with no local payload, a risky bid beats a missed slot.

Operators can permanently ban indices with --builder-index-denylist. The thresholds are BeaconChainConfig defaults.

Relay tracking and correlating builder indices to a relay are left for a follow-up, as is any trusted vs untrusted distinction.

