### PR TITLE
Mark state fields dirty on early return

### DIFF
--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -607,6 +607,15 @@ func (b *BeaconState) DecreaseWithdrawalBalances(withdrawals []*enginev1.Withdra
 		balanceIndices  []uint64
 		buildersChanged bool
 	)
+	defer func() {
+		if len(balanceIndices) > 0 {
+			b.markFieldAsDirty(types.Balances)
+			b.addDirtyIndices(types.Balances, balanceIndices)
+		}
+		if buildersChanged {
+			b.markFieldAsDirty(types.Builders)
+		}
+	}()
 
 	for _, withdrawal := range withdrawals {
 		if withdrawal == nil {
@@ -634,17 +643,6 @@ func (b *BeaconState) DecreaseWithdrawalBalances(withdrawals []*enginev1.Withdra
 			return pkgerrors.Wrap(err, "could not update balances")
 		}
 		balanceIndices = append(balanceIndices, uint64(withdrawal.ValidatorIndex))
-	}
-
-	if len(balanceIndices) > 0 {
-		b.markFieldAsDirty(types.Balances)
-		b.addDirtyIndices(types.Balances, balanceIndices)
-	}
-
-	// NOTE: Field "Builders" is not in fieldMap so per-index dirty tracking with addDirtyIndices is a no-op.
-	// Only mark the entire field as dirty if any builder balances were changed.
-	if buildersChanged {
-		b.markFieldAsDirty(types.Builders)
 	}
 
 	return nil

--- a/beacon-chain/state/state-native/setters_validator.go
+++ b/beacon-chain/state/state-native/setters_validator.go
@@ -32,6 +32,16 @@ func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
 // validator registry.
 func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val state.ReadOnlyValidator) (*ethpb.Validator, error)) error {
 	var changedVals []uint64
+	defer func() {
+		if len(changedVals) == 0 {
+			return
+		}
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		b.markFieldAsDirty(types.Validators)
+		b.addDirtyIndices(types.Validators, changedVals)
+	}()
+
 	l := b.validatorsMultiValue.Len(b)
 	ro := new(readOnlyValidator)
 	for i := range l {
@@ -45,21 +55,14 @@ func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val state.ReadOnlyVa
 			return err
 		}
 		if newVal != nil {
-			changedVals = append(changedVals, uint64(i))
 			compactValidator := stateutil.CompactValidatorFromProto(newVal)
 			if err := b.validatorsMultiValue.UpdateAt(b, uint64(i), compactValidator); err != nil {
 				return errors.Wrapf(err, "could not update validator at index %d", i)
 			}
+			changedVals = append(changedVals, uint64(i))
 		}
 	}
 
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	if len(changedVals) > 0 {
-		b.markFieldAsDirty(types.Validators)
-		b.addDirtyIndices(types.Validators, changedVals)
-	}
 	return nil
 }
 

--- a/changelog/kasey_state-dirty-tracking-early-return.md
+++ b/changelog/kasey_state-dirty-tracking-early-return.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Mark validator, balance and builder state fields dirty even when the
+  enclosing setter returns early with an error.


### PR DESCRIPTION
# Mark state fields dirty on early return

`ApplyToEveryValidator` and `DecreaseWithdrawalBalances` mutate the multi-value validator and
balance slices in place as they iterate, but they only recorded their dirty field indices *after*
the loop ran to completion. Any error part way through returns early and skips that bookkeeping, so
mutations that were already applied to the state end up untracked. The next `HashTreeRoot` then
reuses stale cached subtrees for those fields and computes a root that does not match the state's
actual contents.

The fix moves the dirty-field bookkeeping into a `defer` so it runs on every exit
path, and in `ApplyToEveryValidator` record an index only once its update has actually succeeded. No new tests accompany the change; it is a bookkeeping correction on error paths that the existing state setter tests do not exercise.

(Kasey is opening this PR stack to streamline the review process but the author is @Inspector-Butters).

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>