### PR TITLE
Verify weak subjectivity checkpoint against the finalized canonical chain

### DIFF
--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -29,6 +29,8 @@ var (
 	errWSBlockNotFound = errors.New("weak subjectivity root not found in db")
 	// errWSBlockNotFoundInEpoch is returned when a block is not found in the WS cache or DB within epoch.
 	errWSBlockNotFoundInEpoch = errors.New("weak subjectivity root not found in db within epoch")
+	// errWSBlockNotCanonical is returned when a block is in the DB but not part of the finalized canonical chain.
+	errWSBlockNotCanonical = errors.New("weak subjectivity root is not canonical")
 	// ErrNotDescendantOfFinalized is returned when a block is not a descendant of the finalized checkpoint
 	ErrNotDescendantOfFinalized = errors.New("not descendant of finalized checkpoint")
 	// ErrNotCheckpoint is returned when a given checkpoint is not a

--- a/beacon-chain/blockchain/weak_subjectivity_checks.go
+++ b/beacon-chain/blockchain/weak_subjectivity_checks.go
@@ -16,6 +16,7 @@ import (
 
 type weakSubjectivityDB interface {
 	HasBlock(ctx context.Context, blockRoot [32]byte) bool
+	IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool
 	BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][32]byte, error)
 }
 
@@ -66,7 +67,7 @@ func (v *WeakSubjectivityVerifier) VerifyWeakSubjectivity(ctx context.Context, f
 	// IF epoch_number <= store.finalized_checkpoint.epoch,
 	// then ASSERT that the block in the canonical chain at epoch epoch_number has root block_root.
 	// Emit descriptive critical error if this assert fails, then exit client process.
-	if v.epoch > finalizedEpoch {
+	if v.epoch >= finalizedEpoch {
 		return nil
 	}
 	log.Infof("Performing weak subjectivity check for root %#x in epoch %d", v.root, v.epoch)
@@ -74,7 +75,10 @@ func (v *WeakSubjectivityVerifier) VerifyWeakSubjectivity(ctx context.Context, f
 	if !v.db.HasBlock(ctx, v.root) {
 		return errors.Wrap(errWSBlockNotFound, fmt.Sprintf("missing root %#x", v.root))
 	}
-	endSlot := v.slot + params.BeaconConfig().SlotsPerEpoch
+	if !v.db.IsFinalizedBlock(ctx, v.root) {
+		return errors.Wrap(errWSBlockNotCanonical, fmt.Sprintf("root=%#x, epoch=%d", v.root, v.epoch))
+	}
+	endSlot := v.slot + params.BeaconConfig().SlotsPerEpoch - 1
 	filter := filters.NewFilter().SetStartSlot(v.slot).SetEndSlot(endSlot)
 	// A node should have the weak subjectivity block corresponds to the correct epoch in the DB.
 	log.Infof("Searching block roots for weak subjectivity root=%#x, between slots %d-%d", v.root, v.slot, endSlot)

--- a/beacon-chain/blockchain/weak_subjectivity_checks_test.go
+++ b/beacon-chain/blockchain/weak_subjectivity_checks_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
-	"github.com/pkg/errors"
 )
 
 func TestService_VerifyWeakSubjectivityRoot(t *testing.T) {
@@ -20,7 +19,20 @@ func TestService_VerifyWeakSubjectivityRoot(t *testing.T) {
 	r, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 
+	forkBlock := util.NewBeaconBlock()
+	forkBlock.Block.Slot = b.Block.Slot
+	forkBlock.Block.ProposerIndex = 1
+	forkRoot, err := forkBlock.Block.HashTreeRoot()
+	require.NoError(t, err)
+
 	blockEpoch := slots.ToEpoch(b.Block.Slot)
+	childSlot, err := slots.EpochStart(blockEpoch + 1)
+	require.NoError(t, err)
+	childBlock := util.NewBeaconBlock()
+	childBlock.Block.Slot = childSlot
+	childBlock.Block.ParentRoot = r[:]
+	childRoot, err := childBlock.Block.HashTreeRoot()
+	require.NoError(t, err)
 	tests := []struct {
 		wsVerified     bool
 		disabled       bool
@@ -51,12 +63,24 @@ func TestService_VerifyWeakSubjectivityRoot(t *testing.T) {
 			wantErr:        errWSBlockNotFoundInEpoch,
 		},
 		{
+			name:           "block in db but not canonical",
+			checkpt:        &ethpb.Checkpoint{Root: forkRoot[:], Epoch: blockEpoch},
+			finalizedEpoch: blockEpoch + 1,
+			wantErr:        errWSBlockNotCanonical,
+		},
+		{
+			name:           "canonical block from next epoch fails epoch range",
+			checkpt:        &ethpb.Checkpoint{Root: childRoot[:], Epoch: blockEpoch},
+			finalizedEpoch: blockEpoch + 1,
+			wantErr:        errWSBlockNotFoundInEpoch,
+		},
+		{
 			name:           "can verify and pass",
 			checkpt:        &ethpb.Checkpoint{Root: r[:], Epoch: blockEpoch},
 			finalizedEpoch: blockEpoch + 1,
 		},
 		{
-			name:           "equal epoch",
+			name:           "not yet to verify, equal epoch",
 			checkpt:        &ethpb.Checkpoint{Root: r[:], Epoch: blockEpoch},
 			finalizedEpoch: blockEpoch,
 		},
@@ -66,6 +90,10 @@ func TestService_VerifyWeakSubjectivityRoot(t *testing.T) {
 			s := testServiceWithDB(t)
 			beaconDB := s.cfg.BeaconDB
 			util.SaveBlock(t, t.Context(), beaconDB, b)
+			util.SaveBlock(t, t.Context(), beaconDB, forkBlock)
+			util.SaveBlock(t, t.Context(), beaconDB, childBlock)
+			require.NoError(t, beaconDB.SaveGenesisBlockRoot(t.Context(), bytesutil.ToBytes32(b.Block.ParentRoot)))
+			require.NoError(t, beaconDB.SaveFinalizedCheckpoint(t.Context(), &ethpb.Checkpoint{Root: childRoot[:], Epoch: blockEpoch + 1}))
 			wv, err := NewWeakSubjectivityVerifier(tt.checkpt, beaconDB)
 			require.NoError(t, err)
 			s.cfg.WeakSubjectivityCheckpt = tt.checkpt
@@ -77,7 +105,7 @@ func TestService_VerifyWeakSubjectivityRoot(t *testing.T) {
 			if tt.wantErr == nil {
 				require.NoError(t, err)
 			} else {
-				require.Equal(t, true, errors.Is(err, tt.wantErr))
+				require.ErrorIs(t, err, tt.wantErr)
 			}
 		})
 	}

--- a/changelog/terence_ws-check-canonical.md
+++ b/changelog/terence_ws-check-canonical.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Weak subjectivity checkpoint verification now requires the root to be in the finalized canonical chain instead of accepting any stored block in the epoch's slot range.


### PR DESCRIPTION
- VerifyWeakSubjectivity accepted any stored block in the epoch's slot range, so a non-canonical fork block satisfied the check. Now also requires the root to be in the finalized block roots index.
- Verification waits until finality passes the checkpoint epoch, since the index only becomes canonical-exact for epochs older than the latest finalized epoch.
- Fixed the search range overshooting into the first slot of the next epoch.