### PR TITLE
Fix Gloas backfill handling of withheld payload columns

### DIFF
--- a/beacon-chain/sync/backfill/BUILD.bazel
+++ b/beacon-chain/sync/backfill/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "batcher_expiration_test.go",
         "batcher_test.go",
         "blobs_test.go",
+        "columns_gloas_test.go",
         "columns_test.go",
         "fulu_transition_test.go",
         "log_test.go",

--- a/beacon-chain/sync/backfill/batch.go
+++ b/beacon-chain/sync/backfill/batch.go
@@ -73,6 +73,7 @@ type batch struct {
 	seq            int // sequence identifier, ie how many times has the sequence() method served this batch
 	retries        int
 	retryAfter     time.Time
+	retryFrom      batchState // state the batch was in when the retryable error occurred
 	begin          primitives.Slot
 	end            primitives.Slot // half-open interval, [begin, end), ie >= begin, < end.
 	blocks         verifiedROBlocks
@@ -111,6 +112,9 @@ func (b batch) logFields() logrus.Fields {
 	}
 	if b.state == batchSyncColumns {
 		f["nextColumns"] = fmt.Sprintf("%v", b.nextReqCols)
+	}
+	if b.state == batchErrRetryable {
+		f["retryFrom"] = b.retryFrom.String()
 	}
 	if b.state == batchErrRetryable && b.blobs != nil {
 		f["blobsMissing"] = b.blobs.needed()
@@ -193,6 +197,7 @@ func (b batch) withRetryableError(err error) batch {
 	b.err = err
 	b.retries += 1
 	b.retryAfter = time.Now().Add(retryDelay)
+	b.retryFrom = b.state
 
 	msg := "Could not proceed with batch processing due to error"
 	logBase := log.WithFields(b.logFields()).WithError(err)

--- a/beacon-chain/sync/backfill/columns.go
+++ b/beacon-chain/sync/backfill/columns.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/sync"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
@@ -33,6 +34,23 @@ var (
 // requesting so much at once.
 const columnRequestLimit = 128 * 4
 
+// payloadFullness classifies whether a block's execution payload was revealed on chain.
+// Pre-gloas payloads are always revealed. A gloas payload may be withheld, in which case no
+// data columns exist for the block; the canonical child's bid testifies either way.
+type payloadFullness int
+
+const (
+	// fullnessUnknown means no canonical child was available to testify; only the batch tail can stay unknown.
+	fullnessUnknown payloadFullness = iota
+	// fullnessRevealed means the payload was revealed, so custody columns are required.
+	fullnessRevealed
+	// fullnessWithheld means the payload was withheld, so there are no columns to require.
+	fullnessWithheld
+)
+
+// boundaryChildFn looks up the already-imported canonical child of the given root, returning nil when it isn't known.
+type boundaryChildFn func(ctx context.Context, parentRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error)
+
 type columnBatch struct {
 	first         primitives.Slot
 	last          primitives.Slot
@@ -45,6 +63,7 @@ type toDownload struct {
 	commitments    [][]byte
 	slot           primitives.Slot
 	blockSignature [fieldparams.BLSSignatureLength]byte
+	fullness       payloadFullness
 }
 
 func (cs *columnBatch) needed() peerdas.ColumnIndices {
@@ -115,7 +134,7 @@ func newColumnSync(ctx context.Context, b batch, blks verifiedROBlocks, current 
 	if err != nil {
 		return nil, errors.Wrap(err, "custody group count")
 	}
-	cb, err := buildColumnBatch(ctx, b, blks, p, cfg.colStore, cfg.currentNeeds())
+	cb, err := buildColumnBatch(ctx, b, blks, p, cfg.colStore, cfg.currentNeeds(), cfg.boundaryChild)
 	if err != nil {
 		return nil, err
 	}
@@ -137,14 +156,23 @@ func newColumnSync(ctx context.Context, b batch, blks verifiedROBlocks, current 
 }
 
 func (cs *columnSync) blockColumns(root [32]byte) *toDownload {
-	if cs.columnBatch == nil {
+	if cs == nil || cs.columnBatch == nil {
 		return nil
 	}
 	return cs.columnBatch.toDownload[root]
 }
 
+// fullness returns the payload fullness recorded for the given block root, or unknown if untracked.
+func (cs *columnSync) fullness(root [32]byte) payloadFullness {
+	td := cs.blockColumns(root)
+	if td == nil {
+		return fullnessUnknown
+	}
+	return td.fullness
+}
+
 func (cs *columnSync) columnsNeeded() peerdas.ColumnIndices {
-	if cs.columnBatch == nil {
+	if cs == nil || cs.columnBatch == nil {
 		return peerdas.ColumnIndices{}
 	}
 	return cs.columnBatch.needed()
@@ -261,7 +289,7 @@ func currentCustodiedColumns(ctx context.Context, p p2p.P2P) (peerdas.ColumnIndi
 	return peerdas.NewColumnIndicesFromMap(peerInfo.CustodyColumns), nil
 }
 
-func buildColumnBatch(ctx context.Context, b batch, blks verifiedROBlocks, p p2p.P2P, store *filesystem.DataColumnStorage, needs das.CurrentNeeds) (*columnBatch, error) {
+func buildColumnBatch(ctx context.Context, b batch, blks verifiedROBlocks, p p2p.P2P, store *filesystem.DataColumnStorage, needs das.CurrentNeeds, child boundaryChildFn) (*columnBatch, error) {
 	if len(blks) == 0 {
 		return nil, nil
 	}
@@ -290,19 +318,16 @@ func buildColumnBatch(ctx context.Context, b batch, blks verifiedROBlocks, p p2p
 		if len(cmts) == 0 {
 			continue
 		}
-		// Adjacent blocks are parent linked by verify, so the direct child is at i+1 when present.
-		full := true
-		if b.Block().Version() >= version.Gloas && i+1 < len(blks) {
-			full, err = blocks.BlockBuiltOnParentPayload(b.Block(), blks[i+1].Block())
-			if err != nil {
-				return nil, errors.Wrap(err, "block built on parent payload")
-			}
+		fullness, err := blockFullness(ctx, blks, i, child)
+		if err != nil {
+			return nil, err
 		}
 		var remaining peerdas.ColumnIndices
-		if full {
+		if fullness == fullnessRevealed {
 			remaining = das.IndicesNotStored(store.Summary(b.Root()), indices)
 		} else {
-			// Empty slots have no canonical columns to require, but keep the root known so peers still serving them are not penalized.
+			// Withheld and unresolved payloads have no columns to require, but keep the root known
+			// so peers still serving columns for them are not penalized.
 			remaining = peerdas.ColumnIndices{}
 		}
 		// The last block this part of the loop sees will be the last one
@@ -317,8 +342,48 @@ func buildColumnBatch(ctx context.Context, b batch, blks verifiedROBlocks, p p2p
 			commitments:    cmts,
 			slot:           slot,
 			blockSignature: b.Signature(),
+			fullness:       fullness,
 		}
 	}
 
 	return summary, nil
+}
+
+// blockFullness classifies the payload fullness of blks[i]. Batch blocks are parent-linked by
+// verify, so blks[i+1] is the direct child even across skipped slots. The batch tail has no
+// in-batch child; the boundary child (the already-imported block just above the batch) may
+// testify, otherwise the tail stays unknown until import time rather than defaulting to revealed.
+func blockFullness(ctx context.Context, blks verifiedROBlocks, i int, child boundaryChildFn) (payloadFullness, error) {
+	blk := blks[i]
+	if blk.Block().Version() < version.Gloas {
+		return fullnessRevealed, nil
+	}
+	if i+1 < len(blks) {
+		return fullnessFromChild(blk.Block(), blks[i+1].Block())
+	}
+	if child == nil {
+		return fullnessUnknown, nil
+	}
+	cb, err := child(ctx, blk.Root())
+	if err != nil {
+		// The build-time lookup is best-effort; the importer authoritatively resolves the tail.
+		log.WithError(err).WithField("root", fmt.Sprintf("%#x", blk.Root())).Debug("Boundary child lookup failed, leaving tail fullness unknown")
+		return fullnessUnknown, nil
+	}
+	if cb == nil {
+		return fullnessUnknown, nil
+	}
+	return fullnessFromChild(blk.Block(), cb.Block())
+}
+
+// fullnessFromChild classifies a gloas parent's payload fullness from its direct child's bid.
+func fullnessFromChild(parent, child interfaces.ReadOnlyBeaconBlock) (payloadFullness, error) {
+	full, err := blocks.BlockBuiltOnParentPayload(parent, child)
+	if err != nil {
+		return fullnessUnknown, errors.Wrap(err, "block built on parent payload")
+	}
+	if full {
+		return fullnessRevealed, nil
+	}
+	return fullnessWithheld, nil
 }

--- a/beacon-chain/sync/backfill/columns.go
+++ b/beacon-chain/sync/backfill/columns.go
@@ -89,14 +89,30 @@ func (cs *columnBatch) needed() peerdas.ColumnIndices {
 // pruneExpired removes any columns from the batch that are no longer needed.
 // If `pruned` is non-nil, it is populated with the roots that were removed.
 func (cs *columnBatch) pruneExpired(needs das.CurrentNeeds, pruned map[[32]byte]struct{}) {
+	var first, last primitives.Slot
+	hasTrackedBlock := false
 	for root, td := range cs.toDownload {
 		if !needs.Col.At(td.slot) {
 			delete(cs.toDownload, root)
 			if pruned != nil {
 				pruned[root] = struct{}{}
 			}
+			continue
 		}
+		if !hasTrackedBlock || td.slot < first {
+			first = td.slot
+		}
+		if !hasTrackedBlock || td.slot > last {
+			last = td.slot
+		}
+		hasTrackedBlock = true
 	}
+	// Keep the request range aligned with toDownload. In particular, do not request roots
+	// that were just deleted: a peer may still serve them and the validator would reject them
+	// as unexpected. The zero values are harmless when every tracked block was pruned because
+	// no column request will be made.
+	cs.first = first
+	cs.last = last
 }
 
 // neededSidecarCount returns the total number of sidecars still needed to complete the batch.

--- a/beacon-chain/sync/backfill/columns_gloas_test.go
+++ b/beacon-chain/sync/backfill/columns_gloas_test.go
@@ -510,75 +510,96 @@ func TestDefaultBatchImporterGloasTail(t *testing.T) {
 	})
 }
 
-// TestPromotedTailColumnExpiryInPool verifies the batchSyncColumns state-machine path: when the
-// column retention window advances past a promoted tail while its block is still required, the
-// pool prunes the expired column work and hands the batch back as importable without needing any
-// suitable peer or column RPC, and the batch subsequently imports.
+// TestPromotedTailColumnExpiryInPool verifies the column state-machine path: when the column
+// retention window advances past a promoted tail while its block is still required, the pool
+// prunes the expired column work and hands the batch back as importable without needing any
+// suitable peer or column RPC, and the batch subsequently imports. This must hold both for a
+// batch waiting in batchSyncColumns and for one parked in batchErrRetryable by a failed fetch.
 func TestPromotedTailColumnExpiryInPool(t *testing.T) {
 	gloasSlot := setupGloasFullnessConfig(t)
 	ctx := t.Context()
 	tail := gloasBlockWithBid(t, gloasSlot+2, [32]byte{0x99}, 0xcc, 0x99, 1)
 	tailRoot := tail.Root()
 
-	p, custody := testCustodyP2P(t)
-	store := filesystem.NewEphemeralDataColumnStorage(t)
-	bt := batch{begin: gloasSlot, end: gloasSlot + 10, blocks: verifiedROBlocks{tail}}
-	// The batch was built while the tail was still inside the column retention window.
-	cb, err := buildColumnBatch(ctx, bt, bt.blocks, p, store, mockCurrentSpecNeeds(), nil)
-	require.NoError(t, err)
-	bt.columns = &columnSync{columnBatch: cb}
-	// The tail was proven revealed and promoted with outstanding column work.
-	td := cb.toDownload[tailRoot]
-	td.fullness = fullnessRevealed
-	td.remaining = custody.Copy()
-	bt.state = batchSyncColumns
-	require.Equal(t, true, len(bt.columns.columnsNeeded()) > 0)
-
 	// Column retention advances past the tail slot while the block itself remains required.
 	retentionSlots := slots.UnsafeEpochStart(params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest)
 	expiredCurrent := tail.Block().Slot() + retentionSlots + 100
 	sn, err := das.NewSyncNeeds(func() primitives.Slot { return expiredCurrent }, nil, 0)
 	require.NoError(t, err)
-	needs := sn.Currently()
-	require.Equal(t, true, needs.Block.At(bt.end-1))
-	require.Equal(t, false, needs.Col.At(tail.Block().Slot()))
 
-	// No suitable peer exists and none is needed: the state machine completes the batch itself.
-	pool := newP2PBatchWorkerPool(p, 2, sn.Currently)
-	remaining, err := pool.processTodo([]batch{bt}, &mockAssigner{err: peers.ErrInsufficientSuitable}, make(map[peer.ID]bool))
-	require.NoError(t, err)
-	require.Equal(t, 0, len(remaining))
-
-	var got batch
-	select {
-	case got = <-pool.fromRouter:
-		require.Equal(t, batchImportable, got.state)
-		require.Equal(t, 0, len(got.columns.columnsNeeded()))
-	default:
-		t.Fatal("expected the expired-column batch to be handed back as importable")
+	// newPromotedBatch builds a batch, constructed while the tail was still retained, whose
+	// revealed tail was promoted with outstanding column work.
+	newPromotedBatch := func(t *testing.T) (batch, *p2ptest.TestP2P) {
+		p, custody := testCustodyP2P(t)
+		store := filesystem.NewEphemeralDataColumnStorage(t)
+		bt := batch{begin: gloasSlot, end: gloasSlot + 10, blocks: verifiedROBlocks{tail}}
+		cb, err := buildColumnBatch(ctx, bt, bt.blocks, p, store, mockCurrentSpecNeeds(), nil)
+		require.NoError(t, err)
+		bt.columns = &columnSync{columnBatch: cb}
+		td := cb.toDownload[tailRoot]
+		td.fullness = fullnessRevealed
+		td.remaining = custody.Copy()
+		bt.state = batchSyncColumns
+		require.Equal(t, true, len(bt.columns.columnsNeeded()) > 0)
+		needs := sn.Currently()
+		require.Equal(t, true, needs.Block.At(bt.end-1))
+		require.Equal(t, false, needs.Col.At(tail.Block().Slot()))
+		return bt, p
 	}
 
-	// The batch subsequently imports through the service using the real importer. The empty db
-	// also proves no boundary child lookup is attempted for the expired tail.
-	child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
-	mdb := &mockBackfillDB{}
-	su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
-	seqr := newBatchSequencer(1, gloasSlot+10, 10, sn.Currently)
-	seqr.seq[0] = got
-	svc := &Service{
-		clock:     startup.NewClock(time.Now(), [32]byte{}),
-		pool:      &mockPool{todoChan: make(chan batch, 1)},
-		batchSeq:  seqr,
-		store:     su,
-		syncNeeds: sn,
-		dcStore:   filesystem.NewEphemeralDataColumnStorage(t),
+	// completesWithoutPeers runs the state-machine step with no suitable peers and requires the
+	// batch to come back importable with no column work left.
+	completesWithoutPeers := func(t *testing.T, p *p2ptest.TestP2P, bt batch) batch {
+		pool := newP2PBatchWorkerPool(p, 2, sn.Currently)
+		remaining, err := pool.processTodo([]batch{bt}, &mockAssigner{err: peers.ErrInsufficientSuitable}, make(map[peer.ID]bool))
+		require.NoError(t, err)
+		require.Equal(t, 0, len(remaining))
+		select {
+		case got := <-pool.fromRouter:
+			require.Equal(t, batchImportable, got.state)
+			require.Equal(t, 0, len(got.columns.columnsNeeded()))
+			return got
+		default:
+			t.Fatal("expected the expired-column batch to be handed back as importable")
+			return batch{}
+		}
 	}
-	svc.batchImporter = svc.defaultBatchImporter
-	svc.importBatches(ctx)
 
-	require.Equal(t, uint64(gloasSlot+2), su.status().LowSlot)
-	_, saved := mdb.blocks[tailRoot]
-	require.Equal(t, true, saved)
+	t.Run("waiting in column sync", func(t *testing.T) {
+		bt, p := newPromotedBatch(t)
+		got := completesWithoutPeers(t, p, bt)
+
+		// The batch subsequently imports through the service using the real importer. The empty
+		// db also proves no boundary child lookup is attempted for the expired tail.
+		child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
+		mdb := &mockBackfillDB{}
+		su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+		seqr := newBatchSequencer(1, gloasSlot+10, 10, sn.Currently)
+		seqr.seq[0] = got
+		svc := &Service{
+			clock:     startup.NewClock(time.Now(), [32]byte{}),
+			pool:      &mockPool{todoChan: make(chan batch, 1)},
+			batchSeq:  seqr,
+			store:     su,
+			syncNeeds: sn,
+			dcStore:   filesystem.NewEphemeralDataColumnStorage(t),
+		}
+		svc.batchImporter = svc.defaultBatchImporter
+		svc.importBatches(ctx)
+
+		require.Equal(t, uint64(gloasSlot+2), su.status().LowSlot)
+		_, saved := mdb.blocks[tailRoot]
+		require.Equal(t, true, saved)
+	})
+
+	t.Run("parked retryable by a failed column fetch", func(t *testing.T) {
+		bt, p := newPromotedBatch(t)
+		bt = bt.withRetryableError(errors.New("column RPC timeout"))
+		require.Equal(t, batchErrRetryable, bt.state)
+		require.Equal(t, batchSyncColumns, bt.retryFrom)
+
+		completesWithoutPeers(t, p, bt)
+	})
 }
 
 // TestImportBatchesTailPromotion verifies that a batch failing import with errTailColumnsNeeded

--- a/beacon-chain/sync/backfill/columns_gloas_test.go
+++ b/beacon-chain/sync/backfill/columns_gloas_test.go
@@ -1,0 +1,616 @@
+package backfill
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/das"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/peers"
+	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/proto/dbval"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/pkg/errors"
+)
+
+// setupGloasFullnessConfig ensures the fulu and gloas fork epochs are set and returns the first
+// gloas slot, so fixtures live at actual gloas slots covered by the column retention window.
+func setupGloasFullnessConfig(t *testing.T) primitives.Slot {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	if cfg.FuluForkEpoch == cfg.FarFutureEpoch {
+		cfg.FuluForkEpoch = cfg.DenebForkEpoch + 4096*2
+	}
+	if cfg.GloasForkEpoch == cfg.FarFutureEpoch {
+		cfg.GloasForkEpoch = cfg.FuluForkEpoch + 8
+	}
+	gloasSlot, err := slots.EpochStart(cfg.GloasForkEpoch)
+	require.NoError(t, err)
+	return gloasSlot
+}
+
+// gloasBlockWithBid builds a gloas ROBlock whose bid carries nCmts KZG commitments plus the
+// given payload hashes, which is everything payload fullness classification reads.
+func gloasBlockWithBid(t *testing.T, slot primitives.Slot, parentRoot [32]byte, blockHash, parentBlockHash byte, nCmts int) blocks.ROBlock {
+	pb := util.NewBeaconBlockGloas()
+	pb.Block.Slot = slot
+	pb.Block.ParentRoot = parentRoot[:]
+	bid := pb.Block.Body.SignedExecutionPayloadBid.Message
+	bid.BlockHash = make([]byte, 32)
+	bid.BlockHash[0] = blockHash
+	bid.ParentBlockHash = make([]byte, 32)
+	bid.ParentBlockHash[0] = parentBlockHash
+	bid.BlobKzgCommitments = make([][]byte, nCmts)
+	for i := range bid.BlobKzgCommitments {
+		bid.BlobKzgCommitments[i] = make([]byte, 48)
+	}
+	sb, err := blocks.NewSignedBeaconBlock(pb)
+	require.NoError(t, err)
+	rob, err := blocks.NewROBlock(sb)
+	require.NoError(t, err)
+	return rob
+}
+
+func testCustodyP2P(t *testing.T) (*p2ptest.TestP2P, peerdas.ColumnIndices) {
+	p := p2ptest.NewTestP2P(t)
+	_, _, err := p.UpdateCustodyInfo(0, 4)
+	require.NoError(t, err)
+	custody, err := currentCustodiedColumns(context.Background(), p)
+	require.NoError(t, err)
+	require.Equal(t, true, custody.Count() > 0)
+	return p, custody
+}
+
+// TestBuildColumnBatchGloasFullness covers how gloas payload fullness drives column requirements:
+// an interior revealed block requires custody columns, an interior withheld block requires none,
+// and the batch tail without a child stays unknown without holding the batch in column sync.
+func TestBuildColumnBatchGloasFullness(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+
+	// Three parent-linked gloas blocks with skipped slots between them:
+	// a's payload (hash 0xaa) is proven revealed by b's bid building on it.
+	// b's payload (hash 0xbb) is proven withheld: c's bid builds on 0xaa, not 0xbb.
+	// c is the batch tail, so no in-batch child can testify either way.
+	a := gloasBlockWithBid(t, gloasSlot, [32]byte{0x99}, 0xaa, 0x99, 1)
+	b := gloasBlockWithBid(t, gloasSlot+3, a.Root(), 0xbb, 0xaa, 1)
+	c := gloasBlockWithBid(t, gloasSlot+7, b.Root(), 0xcc, 0xaa, 1)
+	blks := verifiedROBlocks{a, b, c}
+
+	ctx := t.Context()
+	p, custody := testCustodyP2P(t)
+	store := filesystem.NewEphemeralDataColumnStorage(t)
+	bt := batch{begin: gloasSlot, end: gloasSlot + 10}
+	cb, err := buildColumnBatch(ctx, bt, blks, p, store, mockCurrentSpecNeeds(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, cb)
+	require.Equal(t, 3, len(cb.toDownload))
+
+	// a: payload revealed, so its custody columns are required.
+	require.Equal(t, fullnessRevealed, cb.toDownload[a.Root()].fullness)
+	require.Equal(t, custody.Count(), cb.toDownload[a.Root()].remaining.Count())
+	// b: payload withheld, so no columns exist and none are required.
+	require.Equal(t, fullnessWithheld, cb.toDownload[b.Root()].fullness)
+	require.Equal(t, 0, cb.toDownload[b.Root()].remaining.Count())
+	// c: batch tail with no child, fullness unknown; it must not require columns.
+	require.Equal(t, fullnessUnknown, cb.toDownload[c.Root()].fullness)
+	require.Equal(t, 0, cb.toDownload[c.Root()].remaining.Count())
+
+	// Only a's columns are needed; once they are downloaded the unknown tail must not keep
+	// the batch in the column-fetch state.
+	require.Equal(t, custody.Count(), cb.needed().Count())
+	cb.toDownload[a.Root()].remaining = peerdas.NewColumnIndices()
+	require.Equal(t, 0, cb.needed().Count())
+	bt.blocks = blks
+	bt.columns = &columnSync{columnBatch: cb}
+	require.Equal(t, batchImportable, bt.transitionToNext().state)
+}
+
+// TestBuildColumnBatchGloasPreGloasUnchanged verifies pre-gloas blocks are always treated as
+// revealed and gloas blocks without commitments are skipped entirely.
+func TestBuildColumnBatchGloasPreGloasUnchanged(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+	fuluSlot, err := slots.EpochStart(params.BeaconConfig().FuluForkEpoch)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	p, custody := testCustodyP2P(t)
+	store := filesystem.NewEphemeralDataColumnStorage(t)
+
+	t.Run("pre-gloas blocks are revealed", func(t *testing.T) {
+		blks, _ := testBlobGen(t, fuluSlot, 2)
+		cb, err := buildColumnBatch(ctx, batch{begin: fuluSlot, end: fuluSlot + 10}, blks, p, store, mockCurrentSpecNeeds(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, cb)
+		require.Equal(t, 2, len(cb.toDownload))
+		for _, td := range cb.toDownload {
+			// The batch tail rule only applies to gloas blocks; pre-gloas payloads are always revealed.
+			require.Equal(t, fullnessRevealed, td.fullness)
+			require.Equal(t, custody.Count(), td.remaining.Count())
+		}
+	})
+
+	t.Run("gloas blocks without commitments are skipped", func(t *testing.T) {
+		a := gloasBlockWithBid(t, gloasSlot, [32]byte{0x99}, 0xaa, 0x99, 1)
+		b := gloasBlockWithBid(t, gloasSlot+1, a.Root(), 0xbb, 0xaa, 0)
+		cb, err := buildColumnBatch(ctx, batch{begin: gloasSlot, end: gloasSlot + 10}, verifiedROBlocks{a, b}, p, store, mockCurrentSpecNeeds(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, cb)
+		require.Equal(t, 1, len(cb.toDownload))
+		require.NotNil(t, cb.toDownload[a.Root()])
+	})
+}
+
+// TestBuildColumnBatchBoundaryChild verifies that a direct boundary child can prove the batch
+// tail revealed or withheld at build time, and that a missing or failing lookup never
+// defaults the tail to revealed.
+func TestBuildColumnBatchBoundaryChild(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+
+	a := gloasBlockWithBid(t, gloasSlot, [32]byte{0x99}, 0xaa, 0x99, 1)
+	tail := gloasBlockWithBid(t, gloasSlot+1, a.Root(), 0xcc, 0xaa, 1)
+	blks := verifiedROBlocks{a, tail}
+
+	ctx := t.Context()
+	p, custody := testCustodyP2P(t)
+	store := filesystem.NewEphemeralDataColumnStorage(t)
+	bt := batch{begin: gloasSlot, end: gloasSlot + 10}
+
+	childFn := func(child blocks.ROBlock) boundaryChildFn {
+		return func(_ context.Context, parentRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
+			require.Equal(t, tail.Root(), parentRoot)
+			return child, nil
+		}
+	}
+
+	t.Run("child proves tail revealed", func(t *testing.T) {
+		child := gloasBlockWithBid(t, gloasSlot+2, tail.Root(), 0xdd, 0xcc, 0)
+		cb, err := buildColumnBatch(ctx, bt, blks, p, store, mockCurrentSpecNeeds(), childFn(child))
+		require.NoError(t, err)
+		require.Equal(t, fullnessRevealed, cb.toDownload[tail.Root()].fullness)
+		require.Equal(t, custody.Count(), cb.toDownload[tail.Root()].remaining.Count())
+	})
+
+	t.Run("child proves tail withheld", func(t *testing.T) {
+		child := gloasBlockWithBid(t, gloasSlot+2, tail.Root(), 0xdd, 0xaa, 0)
+		cb, err := buildColumnBatch(ctx, bt, blks, p, store, mockCurrentSpecNeeds(), childFn(child))
+		require.NoError(t, err)
+		require.Equal(t, fullnessWithheld, cb.toDownload[tail.Root()].fullness)
+		require.Equal(t, 0, cb.toDownload[tail.Root()].remaining.Count())
+	})
+
+	t.Run("no child leaves tail unknown", func(t *testing.T) {
+		nilFn := func(context.Context, [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
+			return nil, nil
+		}
+		cb, err := buildColumnBatch(ctx, bt, blks, p, store, mockCurrentSpecNeeds(), nilFn)
+		require.NoError(t, err)
+		require.Equal(t, fullnessUnknown, cb.toDownload[tail.Root()].fullness)
+		require.Equal(t, 0, cb.toDownload[tail.Root()].remaining.Count())
+	})
+
+	t.Run("child lookup failure is best-effort and leaves tail unknown", func(t *testing.T) {
+		errFn := func(context.Context, [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
+			return nil, errors.New("db unavailable")
+		}
+		cb, err := buildColumnBatch(ctx, bt, blks, p, store, mockCurrentSpecNeeds(), errFn)
+		require.NoError(t, err)
+		require.Equal(t, fullnessUnknown, cb.toDownload[tail.Root()].fullness)
+		require.Equal(t, 0, cb.toDownload[tail.Root()].remaining.Count())
+	})
+}
+
+// TestStoreBoundaryChild verifies boundaryChild only returns the block at BackfillStatus.LowRoot
+// when it is the direct child of the requested root.
+func TestStoreBoundaryChild(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+	ctx := t.Context()
+	tail := gloasBlockWithBid(t, gloasSlot, [32]byte{0x01}, 0xcc, 0x99, 1)
+	tailRoot := tail.Root()
+	child := gloasBlockWithBid(t, gloasSlot+1, tailRoot, 0xdd, 0xcc, 0)
+
+	status := func() *dbval.BackfillStatus {
+		return &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 1), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}
+	}
+
+	t.Run("direct child returned", func(t *testing.T) {
+		mdb := &mockBackfillDB{blocks: map[[32]byte]blocks.ROBlock{child.Root(): child}}
+		su := &Store{store: mdb, bs: status()}
+		got, err := su.boundaryChild(ctx, tailRoot)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, tailRoot, got.Block().ParentRoot())
+	})
+
+	t.Run("not the direct child returns nil", func(t *testing.T) {
+		mdb := &mockBackfillDB{blocks: map[[32]byte]blocks.ROBlock{child.Root(): child}}
+		su := &Store{store: mdb, bs: status()}
+		got, err := su.boundaryChild(ctx, [32]byte{0xff})
+		require.NoError(t, err)
+		require.IsNil(t, got)
+	})
+
+	t.Run("missing child block errors", func(t *testing.T) {
+		su := &Store{store: &mockBackfillDB{}, bs: status()}
+		_, err := su.boundaryChild(ctx, tailRoot)
+		require.NotNil(t, err)
+	})
+
+	t.Run("child with mismatched parent root errors", func(t *testing.T) {
+		other := gloasBlockWithBid(t, gloasSlot+1, [32]byte{0xab}, 0xdd, 0xcc, 0)
+		bs := status()
+		bs.LowRoot = other.RootSlice()
+		mdb := &mockBackfillDB{blocks: map[[32]byte]blocks.ROBlock{other.Root(): other}}
+		su := &Store{store: mdb, bs: bs}
+		_, err := su.boundaryChild(ctx, tailRoot)
+		require.ErrorIs(t, err, errBatchDisconnected)
+	})
+}
+
+// TestCheckMultiplexerGloasFullness verifies that import-time DA checking receives revealed gloas
+// blocks, skips withheld ones, and refuses to guess for unresolved fullness.
+func TestCheckMultiplexerGloasFullness(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+
+	a := gloasBlockWithBid(t, gloasSlot, [32]byte{0x99}, 0xaa, 0x99, 1)
+	b := gloasBlockWithBid(t, gloasSlot+3, a.Root(), 0xbb, 0xaa, 1)
+	c := gloasBlockWithBid(t, gloasSlot+7, b.Root(), 0xcc, 0xaa, 1)
+	blks := verifiedROBlocks{a, b, c}
+
+	ctx := t.Context()
+	p, _ := testCustodyP2P(t)
+	store := filesystem.NewEphemeralDataColumnStorage(t)
+	bt := batch{begin: gloasSlot, end: gloasSlot + 10, blocks: blks}
+	cb, err := buildColumnBatch(ctx, bt, blks, p, store, mockCurrentSpecNeeds(), nil)
+	require.NoError(t, err)
+	bt.columns = &columnSync{columnBatch: cb}
+
+	mux := newCheckMultiplexer(mockCurrentSpecNeeds(), bt)
+	tracker := NewTrackingAvailabilityChecker(&das.MockAvailabilityStore{})
+	mux.colCheck = tracker
+
+	// The unresolved tail must fail the check retryably instead of being imported on a guess.
+	err = mux.IsDataAvailable(ctx, gloasSlot+10, blks...)
+	require.ErrorIs(t, err, errUnresolvedPayloadFullness)
+	require.Equal(t, true, isRetryable(err))
+	require.Equal(t, 0, tracker.GetCallCount())
+
+	// Tail proven withheld: only the revealed block reaches the column checker.
+	cb.toDownload[c.Root()].fullness = fullnessWithheld
+	require.NoError(t, mux.IsDataAvailable(ctx, gloasSlot+10, blks...))
+	require.Equal(t, 1, tracker.GetCallCount())
+	seen := tracker.GetBlocksInCall(0)
+	require.Equal(t, 1, len(seen))
+	require.Equal(t, a.Root(), seen[0].Root())
+
+	// Tail proven revealed: it is checked alongside the other revealed block.
+	cb.toDownload[c.Root()].fullness = fullnessRevealed
+	require.NoError(t, mux.IsDataAvailable(ctx, gloasSlot+10, blks...))
+	require.Equal(t, 2, tracker.GetCallCount())
+	seen = tracker.GetBlocksInCall(1)
+	require.Equal(t, 2, len(seen))
+	require.Equal(t, a.Root(), seen[0].Root())
+	require.Equal(t, c.Root(), seen[1].Root())
+}
+
+// TestDefaultBatchImporterGloasTail verifies import-time resolution of an unknown gloas tail
+// against the already-imported canonical child at BackfillStatus.LowRoot.
+func TestDefaultBatchImporterGloasTail(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+	current := gloasSlot + 100
+	ctx := t.Context()
+
+	newImporterService := func(t *testing.T, currentSlot primitives.Slot) *Service {
+		sn, err := das.NewSyncNeeds(func() primitives.Slot { return currentSlot }, nil, 0)
+		require.NoError(t, err)
+		return &Service{syncNeeds: sn, dcStore: filesystem.NewEphemeralDataColumnStorage(t)}
+	}
+
+	// newTailBatch builds a single-block batch whose gloas tail has unknown fullness.
+	newTailBatch := func(t *testing.T, p *p2ptest.TestP2P, tail blocks.ROBlock) batch {
+		store := filesystem.NewEphemeralDataColumnStorage(t)
+		bt := batch{begin: gloasSlot, end: gloasSlot + 10, blocks: verifiedROBlocks{tail}}
+		cb, err := buildColumnBatch(ctx, bt, bt.blocks, p, store, mockCurrentSpecNeeds(), nil)
+		require.NoError(t, err)
+		require.Equal(t, fullnessUnknown, cb.toDownload[tail.Root()].fullness)
+		bt.columns = &columnSync{columnBatch: cb}
+		return bt
+	}
+
+	tail := gloasBlockWithBid(t, gloasSlot+2, [32]byte{0x99}, 0xcc, 0x99, 1)
+	tailRoot := tail.Root()
+
+	t.Run("tail resolved withheld imports without columns", func(t *testing.T) {
+		p, _ := testCustodyP2P(t)
+		bt := newTailBatch(t, p, tail)
+		// The child's bid builds on 0x99, proving the tail's payload (0xcc) was withheld.
+		child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0x99, 0)
+		mdb := &mockBackfillDB{blocks: map[[32]byte]blocks.ROBlock{child.Root(): child}}
+		su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+		svc := newImporterService(t, current)
+
+		st, err := svc.defaultBatchImporter(ctx, current, bt, su)
+		require.NoError(t, err)
+		require.Equal(t, fullnessWithheld, bt.columns.fullness(tailRoot))
+		require.Equal(t, uint64(gloasSlot+2), st.LowSlot)
+		_, saved := mdb.blocks[tailRoot]
+		require.Equal(t, true, saved)
+	})
+
+	t.Run("tail resolved revealed is promoted and cannot import prematurely", func(t *testing.T) {
+		p, custody := testCustodyP2P(t)
+		bt := newTailBatch(t, p, tail)
+		// The child's bid builds on 0xcc, proving the tail's payload was revealed.
+		child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
+		mdb := &mockBackfillDB{blocks: map[[32]byte]blocks.ROBlock{child.Root(): child}}
+		su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+		svc := newImporterService(t, current)
+
+		_, err := svc.defaultBatchImporter(ctx, current, bt, su)
+		require.ErrorIs(t, err, errTailColumnsNeeded)
+		td := bt.columns.blockColumns(tailRoot)
+		require.Equal(t, fullnessRevealed, td.fullness)
+		require.Equal(t, custody.Count(), td.remaining.Count())
+		_, saved := mdb.blocks[tailRoot]
+		require.Equal(t, false, saved)
+		require.Equal(t, uint64(gloasSlot+3), su.status().LowSlot)
+
+		// Still missing columns on the next attempt: the batch must keep failing to import.
+		_, err = svc.defaultBatchImporter(ctx, current, bt, su)
+		require.ErrorIs(t, err, errTailColumnsNeeded)
+
+		// Even if the fetch state is cleared without the columns being persisted, the DA check
+		// must still refuse to import the revealed tail.
+		td.remaining = peerdas.NewColumnIndices()
+		bt.columns.store = das.NewLazilyPersistentStoreColumn(
+			svc.dcStore, nil, p.NodeID(), 4,
+			newColumnBisector(func(peer.ID, string, error) {}),
+			func(primitives.Slot) bool { return true },
+		)
+		_, err = svc.defaultBatchImporter(ctx, current, bt, su)
+		require.NotNil(t, err)
+		require.Equal(t, false, errors.Is(err, errTailColumnsNeeded))
+		_, saved = mdb.blocks[tailRoot]
+		require.Equal(t, false, saved)
+		require.Equal(t, uint64(gloasSlot+3), su.status().LowSlot)
+	})
+
+	t.Run("promoted columns downloaded and verified allow the next import", func(t *testing.T) {
+		p, custody := testCustodyP2P(t)
+		bt := newTailBatch(t, p, tail)
+		// The child's bid builds on 0xcc, proving the tail's payload was revealed.
+		child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
+		mdb := &mockBackfillDB{blocks: map[[32]byte]blocks.ROBlock{child.Root(): child}}
+		su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+		svc := newImporterService(t, current)
+		// Attach the batch availability store the same way newColumnSync does.
+		bt.columns.store = das.NewLazilyPersistentStoreColumn(
+			svc.dcStore, markAllVerified(&verification.MockDataColumnsVerifier{}), p.NodeID(), 4,
+			newColumnBisector(func(peer.ID, string, error) {}),
+			func(primitives.Slot) bool { return true },
+		)
+
+		_, err := svc.defaultBatchImporter(ctx, current, bt, su)
+		require.ErrorIs(t, err, errTailColumnsNeeded)
+		td := bt.columns.blockColumns(tailRoot)
+		require.Equal(t, custody.Count(), td.remaining.Count())
+
+		// Simulate the worker downloading the promoted columns: each sidecar is persisted to
+		// the batch availability store and cleared from remaining, as countedValidation does.
+		for _, idx := range td.remaining.ToSlice() {
+			sc := &ethpb.DataColumnSidecarGloas{
+				Index:           idx,
+				Slot:            tail.Block().Slot(),
+				BeaconBlockRoot: tailRoot[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			ro, err := blocks.NewRODataColumnGloasWithRoot(sc, tailRoot)
+			require.NoError(t, err)
+			require.NoError(t, bt.columns.store.Persist(current, ro))
+			td.remaining.Unset(idx)
+		}
+		require.Equal(t, 0, td.remaining.Count())
+
+		// The next import verifies and persists the columns, then succeeds.
+		st, err := svc.defaultBatchImporter(ctx, current, bt, su)
+		require.NoError(t, err)
+		require.Equal(t, uint64(gloasSlot+2), st.LowSlot)
+		_, saved := mdb.blocks[tailRoot]
+		require.Equal(t, true, saved)
+		sum := svc.dcStore.Summary(tailRoot)
+		for _, idx := range custody.ToSlice() {
+			require.Equal(t, true, sum.HasIndex(idx))
+		}
+	})
+
+	t.Run("missing boundary child defers import", func(t *testing.T) {
+		p, _ := testCustodyP2P(t)
+		bt := newTailBatch(t, p, tail)
+		child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
+		// The status names the child, but it cannot be read from the db.
+		mdb := &mockBackfillDB{}
+		su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+		svc := newImporterService(t, current)
+
+		_, err := svc.defaultBatchImporter(ctx, current, bt, su)
+		require.NotNil(t, err)
+		require.Equal(t, false, errors.Is(err, errTailColumnsNeeded))
+		require.Equal(t, true, isRetryable(err))
+		require.Equal(t, fullnessUnknown, bt.columns.fullness(tailRoot))
+		require.Equal(t, uint64(gloasSlot+3), su.status().LowSlot)
+	})
+
+	t.Run("non-child boundary block is never assumed full", func(t *testing.T) {
+		p, _ := testCustodyP2P(t)
+		bt := newTailBatch(t, p, tail)
+		// The lowest imported block does not descend from the tail.
+		su := &Store{store: &mockBackfillDB{}, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: []byte{0xee}, LowParentRoot: []byte{0xff}}}
+		svc := newImporterService(t, current)
+
+		err := svc.resolveTailFullness(ctx, su, bt, svc.syncNeeds.Currently())
+		require.ErrorIs(t, err, errChainBroken)
+		require.Equal(t, fullnessUnknown, bt.columns.fullness(tailRoot))
+		require.Equal(t, 0, bt.columns.blockColumns(tailRoot).remaining.Count())
+	})
+
+	// The tail was inside the column retention window when the batch was built, but leaves it
+	// before import: no columns are required and no promotion may occur.
+	t.Run("tail expired before import", func(t *testing.T) {
+		retentionSlots := slots.UnsafeEpochStart(params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest)
+		expiredCurrent := tail.Block().Slot() + retentionSlots + 100
+
+		t.Run("unknown tail imports without resolution", func(t *testing.T) {
+			p, _ := testCustodyP2P(t)
+			bt := newTailBatch(t, p, tail)
+			// No child block is available at all; expiry must make resolution unnecessary.
+			child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
+			mdb := &mockBackfillDB{}
+			su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+			svc := newImporterService(t, expiredCurrent)
+
+			st, err := svc.defaultBatchImporter(ctx, expiredCurrent, bt, su)
+			require.NoError(t, err)
+			require.Equal(t, uint64(gloasSlot+2), st.LowSlot)
+			require.Equal(t, fullnessUnknown, bt.columns.fullness(tailRoot))
+			_, saved := mdb.blocks[tailRoot]
+			require.Equal(t, true, saved)
+		})
+
+		t.Run("promoted revealed tail is not re-required", func(t *testing.T) {
+			p, custody := testCustodyP2P(t)
+			bt := newTailBatch(t, p, tail)
+			child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
+			mdb := &mockBackfillDB{blocks: map[[32]byte]blocks.ROBlock{child.Root(): child}}
+			su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+			// The tail was proven revealed and promoted while still retained.
+			td := bt.columns.blockColumns(tailRoot)
+			td.fullness = fullnessRevealed
+			td.remaining = custody.Copy()
+			svc := newImporterService(t, expiredCurrent)
+
+			st, err := svc.defaultBatchImporter(ctx, expiredCurrent, bt, su)
+			require.NoError(t, err)
+			require.Equal(t, uint64(gloasSlot+2), st.LowSlot)
+			_, saved := mdb.blocks[tailRoot]
+			require.Equal(t, true, saved)
+		})
+	})
+}
+
+// TestPromotedTailColumnExpiryInPool verifies the batchSyncColumns state-machine path: when the
+// column retention window advances past a promoted tail while its block is still required, the
+// pool prunes the expired column work and hands the batch back as importable without needing any
+// suitable peer or column RPC, and the batch subsequently imports.
+func TestPromotedTailColumnExpiryInPool(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+	ctx := t.Context()
+	tail := gloasBlockWithBid(t, gloasSlot+2, [32]byte{0x99}, 0xcc, 0x99, 1)
+	tailRoot := tail.Root()
+
+	p, custody := testCustodyP2P(t)
+	store := filesystem.NewEphemeralDataColumnStorage(t)
+	bt := batch{begin: gloasSlot, end: gloasSlot + 10, blocks: verifiedROBlocks{tail}}
+	// The batch was built while the tail was still inside the column retention window.
+	cb, err := buildColumnBatch(ctx, bt, bt.blocks, p, store, mockCurrentSpecNeeds(), nil)
+	require.NoError(t, err)
+	bt.columns = &columnSync{columnBatch: cb}
+	// The tail was proven revealed and promoted with outstanding column work.
+	td := cb.toDownload[tailRoot]
+	td.fullness = fullnessRevealed
+	td.remaining = custody.Copy()
+	bt.state = batchSyncColumns
+	require.Equal(t, true, len(bt.columns.columnsNeeded()) > 0)
+
+	// Column retention advances past the tail slot while the block itself remains required.
+	retentionSlots := slots.UnsafeEpochStart(params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest)
+	expiredCurrent := tail.Block().Slot() + retentionSlots + 100
+	sn, err := das.NewSyncNeeds(func() primitives.Slot { return expiredCurrent }, nil, 0)
+	require.NoError(t, err)
+	needs := sn.Currently()
+	require.Equal(t, true, needs.Block.At(bt.end-1))
+	require.Equal(t, false, needs.Col.At(tail.Block().Slot()))
+
+	// No suitable peer exists and none is needed: the state machine completes the batch itself.
+	pool := newP2PBatchWorkerPool(p, 2, sn.Currently)
+	remaining, err := pool.processTodo([]batch{bt}, &mockAssigner{err: peers.ErrInsufficientSuitable}, make(map[peer.ID]bool))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(remaining))
+
+	var got batch
+	select {
+	case got = <-pool.fromRouter:
+		require.Equal(t, batchImportable, got.state)
+		require.Equal(t, 0, len(got.columns.columnsNeeded()))
+	default:
+		t.Fatal("expected the expired-column batch to be handed back as importable")
+	}
+
+	// The batch subsequently imports through the service using the real importer. The empty db
+	// also proves no boundary child lookup is attempted for the expired tail.
+	child := gloasBlockWithBid(t, gloasSlot+3, tailRoot, 0xdd, 0xcc, 0)
+	mdb := &mockBackfillDB{}
+	su := &Store{store: mdb, bs: &dbval.BackfillStatus{LowSlot: uint64(gloasSlot + 3), LowRoot: child.RootSlice(), LowParentRoot: tailRoot[:]}}
+	seqr := newBatchSequencer(1, gloasSlot+10, 10, sn.Currently)
+	seqr.seq[0] = got
+	svc := &Service{
+		clock:     startup.NewClock(time.Now(), [32]byte{}),
+		pool:      &mockPool{todoChan: make(chan batch, 1)},
+		batchSeq:  seqr,
+		store:     su,
+		syncNeeds: sn,
+		dcStore:   filesystem.NewEphemeralDataColumnStorage(t),
+	}
+	svc.batchImporter = svc.defaultBatchImporter
+	svc.importBatches(ctx)
+
+	require.Equal(t, uint64(gloasSlot+2), su.status().LowSlot)
+	_, saved := mdb.blocks[tailRoot]
+	require.Equal(t, true, saved)
+}
+
+// TestImportBatchesTailPromotion verifies that a batch failing import with errTailColumnsNeeded
+// is sent back through the worker pool in the column-sync state instead of being retried from scratch.
+func TestImportBatchesTailPromotion(t *testing.T) {
+	gloasSlot := setupGloasFullnessConfig(t)
+	tail := gloasBlockWithBid(t, gloasSlot+2, [32]byte{0x99}, 0xcc, 0x99, 1)
+
+	needsCb := mockCurrentNeedsFunc(1, primitives.Slot(math.MaxUint64))
+	seqr := newBatchSequencer(1, gloasSlot+10, 10, needsCb)
+	ib := batch{begin: gloasSlot, end: gloasSlot + 10, state: batchImportable, seq: 1, blocks: verifiedROBlocks{tail}}
+	seqr.seq[0] = ib
+
+	pool := &mockPool{todoChan: make(chan batch, 1)}
+	svc := &Service{
+		clock:    startup.NewClock(time.Now(), [32]byte{}),
+		pool:     pool,
+		batchSeq: seqr,
+		store:    &Store{bs: &dbval.BackfillStatus{}},
+		batchImporter: func(context.Context, primitives.Slot, batch, *Store) (*dbval.BackfillStatus, error) {
+			return nil, errTailColumnsNeeded
+		},
+	}
+	svc.importBatches(t.Context())
+
+	select {
+	case got := <-pool.todoChan:
+		require.Equal(t, batchSyncColumns, got.state)
+		require.Equal(t, ib.begin, got.begin)
+		require.Equal(t, ib.end, got.end)
+	default:
+		t.Fatal("expected the promoted batch to be sent back to the worker pool")
+	}
+	require.Equal(t, batchSyncColumns, seqr.seq[0].state)
+}

--- a/beacon-chain/sync/backfill/columns_test.go
+++ b/beacon-chain/sync/backfill/columns_test.go
@@ -354,7 +354,7 @@ func TestBuildColumnBatch(t *testing.T) {
 		p := p2ptest.NewTestP2P(t)
 		store := filesystem.NewEphemeralDataColumnStorage(t)
 
-		cb, err := buildColumnBatch(ctx, batch{}, verifiedROBlocks{}, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, batch{}, verifiedROBlocks{}, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		nilIshColumnBatch(t, cb)
 	})
@@ -371,7 +371,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   denebSlot + 10,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		nilIshColumnBatch(t, cb)
 	})
@@ -388,7 +388,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot + 10,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		nilIshColumnBatch(t, cb)
 	})
@@ -405,7 +405,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		require.NotNil(t, cb, "batch at Fulu boundary should not be nil")
 	})
@@ -422,7 +422,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot + 1,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		require.NotNil(t, cb, "last block at Fulu boundary should not be nil")
 	})
@@ -438,7 +438,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		nilIshColumnBatch(t, cb)
 	})
@@ -464,7 +464,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot + primitives.Slot(postFuluCount),
 		}
 
-		cb, err := buildColumnBatch(ctx, b, allBlocks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, allBlocks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		require.NotNil(t, cb, "mixed epoch batch should not be nil")
 		// Should only include Fulu blocks
@@ -483,7 +483,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot + 100,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		require.NotNil(t, cb, "first block at Fulu should not be nil")
 		require.Equal(t, 3, len(cb.toDownload), "should include all 3 blocks")
@@ -500,7 +500,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot + 10,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		require.NotNil(t, cb)
 		require.Equal(t, fuluSlot, cb.first, "first slot should be set")
@@ -519,7 +519,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot + 10,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, blks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		require.NotNil(t, cb)
 		require.Equal(t, fuluSlot, cb.first, "first should be slot of first block with commitments")
@@ -549,7 +549,7 @@ func TestBuildColumnBatch(t *testing.T) {
 			end:   fuluSlot + 10,
 		}
 
-		cb, err := buildColumnBatch(ctx, b, allBlocks, p, store, specNeeds)
+		cb, err := buildColumnBatch(ctx, b, allBlocks, p, store, specNeeds, nil)
 		require.NoError(t, err)
 		require.NotNil(t, cb)
 		// Should only have 2 blocks (those with commitments)

--- a/beacon-chain/sync/backfill/columns_test.go
+++ b/beacon-chain/sync/backfill/columns_test.go
@@ -1381,6 +1381,46 @@ func TestNeededSidecarCount(t *testing.T) {
 	}
 }
 
+// TestColumnBatchPruneExpiredUpdatesRequestRange verifies that pruning only part of a
+// column batch also advances the range used for subsequent RPC requests. Otherwise a
+// peer can legitimately return an expired root that is still covered by the stale range,
+// which the response validator rejects because the root was removed from toDownload.
+func TestColumnBatchPruneExpiredUpdatesRequestRange(t *testing.T) {
+	const (
+		expiredSlot       = primitives.Slot(100)
+		firstRetainedSlot = primitives.Slot(101)
+		lastRetainedSlot  = primitives.Slot(102)
+	)
+	remaining := func(slot primitives.Slot) *toDownload {
+		return &toDownload{
+			remaining: peerdas.NewColumnIndicesFromSlice([]uint64{0}),
+			slot:      slot,
+		}
+	}
+	cb := &columnBatch{
+		first:         expiredSlot,
+		last:          lastRetainedSlot,
+		custodyGroups: peerdas.NewColumnIndicesFromSlice([]uint64{0}),
+		toDownload: map[[32]byte]*toDownload{
+			{0x01}: remaining(expiredSlot),
+			{0x02}: remaining(firstRetainedSlot),
+			{0x03}: remaining(lastRetainedSlot),
+		},
+	}
+
+	cb.pruneExpired(das.CurrentNeeds{Col: das.NeedSpan{
+		Begin: firstRetainedSlot,
+		End:   lastRetainedSlot + 1,
+	}}, nil)
+	require.Equal(t, 2, len(cb.toDownload))
+
+	cs := &columnSync{columnBatch: cb}
+	req, err := cs.request([]uint64{0}, columnRequestLimit)
+	require.NoError(t, err)
+	require.Equal(t, firstRetainedSlot, req.StartSlot)
+	require.Equal(t, uint64(2), req.Count)
+}
+
 // TestColumnSyncRequest is a table-driven test that verifies the request method
 // correctly applies fast path (no truncation) and slow path (with truncation) logic
 // based on whether the total sidecar count exceeds the limit.

--- a/beacon-chain/sync/backfill/fulu_transition.go
+++ b/beacon-chain/sync/backfill/fulu_transition.go
@@ -6,16 +6,19 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/das"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 )
 
 var errMissingAvailabilityChecker = errors.Wrap(errUnrecoverable, "batch is missing required availability checker")
 var errUnsafeRange = errors.Wrap(errUnrecoverable, "invalid slice indices")
+var errUnresolvedPayloadFullness = errors.New("gloas block with unresolved payload fullness cannot be imported")
 
 type checkMultiplexer struct {
 	blobCheck    das.AvailabilityChecker
 	colCheck     das.AvailabilityChecker
 	currentNeeds das.CurrentNeeds
+	columns      *columnSync
 }
 
 // Persist implements das.AvailabilityStore.
@@ -24,7 +27,7 @@ var _ das.AvailabilityChecker = &checkMultiplexer{}
 // newCheckMultiplexer initializes an AvailabilityChecker that multiplexes to the BlobSidecar and DataColumnSidecar
 // AvailabilityCheckers present in the batch.
 func newCheckMultiplexer(needs das.CurrentNeeds, b batch) *checkMultiplexer {
-	s := &checkMultiplexer{currentNeeds: needs}
+	s := &checkMultiplexer{currentNeeds: needs, columns: b.columns}
 	if b.blobs != nil && b.blobs.store != nil {
 		s.blobCheck = b.blobs.store
 	}
@@ -39,6 +42,10 @@ func newCheckMultiplexer(needs das.CurrentNeeds, b batch) *checkMultiplexer {
 func (m *checkMultiplexer) IsDataAvailable(ctx context.Context, current primitives.Slot, blks ...blocks.ROBlock) error {
 	needs, err := m.divideByChecker(blks)
 	if err != nil {
+		// An unresolved gloas tail is retryable; the importer settles it against the canonical child.
+		if errors.Is(err, errUnresolvedPayloadFullness) {
+			return err
+		}
 		return errors.Wrap(errUnrecoverable, "failed to slice blocks by DA type")
 	}
 	if err := doAvailabilityCheck(ctx, m.blobCheck, current, needs.blobs); err != nil {
@@ -67,9 +74,10 @@ type daGroups struct {
 	cols  []blocks.ROBlock
 }
 
-// blocksByDaType slices the given blocks into two slices: one for deneb blocks (BlobSidecar)
+// divideByChecker slices the given blocks into two slices: one for deneb blocks (BlobSidecar)
 // and one for fulu blocks (DataColumnSidecar). Blocks that are pre-deneb or have no
-// blob commitments are skipped.
+// blob commitments are skipped, as are gloas blocks whose payload was withheld, since no
+// columns exist for them. A gloas block with unresolved fullness must not be imported on a guess.
 func (m *checkMultiplexer) divideByChecker(blks []blocks.ROBlock) (daGroups, error) {
 	needs := daGroups{}
 	for _, blk := range blks {
@@ -86,6 +94,14 @@ func (m *checkMultiplexer) divideByChecker(blks []blocks.ROBlock) (daGroups, err
 			continue
 		}
 		if m.currentNeeds.Col.At(slot) {
+			if blk.Block().Version() >= version.Gloas {
+				switch m.columns.fullness(blk.Root()) {
+				case fullnessWithheld:
+					continue
+				case fullnessUnknown:
+					return needs, errors.Wrapf(errUnresolvedPayloadFullness, "root=%#x, slot=%d", blk.Root(), slot)
+				}
+			}
 			needs.cols = append(needs.cols, blk)
 			continue
 		}

--- a/beacon-chain/sync/backfill/pool.go
+++ b/beacon-chain/sync/backfill/pool.go
@@ -158,6 +158,10 @@ func (p *p2pBatchWorkerPool) processTodo(todo []batch, pa PeerAssigner, busy map
 	if len(todo) == 0 {
 		return todo, nil
 	}
+	todo = p.completeExpiredColumnWork(todo)
+	if len(todo) == 0 {
+		return todo, nil
+	}
 	notBusy, err := pa.Assign(peers.NotBusy(busy))
 	if err != nil {
 		if errors.Is(err, peers.ErrInsufficientSuitable) {
@@ -226,6 +230,37 @@ func (p *p2pBatchWorkerPool) processTodo(todo []batch, pa PeerAssigner, busy map
 		p.updateEarliest(b.begin)
 	}
 	return []batch{}, nil
+}
+
+// completeExpiredColumnWork prunes column downloads that left the retention window while their
+// batch waited in the column-sync state. A batch left with no column work is transitioned and,
+// when importable, handed back to the service without requiring any peer or column request.
+func (p *p2pBatchWorkerPool) completeExpiredColumnWork(todo []batch) []batch {
+	needs := p.needs()
+	kept := todo[:0]
+	for _, b := range todo {
+		if b.state != batchSyncColumns || b.expired(needs) {
+			kept = append(kept, b)
+			continue
+		}
+		// A batch in batchSyncColumns always has initialized column state, but stay defensive.
+		if b.columns == nil || b.columns.columnBatch == nil {
+			kept = append(kept, b)
+			continue
+		}
+		b.columns.pruneExpired(needs, nil)
+		if len(b.columns.columnsNeeded()) > 0 {
+			kept = append(kept, b)
+			continue
+		}
+		b = b.transitionToNext()
+		if b.workComplete() {
+			p.fromRouter <- b
+			continue
+		}
+		kept = append(kept, b)
+	}
+	return kept
 }
 
 func busyCopy(busy map[peer.ID]bool) map[peer.ID]bool {

--- a/beacon-chain/sync/backfill/pool.go
+++ b/beacon-chain/sync/backfill/pool.go
@@ -233,13 +233,27 @@ func (p *p2pBatchWorkerPool) processTodo(todo []batch, pa PeerAssigner, busy map
 }
 
 // completeExpiredColumnWork prunes column downloads that left the retention window while their
-// batch waited in the column-sync state. A batch left with no column work is transitioned and,
-// when importable, handed back to the service without requiring any peer or column request.
+// batch waited in the column-sync state, including column fetches parked in the retryable state.
+// A batch left with no column work is transitioned and, when importable, handed back to the
+// service without requiring any peer or column request.
 func (p *p2pBatchWorkerPool) completeExpiredColumnWork(todo []batch) []batch {
 	needs := p.needs()
 	kept := todo[:0]
 	for _, b := range todo {
-		if b.state != batchSyncColumns || b.expired(needs) {
+		if b.expired(needs) {
+			kept = append(kept, b)
+			continue
+		}
+		// Failed column fetches must reset their retry bookkeeping before expired work can be
+		// pruned; retries from other states keep their own semantics and are left alone.
+		if b.state == batchErrRetryable && b.retryFrom == batchSyncColumns {
+			b = resetToRetryColumns(b, needs)
+			if b.workComplete() {
+				p.fromRouter <- b
+				continue
+			}
+		}
+		if b.state != batchSyncColumns {
 			kept = append(kept, b)
 			continue
 		}

--- a/beacon-chain/sync/backfill/service.go
+++ b/beacon-chain/sync/backfill/service.go
@@ -179,6 +179,15 @@ func (s *Service) importBatches(ctx context.Context) {
 		}
 		_, err := s.batchImporter(ctx, current, ib, s.store)
 		if err != nil {
+			if errors.Is(err, errTailColumnsNeeded) {
+				// The tail proved revealed at import time; send the batch back through the worker
+				// pool to download its promoted custody columns without discarding verified blocks.
+				log.WithFields(ib.logFields()).WithError(err).Debug("Returning batch to column sync for revealed tail payload")
+				retry := ib.withState(batchSyncColumns)
+				s.batchSeq.update(retry)
+				s.pool.todo(retry)
+				break
+			}
 			log.WithError(err).WithFields(ib.logFields()).Debug("Backfill batch failed to import")
 			s.batchSeq.update(ib.withError(err))
 			// If a batch fails, the subsequent batches are no longer considered importable.
@@ -223,12 +232,71 @@ func (s *Service) defaultBatchImporter(ctx context.Context, current primitives.S
 	if err := b.ensureParent(bytesutil.ToBytes32(status.LowParentRoot)); err != nil {
 		return status, err
 	}
+	needs := s.syncNeeds.Currently()
+	// A gloas batch tail has no in-batch child to prove payload fullness; settle it against the
+	// already-imported child before the availability check decides whether its columns are required.
+	if err := s.resolveTailFullness(ctx, su, b, needs); err != nil {
+		return status, err
+	}
 	// Import blocks to db and update db state to reflect the newly imported blocks.
 	// Other parts of the beacon node may use the same StatusUpdater instance
 	// via the coverage.AvailableBlocker interface to safely determine if a given slot has been backfilled.
 
-	checker := newCheckMultiplexer(s.syncNeeds.Currently(), b)
+	checker := newCheckMultiplexer(needs, b)
 	return su.fillBack(ctx, current, b.blocks, checker)
+}
+
+// errTailColumnsNeeded means the batch tail was proven to have revealed its payload at import time,
+// so its custody columns became required work that must be downloaded before the batch can import.
+var errTailColumnsNeeded = errors.New("batch tail payload revealed, custody columns required")
+
+// resolveTailFullness settles the payload fullness of the batch tail using the canonical child at
+// BackfillStatus.LowRoot, which ensureParent has proven to be the tail's direct child. A withheld
+// tail needs no columns; a revealed tail has its missing custody columns promoted to required work
+// via errTailColumnsNeeded. If the child cannot be read, the import is deferred rather than guessed.
+func (s *Service) resolveTailFullness(ctx context.Context, su *Store, b batch, needs das.CurrentNeeds) error {
+	if len(b.blocks) == 0 {
+		return nil
+	}
+	tail := b.blocks[len(b.blocks)-1]
+	td := b.columns.blockColumns(tail.Root())
+	if td == nil || td.fullness == fullnessWithheld {
+		return nil
+	}
+	// If the tail left the column retention window while waiting to import, peers are no longer
+	// obligated to serve its columns and none are required; the DA check skips it the same way.
+	if !needs.Col.At(tail.Block().Slot()) {
+		return nil
+	}
+	if td.fullness == fullnessRevealed {
+		// A previously promoted tail stays in column sync until its columns are downloaded.
+		if td.remaining.Count() > 0 {
+			return errors.Wrapf(errTailColumnsNeeded, "root=%#x, slot=%d", tail.Root(), tail.Block().Slot())
+		}
+		return nil
+	}
+	child, err := su.boundaryChild(ctx, tail.Root())
+	if err != nil {
+		return errors.Wrap(err, "boundary child")
+	}
+	if child == nil {
+		// Unreachable after ensureParent; defer the import rather than guess.
+		return errors.Wrapf(errChainBroken, "no imported child to prove payload fullness of tail root=%#x", tail.Root())
+	}
+	fullness, err := fullnessFromChild(tail.Block(), child.Block())
+	if err != nil {
+		return err
+	}
+	td.fullness = fullness
+	if fullness == fullnessWithheld {
+		return nil
+	}
+	td.remaining = das.IndicesNotStored(s.dcStore.Summary(tail.Root()), b.columns.custodyGroups)
+	if td.remaining.Count() == 0 {
+		// All custody columns are already on disk, e.g. persisted by a previous run.
+		return nil
+	}
+	return errors.Wrapf(errTailColumnsNeeded, "root=%#x, slot=%d", tail.Root(), tail.Block().Slot())
 }
 
 func (s *Service) scheduleTodos() {

--- a/beacon-chain/sync/backfill/status.go
+++ b/beacon-chain/sync/backfill/status.go
@@ -112,6 +112,28 @@ func (s *Store) fillBack(ctx context.Context, current primitives.Slot, blocks []
 	return status, s.saveStatus(ctx, status)
 }
 
+// boundaryChild returns the lowest imported block when it is the direct child of the given root.
+// During backfill, the block at BackfillStatus.LowRoot is the canonical child of the next batch's
+// tail block; for gloas its bid testifies whether the tail's payload was revealed or withheld.
+func (s *Store) boundaryChild(ctx context.Context, parentRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
+	status := s.status()
+	if bytesutil.ToBytes32(status.LowParentRoot) != parentRoot {
+		return nil, nil
+	}
+	child, err := s.store.Block(ctx, bytesutil.ToBytes32(status.LowRoot))
+	if err != nil {
+		return nil, errors.Wrapf(err, "block at backfill low root %#x", status.LowRoot)
+	}
+	if err := blocks.BeaconBlockIsNil(child); err != nil {
+		return nil, errors.Wrapf(err, "block at backfill low root %#x", status.LowRoot)
+	}
+	if child.Block().ParentRoot() != parentRoot {
+		return nil, errors.Wrapf(errBatchDisconnected, "block at low root %#x has parent_root=%#x, expected %#x",
+			status.LowRoot, child.Block().ParentRoot(), parentRoot)
+	}
+	return child, nil
+}
+
 // recoverLegacy will check to see if the db is from a legacy checkpoint sync, and either build a new BackfillStatus
 // or label the node as synced from genesis.
 func (s *Store) recoverLegacy(ctx context.Context) error {

--- a/beacon-chain/sync/backfill/worker.go
+++ b/beacon-chain/sync/backfill/worker.go
@@ -30,6 +30,9 @@ type workerCfg struct {
 	colStore     *filesystem.DataColumnStorage
 	downscore    peerDownscorer
 	currentNeeds func() das.CurrentNeeds
+	// boundaryChild is a best-effort lookup used to resolve batch-tail payload fullness at
+	// build time; the importer remains the authoritative resolver.
+	boundaryChild boundaryChildFn
 }
 
 func initWorkerCfg(ctx context.Context, cfg *workerCfg, vw InitializerWaiter, store *Store) error {
@@ -58,6 +61,7 @@ func initWorkerCfg(ctx context.Context, cfg *workerCfg, vw InitializerWaiter, st
 	cfg.ctxMap = cm
 	cfg.newVB = newBlobVerifierFromInitializer(vi)
 	cfg.newVC = newDataColumnVerifierFromInitializer(vi)
+	cfg.boundaryChild = store.boundaryChild
 	return nil
 }
 

--- a/changelog/satushh_gloas-backfill-withheld-columns.md
+++ b/changelog/satushh_gloas-backfill-withheld-columns.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix backfill handling of gloas withheld-payload data columns: classify payload fullness as revealed, withheld, or unknown instead of assuming the batch-tail block is revealed, resolve an unknown tail against the already-imported child at `BackfillStatus.LowRoot` before import, and exclude withheld blocks from the data column availability check so batches no longer wedge in `batchSyncColumns` or fail import forever.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

- Classify Gloas backfill payloads as revealed, withheld, or unresolved using their canonical child, and exclude withheld payloads from column availability checks.
- Resolve batch-tail fullness safely at import time and retry revealed tails for columns without wedging when column retention expires.
- Add regression coverage for classification, downloading, persistence, import, and retention expiry.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
