### PR TITLE
spectest alpha 12 compliance (spec pin bump and assorted fix commits)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,6 +24,11 @@ build --workspace_status_command=./hack/workspace_status.sh
 build --define blst_disabled=false
 run --define blst_disabled=false
 
+# SSZ progressive merkleization is ON by default: gloas (EIP-7688) mandates it
+# and the consensus-spec fixtures expect the progressive hash_tree_root values.
+# Pass --//tools:disable_progressive_merkleization to build/test the bounded
+# form instead. See //tools:BUILD.bazel.
+
 build:blst_disabled --define blst_disabled=true
 build:blst_disabled --define gotags=blst_disabled
 

--- a/.ethspecify.yml
+++ b/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.11
+version: v1.7.0-alpha.12
 style: full
 
 specrefs:

--- a/.ethspecify.yml
+++ b/.ethspecify.yml
@@ -18,7 +18,6 @@ specrefs:
 exceptions:
   presets:
     # gloas
-    - BUILDER_PENDING_WITHDRAWALS_LIMIT#gloas
     - MAX_PAYLOAD_ATTESTATIONS#gloas
     - PTC_SIZE#gloas
 
@@ -100,6 +99,7 @@ exceptions:
     # phase0
     - Eth1Block#phase0
     # fulu
+    - PartialDataColumnGroupID#fulu
     - PartialDataColumnHeader#fulu
     - PartialDataColumnPartsMetadata#fulu
     - PartialDataColumnSidecar#fulu
@@ -253,7 +253,7 @@ exceptions:
     - get_current_balance_source#phase0
     - get_current_target#phase0
     - get_current_target_score#phase0
-    - get_dependent_root#phase0
+    - get_shuffling_dependent_root#phase0
     - get_equivocation_score#phase0
     - get_fast_confirmation_store#phase0
     - get_latest_confirmed#phase0
@@ -478,7 +478,7 @@ exceptions:
     - get_forkchoice_store#gloas
     - get_head#gloas
     - get_indexed_payload_attestation#gloas
-    - get_dependent_root#gloas
+    - get_shuffling_dependent_root#gloas
     - get_next_sync_committee_indices#gloas
     - get_node_children#gloas
     - get_node_for_root#gloas
@@ -536,7 +536,7 @@ exceptions:
     - get_builder_withdrawals#gloas
     - get_builders_sweep_withdrawals#gloas
     - get_index_for_new_builder#gloas
-    - get_proposer_preferences_signature#gloas
+    - get_signed_proposer_preferences#gloas
     - get_upcoming_proposal_slots#gloas
     - is_active_builder#gloas
     - is_builder_index#gloas
@@ -559,11 +559,13 @@ exceptions:
     - block_to_light_client_header#gloas
     - compute_exit_epoch_and_update_churn#gloas
     - compute_weak_subjectivity_period#gloas
+    - current_sync_committee_gindex_at_slot#gloas
+    - finalized_root_gindex_at_slot#gloas
+    - next_sync_committee_gindex_at_slot#gloas
     - get_activation_churn_limit#gloas
     - get_consolidation_churn_limit#gloas
     - get_exit_churn_limit#gloas
     - get_lc_execution_root#gloas
-    - get_proposer_dependent_root#gloas
     - is_valid_light_client_header#gloas
     - process_pending_deposits#gloas
     - upgrade_lc_bootstrap_to_gloas#gloas
@@ -577,8 +579,10 @@ exceptions:
     - compute_fork_version#heze
     - get_forkchoice_store#heze
     - get_inclusion_list_committee_assignment#heze
+    - get_inclusion_list_bits#heze
     - get_inclusion_list_committee#heze
     - get_inclusion_list_signature#heze
+    - is_inclusion_list_bits_inclusive#heze
     - get_inclusion_list_store#heze
     - get_inclusion_list_transactions#heze
     - is_payload_inclusion_list_satisfied#heze
@@ -599,16 +603,21 @@ exceptions:
     - process_builder_deposit_request#gloas
     - process_builder_exit_request#gloas
     # phase0
-    - is_epoch_boundary#phase0
+    - is_not_epoch_boundary#phase0
   presets:
     # gloas
-    - BUILDER_PENDING_WITHDRAWALS_LIMIT#gloas
-    - BUILDER_REGISTRY_LIMIT#gloas
+    - MAX_ATTESTER_SLASHING_SIZE#gloas
     - MAX_BUILDERS_PER_WITHDRAWALS_SWEEP#gloas
+    - MAX_DATA_COLUMN_SIDECAR_SIZE#gloas
+    - MAX_PARTIAL_DATA_COLUMN_SIDECAR_SIZE#gloas
     - MAX_PAYLOAD_ATTESTATIONS#gloas
+    - MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE#gloas
+    - MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE#gloas
     - PTC_SIZE#gloas
     # heze
     - INCLUSION_LIST_COMMITTEE_SIZE#heze
+    - MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE#heze
+    - MAX_SIGNED_INCLUSION_LIST_SIZE#heze
     # gloas (EIP-8282)
     - MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD#gloas
     - MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD#gloas

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -282,16 +282,16 @@ filegroup(
     url = "https://github.com/ethereum/EIPs/archive/5480440fe51742ed23342b68cf106cefd427e39d.tar.gz",
 )
 
-consensus_spec_version = "v1.7.0-alpha.11"
+consensus_spec_version = "v1.7.0-alpha.12"
 
 load("@prysm//tools:download_spectests.bzl", "consensus_spec_tests")
 
 consensus_spec_tests(
     name = "consensus_spec_tests",
     flavors = {
-        "general": "sha256-szDpBVO2Ebi8/bwbiWFpW6H4c5gxnpU3hAUS31AF02E=",
-        "minimal": "sha256-irUv63gOA03eGIFD23Ca3PsDq87ovrA/HVAvtSG6/0o=",
-        "mainnet": "sha256-lWzAX5uy50Xs0Etg+yu5FnnIDt6C6BtIm11HqdZetms=",
+        "general": "sha256-Mp889Ykn3yYU7K+8546zxSWKE+hzHS9BC7Mdjkpbnq8=",
+        "minimal": "sha256-fXng6W/dZmqnDLdBNyk1xdMNStYHrjmYhSEulxSliwc=",
+        "mainnet": "sha256-8AV9Ks3qJzDsaMrCx5aq2JF04Q6bOKxorX2KocDL2Fw=",
     },
     version = consensus_spec_version,
 )
@@ -307,7 +307,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    integrity = "sha256-6XWl6m5tkPIlx5eh3DxrHAShRzWh3gz4LlLjIM78wJo=",
+    integrity = "sha256-bd1ii7rnjYwiEun4br2U/E+zJ9lXZ72WxIditScOM/0=",
     strip_prefix = "consensus-specs-" + consensus_spec_version[1:],
     url = "https://github.com/ethereum/consensus-specs/archive/refs/tags/%s.tar.gz" % consensus_spec_version,
 )

--- a/beacon-chain/core/gloas/BUILD.bazel
+++ b/beacon-chain/core/gloas/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "builder_deposit_request_test.go",
         "builder_exit_request_test.go",
         "deposit_request_test.go",
+        "parent_payload_test.go",
         "payload_attestation_test.go",
         "payload_test.go",
         "pending_payment_test.go",

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -93,18 +93,22 @@ func processBuilderDepositRequest(ctx context.Context, st state.BeaconState, req
 
 	pubkey := bytesutil.ToBytes48(request.Pubkey)
 	if idx, isBuilder := st.BuilderIndexByPubkey(pubkey); isBuilder {
-		if err := st.IncreaseBuilderBalance(idx, request.Amount); err != nil {
-			return err
-		}
 		builder, err := st.Builder(idx)
 		if err != nil {
 			return err
 		}
-		if builder.WithdrawableEpoch != params.BeaconConfig().FarFutureEpoch {
+		if builder == nil {
+			return errors.Errorf("builder at index %d is nil", idx)
+		}
+		// Reset only when exited and fully swept, checked before the top-up is credited.
+		if builder.WithdrawableEpoch != params.BeaconConfig().FarFutureEpoch && builder.Balance == 0 {
 			builder.WithdrawableEpoch = slots.ToEpoch(st.Slot()) + params.BeaconConfig().MinBuilderWithdrawabilityDelay
 			if err := st.UpdateBuilderAtIndex(idx, builder); err != nil {
 				return err
 			}
+		}
+		if err := st.IncreaseBuilderBalance(idx, request.Amount); err != nil {
+			return err
 		}
 		builderDepositsProcessedTotal.Inc()
 		return nil

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -27,7 +27,7 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 	newDeposits := make([]*enginev1.BuilderDepositRequest, 0, len(requests))
 	newIdx := make([]int, 0, len(requests))
 	for i, request := range requests {
-		if request == nil {
+		if request == nil || !helpers.IsBuilderWithdrawalCredential(request.WithdrawalCredentials) {
 			continue
 		}
 		if _, isBuilder := st.BuilderIndexByPubkey(bytesutil.ToBytes48(request.Pubkey)); !isBuilder {
@@ -84,6 +84,11 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 func processBuilderDepositRequest(ctx context.Context, st state.BeaconState, request *enginev1.BuilderDepositRequest, status sigStatus) error {
 	if request == nil {
 		return errors.New("nil builder deposit request")
+	}
+
+	// Deposits without BUILDER_WITHDRAWAL_PREFIX are dropped and the funds are lost.
+	if !helpers.IsBuilderWithdrawalCredential(request.WithdrawalCredentials) {
+		return nil
 	}
 
 	pubkey := bytesutil.ToBytes48(request.Pubkey)

--- a/beacon-chain/core/gloas/builder_deposit_request.go
+++ b/beacon-chain/core/gloas/builder_deposit_request.go
@@ -56,15 +56,19 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 
 // processBuilderDepositRequest registers a new builder or tops up an existing one.
 //
-//	<spec fn="process_builder_deposit_request" fork="gloas" hash="c3ba5adf">
+//	<spec fn="process_builder_deposit_request" fork="gloas" hash="1d458f9c">
 //	def process_builder_deposit_request(state: BeaconState, request: BuilderDepositRequest) -> None:
+//	    # Ignore deposits with unexpected withdrawal credential prefixes
+//	    if not is_builder_withdrawal_credential(request.withdrawal_credentials):
+//	        return
+//
 //	    builder_pubkeys = [b.pubkey for b in state.builders]
 //	    if request.pubkey not in builder_pubkeys:
 //	        if is_valid_builder_deposit_signature(request):
 //	            add_builder_to_registry(
 //	                state,
 //	                request.pubkey,
-//	                uint8(request.withdrawal_credentials[0]),
+//	                PAYLOAD_BUILDER_VERSION,
 //	                ExecutionAddress(request.withdrawal_credentials[12:]),
 //	                request.amount,
 //	                state.slot,
@@ -73,13 +77,13 @@ func ProcessBuilderDepositRequests(ctx context.Context, st state.BeaconState, re
 //	        builder_index = BuilderIndex(builder_pubkeys.index(request.pubkey))
 //	        builder = state.builders[builder_index]
 //
-//	        # Increase balance by deposit amount
-//	        builder.balance += request.amount
-//
-//	        # If exited, reset the withdrawable epoch
-//	        if builder.withdrawable_epoch != FAR_FUTURE_EPOCH:
+//	        # If exited and swept, reset the withdrawable epoch
+//	        if builder.withdrawable_epoch != FAR_FUTURE_EPOCH and builder.balance == 0:
 //	            epoch = get_current_epoch(state)
 //	            builder.withdrawable_epoch = epoch + MIN_BUILDER_WITHDRAWABILITY_DELAY
+//
+//	        # Increase balance by deposit amount
+//	        builder.balance += request.amount
 //	</spec>
 func processBuilderDepositRequest(ctx context.Context, st state.BeaconState, request *enginev1.BuilderDepositRequest, status sigStatus) error {
 	if request == nil {

--- a/beacon-chain/core/gloas/builder_deposit_request_test.go
+++ b/beacon-chain/core/gloas/builder_deposit_request_test.go
@@ -11,6 +11,7 @@ import (
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
 func signedBuilderDepositRequest(t *testing.T, sk bls.SecretKey, cred [32]byte, amount uint64) *enginev1.BuilderDepositRequest {
@@ -135,6 +136,68 @@ func TestProcessBuilderDepositRequest_ExistingBuilderTopsUpNoSignatureCheck(t *t
 	builder, err := st.Builder(idx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(205), uint64(builder.Balance))
+}
+
+func TestProcessBuilderDepositRequest_ExitedSweptBuilderTopUpResetsWithdrawableEpoch(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	pubkey := sk.PublicKey().Marshal()
+	builders := []*ethpb.Builder{{
+		Pubkey:            pubkey,
+		Version:           []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           0,
+		WithdrawableEpoch: 0,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	cred := builderWithdrawalCredentials()
+	req := &enginev1.BuilderDepositRequest{
+		Pubkey:                pubkey,
+		WithdrawalCredentials: cred[:],
+		Amount:                200,
+		Signature:             make([]byte, 96),
+	}
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, sigUnverified))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), uint64(builder.Balance))
+	expected := slots.ToEpoch(st.Slot()) + params.BeaconConfig().MinBuilderWithdrawabilityDelay
+	require.Equal(t, expected, builder.WithdrawableEpoch)
+}
+
+func TestProcessBuilderDepositRequest_ExitedUnsweptBuilderTopUpKeepsWithdrawableEpoch(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	pubkey := sk.PublicKey().Marshal()
+	exitedEpoch := primitives.Epoch(1)
+	builders := []*ethpb.Builder{{
+		Pubkey:            pubkey,
+		Version:           []byte{params.BeaconConfig().BuilderWithdrawalPrefixByte},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           5,
+		WithdrawableEpoch: exitedEpoch,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	cred := builderWithdrawalCredentials()
+	req := &enginev1.BuilderDepositRequest{
+		Pubkey:                pubkey,
+		WithdrawalCredentials: cred[:],
+		Amount:                200,
+		Signature:             make([]byte, 96),
+	}
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, sigUnverified))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(205), uint64(builder.Balance))
+	require.Equal(t, exitedEpoch, builder.WithdrawableEpoch)
 }
 
 func TestProcessBuilderDepositRequests_BatchMixedValidInvalidAndTopUp(t *testing.T) {

--- a/beacon-chain/core/gloas/builder_deposit_request_test.go
+++ b/beacon-chain/core/gloas/builder_deposit_request_test.go
@@ -46,7 +46,7 @@ func TestProcessBuilderDepositRequest_NewBuilderValidSignature(t *testing.T) {
 	builder, err := st.Builder(idx)
 	require.NoError(t, err)
 	require.DeepEqual(t, req.Pubkey, builder.Pubkey)
-	require.DeepEqual(t, []byte{cred[0]}, builder.Version)
+	require.DeepEqual(t, []byte{params.BeaconConfig().PayloadBuilderVersion}, builder.Version)
 	require.DeepEqual(t, cred[12:], builder.ExecutionAddress)
 	require.Equal(t, uint64(1234), uint64(builder.Balance))
 	require.Equal(t, params.BeaconConfig().FarFutureEpoch, builder.WithdrawableEpoch)
@@ -63,6 +63,50 @@ func TestProcessBuilderDepositRequest_NewBuilderInvalidSignatureIgnored(t *testi
 
 	_, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
 	require.Equal(t, false, ok)
+}
+
+func TestProcessBuilderDepositRequest_NewBuilderNonBuilderPrefixIgnored(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	cred := builderWithdrawalCredentials()
+	cred[0] = 0x01
+	req := signedBuilderDepositRequest(t, sk, cred, 1234)
+
+	st := newGloasState(t, nil, nil)
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, sigKnownValid))
+
+	_, ok := st.BuilderIndexByPubkey(toBytes48(req.Pubkey))
+	require.Equal(t, false, ok)
+}
+
+func TestProcessBuilderDepositRequest_TopUpNonBuilderPrefixIgnored(t *testing.T) {
+	sk, err := bls.RandKey()
+	require.NoError(t, err)
+	pubkey := sk.PublicKey().Marshal()
+	builders := []*ethpb.Builder{{
+		Pubkey:            pubkey,
+		Version:           []byte{params.BeaconConfig().PayloadBuilderVersion},
+		ExecutionAddress:  bytes.Repeat([]byte{0x11}, 20),
+		Balance:           5,
+		WithdrawableEpoch: params.BeaconConfig().FarFutureEpoch,
+	}}
+	st := newGloasState(t, nil, builders)
+
+	cred := builderWithdrawalCredentials()
+	cred[0] = 0x01
+	req := &enginev1.BuilderDepositRequest{
+		Pubkey:                pubkey,
+		WithdrawalCredentials: cred[:],
+		Amount:                200,
+		Signature:             make([]byte, 96),
+	}
+	require.NoError(t, processBuilderDepositRequest(t.Context(), st, req, sigKnownValid))
+
+	idx, ok := st.BuilderIndexByPubkey(toBytes48(pubkey))
+	require.Equal(t, true, ok)
+	builder, err := st.Builder(idx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), uint64(builder.Balance))
 }
 
 func TestProcessBuilderDepositRequest_ExistingBuilderTopsUpNoSignatureCheck(t *testing.T) {

--- a/beacon-chain/core/gloas/parent_payload.go
+++ b/beacon-chain/core/gloas/parent_payload.go
@@ -6,6 +6,7 @@ import (
 
 	requests "github.com/OffchainLabs/prysm/v7/beacon-chain/core/requests"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
@@ -63,7 +64,11 @@ func ProcessParentExecutionPayload(ctx context.Context, st state.BeaconState, bl
 // and mutates st. Called by ProcessParentExecutionPayload and by the validator during
 // block production before computing withdrawals.
 //
-//	<spec fn="apply_parent_execution_payload" fork="gloas" hash="defer_payload">
+//	<spec fn="apply_parent_execution_payload" fork="gloas" hash="bd6df5afe2">
+//	    assert len(requests.withdrawals) <= MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
+//	    assert len(requests.consolidations) <= MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
+//	    assert len(requests.builder_deposits) <= MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD
+//	    assert len(requests.builder_exits) <= MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD
 func ApplyParentExecutionPayload(
 	ctx context.Context,
 	st state.BeaconState,
@@ -74,6 +79,10 @@ func ApplyParentExecutionPayload(
 		return errors.Wrap(err, "could not get latest execution payload bid")
 	}
 	parentSlot := parentBid.Slot()
+
+	if err := validateExecutionRequestLengths(reqs); err != nil {
+		return err
+	}
 
 	if err := processExecutionRequests(ctx, st, reqs); err != nil {
 		return errors.Wrap(err, "could not process parent execution requests")
@@ -92,6 +101,25 @@ func ApplyParentExecutionPayload(
 		return errors.Wrap(err, "could not set latest block hash")
 	}
 
+	return nil
+}
+
+// validateExecutionRequestLengths enforces the per-payload maxima that remain
+// consensus-layer checks now that EIP-7688 uses ProgressiveList SSZ types.
+func validateExecutionRequestLengths(reqs *enginev1.ExecutionRequestsGloas) error {
+	cfg := params.BeaconConfig()
+	if uint64(len(reqs.GetWithdrawals())) > cfg.MaxWithdrawalRequestsPerPayload {
+		return errors.Errorf("too many withdrawal requests: %d > %d", len(reqs.GetWithdrawals()), cfg.MaxWithdrawalRequestsPerPayload)
+	}
+	if uint64(len(reqs.GetConsolidations())) > cfg.MaxConsolidationsRequestsPerPayload {
+		return errors.Errorf("too many consolidation requests: %d > %d", len(reqs.GetConsolidations()), cfg.MaxConsolidationsRequestsPerPayload)
+	}
+	if uint64(len(reqs.GetBuilderDeposits())) > cfg.MaxBuilderDepositRequestsPerPayload {
+		return errors.Errorf("too many builder deposit requests: %d > %d", len(reqs.GetBuilderDeposits()), cfg.MaxBuilderDepositRequestsPerPayload)
+	}
+	if uint64(len(reqs.GetBuilderExits())) > cfg.MaxBuilderExitRequestsPerPayload {
+		return errors.Errorf("too many builder exit requests: %d > %d", len(reqs.GetBuilderExits()), cfg.MaxBuilderExitRequestsPerPayload)
+	}
 	return nil
 }
 

--- a/beacon-chain/core/gloas/parent_payload_test.go
+++ b/beacon-chain/core/gloas/parent_payload_test.go
@@ -1,0 +1,27 @@
+package gloas
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func TestValidateExecutionRequestLengths_DepositsUnbounded(t *testing.T) {
+	cfg := params.BeaconConfig()
+	reqs := &enginev1.ExecutionRequestsGloas{
+		Deposits: make([]*enginev1.DepositRequest, int(cfg.MaxDepositRequestsPerPayload)+1),
+	}
+
+	require.NoError(t, validateExecutionRequestLengths(reqs))
+}
+
+func TestValidateExecutionRequestLengths_WithdrawalsBounded(t *testing.T) {
+	cfg := params.BeaconConfig()
+	reqs := &enginev1.ExecutionRequestsGloas{
+		Withdrawals: make([]*enginev1.WithdrawalRequest, int(cfg.MaxWithdrawalRequestsPerPayload)+1),
+	}
+
+	require.ErrorContains(t, "too many withdrawal requests", validateExecutionRequestLengths(reqs))
+}

--- a/beacon-chain/core/gloas/upgrade.go
+++ b/beacon-chain/core/gloas/upgrade.go
@@ -17,7 +17,7 @@ import (
 
 // UpgradeToGloas updates inputs a generic state to return the version Gloas state.
 //
-//	<spec fn="upgrade_to_gloas" fork="gloas" hash="c769e40a">
+//	<spec fn="upgrade_to_gloas" fork="gloas" hash="571abe9a">
 //	def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
 //	    epoch = fulu.get_current_epoch(pre)
 //
@@ -38,17 +38,26 @@ import (
 //	        eth1_data=pre.eth1_data,
 //	        eth1_data_votes=pre.eth1_data_votes,
 //	        eth1_deposit_index=pre.eth1_deposit_index,
-//	        validators=pre.validators,
-//	        balances=pre.balances,
+//	        # [Modified in Gloas:EIP7688]
+//	        validators=ProgressiveList[Validator](list(pre.validators)),
+//	        # [Modified in Gloas:EIP7688]
+//	        balances=ProgressiveList[Gwei](list(pre.balances)),
 //	        randao_mixes=pre.randao_mixes,
 //	        slashings=pre.slashings,
-//	        previous_epoch_participation=pre.previous_epoch_participation,
-//	        current_epoch_participation=pre.current_epoch_participation,
+//	        # [Modified in Gloas:EIP7688]
+//	        previous_epoch_participation=ProgressiveList[ParticipationFlags](
+//	            list(pre.previous_epoch_participation)
+//	        ),
+//	        # [Modified in Gloas:EIP7688]
+//	        current_epoch_participation=ProgressiveList[ParticipationFlags](
+//	            list(pre.current_epoch_participation)
+//	        ),
 //	        justification_bits=pre.justification_bits,
 //	        previous_justified_checkpoint=pre.previous_justified_checkpoint,
 //	        current_justified_checkpoint=pre.current_justified_checkpoint,
 //	        finalized_checkpoint=pre.finalized_checkpoint,
-//	        inactivity_scores=pre.inactivity_scores,
+//	        # [Modified in Gloas:EIP7688]
+//	        inactivity_scores=ProgressiveList[uint64](list(pre.inactivity_scores)),
 //	        current_sync_committee=pre.current_sync_committee,
 //	        next_sync_committee=pre.next_sync_committee,
 //	        # [Modified in Gloas:EIP7732]
@@ -64,9 +73,16 @@ import (
 //	        earliest_exit_epoch=pre.earliest_exit_epoch,
 //	        consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
 //	        earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
-//	        pending_deposits=pre.pending_deposits,
-//	        pending_partial_withdrawals=pre.pending_partial_withdrawals,
-//	        pending_consolidations=pre.pending_consolidations,
+//	        # [Modified in Gloas:EIP7688]
+//	        pending_deposits=ProgressiveList[PendingDeposit](list(pre.pending_deposits)),
+//	        # [Modified in Gloas:EIP7688]
+//	        pending_partial_withdrawals=ProgressiveList[PendingPartialWithdrawal](
+//	            list(pre.pending_partial_withdrawals)
+//	        ),
+//	        # [Modified in Gloas:EIP7688]
+//	        pending_consolidations=ProgressiveList[PendingConsolidation](
+//	            list(pre.pending_consolidations)
+//	        ),
 //	        proposer_lookahead=pre.proposer_lookahead,
 //	        # [New in Gloas:EIP7732]
 //	        builders=[],

--- a/beacon-chain/core/gloas/withdrawals.go
+++ b/beacon-chain/core/gloas/withdrawals.go
@@ -11,31 +11,35 @@ import (
 //
 // <spec fn="process_withdrawals" fork="gloas" hash="24ca56d3">
 // def process_withdrawals(
-//     state: BeaconState,
-//     # [Modified in Gloas:EIP7732]
-//     # Removed `payload`
+//
+//	state: BeaconState,
+//	# [Modified in Gloas:EIP7732]
+//	# Removed `payload`
+//
 // ) -> None:
-//     # [New in Gloas:EIP7732]
-//     # Return early if the parent block is empty
-//     if state.latest_block_hash != state.latest_execution_payload_bid.block_hash:
-//         return
 //
-//     # Get expected withdrawals
-//     expected = get_expected_withdrawals(state)
+//	# [New in Gloas:EIP7732]
+//	# Return early if the parent block is empty
+//	if state.latest_block_hash != state.latest_execution_payload_bid.block_hash:
+//	    return
 //
-//     # Apply expected withdrawals
-//     apply_withdrawals(state, expected.withdrawals)
+//	# Get expected withdrawals
+//	expected = get_expected_withdrawals(state)
 //
-//     # Update withdrawals fields in the state
-//     update_next_withdrawal_index(state, expected.withdrawals)
-//     # [New in Gloas:EIP7732]
-//     update_payload_expected_withdrawals(state, expected.withdrawals)
-//     # [New in Gloas:EIP7732]
-//     update_builder_pending_withdrawals(state, expected.processed_builder_withdrawals_count)
-//     update_pending_partial_withdrawals(state, expected.processed_partial_withdrawals_count)
-//     # [New in Gloas:EIP7732]
-//     update_next_withdrawal_builder_index(state, expected.processed_builders_sweep_count)
-//     update_next_withdrawal_validator_index(state, expected.withdrawals)
+//	# Apply expected withdrawals
+//	apply_withdrawals(state, expected.withdrawals)
+//
+//	# Update withdrawals fields in the state
+//	update_next_withdrawal_index(state, expected.withdrawals)
+//	# [New in Gloas:EIP7732]
+//	update_payload_expected_withdrawals(state, expected.withdrawals)
+//	# [New in Gloas:EIP7732]
+//	update_builder_pending_withdrawals(state, expected.processed_builder_withdrawals_count)
+//	update_pending_partial_withdrawals(state, expected.processed_partial_withdrawals_count)
+//	# [New in Gloas:EIP7732]
+//	update_next_withdrawal_builder_index(state, expected.processed_builders_sweep_count)
+//	update_next_withdrawal_validator_index(state, expected.withdrawals)
+//
 // </spec>
 func ProcessWithdrawals(st state.BeaconState) error {
 	// Must be called before ProcessExecutionPayloadBid for the current block.

--- a/beacon-chain/core/gloas/withdrawals.go
+++ b/beacon-chain/core/gloas/withdrawals.go
@@ -11,35 +11,31 @@ import (
 //
 // <spec fn="process_withdrawals" fork="gloas" hash="24ca56d3">
 // def process_withdrawals(
-//
-//	state: BeaconState,
-//	# [Modified in Gloas:EIP7732]
-//	# Removed `payload`
-//
+//     state: BeaconState,
+//     # [Modified in Gloas:EIP7732]
+//     # Removed `payload`
 // ) -> None:
+//     # [New in Gloas:EIP7732]
+//     # Return early if the parent block is empty
+//     if state.latest_block_hash != state.latest_execution_payload_bid.block_hash:
+//         return
 //
-//	# [New in Gloas:EIP7732]
-//	# Return early if the parent block is empty
-//	if state.latest_block_hash != state.latest_execution_payload_bid.block_hash:
-//	    return
+//     # Get expected withdrawals
+//     expected = get_expected_withdrawals(state)
 //
-//	# Get expected withdrawals
-//	expected = get_expected_withdrawals(state)
+//     # Apply expected withdrawals
+//     apply_withdrawals(state, expected.withdrawals)
 //
-//	# Apply expected withdrawals
-//	apply_withdrawals(state, expected.withdrawals)
-//
-//	# Update withdrawals fields in the state
-//	update_next_withdrawal_index(state, expected.withdrawals)
-//	# [New in Gloas:EIP7732]
-//	update_payload_expected_withdrawals(state, expected.withdrawals)
-//	# [New in Gloas:EIP7732]
-//	update_builder_pending_withdrawals(state, expected.processed_builder_withdrawals_count)
-//	update_pending_partial_withdrawals(state, expected.processed_partial_withdrawals_count)
-//	# [New in Gloas:EIP7732]
-//	update_next_withdrawal_builder_index(state, expected.processed_builders_sweep_count)
-//	update_next_withdrawal_validator_index(state, expected.withdrawals)
-//
+//     # Update withdrawals fields in the state
+//     update_next_withdrawal_index(state, expected.withdrawals)
+//     # [New in Gloas:EIP7732]
+//     update_payload_expected_withdrawals(state, expected.withdrawals)
+//     # [New in Gloas:EIP7732]
+//     update_builder_pending_withdrawals(state, expected.processed_builder_withdrawals_count)
+//     update_pending_partial_withdrawals(state, expected.processed_partial_withdrawals_count)
+//     # [New in Gloas:EIP7732]
+//     update_next_withdrawal_builder_index(state, expected.processed_builders_sweep_count)
+//     update_next_withdrawal_validator_index(state, expected.withdrawals)
 // </spec>
 func ProcessWithdrawals(st state.BeaconState) error {
 	// Must be called before ProcessExecutionPayloadBid for the current block.

--- a/beacon-chain/core/transition/gloas.go
+++ b/beacon-chain/core/transition/gloas.go
@@ -20,13 +20,21 @@ import (
 //
 // Spec definition:
 //
-//	<spec fn="process_operations" fork="gloas" hash="4864d8ef">
+//	<spec fn="process_operations" fork="gloas" hash="5009f53b">
 //	def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
 //	    assert len(body.deposits) == 0
 //
 //	    def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
 //	        for operation in operations:
 //	            fn(state, operation)
+//
+//	    # [New in Gloas:EIP7688]
+//	    assert len(body.proposer_slashings) <= MAX_PROPOSER_SLASHINGS
+//	    assert len(body.attester_slashings) <= MAX_ATTESTER_SLASHINGS_ELECTRA
+//	    assert len(body.attestations) <= MAX_ATTESTATIONS_ELECTRA
+//	    assert len(body.voluntary_exits) <= MAX_VOLUNTARY_EXITS
+//	    assert len(body.bls_to_execution_changes) <= MAX_BLS_TO_EXECUTION_CHANGES
+//	    assert len(body.payload_attestations) <= MAX_PAYLOAD_ATTESTATIONS
 //
 //	    # [Modified in Gloas:EIP7732]
 //	    for_ops(body.proposer_slashings, process_proposer_slashing)

--- a/beacon-chain/core/transition/gloas_operations_test.go
+++ b/beacon-chain/core/transition/gloas_operations_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/OffchainLabs/go-bitfield"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -26,6 +28,198 @@ func newGloasBlock(t *testing.T, body *ethpb.BeaconBlockBodyGloas) interfaces.Re
 
 func emptyGloasBody() *ethpb.BeaconBlockBodyGloas {
 	return util.HydrateBeaconBlockBodyGloas(nil)
+}
+
+// TestVerifyOperationLengths_Gloas exercises the operation length bounds asserted by the
+// gloas process_operations spec, all of which are enforced by VerifyOperationLengths.
+func TestVerifyOperationLengths_Gloas(t *testing.T) {
+	cfg := params.BeaconConfig()
+
+	proposerSlashings := func(n uint64) []*ethpb.ProposerSlashing {
+		header := func() *ethpb.SignedBeaconBlockHeader {
+			return &ethpb.SignedBeaconBlockHeader{
+				Header: &ethpb.BeaconBlockHeader{
+					ParentRoot: make([]byte, 32),
+					StateRoot:  make([]byte, 32),
+					BodyRoot:   make([]byte, 32),
+				},
+				Signature: make([]byte, 96),
+			}
+		}
+		s := make([]*ethpb.ProposerSlashing, n)
+		for i := range s {
+			s[i] = &ethpb.ProposerSlashing{Header_1: header(), Header_2: header()}
+		}
+		return s
+	}
+	attesterSlashings := func(n uint64) []*ethpb.AttesterSlashingGloas {
+		indexed := func() *ethpb.IndexedAttestationGloas {
+			return &ethpb.IndexedAttestationGloas{
+				Data: &ethpb.AttestationData{
+					BeaconBlockRoot: make([]byte, 32),
+					Source:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+					Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+				},
+				Signature: make([]byte, 96),
+			}
+		}
+		s := make([]*ethpb.AttesterSlashingGloas, n)
+		for i := range s {
+			s[i] = &ethpb.AttesterSlashingGloas{Attestation_1: indexed(), Attestation_2: indexed()}
+		}
+		return s
+	}
+	attestations := func(n uint64) []*ethpb.AttestationGloas {
+		s := make([]*ethpb.AttestationGloas, n)
+		for i := range s {
+			s[i] = &ethpb.AttestationGloas{
+				AggregationBits: []byte{0b00000001},
+				Data: &ethpb.AttestationData{
+					BeaconBlockRoot: make([]byte, 32),
+					Source:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+					Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+				},
+				CommitteeBits: []byte{0b00000001},
+				Signature:     make([]byte, 96),
+			}
+		}
+		return s
+	}
+	deposits := func(n uint64) []*ethpb.Deposit {
+		s := make([]*ethpb.Deposit, n)
+		for i := range s {
+			s[i] = &ethpb.Deposit{
+				Proof: [][]byte{},
+				Data: &ethpb.Deposit_Data{
+					PublicKey:             make([]byte, 48),
+					WithdrawalCredentials: make([]byte, 32),
+					Signature:             make([]byte, 96),
+				},
+			}
+		}
+		return s
+	}
+	voluntaryExits := func(n uint64) []*ethpb.SignedVoluntaryExit {
+		s := make([]*ethpb.SignedVoluntaryExit, n)
+		for i := range s {
+			s[i] = &ethpb.SignedVoluntaryExit{
+				Exit:      &ethpb.VoluntaryExit{},
+				Signature: make([]byte, 96),
+			}
+		}
+		return s
+	}
+	blsChanges := func(n uint64) []*ethpb.SignedBLSToExecutionChange {
+		s := make([]*ethpb.SignedBLSToExecutionChange, n)
+		for i := range s {
+			s[i] = &ethpb.SignedBLSToExecutionChange{
+				Message: &ethpb.BLSToExecutionChange{
+					FromBlsPubkey:      make([]byte, 48),
+					ToExecutionAddress: make([]byte, 20),
+				},
+				Signature: make([]byte, 96),
+			}
+		}
+		return s
+	}
+	payloadAtts := func(n uint64) []*ethpb.PayloadAttestation {
+		s := make([]*ethpb.PayloadAttestation, n)
+		for i := range s {
+			s[i] = &ethpb.PayloadAttestation{
+				AggregationBits: bitfield.NewBitvector512(),
+				Data:            &ethpb.PayloadAttestationData{BeaconBlockRoot: make([]byte, 32)},
+				Signature:       make([]byte, 96),
+			}
+		}
+		return s
+	}
+
+	tests := []struct {
+		name    string
+		modify  func(*ethpb.BeaconBlockBodyGloas)
+		wantErr string // empty means the check should pass
+	}{
+		{
+			name:   "empty body passes",
+			modify: func(*ethpb.BeaconBlockBodyGloas) {},
+		},
+		{
+			name: "all operations at their limits pass",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.ProposerSlashings = proposerSlashings(cfg.MaxProposerSlashings)
+				b.AttesterSlashings = attesterSlashings(cfg.MaxAttesterSlashingsElectra)
+				b.Attestations = attestations(cfg.MaxAttestationsElectra)
+				b.VoluntaryExits = voluntaryExits(cfg.MaxVoluntaryExits)
+				b.BlsToExecutionChanges = blsChanges(cfg.MaxBlsToExecutionChanges)
+				b.PayloadAttestations = payloadAtts(fieldparams.MaxPayloadAttestations)
+			},
+		},
+		{
+			name: "non-empty deposits",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.Deposits = deposits(1)
+			},
+			wantErr: "eth1 bridge deposits are not allowed from Fulu",
+		},
+		{
+			name: "too many proposer slashings",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.ProposerSlashings = proposerSlashings(cfg.MaxProposerSlashings + 1)
+			},
+			wantErr: "number of proposer slashings",
+		},
+		{
+			name: "too many attester slashings",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.AttesterSlashings = attesterSlashings(cfg.MaxAttesterSlashingsElectra + 1)
+			},
+			wantErr: "number of attester slashings",
+		},
+		{
+			name: "too many attestations",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.Attestations = attestations(cfg.MaxAttestationsElectra + 1)
+			},
+			wantErr: "number of attestations",
+		},
+		{
+			name: "too many voluntary exits",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.VoluntaryExits = voluntaryExits(cfg.MaxVoluntaryExits + 1)
+			},
+			wantErr: "number of voluntary exits",
+		},
+		{
+			name: "too many BLS to execution changes",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.BlsToExecutionChanges = blsChanges(cfg.MaxBlsToExecutionChanges + 1)
+			},
+			wantErr: "number of BLS to execution changes",
+		},
+		{
+			name: "too many payload attestations",
+			modify: func(b *ethpb.BeaconBlockBodyGloas) {
+				b.PayloadAttestations = payloadAtts(fieldparams.MaxPayloadAttestations + 1)
+			},
+			wantErr: "number of payload attestations",
+		},
+	}
+
+	st, _ := util.DeterministicGenesisStateGloas(t, 64)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := emptyGloasBody()
+			tc.modify(body)
+			blk := newGloasBlock(t, body)
+
+			_, err := transition.VerifyOperationLengths(context.Background(), st, blk)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, tc.wantErr, err)
+			}
+		})
+	}
 }
 
 func TestGloasOperations_HappyPath(t *testing.T) {
@@ -127,25 +321,6 @@ func TestGloasOperations_ProcessingErrors(t *testing.T) {
 			},
 			errSentinel: transition.ErrProcessAttestationsFailed,
 			errSubstr:   "process attestations failed",
-		},
-
-		{
-			name: "ErrProcessDepositsFailed – empty merkle proof",
-			modifyBlk: func(b *ethpb.BeaconBlockBodyGloas) {
-				b.Deposits = []*ethpb.Deposit{
-					{
-						Proof: [][]byte{}, // invalid: proof must not be empty
-						Data: &ethpb.Deposit_Data{
-							PublicKey:             make([]byte, 48),
-							WithdrawalCredentials: make([]byte, 32),
-							Amount:                32_000_000_000,
-							Signature:             make([]byte, 96),
-						},
-					},
-				}
-			},
-			errSentinel: transition.ErrProcessDepositsFailed,
-			errSubstr:   "process deposits failed",
 		},
 
 		{

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -21,6 +21,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/time"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/features"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
@@ -486,6 +487,35 @@ func VerifyOperationLengths(_ context.Context, state state.BeaconState, b interf
 			params.BeaconConfig().MaxVoluntaryExits,
 		)
 	}
+
+	if body.Version() >= version.Capella {
+		changes, err := body.BLSToExecutionChanges()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get BLS to execution changes")
+		}
+		if uint64(len(changes)) > params.BeaconConfig().MaxBlsToExecutionChanges {
+			return nil, fmt.Errorf(
+				"number of BLS to execution changes (%d) in block body exceeds allowed threshold of %d",
+				len(changes),
+				params.BeaconConfig().MaxBlsToExecutionChanges,
+			)
+		}
+	}
+
+	if body.Version() >= version.Gloas {
+		payloadAtts, err := body.PayloadAttestations()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get payload attestations")
+		}
+		if len(payloadAtts) > fieldparams.MaxPayloadAttestations {
+			return nil, fmt.Errorf(
+				"number of payload attestations (%d) in block body exceeds allowed threshold of %d",
+				len(payloadAtts),
+				fieldparams.MaxPayloadAttestations,
+			)
+		}
+	}
+
 	eth1Data := state.Eth1Data()
 	if eth1Data == nil {
 		return nil, errors.New("nil eth1data in state")

--- a/beacon-chain/light-client/lightclient.go
+++ b/beacon-chain/light-client/lightclient.go
@@ -525,7 +525,7 @@ func ComputeWithdrawalsRoot(payload interfaces.ExecutionData) ([]byte, error) {
 }
 
 func progressiveExecutionPayloadSSZEnabled(payload interfaces.ExecutionData) bool {
-	if payload == nil || !features.Get().EnableProgressiveSSZ {
+	if payload == nil || !features.ProgressiveSSZEnabled(version.Gloas) {
 		return false
 	}
 	_, ok := payload.Proto().(*enginev1.ExecutionPayloadGloas)

--- a/beacon-chain/light-client/progressive_ssz_test.go
+++ b/beacon-chain/light-client/progressive_ssz_test.go
@@ -29,7 +29,7 @@ func TestProgressiveExecutionPayloadSSZEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: tt.enabled})
+			reset := features.InitWithReset(&features.Flags{DisableProgressiveSSZ: !tt.enabled})
 			defer reset()
 
 			require.Equal(t, tt.want, progressiveExecutionPayloadSSZEnabled(tt.payload))

--- a/beacon-chain/state/fieldtrie/progressive_test.go
+++ b/beacon-chain/state/fieldtrie/progressive_test.go
@@ -19,7 +19,7 @@ import (
 // stateutil reference helpers return the progressive form.
 func progressiveRootsEnabled(t *testing.T) {
 	t.Helper()
-	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset := features.InitWithReset(&features.Flags{})
 	t.Cleanup(reset)
 }
 

--- a/beacon-chain/state/state-native/progressive_ssz_test.go
+++ b/beacon-chain/state/state-native/progressive_ssz_test.go
@@ -20,11 +20,11 @@ import (
 )
 
 func TestProgressiveSSZEnabled(t *testing.T) {
-	reset := features.InitWithReset(&features.Flags{})
+	reset := features.InitWithReset(&features.Flags{DisableProgressiveSSZ: true})
 	defer reset()
 	require.Equal(t, false, features.ProgressiveSSZEnabled(version.Gloas))
 
-	reset = features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset = features.InitWithReset(&features.Flags{})
 	defer reset()
 	require.Equal(t, true, features.ProgressiveSSZEnabled(version.Gloas))
 	require.Equal(t, false, features.ProgressiveSSZEnabled(version.Fulu))
@@ -43,7 +43,7 @@ func TestComputeFieldRootsWithHasher_ProgressiveSSZFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: tt.progressive})
+			reset := features.InitWithReset(&features.Flags{DisableProgressiveSSZ: !tt.progressive})
 			defer reset()
 
 			roots, err := ComputeFieldRootsWithHasher(context.Background(), st)
@@ -116,7 +116,7 @@ func TestHashTreeRoot(t *testing.T) {
 	t.Run("ProgressiveSSZGate", func(t *testing.T) {
 		st := newGloasStateForProgressiveSSZTests(t)
 
-		reset := features.InitWithReset(&features.Flags{})
+		reset := features.InitWithReset(&features.Flags{DisableProgressiveSSZ: true})
 		defer reset()
 
 		legacyRoot, err := st.HashTreeRoot(context.Background())
@@ -128,7 +128,7 @@ func TestHashTreeRoot(t *testing.T) {
 		expectedLegacyRoot := bytesutil.ToBytes32(legacyLayers[len(legacyLayers)-1][0])
 		require.Equal(t, expectedLegacyRoot, legacyRoot)
 
-		reset = features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+		reset = features.InitWithReset(&features.Flags{DisableProgressiveSSZ: false})
 		defer reset()
 
 		progressiveRoot, err := st.HashTreeRoot(context.Background())
@@ -157,9 +157,6 @@ func TestHashTreeRoot(t *testing.T) {
 	})
 
 	t.Run("ProgressiveSSZIncremental", func(t *testing.T) {
-		reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
-		defer reset()
-
 		st := newGloasStateForProgressiveSSZTests(t)
 		initialRoot, err := st.HashTreeRoot(context.Background())
 		require.NoError(t, err)
@@ -195,9 +192,6 @@ func TestHashTreeRoot(t *testing.T) {
 	})
 
 	t.Run("ProgressiveSSZCopy", func(t *testing.T) {
-		reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
-		defer reset()
-
 		st := newGloasStateForProgressiveSSZTests(t)
 		originalRoot, err := st.HashTreeRoot(context.Background())
 		require.NoError(t, err)

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -368,8 +368,7 @@ func (b *BeaconState) AddBuilderFromDeposit(pubkey [fieldparams.BLSPubkeyLength]
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	// process_builder_deposit_request sets version to withdrawal_credentials[0].
-	return b.addBuilderFromDepositAtEpoch(pubkey, withdrawalCredentials[0], withdrawalCredentials, amount, slots.ToEpoch(b.slot))
+	return b.addBuilderFromDepositAtEpoch(pubkey, params.BeaconConfig().PayloadBuilderVersion, withdrawalCredentials, amount, slots.ToEpoch(b.slot))
 }
 
 func (b *BeaconState) addBuilderFromDepositAtEpoch(pubkey [fieldparams.BLSPubkeyLength]byte, builderVersion byte, withdrawalCredentials [fieldparams.RootLength]byte, amount uint64, depositEpoch primitives.Epoch) error {

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -910,7 +910,7 @@ func TestAddBuilderFromDeposit(t *testing.T) {
 		copy(pubkey[:], bytes.Repeat([]byte{0xAA}, 48))
 		var wc [32]byte
 		copy(wc[:], bytes.Repeat([]byte{0xBB}, 32))
-		wc[0] = 0x42 // version byte
+		wc[0] = 0x42 // registered version must ignore the credential prefix
 
 		st := &BeaconState{
 			version:     version.Gloas,
@@ -933,7 +933,7 @@ func TestAddBuilderFromDeposit(t *testing.T) {
 		got := st.builders[0]
 		require.NotNil(t, got)
 		require.DeepEqual(t, pubkey[:], got.Pubkey)
-		require.DeepEqual(t, []byte{0x42}, got.Version)
+		require.DeepEqual(t, []byte{params.BeaconConfig().PayloadBuilderVersion}, got.Version)
 		require.DeepEqual(t, wc[12:], got.ExecutionAddress)
 		require.Equal(t, primitives.Gwei(123), got.Balance)
 		require.Equal(t, primitives.Epoch(0), got.DepositEpoch)

--- a/beacon-chain/state/stateutil/progressive_root_test.go
+++ b/beacon-chain/state/stateutil/progressive_root_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestValidatorRegistryRootProgressive(t *testing.T) {
-	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset := features.InitWithReset(&features.Flags{})
 	defer reset()
 
 	pubkey := make([]byte, fieldparams.BLSPubkeyLength)
@@ -49,7 +49,7 @@ func TestValidatorRegistryRootProgressive(t *testing.T) {
 }
 
 func TestUint64ListRootProgressive(t *testing.T) {
-	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset := features.InitWithReset(&features.Flags{})
 	defer reset()
 
 	vals := []uint64{1, 2, 3, 4, 5, 6, 7}
@@ -67,7 +67,7 @@ func TestUint64ListRootProgressive(t *testing.T) {
 }
 
 func TestParticipationBitsRootProgressive(t *testing.T) {
-	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset := features.InitWithReset(&features.Flags{})
 	defer reset()
 
 	bits := []byte{0x01, 0x02, 0x03, 0x04}
@@ -81,7 +81,7 @@ func TestParticipationBitsRootProgressive(t *testing.T) {
 }
 
 func TestBuildersRootProgressive(t *testing.T) {
-	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset := features.InitWithReset(&features.Flags{})
 	defer reset()
 
 	builders := []*ethpb.Builder{{
@@ -101,7 +101,7 @@ func TestBuildersRootProgressive(t *testing.T) {
 }
 
 func TestPendingRootsProgressive(t *testing.T) {
-	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset := features.InitWithReset(&features.Flags{})
 	defer reset()
 
 	pendingDeposits := []*ethpb.PendingDeposit{{
@@ -131,7 +131,7 @@ func TestPendingRootsProgressive(t *testing.T) {
 }
 
 func TestBuilderPendingWithdrawalsRootProgressive(t *testing.T) {
-	reset := features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset := features.InitWithReset(&features.Flags{})
 	defer reset()
 
 	withdrawals := []*ethpb.BuilderPendingWithdrawal{{

--- a/build/gen/ssz.go
+++ b/build/gen/ssz.go
@@ -32,14 +32,18 @@ func genSSZ() error {
 		return fmt.Errorf("load methodical targets: %w", err)
 	}
 
-	// Progressive merkleization is gated OFF by default so that generated
-	// hash_tree_root values match the current (non-progressive) spectest
-	// fixtures. This mirrors the //tools:disable_progressive_merkleization
-	// default set in .bazelrc. Set SSZ_PROGRESSIVE=1 to generate the
-	// progressive form once upstream fixtures move to it.
-	progressive, _ := strconv.ParseBool(os.Getenv("SSZ_PROGRESSIVE"))
-	if progressive {
-		fmt.Println("SSZ_PROGRESSIVE=1: generating with progressive merkleization ON")
+	// Progressive merkleization is ON by default: gloas (EIP-7688) mandates it
+	// and the consensus-spec fixtures expect the progressive hash_tree_root
+	// values. This mirrors the //tools:disable_progressive_merkleization
+	// default in .bazelrc. Set SSZ_PROGRESSIVE=0 to generate the bounded form.
+	progressive := true
+	if v, ok := os.LookupEnv("SSZ_PROGRESSIVE"); ok {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			progressive = parsed
+		}
+	}
+	if !progressive {
+		fmt.Println("SSZ_PROGRESSIVE=0: generating with progressive merkleization OFF")
 	}
 
 	for _, t := range targets {

--- a/changelog/syjn99_fix-builder-withdrawal-prefix.md
+++ b/changelog/syjn99_fix-builder-withdrawal-prefix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Set `BUILDER_WITHDRAWAL_PREFIX` to `0xB0`.

--- a/changelog/terence_builder-deposit-prefix.md
+++ b/changelog/terence_builder-deposit-prefix.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Ignore builder deposit requests without `BUILDER_WITHDRAWAL_PREFIX` and register new builders with `PAYLOAD_BUILDER_VERSION`.

--- a/changelog/terence_builder-topup-swept-reset.md
+++ b/changelog/terence_builder-topup-swept-reset.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reset an exited builder's withdrawable epoch on top-up only when its balance has been swept.

--- a/changelog/terence_builder-withdrawability-delay-64.md
+++ b/changelog/terence_builder-withdrawability-delay-64.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reduce `MIN_BUILDER_WITHDRAWABILITY_DELAY` to 64 epochs.

--- a/changelog/terence_gloas-remove-deposit-limit.md
+++ b/changelog/terence_gloas-remove-deposit-limit.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Remove the `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` bound on Gloas execution request decoding.

--- a/changelog/terence_payload-due-bps-5000.md
+++ b/changelog/terence_payload-due-bps-5000.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Set `PAYLOAD_DUE_BPS` to 5000.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -50,7 +50,7 @@ type Flags struct {
 	DisableDutiesV2                     bool // DisableDutiesV2 sets validator client to use the get Duties endpoint
 	EnableWeb                           bool // EnableWeb enables the webui on the validator client
 	EnableStateDiff                     bool // EnableStateDiff enables the experimental state diff feature for the beacon node.
-	EnableProgressiveSSZ                bool // EnableProgressiveSSZ enables experimental progressive SSZ merkleization for converted consensus types.
+	DisableProgressiveSSZ               bool // DisableProgressiveSSZ turns off progressive SSZ merkleization for Gloas consensus types.
 	ReorgLatePayloads                   bool // ReorgLatePayloads enables reorging late payloads in the beacon node.
 	SubmitBlacklistedBuilderBids        bool // SubmitBlacklistedBuilderBids skips the circuit breaker check when submitting a signed execution payload bid.
 
@@ -114,7 +114,7 @@ func Get() *Flags {
 // ProgressiveSSZEnabled reports whether progressive SSZ is enabled for the
 // supplied state version.
 func ProgressiveSSZEnabled(stateVersion int) bool {
-	return stateVersion >= version.Gloas && Get().EnableProgressiveSSZ
+	return stateVersion >= version.Gloas && !Get().DisableProgressiveSSZ
 }
 
 // Init sets the global config equal to the config that is passed in.
@@ -306,9 +306,9 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 			cfg.EnableHistoricalSpaceRepresentation = false
 		}
 	}
-	if ctx.IsSet(EnableProgressiveSSZ.Name) {
-		logEnabled(EnableProgressiveSSZ)
-		cfg.EnableProgressiveSSZ = true
+	if ctx.IsSet(DisableProgressiveSSZ.Name) {
+		logDisabled(DisableProgressiveSSZ)
+		cfg.DisableProgressiveSSZ = true
 	}
 	if ctx.Bool(reorgLatePayloads.Name) {
 		logEnabled(reorgLatePayloads)

--- a/config/features/config_test.go
+++ b/config/features/config_test.go
@@ -70,16 +70,14 @@ func TestConfigureBeaconConfig(t *testing.T) {
 	assert.Equal(t, true, c.SaveInvalidBlock)
 }
 
-func TestConfigureBeaconConfig_EnableProgressiveSSZ(t *testing.T) {
-	defer Init(&Flags{})
-
+func TestConfigureBeaconConfig_DisableProgressiveSSZ(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
-	set.Bool(EnableProgressiveSSZ.Name, false, "test")
-	require.NoError(t, set.Set(EnableProgressiveSSZ.Name, "true"))
-	context := cli.NewContext(&app, set, nil)
-	require.NoError(t, ConfigureBeaconChain(context))
-	assert.Equal(t, true, Get().EnableProgressiveSSZ)
+	ctx := cli.NewContext(&app, set, nil)
+	set.Bool(DisableProgressiveSSZ.Name, false, "test")
+	require.NoError(t, set.Set(DisableProgressiveSSZ.Name, "true"))
+	require.NoError(t, ConfigureBeaconChain(ctx))
+	assert.Equal(t, true, Get().DisableProgressiveSSZ)
 }
 
 func TestConfigureBeaconConfig_ReorgLatePayloads(t *testing.T) {

--- a/config/features/config_test.go
+++ b/config/features/config_test.go
@@ -71,6 +71,7 @@ func TestConfigureBeaconConfig(t *testing.T) {
 }
 
 func TestConfigureBeaconConfig_DisableProgressiveSSZ(t *testing.T) {
+	defer Init(&Flags{})
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	ctx := cli.NewContext(&app, set, nil)

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -182,9 +182,9 @@ var (
 		Name:  "enable-state-diff",
 		Usage: "Enables the experimental state diff feature.",
 	}
-	EnableProgressiveSSZ = &cli.BoolFlag{
-		Name:   "enable-progressive-ssz",
-		Usage:  "Enables experimental progressive SSZ merkleization for converted consensus types.",
+	DisableProgressiveSSZ = &cli.BoolFlag{
+		Name:   "disable-progressive-ssz",
+		Usage:  "Disables progressive SSZ merkleization for Gloas consensus types. Gloas (EIP-7688) mandates it, so this is an escape hatch for debugging only.",
 		Hidden: true,
 	}
 	reorgLatePayloads = &cli.BoolFlag{
@@ -300,7 +300,7 @@ var BeaconChainFlags = combinedFlags([]cli.Flag{
 	EnableDiscoveryReboot,
 	enableExperimentalAttestationPool,
 	EnableStateDiff,
-	EnableProgressiveSSZ,
+	DisableProgressiveSSZ,
 	reorgLatePayloads,
 	forceHeadFlag,
 	blacklistRoots,

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -96,7 +96,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	BLSWithdrawalPrefixByte:         byte(0),
 	ETH1AddressWithdrawalPrefixByte: byte(1),
 	CompoundingWithdrawalPrefixByte: byte(2),
-	BuilderWithdrawalPrefixByte:     byte(3),
+	BuilderWithdrawalPrefixByte:     byte(0xB0),
 	PayloadBuilderVersion:           byte(0),
 	BuilderIndexSelfBuild:           primitives.BuilderIndex(math.MaxUint64),
 	ZeroHash:                        [32]byte{},

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -135,7 +135,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	SyncMessageDueBPSGloas:   primitives.BP(2500),
 	ContributionDueBPSGloas:  primitives.BP(5000),
 	PayloadAttestationDueBPS: primitives.BP(7500),
-	PayloadDueBPS:            primitives.BP(7500),
+	PayloadDueBPS:            primitives.BP(5000),
 	EquivocationEarlyDueBPS:  primitives.BP(7500),
 
 	// Ethereum PoW parameters.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -112,7 +112,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	EpochsPerEth1VotingPeriod:        64,
 	SlotsPerHistoricalRoot:           8192,
 	MinValidatorWithdrawabilityDelay: 256,
-	MinBuilderWithdrawabilityDelay:   8192,
+	MinBuilderWithdrawabilityDelay:   64,
 	ShardCommitteePeriod:             256,
 	MinEpochsToInactivityPenalty:     4,
 	Eth1FollowDistance:               2048,
@@ -369,8 +369,8 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	ChurnLimitQuotientGloas:              32_768,
 	ConsolidationChurnLimitQuotient:      65_536,
 	MaxPerEpochActivationChurnLimitGloas: 256_000_000_000,
-	MaxBuilderDepositRequestsPerPayload:  256, // 2**8 (= 256)
-	MaxBuilderExitRequestsPerPayload:     16,  // 2**4 (= 16)
+	MaxBuilderDepositRequestsPerPayload:  64, // 2**6 (= 64)
+	MaxBuilderExitRequestsPerPayload:     16, // 2**4 (= 16)
 
 	// Values related to networking parameters.
 	MaxPayloadSize:                  10 * 1 << 20, // 10 MiB

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -31,7 +31,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	// Initial values
 	minimalConfig.BLSWithdrawalPrefixByte = byte(0)
 	minimalConfig.ETH1AddressWithdrawalPrefixByte = byte(1)
-	minimalConfig.BuilderWithdrawalPrefixByte = byte(3)
+	minimalConfig.BuilderWithdrawalPrefixByte = byte(0xB0)
 
 	// Time parameters
 	minimalConfig.SecondsPerSlot = 6

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -41,7 +41,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.SyncMessageDueBPSGloas = 2500
 	minimalConfig.ContributionDueBPSGloas = 5000
 	minimalConfig.PayloadAttestationDueBPS = 7500
-	minimalConfig.PayloadDueBPS = 7500
+	minimalConfig.PayloadDueBPS = 5000
 	minimalConfig.EquivocationEarlyDueBPS = 7500
 	minimalConfig.MinAttestationInclusionDelay = 1
 	minimalConfig.SlotsPerEpoch = 8

--- a/consensus-types/blocks/proofs_test.go
+++ b/consensus-types/blocks/proofs_test.go
@@ -156,7 +156,7 @@ func TestComputeBlockBodyFieldRoots_Gloas_ProgressiveSSZGate(t *testing.T) {
 	b, ok := i.(*BeaconBlockBody)
 	require.Equal(t, true, ok)
 
-	reset := features.InitWithReset(&features.Flags{})
+	reset := features.InitWithReset(&features.Flags{DisableProgressiveSSZ: true})
 	defer reset()
 
 	legacyRoots, err := ComputeBlockBodyFieldRoots(t.Context(), b)
@@ -169,7 +169,7 @@ func TestComputeBlockBodyFieldRoots_Gloas_ProgressiveSSZGate(t *testing.T) {
 	require.NoError(t, err)
 	require.DeepEqual(t, expectedLegacyPayloadAttestationsRoot[:], legacyRoots[11])
 
-	reset = features.InitWithReset(&features.Flags{EnableProgressiveSSZ: true})
+	reset = features.InitWithReset(&features.Flags{})
 	defer reset()
 
 	progressiveRoots, err := ComputeBlockBodyFieldRoots(t.Context(), b)

--- a/proto/engine/v1/electra.go
+++ b/proto/engine/v1/electra.go
@@ -2,6 +2,7 @@ package enginev1
 
 import (
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -93,6 +94,8 @@ func decodeExecutionRequestList(raw [][]byte, limits ExecutionRequestLimits) (*E
 // decodeExecutionRequestListGloas decodes the EIP-7685 flat request list into a
 // gloas ExecutionRequests, including builder deposit/exit requests (EIP-8282).
 func decodeExecutionRequestListGloas(raw [][]byte, limits ExecutionRequestLimits) (*ExecutionRequestsGloas, error) {
+	// Gloas removes MAX_DEPOSIT_REQUESTS_PER_PAYLOAD, the EL bounds deposit requests via the gas limit.
+	limits.Deposits = math.MaxUint64 / uint64(drSize)
 	requests := &ExecutionRequestsGloas{}
 	var prevTypeNum *uint8
 	for i := range raw {

--- a/proto/engine/v1/electra_test.go
+++ b/proto/engine/v1/electra_test.go
@@ -276,3 +276,23 @@ func TestEmptyExecutionRequestsHashTreeRoot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
+
+func TestEmptyExecutionRequestsGloasHashTreeRoot(t *testing.T) {
+	want, err := (&enginev1.ExecutionRequestsGloas{}).HashTreeRoot()
+	require.NoError(t, err)
+	got, err := enginev1.EmptyExecutionRequestsHashTreeRoot()
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestGetDecodedExecutionRequestsGloas_NoDepositLimit(t *testing.T) {
+	cfg := params.BeaconConfig()
+	count := int(cfg.MaxDepositRequestsPerPayload) + 1
+	depositRequestBytes := make([]byte, count*(&enginev1.DepositRequest{}).SizeSSZ())
+	ebg := &enginev1.ExecutionBundleGloas{
+		ExecutionRequests: [][]byte{append([]byte{uint8(enginev1.DepositRequestType)}, depositRequestBytes...)},
+	}
+	requests, err := ebg.GetDecodedExecutionRequests(cfg.ExecutionRequestLimits())
+	require.NoError(t, err)
+	require.Equal(t, count, len(requests.Deposits))
+}

--- a/proto/engine/v1/electra_test.go
+++ b/proto/engine/v1/electra_test.go
@@ -269,14 +269,6 @@ func TestMarshalItems_OK(t *testing.T) {
 	require.DeepEqual(t, depositRequestsSSZHex, hexutil.Encode(drbs))
 }
 
-func TestEmptyExecutionRequestsHashTreeRoot(t *testing.T) {
-	want, err := (&enginev1.ExecutionRequestsGloas{}).HashTreeRoot()
-	require.NoError(t, err)
-	got, err := enginev1.EmptyExecutionRequestsHashTreeRoot()
-	require.NoError(t, err)
-	require.Equal(t, want, got)
-}
-
 func TestEmptyExecutionRequestsGloasHashTreeRoot(t *testing.T) {
 	want, err := (&enginev1.ExecutionRequestsGloas{}).HashTreeRoot()
 	require.NoError(t, err)

--- a/proto/engine/v1/engine.minimal.ssz.go
+++ b/proto/engine/v1/engine.minimal.ssz.go
@@ -2088,9 +2088,6 @@ func (c *ExecutionPayloadGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.ExtraData...)
 
 	// Field 13: Transactions
-	if len(c.Transactions) > 1048576 {
-		return nil, ssz.ErrListTooBig
-	}
 	{
 		offset = 4 * len(c.Transactions)
 		for _, o := range c.Transactions {
@@ -2099,16 +2096,10 @@ func (c *ExecutionPayloadGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 		}
 	}
 	for _, o := range c.Transactions {
-		if len(o) > 1073741824 {
-			return nil, ssz.ErrListTooBig
-		}
 		dst = append(dst, o...)
 	}
 
 	// Field 14: Withdrawals
-	if len(c.Withdrawals) > 4 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Withdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Withdrawals: %w", err)
@@ -2116,9 +2107,6 @@ func (c *ExecutionPayloadGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 17: BlockAccessList
-	if len(c.BlockAccessList) > 1073741824 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.BlockAccessList...)
 	return dst, err
 }
@@ -2230,9 +2218,6 @@ func (c *ExecutionPayloadGloas) UnmarshalSSZ(buf []byte) error {
 				return fmt.Errorf("misaligned list bytes: when decoding c.Transactions, end-of-list offset is %d, which is not a multiple of 4 (offset size)", startOffset)
 			}
 			listLen := startOffset / 4
-			if listLen > 1048576 {
-				return fmt.Errorf("ssz-max exceeded: c.Transactions has %d elements, ssz-max is 1048576: %w", listLen, ssz.ErrListTooBig)
-			}
 			totalVarBytes := uint64(len(sszSlice13))
 			if totalVarBytes < startOffset {
 				return fmt.Errorf("list bytes too short to contain an offset when decoding c.Transactions")
@@ -2271,9 +2256,6 @@ func (c *ExecutionPayloadGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Withdrawals length is %d, which is not a multiple of 44: %w", len(sszSlice14), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice14) / 44
-		if numElem > 4 {
-			return fmt.Errorf("ssz-max exceeded: c.Withdrawals has %d elements, ssz-max is 4: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Withdrawals = make([]*Withdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Withdrawal
@@ -2303,8 +2285,18 @@ func (c *ExecutionPayloadGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionPayloadGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionPayloadGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionPayloadGloas = []byte{0b11111111, 0b11111111, 0b00000111}
+
+func (c *ExecutionPayloadGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -2313,7 +2305,7 @@ func (c *ExecutionPayloadGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionPayloadGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionPayloadGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: ParentHash
 	if len(c.ParentHash) != 32 {
@@ -2377,59 +2369,41 @@ func (c *ExecutionPayloadGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(c.BlockHash)
 	// Field 13: Transactions
 	{
-		if len(c.Transactions) > 1048576 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Transactions {
-
 			{
-				if len(o) > 1073741824 {
-					return ssz.ErrBytesLength
-				}
 				subIndx := hh.Index()
 				hh.AppendBytes32(o)
-				numItems := uint64(len(o))
-				hh.MerkleizeWithMixin(subIndx, numItems, (1073741824*1+31)/32)
+				hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(o)))
 			}
-
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Transactions)), 1048576)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Transactions)))
 	}
 	// Field 14: Withdrawals
 	{
-		if len(c.Withdrawals) > 4 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Withdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Withdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Withdrawals)), 4)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Withdrawals)))
 	}
 	// Field 15: BlobGasUsed
 	hh.PutUint64(c.BlobGasUsed)
 	// Field 16: ExcessBlobGas
 	hh.PutUint64(c.ExcessBlobGas)
 	// Field 17: BlockAccessList
-
 	{
-		if len(c.BlockAccessList) > 1073741824 {
-			return ssz.ErrBytesLength
-		}
 		subIndx := hh.Index()
 		hh.AppendBytes32(c.BlockAccessList)
-		numItems := uint64(len(c.BlockAccessList))
-		hh.MerkleizeWithMixin(subIndx, numItems, (1073741824*1+31)/32)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BlockAccessList)))
 	}
-
 	// Field 18: SlotNumber
 	if err := c.SlotNumber.HashTreeRootWith(hh); err != nil {
 		return fmt.Errorf("SlotNumber: %w", err)
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionPayloadGloas)
 	return nil
 }
 
@@ -3721,9 +3695,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	offset += len(c.BuilderExits) * 68
 
 	// Field 0: Deposits
-	if len(c.Deposits) > 8192 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Deposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Deposits: %w", err)
@@ -3731,9 +3702,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 1: Withdrawals
-	if len(c.Withdrawals) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Withdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Withdrawals: %w", err)
@@ -3741,9 +3709,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 2: Consolidations
-	if len(c.Consolidations) > 2 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Consolidations {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Consolidations: %w", err)
@@ -3751,9 +3716,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 3: BuilderDeposits
-	if len(c.BuilderDeposits) > 256 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BuilderDeposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BuilderDeposits: %w", err)
@@ -3761,9 +3723,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 4: BuilderExits
-	if len(c.BuilderExits) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BuilderExits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BuilderExits: %w", err)
@@ -3814,9 +3773,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Deposits length is %d, which is not a multiple of 192: %w", len(sszSlice0), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice0) / 192
-		if numElem > 8192 {
-			return fmt.Errorf("ssz-max exceeded: c.Deposits has %d elements, ssz-max is 8192: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Deposits = make([]*DepositRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *DepositRequest
@@ -3835,9 +3791,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Withdrawals length is %d, which is not a multiple of 76: %w", len(sszSlice1), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice1) / 76
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.Withdrawals has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Withdrawals = make([]*WithdrawalRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *WithdrawalRequest
@@ -3856,9 +3809,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Consolidations length is %d, which is not a multiple of 116: %w", len(sszSlice2), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice2) / 116
-		if numElem > 2 {
-			return fmt.Errorf("ssz-max exceeded: c.Consolidations has %d elements, ssz-max is 2: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Consolidations = make([]*ConsolidationRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *ConsolidationRequest
@@ -3877,9 +3827,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BuilderDeposits length is %d, which is not a multiple of 184: %w", len(sszSlice3), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice3) / 184
-		if numElem > 256 {
-			return fmt.Errorf("ssz-max exceeded: c.BuilderDeposits has %d elements, ssz-max is 256: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BuilderDeposits = make([]*BuilderDepositRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *BuilderDepositRequest
@@ -3898,9 +3845,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BuilderExits length is %d, which is not a multiple of 68: %w", len(sszSlice4), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice4) / 68
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.BuilderExits has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BuilderExits = make([]*BuilderExitRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *BuilderExitRequest
@@ -3916,8 +3860,18 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionRequestsGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionRequestsGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionRequestsGloas = []byte{0b00011111}
+
+func (c *ExecutionRequestsGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -3926,74 +3880,59 @@ func (c *ExecutionRequestsGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionRequestsGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionRequestsGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: Deposits
 	{
-		if len(c.Deposits) > 8192 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Deposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Deposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Deposits)), 8192)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Deposits)))
 	}
 	// Field 1: Withdrawals
 	{
-		if len(c.Withdrawals) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Withdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Withdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Withdrawals)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Withdrawals)))
 	}
 	// Field 2: Consolidations
 	{
-		if len(c.Consolidations) > 2 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Consolidations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Consolidations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Consolidations)), 2)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Consolidations)))
 	}
 	// Field 3: BuilderDeposits
 	{
-		if len(c.BuilderDeposits) > 256 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BuilderDeposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BuilderDeposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BuilderDeposits)), 256)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BuilderDeposits)))
 	}
 	// Field 4: BuilderExits
 	{
-		if len(c.BuilderExits) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BuilderExits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BuilderExits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BuilderExits)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BuilderExits)))
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionRequestsGloas)
 	return nil
 }
 

--- a/proto/engine/v1/engine.ssz.go
+++ b/proto/engine/v1/engine.ssz.go
@@ -2088,9 +2088,6 @@ func (c *ExecutionPayloadGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.ExtraData...)
 
 	// Field 13: Transactions
-	if len(c.Transactions) > 1048576 {
-		return nil, ssz.ErrListTooBig
-	}
 	{
 		offset = 4 * len(c.Transactions)
 		for _, o := range c.Transactions {
@@ -2099,16 +2096,10 @@ func (c *ExecutionPayloadGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 		}
 	}
 	for _, o := range c.Transactions {
-		if len(o) > 1073741824 {
-			return nil, ssz.ErrListTooBig
-		}
 		dst = append(dst, o...)
 	}
 
 	// Field 14: Withdrawals
-	if len(c.Withdrawals) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Withdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Withdrawals: %w", err)
@@ -2116,9 +2107,6 @@ func (c *ExecutionPayloadGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 17: BlockAccessList
-	if len(c.BlockAccessList) > 1073741824 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.BlockAccessList...)
 	return dst, err
 }
@@ -2230,9 +2218,6 @@ func (c *ExecutionPayloadGloas) UnmarshalSSZ(buf []byte) error {
 				return fmt.Errorf("misaligned list bytes: when decoding c.Transactions, end-of-list offset is %d, which is not a multiple of 4 (offset size)", startOffset)
 			}
 			listLen := startOffset / 4
-			if listLen > 1048576 {
-				return fmt.Errorf("ssz-max exceeded: c.Transactions has %d elements, ssz-max is 1048576: %w", listLen, ssz.ErrListTooBig)
-			}
 			totalVarBytes := uint64(len(sszSlice13))
 			if totalVarBytes < startOffset {
 				return fmt.Errorf("list bytes too short to contain an offset when decoding c.Transactions")
@@ -2271,9 +2256,6 @@ func (c *ExecutionPayloadGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Withdrawals length is %d, which is not a multiple of 44: %w", len(sszSlice14), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice14) / 44
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.Withdrawals has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Withdrawals = make([]*Withdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Withdrawal
@@ -2303,8 +2285,18 @@ func (c *ExecutionPayloadGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionPayloadGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionPayloadGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionPayloadGloas = []byte{0b11111111, 0b11111111, 0b00000111}
+
+func (c *ExecutionPayloadGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -2313,7 +2305,7 @@ func (c *ExecutionPayloadGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionPayloadGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionPayloadGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: ParentHash
 	if len(c.ParentHash) != 32 {
@@ -2377,59 +2369,41 @@ func (c *ExecutionPayloadGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(c.BlockHash)
 	// Field 13: Transactions
 	{
-		if len(c.Transactions) > 1048576 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Transactions {
-
 			{
-				if len(o) > 1073741824 {
-					return ssz.ErrBytesLength
-				}
 				subIndx := hh.Index()
 				hh.AppendBytes32(o)
-				numItems := uint64(len(o))
-				hh.MerkleizeWithMixin(subIndx, numItems, (1073741824*1+31)/32)
+				hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(o)))
 			}
-
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Transactions)), 1048576)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Transactions)))
 	}
 	// Field 14: Withdrawals
 	{
-		if len(c.Withdrawals) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Withdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Withdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Withdrawals)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Withdrawals)))
 	}
 	// Field 15: BlobGasUsed
 	hh.PutUint64(c.BlobGasUsed)
 	// Field 16: ExcessBlobGas
 	hh.PutUint64(c.ExcessBlobGas)
 	// Field 17: BlockAccessList
-
 	{
-		if len(c.BlockAccessList) > 1073741824 {
-			return ssz.ErrBytesLength
-		}
 		subIndx := hh.Index()
 		hh.AppendBytes32(c.BlockAccessList)
-		numItems := uint64(len(c.BlockAccessList))
-		hh.MerkleizeWithMixin(subIndx, numItems, (1073741824*1+31)/32)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BlockAccessList)))
 	}
-
 	// Field 18: SlotNumber
 	if err := c.SlotNumber.HashTreeRootWith(hh); err != nil {
 		return fmt.Errorf("SlotNumber: %w", err)
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionPayloadGloas)
 	return nil
 }
 
@@ -3721,9 +3695,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	offset += len(c.BuilderExits) * 68
 
 	// Field 0: Deposits
-	if len(c.Deposits) > 8192 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Deposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Deposits: %w", err)
@@ -3731,9 +3702,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 1: Withdrawals
-	if len(c.Withdrawals) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Withdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Withdrawals: %w", err)
@@ -3741,9 +3709,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 2: Consolidations
-	if len(c.Consolidations) > 2 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Consolidations {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Consolidations: %w", err)
@@ -3751,9 +3716,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 3: BuilderDeposits
-	if len(c.BuilderDeposits) > 256 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BuilderDeposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BuilderDeposits: %w", err)
@@ -3761,9 +3723,6 @@ func (c *ExecutionRequestsGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 4: BuilderExits
-	if len(c.BuilderExits) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BuilderExits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BuilderExits: %w", err)
@@ -3814,9 +3773,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Deposits length is %d, which is not a multiple of 192: %w", len(sszSlice0), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice0) / 192
-		if numElem > 8192 {
-			return fmt.Errorf("ssz-max exceeded: c.Deposits has %d elements, ssz-max is 8192: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Deposits = make([]*DepositRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *DepositRequest
@@ -3835,9 +3791,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Withdrawals length is %d, which is not a multiple of 76: %w", len(sszSlice1), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice1) / 76
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.Withdrawals has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Withdrawals = make([]*WithdrawalRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *WithdrawalRequest
@@ -3856,9 +3809,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Consolidations length is %d, which is not a multiple of 116: %w", len(sszSlice2), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice2) / 116
-		if numElem > 2 {
-			return fmt.Errorf("ssz-max exceeded: c.Consolidations has %d elements, ssz-max is 2: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Consolidations = make([]*ConsolidationRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *ConsolidationRequest
@@ -3877,9 +3827,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BuilderDeposits length is %d, which is not a multiple of 184: %w", len(sszSlice3), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice3) / 184
-		if numElem > 256 {
-			return fmt.Errorf("ssz-max exceeded: c.BuilderDeposits has %d elements, ssz-max is 256: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BuilderDeposits = make([]*BuilderDepositRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *BuilderDepositRequest
@@ -3898,9 +3845,6 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BuilderExits length is %d, which is not a multiple of 68: %w", len(sszSlice4), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice4) / 68
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.BuilderExits has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BuilderExits = make([]*BuilderExitRequest, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *BuilderExitRequest
@@ -3916,8 +3860,18 @@ func (c *ExecutionRequestsGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionRequestsGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionRequestsGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionRequestsGloas = []byte{0b00011111}
+
+func (c *ExecutionRequestsGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -3926,74 +3880,59 @@ func (c *ExecutionRequestsGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionRequestsGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionRequestsGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: Deposits
 	{
-		if len(c.Deposits) > 8192 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Deposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Deposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Deposits)), 8192)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Deposits)))
 	}
 	// Field 1: Withdrawals
 	{
-		if len(c.Withdrawals) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Withdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Withdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Withdrawals)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Withdrawals)))
 	}
 	// Field 2: Consolidations
 	{
-		if len(c.Consolidations) > 2 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Consolidations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Consolidations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Consolidations)), 2)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Consolidations)))
 	}
 	// Field 3: BuilderDeposits
 	{
-		if len(c.BuilderDeposits) > 256 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BuilderDeposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BuilderDeposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BuilderDeposits)), 256)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BuilderDeposits)))
 	}
 	// Field 4: BuilderExits
 	{
-		if len(c.BuilderExits) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BuilderExits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BuilderExits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BuilderExits)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BuilderExits)))
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionRequestsGloas)
 	return nil
 }
 

--- a/proto/engine/v1/engine.yaml
+++ b/proto/engine/v1/engine.yaml
@@ -10,12 +10,29 @@ types:
   - name: "ExecutionPayloadCapella"
   - name: "ExecutionPayloadDeneb"
   - name: "ExecutionPayloadGloas"
+    progressive: {}
+    fields:
+      Transactions:    {type: "ProgressiveList", element: {type: "ProgressiveByteList"}}
+      Withdrawals:     {type: "ProgressiveList"}
+      BlockAccessList: {type: "ProgressiveList"}
   - name: "ExecutionPayloadDenebAndBlobsBundle"
   - name: "ExecutionPayloadDenebAndBlobsBundleV2"
   - name: "ExecutionPayloadHeader"
   - name: "ExecutionPayloadHeaderCapella"
   - name: "ExecutionPayloadHeaderDeneb"
+  # Base ExecutionRequests is the electra/fulu (pre-gloas) type: bounded lists,
+  # NOT progressive. Progressive merkleization is introduced only at gloas
+  # (EIP-7688), and gloas uses the distinct ExecutionRequestsGloas message
+  # below. Annotating this base type progressive leaks into electra/fulu and
+  # breaks pre-gloas containment.
   - name: "ExecutionRequests"
   - name: "ExecutionRequestsGloas"
+    progressive: {}
+    fields:
+      Deposits: {type: "ProgressiveList"}
+      Withdrawals: {type: "ProgressiveList"}
+      Consolidations: {type: "ProgressiveList"}
+      BuilderDeposits: {type: "ProgressiveList"}
+      BuilderExits: {type: "ProgressiveList"}
   - name: "Withdrawal"
   - name: "WithdrawalRequest"

--- a/proto/prysm/v1alpha1/gloas.minimal.ssz.go
+++ b/proto/prysm/v1alpha1/gloas.minimal.ssz.go
@@ -51,9 +51,6 @@ func (c *AttestationGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, []byte(c.CommitteeBits)...)
 
 	// Field 0: AggregationBits
-	if len(c.AggregationBits) > 8192 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.AggregationBits...)
 	return dst, err
 }
@@ -79,7 +76,7 @@ func (c *AttestationGloas) UnmarshalSSZ(buf []byte) error {
 	sszSlice0 := buf[sszVarOffset0:] // c.AggregationBits
 
 	// Field 0: AggregationBits
-	if err = ssz.ValidateBitlist(sszSlice0, 8192); err != nil {
+	if err = ssz.ValidateProgressiveBitlist(sszSlice0); err != nil {
 		return fmt.Errorf("AggregationBits: %w", err)
 	}
 	c.AggregationBits = append([]byte{}, go_bitfield.Bitlist(sszSlice0)...)
@@ -101,8 +98,18 @@ func (c *AttestationGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *AttestationGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *AttestationGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsAttestationGloas = []byte{0b00001111}
+
+func (c *AttestationGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -111,13 +118,13 @@ func (c *AttestationGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *AttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *AttestationGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: AggregationBits
 	if len(c.AggregationBits) == 0 {
 		return ssz.ErrEmptyBitlist
 	}
-	hh.PutBitlist(c.AggregationBits, 8192)
+	hh.PutProgressiveBitlist(c.AggregationBits)
 	// Field 1: Data
 	if err := c.Data.HashTreeRootWith(hh); err != nil {
 		return fmt.Errorf("Data: %w", err)
@@ -132,7 +139,7 @@ func (c *AttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes([]byte(c.CommitteeBits))
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsAttestationGloas)
 	return nil
 }
 
@@ -559,9 +566,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	offset += c.ParentExecutionRequests.SizeSSZ()
 
 	// Field 3: ProposerSlashings
-	if len(c.ProposerSlashings) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.ProposerSlashings {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("ProposerSlashings: %w", err)
@@ -569,9 +573,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 4: AttesterSlashings
-	if len(c.AttesterSlashings) > 1 {
-		return nil, ssz.ErrListTooBig
-	}
 	{
 		offset = 4 * len(c.AttesterSlashings)
 		for _, o := range c.AttesterSlashings {
@@ -586,9 +587,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 5: Attestations
-	if len(c.Attestations) > 8 {
-		return nil, ssz.ErrListTooBig
-	}
 	{
 		offset = 4 * len(c.Attestations)
 		for _, o := range c.Attestations {
@@ -603,9 +601,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 6: Deposits
-	if len(c.Deposits) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Deposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Deposits: %w", err)
@@ -613,9 +608,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 7: VoluntaryExits
-	if len(c.VoluntaryExits) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.VoluntaryExits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("VoluntaryExits: %w", err)
@@ -623,9 +615,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 9: BlsToExecutionChanges
-	if len(c.BlsToExecutionChanges) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BlsToExecutionChanges {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BlsToExecutionChanges: %w", err)
@@ -638,9 +627,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 11: PayloadAttestations
-	if len(c.PayloadAttestations) > 4 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PayloadAttestations {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PayloadAttestations: %w", err)
@@ -735,9 +721,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.ProposerSlashings length is %d, which is not a multiple of 416: %w", len(sszSlice3), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice3) / 416
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.ProposerSlashings has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.ProposerSlashings = make([]*ProposerSlashing, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *ProposerSlashing
@@ -763,9 +746,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 				return fmt.Errorf("misaligned list bytes: when decoding c.AttesterSlashings, end-of-list offset is %d, which is not a multiple of 4 (offset size)", startOffset)
 			}
 			listLen := startOffset / 4
-			if listLen > 1 {
-				return fmt.Errorf("ssz-max exceeded: c.AttesterSlashings has %d elements, ssz-max is 1: %w", listLen, ssz.ErrListTooBig)
-			}
 			totalVarBytes := uint64(len(sszSlice4))
 			if totalVarBytes < startOffset {
 				return fmt.Errorf("list bytes too short to contain an offset when decoding c.AttesterSlashings")
@@ -813,9 +793,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 				return fmt.Errorf("misaligned list bytes: when decoding c.Attestations, end-of-list offset is %d, which is not a multiple of 4 (offset size)", startOffset)
 			}
 			listLen := startOffset / 4
-			if listLen > 8 {
-				return fmt.Errorf("ssz-max exceeded: c.Attestations has %d elements, ssz-max is 8: %w", listLen, ssz.ErrListTooBig)
-			}
 			totalVarBytes := uint64(len(sszSlice5))
 			if totalVarBytes < startOffset {
 				return fmt.Errorf("list bytes too short to contain an offset when decoding c.Attestations")
@@ -856,9 +833,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Deposits length is %d, which is not a multiple of 1240: %w", len(sszSlice6), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice6) / 1240
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.Deposits has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Deposits = make([]*Deposit, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Deposit
@@ -877,9 +851,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.VoluntaryExits length is %d, which is not a multiple of 112: %w", len(sszSlice7), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice7) / 112
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.VoluntaryExits has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.VoluntaryExits = make([]*SignedVoluntaryExit, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *SignedVoluntaryExit
@@ -904,9 +875,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BlsToExecutionChanges length is %d, which is not a multiple of 172: %w", len(sszSlice9), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice9) / 172
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.BlsToExecutionChanges has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BlsToExecutionChanges = make([]*SignedBLSToExecutionChange, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *SignedBLSToExecutionChange
@@ -931,9 +899,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PayloadAttestations length is %d, which is not a multiple of 140: %w", len(sszSlice11), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice11) / 140
-		if numElem > 4 {
-			return fmt.Errorf("ssz-max exceeded: c.PayloadAttestations has %d elements, ssz-max is 4: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PayloadAttestations = make([]*PayloadAttestation, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PayloadAttestation
@@ -955,8 +920,18 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *BeaconBlockBodyGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsBeaconBlockBodyGloas = []byte{0b11111111, 0b00011111}
+
+func (c *BeaconBlockBodyGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -965,7 +940,7 @@ func (c *BeaconBlockBodyGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *BeaconBlockBodyGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: RandaoReveal
 	if len(c.RandaoReveal) != 96 {
@@ -983,68 +958,53 @@ func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(c.Graffiti)
 	// Field 3: ProposerSlashings
 	{
-		if len(c.ProposerSlashings) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.ProposerSlashings {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("ProposerSlashings: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.ProposerSlashings)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.ProposerSlashings)))
 	}
 	// Field 4: AttesterSlashings
 	{
-		if len(c.AttesterSlashings) > 1 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.AttesterSlashings {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("AttesterSlashings: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.AttesterSlashings)), 1)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.AttesterSlashings)))
 	}
 	// Field 5: Attestations
 	{
-		if len(c.Attestations) > 8 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Attestations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Attestations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Attestations)), 8)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Attestations)))
 	}
 	// Field 6: Deposits
 	{
-		if len(c.Deposits) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Deposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Deposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Deposits)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Deposits)))
 	}
 	// Field 7: VoluntaryExits
 	{
-		if len(c.VoluntaryExits) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.VoluntaryExits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("VoluntaryExits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.VoluntaryExits)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.VoluntaryExits)))
 	}
 	// Field 8: SyncAggregate
 	if err := c.SyncAggregate.HashTreeRootWith(hh); err != nil {
@@ -1052,16 +1012,13 @@ func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 9: BlsToExecutionChanges
 	{
-		if len(c.BlsToExecutionChanges) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BlsToExecutionChanges {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BlsToExecutionChanges: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BlsToExecutionChanges)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BlsToExecutionChanges)))
 	}
 	// Field 10: SignedExecutionPayloadBid
 	if err := c.SignedExecutionPayloadBid.HashTreeRootWith(hh); err != nil {
@@ -1069,22 +1026,19 @@ func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 11: PayloadAttestations
 	{
-		if len(c.PayloadAttestations) > 4 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PayloadAttestations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PayloadAttestations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PayloadAttestations)), 4)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PayloadAttestations)))
 	}
 	// Field 12: ParentExecutionRequests
 	if err := c.ParentExecutionRequests.HashTreeRootWith(hh); err != nil {
 		return fmt.Errorf("ParentExecutionRequests: %w", err)
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsBeaconBlockBodyGloas)
 	return nil
 }
 
@@ -1774,9 +1728,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 11: Validators
-	if len(c.Validators) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Validators {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Validators: %w", err)
@@ -1784,29 +1735,17 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 12: Balances
-	if len(c.Balances) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Balances {
 		dst = binary.LittleEndian.AppendUint64(dst, o)
 	}
 
 	// Field 15: PreviousEpochParticipation
-	if len(c.PreviousEpochParticipation) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.PreviousEpochParticipation...)
 
 	// Field 16: CurrentEpochParticipation
-	if len(c.CurrentEpochParticipation) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.CurrentEpochParticipation...)
 
 	// Field 21: InactivityScores
-	if len(c.InactivityScores) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.InactivityScores {
 		dst = binary.LittleEndian.AppendUint64(dst, o)
 	}
@@ -1822,9 +1761,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 34: PendingDeposits
-	if len(c.PendingDeposits) > 134217728 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PendingDeposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PendingDeposits: %w", err)
@@ -1832,9 +1768,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 35: PendingPartialWithdrawals
-	if len(c.PendingPartialWithdrawals) > 64 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PendingPartialWithdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PendingPartialWithdrawals: %w", err)
@@ -1842,9 +1775,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 36: PendingConsolidations
-	if len(c.PendingConsolidations) > 64 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PendingConsolidations {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PendingConsolidations: %w", err)
@@ -1852,9 +1782,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 38: Builders
-	if len(c.Builders) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Builders {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Builders: %w", err)
@@ -1862,9 +1789,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 42: BuilderPendingWithdrawals
-	if len(c.BuilderPendingWithdrawals) > 1048576 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BuilderPendingWithdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BuilderPendingWithdrawals: %w", err)
@@ -1877,9 +1801,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 44: PayloadExpectedWithdrawals
-	if len(c.PayloadExpectedWithdrawals) > 4 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PayloadExpectedWithdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PayloadExpectedWithdrawals: %w", err)
@@ -2112,9 +2033,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Validators length is %d, which is not a multiple of 121: %w", len(sszSlice11), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice11) / 121
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.Validators has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Validators = make([]*Validator, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Validator
@@ -2133,9 +2051,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Balances length is %d, which is not a multiple of 8: %w", len(sszSlice12), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice12) / 8
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.Balances has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Balances = make([]uint64, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp uint64
@@ -2205,9 +2120,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.InactivityScores length is %d, which is not a multiple of 8: %w", len(sszSlice21), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice21) / 8
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.InactivityScores has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.InactivityScores = make([]uint64, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp uint64
@@ -2297,9 +2209,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PendingDeposits length is %d, which is not a multiple of 192: %w", len(sszSlice34), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice34) / 192
-		if numElem > 134217728 {
-			return fmt.Errorf("ssz-max exceeded: c.PendingDeposits has %d elements, ssz-max is 134217728: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PendingDeposits = make([]*PendingDeposit, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PendingDeposit
@@ -2318,9 +2227,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PendingPartialWithdrawals length is %d, which is not a multiple of 24: %w", len(sszSlice35), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice35) / 24
-		if numElem > 64 {
-			return fmt.Errorf("ssz-max exceeded: c.PendingPartialWithdrawals has %d elements, ssz-max is 64: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PendingPartialWithdrawals = make([]*PendingPartialWithdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PendingPartialWithdrawal
@@ -2339,9 +2245,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PendingConsolidations length is %d, which is not a multiple of 16: %w", len(sszSlice36), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice36) / 16
-		if numElem > 64 {
-			return fmt.Errorf("ssz-max exceeded: c.PendingConsolidations has %d elements, ssz-max is 64: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PendingConsolidations = make([]*PendingConsolidation, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PendingConsolidation
@@ -2374,9 +2277,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Builders length is %d, which is not a multiple of 93: %w", len(sszSlice38), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice38) / 93
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.Builders has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Builders = make([]*Builder, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Builder
@@ -2418,9 +2318,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BuilderPendingWithdrawals length is %d, which is not a multiple of 36: %w", len(sszSlice42), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice42) / 36
-		if numElem > 1048576 {
-			return fmt.Errorf("ssz-max exceeded: c.BuilderPendingWithdrawals has %d elements, ssz-max is 1048576: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BuilderPendingWithdrawals = make([]*BuilderPendingWithdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *BuilderPendingWithdrawal
@@ -2445,9 +2342,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PayloadExpectedWithdrawals length is %d, which is not a multiple of 44: %w", len(sszSlice44), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice44) / 44
-		if numElem > 4 {
-			return fmt.Errorf("ssz-max exceeded: c.PayloadExpectedWithdrawals has %d elements, ssz-max is 4: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PayloadExpectedWithdrawals = make([]*v1.Withdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *v1.Withdrawal
@@ -2477,8 +2371,18 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *BeaconStateGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsBeaconStateGloas = []byte{0b11111111, 0b11111111, 0b11111111, 0b11111111, 0b11111111, 0b00111111}
+
+func (c *BeaconStateGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -2487,7 +2391,7 @@ func (c *BeaconStateGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *BeaconStateGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: GenesisTime
 	hh.PutUint64(c.GenesisTime)
@@ -2571,29 +2475,22 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutUint64(c.Eth1DepositIndex)
 	// Field 11: Validators
 	{
-		if len(c.Validators) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Validators {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Validators: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Validators)), 1099511627776)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Validators)))
 	}
 	// Field 12: Balances
 	{
-		if len(c.Balances) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Balances {
 			hh.AppendUint64(o)
 		}
 		hh.FillUpTo32()
-		numItems := uint64(len(c.Balances))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(1099511627776, numItems, 8))
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Balances)))
 	}
 	// Field 13: RandaoMixes
 	{
@@ -2621,29 +2518,17 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		hh.Merkleize(subIndx)
 	}
 	// Field 15: PreviousEpochParticipation
-
 	{
-		if len(c.PreviousEpochParticipation) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
 		subIndx := hh.Index()
 		hh.AppendBytes32(c.PreviousEpochParticipation)
-		numItems := uint64(len(c.PreviousEpochParticipation))
-		hh.MerkleizeWithMixin(subIndx, numItems, (1099511627776*1+31)/32)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PreviousEpochParticipation)))
 	}
-
 	// Field 16: CurrentEpochParticipation
-
 	{
-		if len(c.CurrentEpochParticipation) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
 		subIndx := hh.Index()
 		hh.AppendBytes32(c.CurrentEpochParticipation)
-		numItems := uint64(len(c.CurrentEpochParticipation))
-		hh.MerkleizeWithMixin(subIndx, numItems, (1099511627776*1+31)/32)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.CurrentEpochParticipation)))
 	}
-
 	// Field 17: JustificationBits
 	if len([]byte(c.JustificationBits)) != 1 {
 		return ssz.ErrBytesLength
@@ -2663,16 +2548,12 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 21: InactivityScores
 	{
-		if len(c.InactivityScores) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.InactivityScores {
 			hh.AppendUint64(o)
 		}
 		hh.FillUpTo32()
-		numItems := uint64(len(c.InactivityScores))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(1099511627776, numItems, 8))
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.InactivityScores)))
 	}
 	// Field 22: CurrentSyncCommittee
 	if err := c.CurrentSyncCommittee.HashTreeRootWith(hh); err != nil {
@@ -2730,42 +2611,33 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 34: PendingDeposits
 	{
-		if len(c.PendingDeposits) > 134217728 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PendingDeposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PendingDeposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PendingDeposits)), 134217728)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PendingDeposits)))
 	}
 	// Field 35: PendingPartialWithdrawals
 	{
-		if len(c.PendingPartialWithdrawals) > 64 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PendingPartialWithdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PendingPartialWithdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PendingPartialWithdrawals)), 64)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PendingPartialWithdrawals)))
 	}
 	// Field 36: PendingConsolidations
 	{
-		if len(c.PendingConsolidations) > 64 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PendingConsolidations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PendingConsolidations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PendingConsolidations)), 64)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PendingConsolidations)))
 	}
 	// Field 37: ProposerLookahead
 	{
@@ -2780,16 +2652,13 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 38: Builders
 	{
-		if len(c.Builders) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Builders {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Builders: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Builders)), 1099511627776)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Builders)))
 	}
 	// Field 39: NextWithdrawalBuilderIndex
 	if err := c.NextWithdrawalBuilderIndex.HashTreeRootWith(hh); err != nil {
@@ -2815,16 +2684,13 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 42: BuilderPendingWithdrawals
 	{
-		if len(c.BuilderPendingWithdrawals) > 1048576 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BuilderPendingWithdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BuilderPendingWithdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BuilderPendingWithdrawals)), 1048576)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BuilderPendingWithdrawals)))
 	}
 	// Field 43: LatestExecutionPayloadBid
 	if err := c.LatestExecutionPayloadBid.HashTreeRootWith(hh); err != nil {
@@ -2832,16 +2698,13 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 44: PayloadExpectedWithdrawals
 	{
-		if len(c.PayloadExpectedWithdrawals) > 4 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PayloadExpectedWithdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PayloadExpectedWithdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PayloadExpectedWithdrawals)), 4)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PayloadExpectedWithdrawals)))
 	}
 	// Field 45: PtcWindow
 	{
@@ -2856,7 +2719,7 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		hh.Merkleize(subIndx)
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsBeaconStateGloas)
 	return nil
 }
 
@@ -3547,9 +3410,6 @@ func (c *DataColumnSidecarGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.BeaconBlockRoot...)
 
 	// Field 1: Column
-	if len(c.Column) > 4096 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Column {
 		if len(o) != 2048 {
 			return nil, ssz.ErrBytesLength
@@ -3558,9 +3418,6 @@ func (c *DataColumnSidecarGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 2: KzgProofs
-	if len(c.KzgProofs) > 4096 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.KzgProofs {
 		if len(o) != 48 {
 			return nil, ssz.ErrBytesLength
@@ -3604,9 +3461,6 @@ func (c *DataColumnSidecarGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Column length is %d, which is not a multiple of 2048: %w", len(sszSlice1), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice1) / 2048
-		if numElem > 4096 {
-			return fmt.Errorf("ssz-max exceeded: c.Column has %d elements, ssz-max is 4096: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Column = make([][]byte, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp []byte
@@ -3624,9 +3478,6 @@ func (c *DataColumnSidecarGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.KzgProofs length is %d, which is not a multiple of 48: %w", len(sszSlice2), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice2) / 48
-		if numElem > 4096 {
-			return fmt.Errorf("ssz-max exceeded: c.KzgProofs has %d elements, ssz-max is 4096: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.KzgProofs = make([][]byte, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp []byte
@@ -3666,9 +3517,6 @@ func (c *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutUint64(c.Index)
 	// Field 1: Column
 	{
-		if len(c.Column) > 4096 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Column {
 			if len(o) != 2048 {
@@ -3676,13 +3524,10 @@ func (c *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			}
 			hh.PutBytes(o)
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Column)), 4096)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Column)))
 	}
 	// Field 2: KzgProofs
 	{
-		if len(c.KzgProofs) > 4096 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.KzgProofs {
 			if len(o) != 48 {
@@ -3690,7 +3535,7 @@ func (c *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			}
 			hh.PutBytes(o)
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.KzgProofs)), 4096)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.KzgProofs)))
 	}
 	// Field 3: Slot
 	if err := c.Slot.HashTreeRootWith(hh); err != nil {
@@ -3784,9 +3629,6 @@ func (c *ExecutionPayloadBid) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.ExecutionRequestsRoot...)
 
 	// Field 10: BlobKzgCommitments
-	if len(c.BlobKzgCommitments) > 4096 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BlobKzgCommitments {
 		if len(o) != 48 {
 			return nil, ssz.ErrBytesLength
@@ -3873,9 +3715,6 @@ func (c *ExecutionPayloadBid) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BlobKzgCommitments length is %d, which is not a multiple of 48: %w", len(sszSlice10), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice10) / 48
-		if numElem > 4096 {
-			return fmt.Errorf("ssz-max exceeded: c.BlobKzgCommitments has %d elements, ssz-max is 4096: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BlobKzgCommitments = make([][]byte, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp []byte
@@ -3894,8 +3733,18 @@ func (c *ExecutionPayloadBid) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionPayloadBid) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionPayloadBid = []byte{0b11111111, 0b00001111}
+
+func (c *ExecutionPayloadBid) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -3904,7 +3753,7 @@ func (c *ExecutionPayloadBid) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionPayloadBid) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: ParentBlockHash
 	if len(c.ParentBlockHash) != 32 {
@@ -3951,9 +3800,6 @@ func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 10: BlobKzgCommitments
 	{
-		if len(c.BlobKzgCommitments) > 4096 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BlobKzgCommitments {
 			if len(o) != 48 {
@@ -3961,14 +3807,14 @@ func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			}
 			hh.PutBytes(o)
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BlobKzgCommitments)), 4096)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BlobKzgCommitments)))
 	}
 	// Field 11: ExecutionRequestsRoot
 	if len(c.ExecutionRequestsRoot) != 32 {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.ExecutionRequestsRoot)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionPayloadBid)
 	return nil
 }
 
@@ -4090,8 +3936,18 @@ func (c *ExecutionPayloadEnvelope) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionPayloadEnvelope) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionPayloadEnvelope = []byte{0b00011111}
+
+func (c *ExecutionPayloadEnvelope) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -4100,7 +3956,7 @@ func (c *ExecutionPayloadEnvelope) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionPayloadEnvelope) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: Payload
 	if err := c.Payload.HashTreeRootWith(hh); err != nil {
@@ -4124,7 +3980,7 @@ func (c *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.ParentBeaconBlockRoot)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionPayloadEnvelope)
 	return nil
 }
 
@@ -4162,9 +4018,6 @@ func (c *IndexedAttestationGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.Signature...)
 
 	// Field 0: AttestingIndices
-	if len(c.AttestingIndices) > 8192 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.AttestingIndices {
 		dst = binary.LittleEndian.AppendUint64(dst, o)
 	}
@@ -4196,9 +4049,6 @@ func (c *IndexedAttestationGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.AttestingIndices length is %d, which is not a multiple of 8: %w", len(sszSlice0), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice0) / 8
-		if numElem > 8192 {
-			return fmt.Errorf("ssz-max exceeded: c.AttestingIndices has %d elements, ssz-max is 8192: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.AttestingIndices = make([]uint64, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp uint64
@@ -4222,8 +4072,18 @@ func (c *IndexedAttestationGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *IndexedAttestationGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *IndexedAttestationGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsIndexedAttestationGloas = []byte{0b00000111}
+
+func (c *IndexedAttestationGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -4232,20 +4092,16 @@ func (c *IndexedAttestationGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *IndexedAttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *IndexedAttestationGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: AttestingIndices
 	{
-		if len(c.AttestingIndices) > 8192 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.AttestingIndices {
 			hh.AppendUint64(o)
 		}
 		hh.FillUpTo32()
-		numItems := uint64(len(c.AttestingIndices))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(8192, numItems, 8))
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.AttestingIndices)))
 	}
 	// Field 1: Data
 	if err := c.Data.HashTreeRootWith(hh); err != nil {
@@ -4256,7 +4112,7 @@ func (c *IndexedAttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.Signature)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsIndexedAttestationGloas)
 	return nil
 }
 
@@ -4325,8 +4181,18 @@ func (c *PayloadAttestation) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *PayloadAttestation) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *PayloadAttestation) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsPayloadAttestation = []byte{0b00000111}
+
+func (c *PayloadAttestation) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -4335,7 +4201,7 @@ func (c *PayloadAttestation) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *PayloadAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *PayloadAttestation) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: AggregationBits
 	if len([]byte(c.AggregationBits)) != 2 {
@@ -4351,7 +4217,7 @@ func (c *PayloadAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.Signature)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsPayloadAttestation)
 	return nil
 }
 

--- a/proto/prysm/v1alpha1/gloas.ssz.go
+++ b/proto/prysm/v1alpha1/gloas.ssz.go
@@ -51,9 +51,6 @@ func (c *AttestationGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, []byte(c.CommitteeBits)...)
 
 	// Field 0: AggregationBits
-	if len(c.AggregationBits) > 131072 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.AggregationBits...)
 	return dst, err
 }
@@ -79,7 +76,7 @@ func (c *AttestationGloas) UnmarshalSSZ(buf []byte) error {
 	sszSlice0 := buf[sszVarOffset0:] // c.AggregationBits
 
 	// Field 0: AggregationBits
-	if err = ssz.ValidateBitlist(sszSlice0, 131072); err != nil {
+	if err = ssz.ValidateProgressiveBitlist(sszSlice0); err != nil {
 		return fmt.Errorf("AggregationBits: %w", err)
 	}
 	c.AggregationBits = append([]byte{}, go_bitfield.Bitlist(sszSlice0)...)
@@ -101,8 +98,18 @@ func (c *AttestationGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *AttestationGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *AttestationGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsAttestationGloas = []byte{0b00001111}
+
+func (c *AttestationGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -111,13 +118,13 @@ func (c *AttestationGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *AttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *AttestationGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: AggregationBits
 	if len(c.AggregationBits) == 0 {
 		return ssz.ErrEmptyBitlist
 	}
-	hh.PutBitlist(c.AggregationBits, 131072)
+	hh.PutProgressiveBitlist(c.AggregationBits)
 	// Field 1: Data
 	if err := c.Data.HashTreeRootWith(hh); err != nil {
 		return fmt.Errorf("Data: %w", err)
@@ -132,7 +139,7 @@ func (c *AttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes([]byte(c.CommitteeBits))
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsAttestationGloas)
 	return nil
 }
 
@@ -559,9 +566,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	offset += c.ParentExecutionRequests.SizeSSZ()
 
 	// Field 3: ProposerSlashings
-	if len(c.ProposerSlashings) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.ProposerSlashings {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("ProposerSlashings: %w", err)
@@ -569,9 +573,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 4: AttesterSlashings
-	if len(c.AttesterSlashings) > 1 {
-		return nil, ssz.ErrListTooBig
-	}
 	{
 		offset = 4 * len(c.AttesterSlashings)
 		for _, o := range c.AttesterSlashings {
@@ -586,9 +587,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 5: Attestations
-	if len(c.Attestations) > 8 {
-		return nil, ssz.ErrListTooBig
-	}
 	{
 		offset = 4 * len(c.Attestations)
 		for _, o := range c.Attestations {
@@ -603,9 +601,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 6: Deposits
-	if len(c.Deposits) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Deposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Deposits: %w", err)
@@ -613,9 +608,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 7: VoluntaryExits
-	if len(c.VoluntaryExits) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.VoluntaryExits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("VoluntaryExits: %w", err)
@@ -623,9 +615,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 9: BlsToExecutionChanges
-	if len(c.BlsToExecutionChanges) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BlsToExecutionChanges {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BlsToExecutionChanges: %w", err)
@@ -638,9 +627,6 @@ func (c *BeaconBlockBodyGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 11: PayloadAttestations
-	if len(c.PayloadAttestations) > 4 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PayloadAttestations {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PayloadAttestations: %w", err)
@@ -735,9 +721,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.ProposerSlashings length is %d, which is not a multiple of 416: %w", len(sszSlice3), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice3) / 416
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.ProposerSlashings has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.ProposerSlashings = make([]*ProposerSlashing, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *ProposerSlashing
@@ -763,9 +746,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 				return fmt.Errorf("misaligned list bytes: when decoding c.AttesterSlashings, end-of-list offset is %d, which is not a multiple of 4 (offset size)", startOffset)
 			}
 			listLen := startOffset / 4
-			if listLen > 1 {
-				return fmt.Errorf("ssz-max exceeded: c.AttesterSlashings has %d elements, ssz-max is 1: %w", listLen, ssz.ErrListTooBig)
-			}
 			totalVarBytes := uint64(len(sszSlice4))
 			if totalVarBytes < startOffset {
 				return fmt.Errorf("list bytes too short to contain an offset when decoding c.AttesterSlashings")
@@ -813,9 +793,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 				return fmt.Errorf("misaligned list bytes: when decoding c.Attestations, end-of-list offset is %d, which is not a multiple of 4 (offset size)", startOffset)
 			}
 			listLen := startOffset / 4
-			if listLen > 8 {
-				return fmt.Errorf("ssz-max exceeded: c.Attestations has %d elements, ssz-max is 8: %w", listLen, ssz.ErrListTooBig)
-			}
 			totalVarBytes := uint64(len(sszSlice5))
 			if totalVarBytes < startOffset {
 				return fmt.Errorf("list bytes too short to contain an offset when decoding c.Attestations")
@@ -856,9 +833,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Deposits length is %d, which is not a multiple of 1240: %w", len(sszSlice6), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice6) / 1240
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.Deposits has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Deposits = make([]*Deposit, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Deposit
@@ -877,9 +851,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.VoluntaryExits length is %d, which is not a multiple of 112: %w", len(sszSlice7), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice7) / 112
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.VoluntaryExits has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.VoluntaryExits = make([]*SignedVoluntaryExit, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *SignedVoluntaryExit
@@ -904,9 +875,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BlsToExecutionChanges length is %d, which is not a multiple of 172: %w", len(sszSlice9), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice9) / 172
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.BlsToExecutionChanges has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BlsToExecutionChanges = make([]*SignedBLSToExecutionChange, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *SignedBLSToExecutionChange
@@ -931,9 +899,6 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PayloadAttestations length is %d, which is not a multiple of 202: %w", len(sszSlice11), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice11) / 202
-		if numElem > 4 {
-			return fmt.Errorf("ssz-max exceeded: c.PayloadAttestations has %d elements, ssz-max is 4: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PayloadAttestations = make([]*PayloadAttestation, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PayloadAttestation
@@ -955,8 +920,18 @@ func (c *BeaconBlockBodyGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *BeaconBlockBodyGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsBeaconBlockBodyGloas = []byte{0b11111111, 0b00011111}
+
+func (c *BeaconBlockBodyGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -965,7 +940,7 @@ func (c *BeaconBlockBodyGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *BeaconBlockBodyGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: RandaoReveal
 	if len(c.RandaoReveal) != 96 {
@@ -983,68 +958,53 @@ func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(c.Graffiti)
 	// Field 3: ProposerSlashings
 	{
-		if len(c.ProposerSlashings) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.ProposerSlashings {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("ProposerSlashings: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.ProposerSlashings)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.ProposerSlashings)))
 	}
 	// Field 4: AttesterSlashings
 	{
-		if len(c.AttesterSlashings) > 1 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.AttesterSlashings {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("AttesterSlashings: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.AttesterSlashings)), 1)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.AttesterSlashings)))
 	}
 	// Field 5: Attestations
 	{
-		if len(c.Attestations) > 8 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Attestations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Attestations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Attestations)), 8)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Attestations)))
 	}
 	// Field 6: Deposits
 	{
-		if len(c.Deposits) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Deposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Deposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Deposits)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Deposits)))
 	}
 	// Field 7: VoluntaryExits
 	{
-		if len(c.VoluntaryExits) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.VoluntaryExits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("VoluntaryExits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.VoluntaryExits)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.VoluntaryExits)))
 	}
 	// Field 8: SyncAggregate
 	if err := c.SyncAggregate.HashTreeRootWith(hh); err != nil {
@@ -1052,16 +1012,13 @@ func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 9: BlsToExecutionChanges
 	{
-		if len(c.BlsToExecutionChanges) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BlsToExecutionChanges {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BlsToExecutionChanges: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BlsToExecutionChanges)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BlsToExecutionChanges)))
 	}
 	// Field 10: SignedExecutionPayloadBid
 	if err := c.SignedExecutionPayloadBid.HashTreeRootWith(hh); err != nil {
@@ -1069,22 +1026,19 @@ func (c *BeaconBlockBodyGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 11: PayloadAttestations
 	{
-		if len(c.PayloadAttestations) > 4 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PayloadAttestations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PayloadAttestations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PayloadAttestations)), 4)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PayloadAttestations)))
 	}
 	// Field 12: ParentExecutionRequests
 	if err := c.ParentExecutionRequests.HashTreeRootWith(hh); err != nil {
 		return fmt.Errorf("ParentExecutionRequests: %w", err)
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsBeaconBlockBodyGloas)
 	return nil
 }
 
@@ -1774,9 +1728,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 11: Validators
-	if len(c.Validators) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Validators {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Validators: %w", err)
@@ -1784,29 +1735,17 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 12: Balances
-	if len(c.Balances) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Balances {
 		dst = binary.LittleEndian.AppendUint64(dst, o)
 	}
 
 	// Field 15: PreviousEpochParticipation
-	if len(c.PreviousEpochParticipation) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.PreviousEpochParticipation...)
 
 	// Field 16: CurrentEpochParticipation
-	if len(c.CurrentEpochParticipation) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	dst = append(dst, c.CurrentEpochParticipation...)
 
 	// Field 21: InactivityScores
-	if len(c.InactivityScores) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.InactivityScores {
 		dst = binary.LittleEndian.AppendUint64(dst, o)
 	}
@@ -1822,9 +1761,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 34: PendingDeposits
-	if len(c.PendingDeposits) > 134217728 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PendingDeposits {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PendingDeposits: %w", err)
@@ -1832,9 +1768,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 35: PendingPartialWithdrawals
-	if len(c.PendingPartialWithdrawals) > 134217728 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PendingPartialWithdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PendingPartialWithdrawals: %w", err)
@@ -1842,9 +1775,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 36: PendingConsolidations
-	if len(c.PendingConsolidations) > 262144 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PendingConsolidations {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PendingConsolidations: %w", err)
@@ -1852,9 +1782,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 38: Builders
-	if len(c.Builders) > 1099511627776 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Builders {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("Builders: %w", err)
@@ -1862,9 +1789,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 42: BuilderPendingWithdrawals
-	if len(c.BuilderPendingWithdrawals) > 1048576 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BuilderPendingWithdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("BuilderPendingWithdrawals: %w", err)
@@ -1877,9 +1801,6 @@ func (c *BeaconStateGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 44: PayloadExpectedWithdrawals
-	if len(c.PayloadExpectedWithdrawals) > 16 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.PayloadExpectedWithdrawals {
 		if dst, err = o.MarshalSSZTo(dst); err != nil {
 			return nil, fmt.Errorf("PayloadExpectedWithdrawals: %w", err)
@@ -2112,9 +2033,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Validators length is %d, which is not a multiple of 121: %w", len(sszSlice11), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice11) / 121
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.Validators has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Validators = make([]*Validator, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Validator
@@ -2133,9 +2051,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Balances length is %d, which is not a multiple of 8: %w", len(sszSlice12), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice12) / 8
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.Balances has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Balances = make([]uint64, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp uint64
@@ -2205,9 +2120,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.InactivityScores length is %d, which is not a multiple of 8: %w", len(sszSlice21), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice21) / 8
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.InactivityScores has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.InactivityScores = make([]uint64, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp uint64
@@ -2297,9 +2209,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PendingDeposits length is %d, which is not a multiple of 192: %w", len(sszSlice34), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice34) / 192
-		if numElem > 134217728 {
-			return fmt.Errorf("ssz-max exceeded: c.PendingDeposits has %d elements, ssz-max is 134217728: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PendingDeposits = make([]*PendingDeposit, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PendingDeposit
@@ -2318,9 +2227,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PendingPartialWithdrawals length is %d, which is not a multiple of 24: %w", len(sszSlice35), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice35) / 24
-		if numElem > 134217728 {
-			return fmt.Errorf("ssz-max exceeded: c.PendingPartialWithdrawals has %d elements, ssz-max is 134217728: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PendingPartialWithdrawals = make([]*PendingPartialWithdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PendingPartialWithdrawal
@@ -2339,9 +2245,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PendingConsolidations length is %d, which is not a multiple of 16: %w", len(sszSlice36), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice36) / 16
-		if numElem > 262144 {
-			return fmt.Errorf("ssz-max exceeded: c.PendingConsolidations has %d elements, ssz-max is 262144: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PendingConsolidations = make([]*PendingConsolidation, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *PendingConsolidation
@@ -2374,9 +2277,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Builders length is %d, which is not a multiple of 93: %w", len(sszSlice38), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice38) / 93
-		if numElem > 1099511627776 {
-			return fmt.Errorf("ssz-max exceeded: c.Builders has %d elements, ssz-max is 1099511627776: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Builders = make([]*Builder, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *Builder
@@ -2418,9 +2318,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BuilderPendingWithdrawals length is %d, which is not a multiple of 36: %w", len(sszSlice42), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice42) / 36
-		if numElem > 1048576 {
-			return fmt.Errorf("ssz-max exceeded: c.BuilderPendingWithdrawals has %d elements, ssz-max is 1048576: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BuilderPendingWithdrawals = make([]*BuilderPendingWithdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *BuilderPendingWithdrawal
@@ -2445,9 +2342,6 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.PayloadExpectedWithdrawals length is %d, which is not a multiple of 44: %w", len(sszSlice44), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice44) / 44
-		if numElem > 16 {
-			return fmt.Errorf("ssz-max exceeded: c.PayloadExpectedWithdrawals has %d elements, ssz-max is 16: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.PayloadExpectedWithdrawals = make([]*v1.Withdrawal, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp *v1.Withdrawal
@@ -2477,8 +2371,18 @@ func (c *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *BeaconStateGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsBeaconStateGloas = []byte{0b11111111, 0b11111111, 0b11111111, 0b11111111, 0b11111111, 0b00111111}
+
+func (c *BeaconStateGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -2487,7 +2391,7 @@ func (c *BeaconStateGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *BeaconStateGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: GenesisTime
 	hh.PutUint64(c.GenesisTime)
@@ -2571,29 +2475,22 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutUint64(c.Eth1DepositIndex)
 	// Field 11: Validators
 	{
-		if len(c.Validators) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Validators {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Validators: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Validators)), 1099511627776)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Validators)))
 	}
 	// Field 12: Balances
 	{
-		if len(c.Balances) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Balances {
 			hh.AppendUint64(o)
 		}
 		hh.FillUpTo32()
-		numItems := uint64(len(c.Balances))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(1099511627776, numItems, 8))
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Balances)))
 	}
 	// Field 13: RandaoMixes
 	{
@@ -2621,29 +2518,17 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		hh.Merkleize(subIndx)
 	}
 	// Field 15: PreviousEpochParticipation
-
 	{
-		if len(c.PreviousEpochParticipation) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
 		subIndx := hh.Index()
 		hh.AppendBytes32(c.PreviousEpochParticipation)
-		numItems := uint64(len(c.PreviousEpochParticipation))
-		hh.MerkleizeWithMixin(subIndx, numItems, (1099511627776*1+31)/32)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PreviousEpochParticipation)))
 	}
-
 	// Field 16: CurrentEpochParticipation
-
 	{
-		if len(c.CurrentEpochParticipation) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
 		subIndx := hh.Index()
 		hh.AppendBytes32(c.CurrentEpochParticipation)
-		numItems := uint64(len(c.CurrentEpochParticipation))
-		hh.MerkleizeWithMixin(subIndx, numItems, (1099511627776*1+31)/32)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.CurrentEpochParticipation)))
 	}
-
 	// Field 17: JustificationBits
 	if len([]byte(c.JustificationBits)) != 1 {
 		return ssz.ErrBytesLength
@@ -2663,16 +2548,12 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 21: InactivityScores
 	{
-		if len(c.InactivityScores) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.InactivityScores {
 			hh.AppendUint64(o)
 		}
 		hh.FillUpTo32()
-		numItems := uint64(len(c.InactivityScores))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(1099511627776, numItems, 8))
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.InactivityScores)))
 	}
 	// Field 22: CurrentSyncCommittee
 	if err := c.CurrentSyncCommittee.HashTreeRootWith(hh); err != nil {
@@ -2730,42 +2611,33 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 34: PendingDeposits
 	{
-		if len(c.PendingDeposits) > 134217728 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PendingDeposits {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PendingDeposits: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PendingDeposits)), 134217728)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PendingDeposits)))
 	}
 	// Field 35: PendingPartialWithdrawals
 	{
-		if len(c.PendingPartialWithdrawals) > 134217728 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PendingPartialWithdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PendingPartialWithdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PendingPartialWithdrawals)), 134217728)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PendingPartialWithdrawals)))
 	}
 	// Field 36: PendingConsolidations
 	{
-		if len(c.PendingConsolidations) > 262144 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PendingConsolidations {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PendingConsolidations: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PendingConsolidations)), 262144)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PendingConsolidations)))
 	}
 	// Field 37: ProposerLookahead
 	{
@@ -2780,16 +2652,13 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 38: Builders
 	{
-		if len(c.Builders) > 1099511627776 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Builders {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("Builders: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Builders)), 1099511627776)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Builders)))
 	}
 	// Field 39: NextWithdrawalBuilderIndex
 	if err := c.NextWithdrawalBuilderIndex.HashTreeRootWith(hh); err != nil {
@@ -2815,16 +2684,13 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 42: BuilderPendingWithdrawals
 	{
-		if len(c.BuilderPendingWithdrawals) > 1048576 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BuilderPendingWithdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("BuilderPendingWithdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BuilderPendingWithdrawals)), 1048576)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BuilderPendingWithdrawals)))
 	}
 	// Field 43: LatestExecutionPayloadBid
 	if err := c.LatestExecutionPayloadBid.HashTreeRootWith(hh); err != nil {
@@ -2832,16 +2698,13 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 44: PayloadExpectedWithdrawals
 	{
-		if len(c.PayloadExpectedWithdrawals) > 16 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.PayloadExpectedWithdrawals {
 			if err := o.HashTreeRootWith(hh); err != nil {
 				return fmt.Errorf("PayloadExpectedWithdrawals: %w", err)
 			}
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.PayloadExpectedWithdrawals)), 16)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.PayloadExpectedWithdrawals)))
 	}
 	// Field 45: PtcWindow
 	{
@@ -2856,7 +2719,7 @@ func (c *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		hh.Merkleize(subIndx)
 	}
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsBeaconStateGloas)
 	return nil
 }
 
@@ -3547,9 +3410,6 @@ func (c *DataColumnSidecarGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.BeaconBlockRoot...)
 
 	// Field 1: Column
-	if len(c.Column) > 4096 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.Column {
 		if len(o) != 2048 {
 			return nil, ssz.ErrBytesLength
@@ -3558,9 +3418,6 @@ func (c *DataColumnSidecarGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	}
 
 	// Field 2: KzgProofs
-	if len(c.KzgProofs) > 4096 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.KzgProofs {
 		if len(o) != 48 {
 			return nil, ssz.ErrBytesLength
@@ -3604,9 +3461,6 @@ func (c *DataColumnSidecarGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.Column length is %d, which is not a multiple of 2048: %w", len(sszSlice1), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice1) / 2048
-		if numElem > 4096 {
-			return fmt.Errorf("ssz-max exceeded: c.Column has %d elements, ssz-max is 4096: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.Column = make([][]byte, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp []byte
@@ -3624,9 +3478,6 @@ func (c *DataColumnSidecarGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.KzgProofs length is %d, which is not a multiple of 48: %w", len(sszSlice2), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice2) / 48
-		if numElem > 4096 {
-			return fmt.Errorf("ssz-max exceeded: c.KzgProofs has %d elements, ssz-max is 4096: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.KzgProofs = make([][]byte, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp []byte
@@ -3666,9 +3517,6 @@ func (c *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutUint64(c.Index)
 	// Field 1: Column
 	{
-		if len(c.Column) > 4096 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.Column {
 			if len(o) != 2048 {
@@ -3676,13 +3524,10 @@ func (c *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			}
 			hh.PutBytes(o)
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.Column)), 4096)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.Column)))
 	}
 	// Field 2: KzgProofs
 	{
-		if len(c.KzgProofs) > 4096 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.KzgProofs {
 			if len(o) != 48 {
@@ -3690,7 +3535,7 @@ func (c *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			}
 			hh.PutBytes(o)
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.KzgProofs)), 4096)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.KzgProofs)))
 	}
 	// Field 3: Slot
 	if err := c.Slot.HashTreeRootWith(hh); err != nil {
@@ -3784,9 +3629,6 @@ func (c *ExecutionPayloadBid) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.ExecutionRequestsRoot...)
 
 	// Field 10: BlobKzgCommitments
-	if len(c.BlobKzgCommitments) > 4096 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.BlobKzgCommitments {
 		if len(o) != 48 {
 			return nil, ssz.ErrBytesLength
@@ -3873,9 +3715,6 @@ func (c *ExecutionPayloadBid) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.BlobKzgCommitments length is %d, which is not a multiple of 48: %w", len(sszSlice10), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice10) / 48
-		if numElem > 4096 {
-			return fmt.Errorf("ssz-max exceeded: c.BlobKzgCommitments has %d elements, ssz-max is 4096: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.BlobKzgCommitments = make([][]byte, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp []byte
@@ -3894,8 +3733,18 @@ func (c *ExecutionPayloadBid) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionPayloadBid) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionPayloadBid = []byte{0b11111111, 0b00001111}
+
+func (c *ExecutionPayloadBid) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -3904,7 +3753,7 @@ func (c *ExecutionPayloadBid) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionPayloadBid) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: ParentBlockHash
 	if len(c.ParentBlockHash) != 32 {
@@ -3951,9 +3800,6 @@ func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	// Field 10: BlobKzgCommitments
 	{
-		if len(c.BlobKzgCommitments) > 4096 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.BlobKzgCommitments {
 			if len(o) != 48 {
@@ -3961,14 +3807,14 @@ func (c *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			}
 			hh.PutBytes(o)
 		}
-		hh.MerkleizeWithMixin(subIndx, uint64(len(c.BlobKzgCommitments)), 4096)
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.BlobKzgCommitments)))
 	}
 	// Field 11: ExecutionRequestsRoot
 	if len(c.ExecutionRequestsRoot) != 32 {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.ExecutionRequestsRoot)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionPayloadBid)
 	return nil
 }
 
@@ -4090,8 +3936,18 @@ func (c *ExecutionPayloadEnvelope) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *ExecutionPayloadEnvelope) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsExecutionPayloadEnvelope = []byte{0b00011111}
+
+func (c *ExecutionPayloadEnvelope) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -4100,7 +3956,7 @@ func (c *ExecutionPayloadEnvelope) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *ExecutionPayloadEnvelope) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: Payload
 	if err := c.Payload.HashTreeRootWith(hh); err != nil {
@@ -4124,7 +3980,7 @@ func (c *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.ParentBeaconBlockRoot)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsExecutionPayloadEnvelope)
 	return nil
 }
 
@@ -4162,9 +4018,6 @@ func (c *IndexedAttestationGloas) MarshalSSZTo(dst []byte) ([]byte, error) {
 	dst = append(dst, c.Signature...)
 
 	// Field 0: AttestingIndices
-	if len(c.AttestingIndices) > 131072 {
-		return nil, ssz.ErrListTooBig
-	}
 	for _, o := range c.AttestingIndices {
 		dst = binary.LittleEndian.AppendUint64(dst, o)
 	}
@@ -4196,9 +4049,6 @@ func (c *IndexedAttestationGloas) UnmarshalSSZ(buf []byte) error {
 			return fmt.Errorf("misaligned bytes: c.AttestingIndices length is %d, which is not a multiple of 8: %w", len(sszSlice0), ssz.ErrIncorrectListSize)
 		}
 		numElem := len(sszSlice0) / 8
-		if numElem > 131072 {
-			return fmt.Errorf("ssz-max exceeded: c.AttestingIndices has %d elements, ssz-max is 131072: %w", numElem, ssz.ErrListTooBig)
-		}
 		c.AttestingIndices = make([]uint64, numElem)
 		for i := 0; i < numElem; i++ {
 			var tmp uint64
@@ -4222,8 +4072,18 @@ func (c *IndexedAttestationGloas) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *IndexedAttestationGloas) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *IndexedAttestationGloas) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsIndexedAttestationGloas = []byte{0b00000111}
+
+func (c *IndexedAttestationGloas) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -4232,20 +4092,16 @@ func (c *IndexedAttestationGloas) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *IndexedAttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *IndexedAttestationGloas) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: AttestingIndices
 	{
-		if len(c.AttestingIndices) > 131072 {
-			return ssz.ErrListTooBig
-		}
 		subIndx := hh.Index()
 		for _, o := range c.AttestingIndices {
 			hh.AppendUint64(o)
 		}
 		hh.FillUpTo32()
-		numItems := uint64(len(c.AttestingIndices))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(131072, numItems, 8))
+		hh.MerkleizeProgressiveWithMixin(subIndx, uint64(len(c.AttestingIndices)))
 	}
 	// Field 1: Data
 	if err := c.Data.HashTreeRootWith(hh); err != nil {
@@ -4256,7 +4112,7 @@ func (c *IndexedAttestationGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.Signature)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsIndexedAttestationGloas)
 	return nil
 }
 
@@ -4325,8 +4181,18 @@ func (c *PayloadAttestation) UnmarshalSSZ(buf []byte) error {
 }
 
 func (c *PayloadAttestation) HashTreeRoot() ([32]byte, error) {
+	return c.ProgressiveHashTreeRoot()
+}
+
+func (c *PayloadAttestation) HashTreeRootWith(hh *ssz.Hasher) error {
+	return c.ProgressiveHashTreeRootWith(hh)
+}
+
+var activeFieldsPayloadAttestation = []byte{0b00000111}
+
+func (c *PayloadAttestation) ProgressiveHashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
-	if err := c.HashTreeRootWith(hh); err != nil {
+	if err := c.ProgressiveHashTreeRootWith(hh); err != nil {
 		ssz.DefaultHasherPool.Put(hh)
 		return [32]byte{}, err
 	}
@@ -4335,7 +4201,7 @@ func (c *PayloadAttestation) HashTreeRoot() ([32]byte, error) {
 	return root, err
 }
 
-func (c *PayloadAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+func (c *PayloadAttestation) ProgressiveHashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 	// Field 0: AggregationBits
 	if len([]byte(c.AggregationBits)) != 64 {
@@ -4351,7 +4217,7 @@ func (c *PayloadAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		return ssz.ErrBytesLength
 	}
 	hh.PutBytes(c.Signature)
-	hh.Merkleize(indx)
+	hh.MerkleizeProgressiveWithActiveFields(indx, activeFieldsPayloadAttestation)
 	return nil
 }
 

--- a/proto/prysm/v1alpha1/gloas.yaml
+++ b/proto/prysm/v1alpha1/gloas.yaml
@@ -1,13 +1,38 @@
 package: "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 types:
   - name: "AttestationGloas"
+    progressive: {}
+    fields:
+      AggregationBits: {type: "ProgressiveBitlist"}
   - name: "AggregateAttestationAndProofGloas"
   - name: "SignedAggregateAttestationAndProofGloas"
   - name: "AttesterSlashingGloas"
   - name: "BeaconBlockBodyGloas"
+    progressive: {}
+    fields:
+      ProposerSlashings:          {type: "ProgressiveList"}
+      AttesterSlashings:          {type: "ProgressiveList"}
+      Attestations:          {type: "ProgressiveList"}
+      Deposits:          {type: "ProgressiveList"}
+      VoluntaryExits:          {type: "ProgressiveList"}
+      BlsToExecutionChanges:          {type: "ProgressiveList"}
+      PayloadAttestations: {type: "ProgressiveList"}
   - name: "BeaconBlockContentsGloas"
   - name: "BeaconBlockGloas"
   - name: "BeaconStateGloas"
+    progressive: {}
+    fields:
+      Validators:                 {type: "ProgressiveList"}
+      Balances:                   {type: "ProgressiveList"}
+      PreviousEpochParticipation: {type: "ProgressiveList"}
+      CurrentEpochParticipation:  {type: "ProgressiveList"}
+      InactivityScores:           {type: "ProgressiveList"}
+      PendingDeposits:            {type: "ProgressiveList"}
+      PendingPartialWithdrawals:  {type: "ProgressiveList"}
+      PendingConsolidations:      {type: "ProgressiveList"}
+      Builders:                   {type: "ProgressiveList"}
+      BuilderPendingWithdrawals:  {type: "ProgressiveList"}
+      PayloadExpectedWithdrawals: {type: "ProgressiveList"}
   - name: "BlindedExecutionPayloadEnvelope"
   - name: "Builder"
   - name: "BuilderPendingPayment"
@@ -15,10 +40,21 @@ types:
   - name: "BuilderPreferencesRequest"
   - name: "BuilderPreferences"
   - name: "DataColumnSidecarGloas"
+    fields:
+      Column:    {type: "ProgressiveList"}
+      KzgProofs: {type: "ProgressiveList"}
   - name: "ExecutionPayloadBid"
+    progressive: {}
+    fields:
+      BlobKzgCommitments: {type: "ProgressiveList"}
   - name: "ExecutionPayloadEnvelope"
+    progressive: {}
   - name: "IndexedAttestationGloas"
+    progressive: {}
+    fields:
+      AttestingIndices: {type: "ProgressiveList"}
   - name: "PayloadAttestation"
+    progressive: {}
   - name: "PayloadAttestationData"
   - name: "PayloadAttestationMessage"
   - name: "ProposerPreferences"

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -225,8 +225,8 @@
       search: CustodyRequirement\s+uint64.*yaml:"CUSTODY_REQUIREMENT"
       regex: true
   spec: |
-    <spec config_var="CUSTODY_REQUIREMENT" fork="fulu" hash="b7340203">
-    CUSTODY_REQUIREMENT = 4
+    <spec config_var="CUSTODY_REQUIREMENT" fork="fulu" hash="3ed53d1d">
+    CUSTODY_REQUIREMENT: uint64 = 4
     </spec>
 
 - name: DATA_COLUMN_SIDECAR_SUBNET_COUNT#fulu
@@ -235,8 +235,8 @@
       search: DataColumnSidecarSubnetCount\s+uint64
       regex: true
   spec: |
-    <spec config_var="DATA_COLUMN_SIDECAR_SUBNET_COUNT" fork="fulu" hash="626172a6">
-    DATA_COLUMN_SIDECAR_SUBNET_COUNT = 128
+    <spec config_var="DATA_COLUMN_SIDECAR_SUBNET_COUNT" fork="fulu" hash="4b4dd06b">
+    DATA_COLUMN_SIDECAR_SUBNET_COUNT: uint64 = 128
     </spec>
 
 - name: DENEB_FORK_EPOCH#deneb
@@ -540,8 +540,8 @@
     - file: config/params/mainnet_config.go
       search: MinBuilderWithdrawabilityDelay
   spec: |
-    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="e1cd053c">
-    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 8192
+    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="be7f8473">
+    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 64
     </spec>
 
 - name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS#deneb
@@ -560,8 +560,8 @@
       search: MinEpochsForDataColumnSidecarsRequest\s+primitives.Epoch
       regex: true
   spec: |
-    <spec config_var="MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS" fork="fulu" hash="910e49bb">
-    MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS = 4096
+    <spec config_var="MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS" fork="fulu" hash="b717a22d">
+    MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS: uint64 = 4096
     </spec>
 
 - name: MIN_GENESIS_ACTIVE_VALIDATOR_COUNT#phase0
@@ -620,8 +620,8 @@
       search: NumberOfCustodyGroups\s+uint64
       regex: true
   spec: |
-    <spec config_var="NUMBER_OF_CUSTODY_GROUPS" fork="fulu" hash="05e3016e">
-    NUMBER_OF_CUSTODY_GROUPS = 128
+    <spec config_var="NUMBER_OF_CUSTODY_GROUPS" fork="fulu" hash="ef65e821">
+    NUMBER_OF_CUSTODY_GROUPS: uint64 = 128
     </spec>
 
 - name: PAYLOAD_ATTESTATION_DUE_BPS#gloas
@@ -640,8 +640,8 @@
       search: PayloadDueBPS\s+primitives.BP
       regex: true
   spec: |
-    <spec config_var="PAYLOAD_DUE_BPS" fork="gloas" hash="ee4d44de">
-    PAYLOAD_DUE_BPS: uint64 = 7500
+    <spec config_var="PAYLOAD_DUE_BPS" fork="gloas" hash="07d2a783">
+    PAYLOAD_DUE_BPS: uint64 = 5000
     </spec>
 
 - name: PROPOSER_REORG_CUTOFF_BPS#phase0
@@ -700,8 +700,8 @@
       search: SamplesPerSlot\s+uint64
       regex: true
   spec: |
-    <spec config_var="SAMPLES_PER_SLOT" fork="fulu" hash="158798b8">
-    SAMPLES_PER_SLOT = 8
+    <spec config_var="SAMPLES_PER_SLOT" fork="fulu" hash="dfbcb295">
+    SAMPLES_PER_SLOT: uint64 = 8
     </spec>
 
 - name: SECONDS_PER_ETH1_BLOCK#phase0

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -84,8 +84,8 @@
 - name: BUILDER_WITHDRAWAL_PREFIX#gloas
   sources: []
   spec: |
-    <spec constant_var="BUILDER_WITHDRAWAL_PREFIX" fork="gloas" hash="1094ce21">
-    BUILDER_WITHDRAWAL_PREFIX: Bytes1 = '0x03'
+    <spec constant_var="BUILDER_WITHDRAWAL_PREFIX" fork="gloas" hash="d3243a75">
+    BUILDER_WITHDRAWAL_PREFIX: Bytes1 = '0xB0'
     </spec>
 
 - name: BYTES_PER_COMMITMENT#deneb
@@ -432,8 +432,8 @@
 - name: KZG_SETUP_G2_LENGTH#deneb
   sources: []
   spec: |
-    <spec constant_var="KZG_SETUP_G2_LENGTH" fork="deneb" hash="6cb8d5fd">
-    KZG_SETUP_G2_LENGTH = 65
+    <spec constant_var="KZG_SETUP_G2_LENGTH" fork="deneb" hash="6435c362">
+    KZG_SETUP_G2_LENGTH: uint64 = 65
     </spec>
 
 - name: KZG_SETUP_G2_MONOMIAL#deneb
@@ -594,8 +594,8 @@
       search: SyncCommitteeSubnetCount\s+.*yaml:"SYNC_COMMITTEE_SUBNET_COUNT"
       regex: true
   spec: |
-    <spec constant_var="SYNC_COMMITTEE_SUBNET_COUNT" fork="altair" hash="58794943">
-    SYNC_COMMITTEE_SUBNET_COUNT = 4
+    <spec constant_var="SYNC_COMMITTEE_SUBNET_COUNT" fork="altair" hash="9b41920c">
+    SYNC_COMMITTEE_SUBNET_COUNT: uint64 = 2**2
     </spec>
 
 - name: SYNC_REWARD_WEIGHT#altair
@@ -624,8 +624,8 @@
       search: TargetAggregatorsPerSyncSubcommittee\s+.*yaml:"TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE"
       regex: true
   spec: |
-    <spec constant_var="TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE" fork="altair" hash="af3f6c9e">
-    TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE = 2**4
+    <spec constant_var="TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE" fork="altair" hash="76404bd9">
+    TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: uint64 = 2**4
     </spec>
 
 - name: TIMELY_HEAD_FLAG_INDEX#altair

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -40,13 +40,26 @@
     - file: proto/prysm/v1alpha1/attestation.proto
       search: message AttestationElectra {
   spec: |
-    <spec ssz_object="Attestation" fork="electra" hash="a27cddfb">
+    <spec ssz_object="Attestation" fork="electra" hash="05913162">
     class Attestation(Container):
         # [Modified in Electra:EIP7549]
-        aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
+        aggregation_bits: AggregationBits
         data: AttestationData
         signature: BLSSignature
         # [New in Electra:EIP7549]
+        committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]
+    </spec>
+
+- name: Attestation#gloas
+  sources:
+    - file: proto/prysm/v1alpha1/attestation.proto
+      search: message AttestationGloas {
+  spec: |
+    <spec ssz_object="Attestation" fork="gloas" hash="6dcc1383">
+    class Attestation(ProgressiveContainer(active_fields=[1] * 4)):  # type: ignore
+        aggregation_bits: AggregationBits
+        data: AttestationData
+        signature: BLSSignature
         committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]
     </spec>
 
@@ -242,20 +255,26 @@
 - name: BeaconBlockBody#gloas
   sources: []
   spec: |
-    <spec ssz_object="BeaconBlockBody" fork="gloas" hash="7a5140aa">
-    class BeaconBlockBody(Container):
+    <spec ssz_object="BeaconBlockBody" fork="gloas" hash="3e50ab06">
+    class BeaconBlockBody(ProgressiveContainer(active_fields=[1] * 13)):  # type: ignore
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]
-        attestations: List[Attestation, MAX_ATTESTATIONS_ELECTRA]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        # [Modified in Gloas:EIP7688]
+        proposer_slashings: ProgressiveList[ProposerSlashing]
+        # [Modified in Gloas:EIP7688]
+        attester_slashings: ProgressiveList[AttesterSlashing]
+        # [Modified in Gloas:EIP7688]
+        attestations: ProgressiveList[Attestation]
+        # [Modified in Gloas:EIP7688]
+        deposits: ProgressiveList[Deposit]
+        # [Modified in Gloas:EIP7688]
+        voluntary_exits: ProgressiveList[SignedVoluntaryExit]
         sync_aggregate: SyncAggregate
         # [Modified in Gloas:EIP7732]
         # Removed `execution_payload`
-        bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
+        # [Modified in Gloas:EIP7688]
+        bls_to_execution_changes: ProgressiveList[SignedBLSToExecutionChange]
         # [Modified in Gloas:EIP7732]
         # Removed `blob_kzg_commitments`
         # [Modified in Gloas:EIP7732]
@@ -263,7 +282,7 @@
         # [New in Gloas:EIP7732]
         signed_execution_payload_bid: SignedExecutionPayloadBid
         # [New in Gloas:EIP7732]
-        payload_attestations: List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]
+        payload_attestations: ProgressiveList[PayloadAttestation]
         # [New in Gloas:EIP7732]
         parent_execution_requests: ExecutionRequests
     </spec>
@@ -570,8 +589,8 @@
 - name: BeaconState#gloas
   sources: []
   spec: |
-    <spec ssz_object="BeaconState" fork="gloas" hash="2c32353c">
-    class BeaconState(Container):
+    <spec ssz_object="BeaconState" fork="gloas" hash="14b204a8">
+    class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
         genesis_time: uint64
         genesis_validators_root: Root
         slot: Slot
@@ -583,17 +602,22 @@
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
         eth1_deposit_index: uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
+        # [Modified in Gloas:EIP7688]
+        validators: ProgressiveList[Validator]
+        # [Modified in Gloas:EIP7688]
+        balances: ProgressiveList[Gwei]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+        # [Modified in Gloas:EIP7688]
+        previous_epoch_participation: ProgressiveList[ParticipationFlags]
+        # [Modified in Gloas:EIP7688]
+        current_epoch_participation: ProgressiveList[ParticipationFlags]
         justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        # [Modified in Gloas:EIP7688]
+        inactivity_scores: ProgressiveList[uint64]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Gloas:EIP7732]
@@ -609,12 +633,15 @@
         earliest_exit_epoch: Epoch
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
-        pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
-        pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
-        pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+        # [Modified in Gloas:EIP7688]
+        pending_deposits: ProgressiveList[PendingDeposit]
+        # [Modified in Gloas:EIP7688]
+        pending_partial_withdrawals: ProgressiveList[PendingPartialWithdrawal]
+        # [Modified in Gloas:EIP7688]
+        pending_consolidations: ProgressiveList[PendingConsolidation]
         proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
         # [New in Gloas:EIP7732]
-        builders: List[Builder, BUILDER_REGISTRY_LIMIT]
+        builders: ProgressiveList[Builder]
         # [New in Gloas:EIP7732]
         next_withdrawal_builder_index: BuilderIndex
         # [New in Gloas:EIP7732]
@@ -622,11 +649,11 @@
         # [New in Gloas:EIP7732]
         builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
         # [New in Gloas:EIP7732]
-        builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
+        builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid: ExecutionPayloadBid
         # [New in Gloas:EIP7732]
-        payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        payload_expected_withdrawals: ProgressiveList[Withdrawal]
         # [New in Gloas:EIP7732]
         ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
     </spec>
@@ -634,8 +661,8 @@
 - name: BeaconState#heze
   sources: []
   spec: |
-    <spec ssz_object="BeaconState" fork="heze" hash="2c32353c">
-    class BeaconState(Container):
+    <spec ssz_object="BeaconState" fork="heze" hash="86ad69e6">
+    class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
         genesis_time: uint64
         genesis_validators_root: Root
         slot: Slot
@@ -647,22 +674,19 @@
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
         eth1_deposit_index: uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
+        validators: ProgressiveList[Validator]
+        balances: ProgressiveList[Gwei]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+        previous_epoch_participation: ProgressiveList[ParticipationFlags]
+        current_epoch_participation: ProgressiveList[ParticipationFlags]
         justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: ProgressiveList[uint64]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
-        # [Modified in Gloas:EIP7732]
-        # Removed `latest_execution_payload_header`
-        # [New in Gloas:EIP7732]
         latest_block_hash: Hash32
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
@@ -673,33 +697,26 @@
         earliest_exit_epoch: Epoch
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
-        pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
-        pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
-        pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+        pending_deposits: ProgressiveList[PendingDeposit]
+        pending_partial_withdrawals: ProgressiveList[PendingPartialWithdrawal]
+        pending_consolidations: ProgressiveList[PendingConsolidation]
         proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
-        # [New in Gloas:EIP7732]
-        builders: List[Builder, BUILDER_REGISTRY_LIMIT]
-        # [New in Gloas:EIP7732]
+        builders: ProgressiveList[Builder]
         next_withdrawal_builder_index: BuilderIndex
-        # [New in Gloas:EIP7732]
         execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
-        # [New in Gloas:EIP7732]
         builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
-        # [New in Gloas:EIP7732]
-        builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
-        # [New in Gloas:EIP7732]
+        builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
+        # [Modified in Heze:EIP7805]
         latest_execution_payload_bid: ExecutionPayloadBid
-        # [New in Gloas:EIP7732]
-        payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
-        # [New in Gloas:EIP7732]
+        payload_expected_withdrawals: ProgressiveList[Withdrawal]
         ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
     </spec>
 
 - name: BeaconState#heze
   sources: []
   spec: |
-    <spec ssz_object="BeaconState" fork="heze" hash="2c32353c">
-    class BeaconState(Container):
+    <spec ssz_object="BeaconState" fork="heze" hash="86ad69e6">
+    class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
         genesis_time: uint64
         genesis_validators_root: Root
         slot: Slot
@@ -711,22 +728,19 @@
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
         eth1_deposit_index: uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
+        validators: ProgressiveList[Validator]
+        balances: ProgressiveList[Gwei]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+        previous_epoch_participation: ProgressiveList[ParticipationFlags]
+        current_epoch_participation: ProgressiveList[ParticipationFlags]
         justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: ProgressiveList[uint64]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
-        # [Modified in Gloas:EIP7732]
-        # Removed `latest_execution_payload_header`
-        # [New in Gloas:EIP7732]
         latest_block_hash: Hash32
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
@@ -737,25 +751,18 @@
         earliest_exit_epoch: Epoch
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
-        pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
-        pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
-        pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+        pending_deposits: ProgressiveList[PendingDeposit]
+        pending_partial_withdrawals: ProgressiveList[PendingPartialWithdrawal]
+        pending_consolidations: ProgressiveList[PendingConsolidation]
         proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
-        # [New in Gloas:EIP7732]
-        builders: List[Builder, BUILDER_REGISTRY_LIMIT]
-        # [New in Gloas:EIP7732]
+        builders: ProgressiveList[Builder]
         next_withdrawal_builder_index: BuilderIndex
-        # [New in Gloas:EIP7732]
         execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
-        # [New in Gloas:EIP7732]
         builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
-        # [New in Gloas:EIP7732]
-        builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
-        # [New in Gloas:EIP7732]
+        builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
+        # [Modified in Heze:EIP7805]
         latest_execution_payload_bid: ExecutionPayloadBid
-        # [New in Gloas:EIP7732]
-        payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
-        # [New in Gloas:EIP7732]
+        payload_expected_withdrawals: ProgressiveList[Withdrawal]
         ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
     </spec>
 
@@ -891,13 +898,15 @@
 - name: DataColumnSidecar#gloas
   sources: []
   spec: |
-    <spec ssz_object="DataColumnSidecar" fork="gloas" hash="332c7cfc">
+    <spec ssz_object="DataColumnSidecar" fork="gloas" hash="18cd6bcf">
     class DataColumnSidecar(Container):
         index: ColumnIndex
-        column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        # [Modified in Gloas:EIP7688]
+        column: ProgressiveList[Cell]
         # [Modified in Gloas:EIP7732]
         # Removed `kzg_commitments`
-        kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        # [Modified in Gloas:EIP7688]
+        kzg_proofs: ProgressiveList[KZGProof]
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
         # [Modified in Gloas:EIP7732]
@@ -1070,8 +1079,8 @@
 - name: ExecutionPayload#gloas
   sources: []
   spec: |
-    <spec ssz_object="ExecutionPayload" fork="gloas" hash="d399d858">
-    class ExecutionPayload(Container):
+    <spec ssz_object="ExecutionPayload" fork="gloas" hash="0bee8801">
+    class ExecutionPayload(ProgressiveContainer(active_fields=[1] * 19)):  # type: ignore
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
@@ -1085,8 +1094,10 @@
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
         base_fee_per_gas: uint256
         block_hash: Hash32
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
-        withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        # [Modified in Gloas:EIP7688]
+        transactions: ProgressiveList[Transaction]
+        # [Modified in Gloas:EIP7688]
+        withdrawals: ProgressiveList[Withdrawal]
         blob_gas_used: uint64
         excess_blob_gas: uint64
         # [New in Gloas:EIP7928]
@@ -1098,8 +1109,8 @@
 - name: ExecutionPayloadBid#gloas
   sources: []
   spec: |
-    <spec ssz_object="ExecutionPayloadBid" fork="gloas" hash="0c77d857">
-    class ExecutionPayloadBid(Container):
+    <spec ssz_object="ExecutionPayloadBid" fork="gloas" hash="7465947d">
+    class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):  # type: ignore
         parent_block_hash: Hash32
         parent_block_root: Root
         block_hash: Hash32
@@ -1110,15 +1121,15 @@
         slot: Slot
         value: Gwei
         execution_payment: Gwei
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        blob_kzg_commitments: ProgressiveList[KZGCommitment]
         execution_requests_root: Root
     </spec>
 
 - name: ExecutionPayloadBid#heze
   sources: []
   spec: |
-    <spec ssz_object="ExecutionPayloadBid" fork="heze" hash="0c77d857">
-    class ExecutionPayloadBid(Container):
+    <spec ssz_object="ExecutionPayloadBid" fork="heze" hash="7d0dbe33">
+    class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 13)):  # type: ignore
         parent_block_hash: Hash32
         parent_block_root: Root
         block_hash: Hash32
@@ -1129,15 +1140,17 @@
         slot: Slot
         value: Gwei
         execution_payment: Gwei
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        blob_kzg_commitments: ProgressiveList[KZGCommitment]
         execution_requests_root: Root
+        # [New in Heze:EIP7805]
+        inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]
     </spec>
 
 - name: ExecutionPayloadEnvelope#gloas
   sources: []
   spec: |
-    <spec ssz_object="ExecutionPayloadEnvelope" fork="gloas" hash="3df22cd3">
-    class ExecutionPayloadEnvelope(Container):
+    <spec ssz_object="ExecutionPayloadEnvelope" fork="gloas" hash="be1e70fd">
+    class ExecutionPayloadEnvelope(ProgressiveContainer(active_fields=[1] * 5)):  # type: ignore
         payload: ExecutionPayload
         execution_requests: ExecutionRequests
         builder_index: BuilderIndex
@@ -1226,28 +1239,28 @@
     - file: proto/engine/v1/electra.proto
       search: message ExecutionRequests {
   spec: |
-    <spec ssz_object="ExecutionRequests" fork="electra" hash="048c4a44">
+    <spec ssz_object="ExecutionRequests" fork="electra" hash="957b3c23">
     class ExecutionRequests(Container):
         # [New in Electra:EIP6110]
-        deposits: List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
+        deposits: DepositRequests
         # [New in Electra:EIP7002:EIP7251]
-        withdrawals: List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]
+        withdrawals: WithdrawalRequests
         # [New in Electra:EIP7251]
-        consolidations: List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
+        consolidations: ConsolidationRequests
     </spec>
 
 - name: ExecutionRequests#gloas
   sources: []
   spec: |
-    <spec ssz_object="ExecutionRequests" fork="gloas" hash="977acaf4">
-    class ExecutionRequests(Container):
-        deposits: List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
-        withdrawals: List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]
-        consolidations: List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
+    <spec ssz_object="ExecutionRequests" fork="gloas" hash="70af6a68">
+    class ExecutionRequests(ProgressiveContainer(active_fields=[1] * 5)):  # type: ignore
+        deposits: DepositRequests
+        withdrawals: WithdrawalRequests
+        consolidations: ConsolidationRequests
         # [New in Gloas:EIP8282]
-        builder_deposits: List[BuilderDepositRequest, MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD]
+        builder_deposits: BuilderDepositRequests
         # [New in Gloas:EIP8282]
-        builder_exits: List[BuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD]
+        builder_exits: BuilderExitRequests
     </spec>
 
 - name: Fork#phase0
@@ -1298,12 +1311,12 @@
 - name: InclusionList#heze
   sources: []
   spec: |
-    <spec ssz_object="InclusionList" fork="heze" hash="7c3fadd5">
+    <spec ssz_object="InclusionList" fork="heze" hash="b6409409">
     class InclusionList(Container):
         slot: Slot
         validator_index: ValidatorIndex
         inclusion_list_committee_root: Root
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+        transactions: ProgressiveList[Transaction]
     </spec>
 
 - name: IndexedAttestation#phase0
@@ -1323,10 +1336,22 @@
     - file: proto/prysm/v1alpha1/beacon_core_types.proto
       search: message IndexedAttestationElectra {
   spec: |
-    <spec ssz_object="IndexedAttestation" fork="electra" hash="2f924640">
+    <spec ssz_object="IndexedAttestation" fork="electra" hash="07f0b3cd">
     class IndexedAttestation(Container):
         # [Modified in Electra:EIP7549]
-        attesting_indices: List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
+        attesting_indices: AttestingIndices
+        data: AttestationData
+        signature: BLSSignature
+    </spec>
+
+- name: IndexedAttestation#gloas
+  sources:
+    - file: proto/prysm/v1alpha1/beacon_core_types.proto
+      search: message IndexedAttestationGloas {
+  spec: |
+    <spec ssz_object="IndexedAttestation" fork="gloas" hash="8eb640da">
+    class IndexedAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
+        attesting_indices: AttestingIndices
         data: AttestationData
         signature: BLSSignature
     </spec>
@@ -1334,8 +1359,8 @@
 - name: IndexedPayloadAttestation#gloas
   sources: []
   spec: |
-    <spec ssz_object="IndexedPayloadAttestation" fork="gloas" hash="fa4832c8">
-    class IndexedPayloadAttestation(Container):
+    <spec ssz_object="IndexedPayloadAttestation" fork="gloas" hash="c165cb61">
+    class IndexedPayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
         attesting_indices: List[ValidatorIndex, PTC_SIZE]
         data: PayloadAttestationData
         signature: BLSSignature
@@ -1510,13 +1535,22 @@
         row_index: RowIndex
     </spec>
 
+- name: PartialDataColumnGroupID#fulu
+  sources: []
+  spec: |
+    <spec ssz_object="PartialDataColumnGroupID" fork="fulu" hash="260b9491">
+    class PartialDataColumnGroupID(Container):
+        beacon_block_root: Root
+    </spec>
+
 - name: PartialDataColumnGroupID#gloas
   sources: []
   spec: |
-    <spec ssz_object="PartialDataColumnGroupID" fork="gloas" hash="9e8865b1">
+    <spec ssz_object="PartialDataColumnGroupID" fork="gloas" hash="ccabab9d">
     class PartialDataColumnGroupID(Container):
-        slot: Slot
         beacon_block_root: Root
+        # [New in Gloas:EIP7732]
+        slot: Slot
     </spec>
 
 - name: PartialDataColumnHeader#fulu
@@ -1563,18 +1597,18 @@
 - name: PartialDataColumnSidecar#gloas
   sources: []
   spec: |
-    <spec ssz_object="PartialDataColumnSidecar" fork="gloas" hash="57b4ad2a">
+    <spec ssz_object="PartialDataColumnSidecar" fork="gloas" hash="0b62b015">
     class PartialDataColumnSidecar(Container):
-        cells_present_bitmap: Bitlist[MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        partial_column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        cells_present_bitmap: ProgressiveBitlist
+        partial_column: ProgressiveList[Cell]
+        kzg_proofs: ProgressiveList[KZGProof]
     </spec>
 
 - name: PayloadAttestation#gloas
   sources: []
   spec: |
-    <spec ssz_object="PayloadAttestation" fork="gloas" hash="c769473d">
-    class PayloadAttestation(Container):
+    <spec ssz_object="PayloadAttestation" fork="gloas" hash="688576d4">
+    class PayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
         aggregation_bits: Bitvector[PTC_SIZE]
         data: PayloadAttestationData
         signature: BLSSignature
@@ -1765,8 +1799,9 @@
 - name: SignedExecutionPayloadBid#heze
   sources: []
   spec: |
-    <spec ssz_object="SignedExecutionPayloadBid" fork="heze" hash="6b344341">
+    <spec ssz_object="SignedExecutionPayloadBid" fork="heze" hash="ce64ecf2">
     class SignedExecutionPayloadBid(Container):
+        # [Modified in Heze:EIP7805]
         message: ExecutionPayloadBid
         signature: BLSSignature
     </spec>

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -199,7 +199,7 @@
     - file: beacon-chain/core/gloas/parent_payload.go
       search: func ApplyParentExecutionPayload(
   spec: |
-    <spec fn="apply_parent_execution_payload" fork="gloas" hash="64e168db">
+    <spec fn="apply_parent_execution_payload" fork="gloas" hash="fd5aac1d">
     def apply_parent_execution_payload(
         state: BeaconState,
         requests: ExecutionRequests,
@@ -207,6 +207,11 @@
         parent_bid = state.latest_execution_payload_bid
         parent_slot = parent_bid.slot
         parent_epoch = compute_epoch_at_slot(parent_slot)
+
+        assert len(requests.withdrawals) <= MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
+        assert len(requests.consolidations) <= MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
+        assert len(requests.builder_deposits) <= MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD
+        assert len(requests.builder_exits) <= MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD
 
         # Process execution requests from parent's payload. The execution
         # requests are processed at state.slot (child's slot), not the parent's slot.
@@ -217,9 +222,7 @@
         for_ops(requests.deposits, process_deposit_request)
         for_ops(requests.withdrawals, process_withdrawal_request)
         for_ops(requests.consolidations, process_consolidation_request)
-        # [New in Gloas:EIP8282]
         for_ops(requests.builder_deposits, process_builder_deposit_request)
-        # [New in Gloas:EIP8282]
         for_ops(requests.builder_exits, process_builder_exit_request)
 
         # Settle the builder payment
@@ -1243,14 +1246,14 @@
     - file: beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_electra.go
       search: func computeOnChainAggregate(
   spec: |
-    <spec fn="compute_on_chain_aggregate" fork="electra" hash="3aa56e8f">
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="70c27acf">
     def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
         aggregates = sorted(
             network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0]
         )
 
         data = aggregates[0].data
-        aggregation_bits = Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]()
+        aggregation_bits = AggregationBits()
         for a in aggregates:
             for b in a.aggregation_bits:
                 aggregation_bits.append(b)
@@ -1932,6 +1935,21 @@
         return CURRENT_SYNC_COMMITTEE_GINDEX
     </spec>
 
+- name: current_sync_committee_gindex_at_slot#gloas
+  sources: []
+  spec: |
+    <spec fn="current_sync_committee_gindex_at_slot" fork="gloas" hash="f4f08e55">
+    def current_sync_committee_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+        epoch = compute_epoch_at_slot(slot)
+
+        # [Modified in Gloas:EIP7688]
+        if epoch >= GLOAS_FORK_EPOCH:
+            return CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS
+        if epoch >= ELECTRA_FORK_EPOCH:
+            return CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA
+        return CURRENT_SYNC_COMMITTEE_GINDEX
+    </spec>
+
 - name: decrease_balance#phase0
   sources:
     - file: beacon-chain/core/helpers/rewards_penalties.go
@@ -2101,6 +2119,21 @@
         epoch = compute_epoch_at_slot(slot)
 
         # [Modified in Electra]
+        if epoch >= ELECTRA_FORK_EPOCH:
+            return FINALIZED_ROOT_GINDEX_ELECTRA
+        return FINALIZED_ROOT_GINDEX
+    </spec>
+
+- name: finalized_root_gindex_at_slot#gloas
+  sources: []
+  spec: |
+    <spec fn="finalized_root_gindex_at_slot" fork="gloas" hash="16378123">
+    def finalized_root_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+        epoch = compute_epoch_at_slot(slot)
+
+        # [Modified in Gloas:EIP7688]
+        if epoch >= GLOAS_FORK_EPOCH:
+            return FINALIZED_ROOT_GINDEX_GLOAS
         if epoch >= ELECTRA_FORK_EPOCH:
             return FINALIZED_ROOT_GINDEX_ELECTRA
         return FINALIZED_ROOT_GINDEX
@@ -3585,40 +3618,6 @@
         )
     </spec>
 
-- name: get_dependent_root#phase0
-  sources: []
-  spec: |
-    <spec fn="get_dependent_root" fork="phase0" hash="6c7301b5">
-    def get_dependent_root(store: Store, root: Root) -> Root:
-        epoch = get_current_store_epoch(store)
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
-        node = ForkChoiceNode(root=root)
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
-        return get_ancestor(store, node, dependent_slot).root
-    </spec>
-
-- name: get_dependent_root#gloas
-  sources: []
-  spec: |
-    <spec fn="get_dependent_root" fork="gloas" hash="4e1d4042">
-    def get_dependent_root(store: Store, root: Root) -> Root:
-        epoch = get_current_store_epoch(store)
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
-        # [Modified in Gloas:EIP7732]
-        node = ForkChoiceNode(
-            root=root,
-            payload_status=PAYLOAD_STATUS_PENDING,
-        )
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
-        return get_ancestor(store, node, dependent_slot).root
-    </spec>
-
 - name: get_domain#phase0
   sources:
     - file: beacon-chain/core/signing/domain.go
@@ -3832,7 +3831,7 @@
     - file: proto/engine/v1/electra.go
       search: func (ebe *ExecutionBundleElectra) GetDecodedExecutionRequests(
   spec: |
-    <spec fn="get_execution_requests" fork="electra" hash="2c0fb728">
+    <spec fn="get_execution_requests" fork="electra" hash="29513408">
     def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
         deposits = []
         withdrawals = []
@@ -3858,17 +3857,11 @@
             prev_request_type = request_type
 
             if request_type == DEPOSIT_REQUEST_TYPE:
-                deposits = ssz_deserialize(
-                    List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD], request_data
-                )
+                deposits = ssz_deserialize(DepositRequests, request_data)
             elif request_type == WITHDRAWAL_REQUEST_TYPE:
-                withdrawals = ssz_deserialize(
-                    List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD], request_data
-                )
+                withdrawals = ssz_deserialize(WithdrawalRequests, request_data)
             elif request_type == CONSOLIDATION_REQUEST_TYPE:
-                consolidations = ssz_deserialize(
-                    List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD], request_data
-                )
+                consolidations = ssz_deserialize(ConsolidationRequests, request_data)
 
         return ExecutionRequests(
             deposits=deposits,
@@ -3880,7 +3873,7 @@
 - name: get_execution_requests#gloas
   sources: []
   spec: |
-    <spec fn="get_execution_requests" fork="gloas" hash="7b351e91">
+    <spec fn="get_execution_requests" fork="gloas" hash="31ff6b3d">
     def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
         deposits = []
         withdrawals = []
@@ -3914,28 +3907,17 @@
             prev_request_type = request_type
 
             if request_type == DEPOSIT_REQUEST_TYPE:
-                deposits = ssz_deserialize(
-                    List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD], request_data
-                )
+                deposits = ssz_deserialize(DepositRequests, request_data)
             elif request_type == WITHDRAWAL_REQUEST_TYPE:
-                withdrawals = ssz_deserialize(
-                    List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD], request_data
-                )
+                withdrawals = ssz_deserialize(WithdrawalRequests, request_data)
             elif request_type == CONSOLIDATION_REQUEST_TYPE:
-                consolidations = ssz_deserialize(
-                    List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD], request_data
-                )
+                consolidations = ssz_deserialize(ConsolidationRequests, request_data)
             # [New in Gloas:EIP8282]
             elif request_type == BUILDER_DEPOSIT_REQUEST_TYPE:
-                builder_deposits = ssz_deserialize(
-                    List[BuilderDepositRequest, MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD],
-                    request_data,
-                )
+                builder_deposits = ssz_deserialize(BuilderDepositRequests, request_data)
             # [New in Gloas:EIP8282]
             elif request_type == BUILDER_EXIT_REQUEST_TYPE:
-                builder_exits = ssz_deserialize(
-                    List[BuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD], request_data
-                )
+                builder_exits = ssz_deserialize(BuilderExitRequests, request_data)
 
         return ExecutionRequests(
             deposits=deposits,
@@ -3953,9 +3935,9 @@
     - file: proto/engine/v1/electra.go
       search: func EncodeExecutionRequests(
   spec: |
-    <spec fn="get_execution_requests_list" fork="electra" hash="0a0be93f">
+    <spec fn="get_execution_requests_list" fork="electra" hash="7fecfd3a">
     def get_execution_requests_list(execution_requests: ExecutionRequests) -> Sequence[bytes]:
-        requests = [
+        requests: Sequence[Tuple[Bytes1, List]] = [
             (DEPOSIT_REQUEST_TYPE, execution_requests.deposits),
             (WITHDRAWAL_REQUEST_TYPE, execution_requests.withdrawals),
             (CONSOLIDATION_REQUEST_TYPE, execution_requests.consolidations),
@@ -3971,9 +3953,9 @@
 - name: get_execution_requests_list#gloas
   sources: []
   spec: |
-    <spec fn="get_execution_requests_list" fork="gloas" hash="a9021134">
+    <spec fn="get_execution_requests_list" fork="gloas" hash="a2274ff3">
     def get_execution_requests_list(execution_requests: ExecutionRequests) -> Sequence[bytes]:
-        requests = [
+        requests: Sequence[Tuple[Bytes1, ProgressiveList]] = [
             (DEPOSIT_REQUEST_TYPE, execution_requests.deposits),
             (WITHDRAWAL_REQUEST_TYPE, execution_requests.withdrawals),
             (CONSOLIDATION_REQUEST_TYPE, execution_requests.consolidations),
@@ -4455,6 +4437,36 @@
         # No penalties associated with inclusion delay
         penalties = [Gwei(0) for _ in range(len(state.validators))]
         return rewards, penalties
+    </spec>
+
+- name: get_inclusion_list_bits#heze
+  sources: []
+  spec: |
+    <spec fn="get_inclusion_list_bits" fork="heze" hash="b044f014">
+    def get_inclusion_list_bits(
+        store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
+    ) -> Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]:
+        """
+        Return a ``Bitvector`` over inclusion list committee indices with bits set
+        for those who provided valid, non-equivocating inclusion lists for the given ``slot``.
+        """
+        committee = get_inclusion_list_committee(state, slot)
+        key = hash_tree_root(committee)
+
+        inclusion_lists = store.inclusion_lists[key]
+        equivocators = store.equivocators[key]
+        timeliness = store.inclusion_list_timeliness
+
+        validator_indices = [
+            inclusion_lists[inclusion_list_root].validator_index
+            for inclusion_list_root in inclusion_lists
+            if inclusion_lists[inclusion_list_root].validator_index not in equivocators
+            if not only_timely or timeliness[inclusion_list_root]
+        ]
+
+        return Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](
+            validator_index in validator_indices for validator_index in committee
+        )
     </spec>
 
 - name: get_inclusion_list_committee#heze
@@ -5213,23 +5225,10 @@
         return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else Epoch(current_epoch - 1)
     </spec>
 
-- name: get_proposer_dependent_root#gloas
-  sources: []
-  spec: |
-    <spec fn="get_proposer_dependent_root" fork="gloas" hash="9a7daf1b">
-    def get_proposer_dependent_root(state: BeaconState, epoch: Epoch) -> Root:
-        """
-        Return the dependent root for the proposer lookahead at ``epoch``.
-        """
-        return get_block_root_at_slot(
-            state, Slot(compute_start_slot_at_epoch(Epoch(epoch - MIN_SEED_LOOKAHEAD)) - 1)
-        )
-    </spec>
-
 - name: get_proposer_head#phase0
   sources: []
   spec: |
-    <spec fn="get_proposer_head" fork="phase0" hash="3558f2cc">
+    <spec fn="get_proposer_head" fork="phase0" hash="6868d4f2">
     def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
         head_block = store.blocks[head_node.root]
         parent_root = head_block.parent_root
@@ -5240,7 +5239,7 @@
         head_late = is_head_late(store, head_node.root)
 
         # Do not re-org on an epoch boundary.
-        epoch_boundary = is_epoch_boundary(slot)
+        not_epoch_boundary = is_not_epoch_boundary(slot)
 
         # Ensure that the FFG information of the new head will be competitive with the current head.
         ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -5268,7 +5267,7 @@
 
         if all([
             head_late,
-            epoch_boundary,
+            not_epoch_boundary,
             ffg_competitive,
             finalization_ok,
             proposing_on_time,
@@ -5287,7 +5286,7 @@
 - name: get_proposer_head#gloas
   sources: []
   spec: |
-    <spec fn="get_proposer_head" fork="gloas" hash="52ed6595">
+    <spec fn="get_proposer_head" fork="gloas" hash="121a187d">
     def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
         head_block = store.blocks[head_node.root]
         parent_root = head_block.parent_root
@@ -5300,7 +5299,7 @@
         head_late = is_head_late(store, head_node.root)
 
         # Do not re-org on an epoch boundary.
-        epoch_boundary = is_epoch_boundary(slot)
+        not_epoch_boundary = is_not_epoch_boundary(slot)
 
         # Ensure that the FFG information of the new head will be competitive with the current head.
         ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -5328,7 +5327,7 @@
 
         if all([
             head_late,
-            epoch_boundary,
+            not_epoch_boundary,
             ffg_competitive,
             finalization_ok,
             proposing_on_time,
@@ -5342,20 +5341,6 @@
             return parent_node
         else:
             return head_node
-    </spec>
-
-- name: get_proposer_preferences_signature#gloas
-  sources: []
-  spec: |
-    <spec fn="get_proposer_preferences_signature" fork="gloas" hash="6a34cb73">
-    def get_proposer_preferences_signature(
-        state: BeaconState, preferences: ProposerPreferences, privkey: int
-    ) -> BLSSignature:
-        domain = get_domain(
-            state, DOMAIN_PROPOSER_PREFERENCES, compute_epoch_at_slot(preferences.proposal_slot)
-        )
-        signing_root = compute_signing_root(preferences, domain)
-        return bls.Sign(privkey, signing_root)
     </spec>
 
 - name: get_proposer_reorg_cutoff_ms#phase0
@@ -6750,14 +6735,6 @@
         )
     </spec>
 
-- name: is_epoch_boundary#phase0
-  sources: []
-  spec: |
-    <spec fn="is_epoch_boundary" fork="phase0" hash="8900b82d">
-    def is_epoch_boundary(slot: Slot) -> bool:
-        return slot % SLOTS_PER_EPOCH != 0
-    </spec>
-
 - name: is_execution_block#bellatrix
   sources:
     - file: beacon-chain/core/blocks/payload.go
@@ -6940,6 +6917,31 @@
     <spec fn="is_in_inactivity_leak" fork="phase0" hash="e95b1146">
     def is_in_inactivity_leak(state: BeaconState) -> bool:
         return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
+    </spec>
+
+- name: is_inclusion_list_bits_inclusive#heze
+  sources: []
+  spec: |
+    <spec fn="is_inclusion_list_bits_inclusive" fork="heze" hash="f8e537b8">
+    def is_inclusion_list_bits_inclusive(
+        store: InclusionListStore,
+        state: BeaconState,
+        slot: Slot,
+        inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE],
+        only_timely: bool = True,
+    ) -> bool:
+        """
+        Return ``True`` if and only if ``inclusion_list_bits`` has a bit set for
+        every bit set in the local inclusion list bits for the given ``slot``.
+        """
+        local_inclusion_list_bits = get_inclusion_list_bits(store, state, slot, only_timely)
+
+        return not any(
+            local_inclusion_bit and not inclusion_bit
+            for inclusion_bit, local_inclusion_bit in zip(
+                inclusion_list_bits, local_inclusion_list_bits, strict=True
+            )
+        )
     </spec>
 
 - name: is_merge_transition_block#bellatrix
@@ -7391,6 +7393,34 @@
         return bls.FastAggregateVerify(pubkeys, signing_root, indexed_attestation.signature)
     </spec>
 
+- name: is_valid_indexed_attestation#gloas
+  sources:
+    - file: beacon-chain/core/blocks/attestation.go
+      search: func VerifyIndexedAttestation(
+  spec: |
+    <spec fn="is_valid_indexed_attestation" fork="gloas" hash="556495e6">
+    def is_valid_indexed_attestation(
+        state: BeaconState, indexed_attestation: IndexedAttestation
+    ) -> bool:
+        """
+        Check if ``indexed_attestation`` is not empty, has sorted and unique indices and has a valid aggregate signature.
+        """
+        # Verify indices are sorted and unique
+        indices = indexed_attestation.attesting_indices
+        if (
+            len(indices) == 0
+            # [New in Gloas:EIP7688]
+            or len(indices) > MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT
+            or indices != sorted(set(indices))
+        ):
+            return False
+        # Verify aggregate signature
+        pubkeys = [state.validators[i].pubkey for i in indices]
+        domain = get_domain(state, DOMAIN_BEACON_ATTESTER, indexed_attestation.data.target.epoch)
+        signing_root = compute_signing_root(indexed_attestation.data, domain)
+        return bls.FastAggregateVerify(pubkeys, signing_root, indexed_attestation.signature)
+    </spec>
+
 - name: is_valid_indexed_payload_attestation#gloas
   sources: []
   spec: |
@@ -7739,6 +7769,21 @@
         epoch = compute_epoch_at_slot(slot)
 
         # [Modified in Electra]
+        if epoch >= ELECTRA_FORK_EPOCH:
+            return NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
+        return NEXT_SYNC_COMMITTEE_GINDEX
+    </spec>
+
+- name: next_sync_committee_gindex_at_slot#gloas
+  sources: []
+  spec: |
+    <spec fn="next_sync_committee_gindex_at_slot" fork="gloas" hash="ada8aa30">
+    def next_sync_committee_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+        epoch = compute_epoch_at_slot(slot)
+
+        # [Modified in Gloas:EIP7688]
+        if epoch >= GLOAS_FORK_EPOCH:
+            return NEXT_SYNC_COMMITTEE_GINDEX_GLOAS
         if epoch >= ELECTRA_FORK_EPOCH:
             return NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
         return NEXT_SYNC_COMMITTEE_GINDEX
@@ -9057,15 +9102,19 @@
 - name: process_builder_deposit_request#gloas
   sources: []
   spec: |
-    <spec fn="process_builder_deposit_request" fork="gloas" hash="c3ba5adf">
+    <spec fn="process_builder_deposit_request" fork="gloas" hash="1d458f9c">
     def process_builder_deposit_request(state: BeaconState, request: BuilderDepositRequest) -> None:
+        # Ignore deposits with unexpected withdrawal credential prefixes
+        if not is_builder_withdrawal_credential(request.withdrawal_credentials):
+            return
+
         builder_pubkeys = [b.pubkey for b in state.builders]
         if request.pubkey not in builder_pubkeys:
             if is_valid_builder_deposit_signature(request):
                 add_builder_to_registry(
                     state,
                     request.pubkey,
-                    uint8(request.withdrawal_credentials[0]),
+                    PAYLOAD_BUILDER_VERSION,
                     ExecutionAddress(request.withdrawal_credentials[12:]),
                     request.amount,
                     state.slot,
@@ -9074,13 +9123,13 @@
             builder_index = BuilderIndex(builder_pubkeys.index(request.pubkey))
             builder = state.builders[builder_index]
 
-            # Increase balance by deposit amount
-            builder.balance += request.amount
-
-            # If exited, reset the withdrawable epoch
-            if builder.withdrawable_epoch != FAR_FUTURE_EPOCH:
+            # If exited and swept, reset the withdrawable epoch
+            if builder.withdrawable_epoch != FAR_FUTURE_EPOCH and builder.balance == 0:
                 epoch = get_current_epoch(state)
                 builder.withdrawable_epoch = epoch + MIN_BUILDER_WITHDRAWABILITY_DELAY
+
+            # Increase balance by deposit amount
+            builder.balance += request.amount
     </spec>
 
 - name: process_builder_exit_request#gloas
@@ -10304,13 +10353,21 @@
 - name: process_operations#gloas
   sources: []
   spec: |
-    <spec fn="process_operations" fork="gloas" hash="4864d8ef">
+    <spec fn="process_operations" fork="gloas" hash="5009f53b">
     def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
         assert len(body.deposits) == 0
 
         def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
             for operation in operations:
                 fn(state, operation)
+
+        # [New in Gloas:EIP7688]
+        assert len(body.proposer_slashings) <= MAX_PROPOSER_SLASHINGS
+        assert len(body.attester_slashings) <= MAX_ATTESTER_SLASHINGS_ELECTRA
+        assert len(body.attestations) <= MAX_ATTESTATIONS_ELECTRA
+        assert len(body.voluntary_exits) <= MAX_VOLUNTARY_EXITS
+        assert len(body.bls_to_execution_changes) <= MAX_BLS_TO_EXECUTION_CHANGES
+        assert len(body.payload_attestations) <= MAX_PAYLOAD_ATTESTATIONS
 
         # [Modified in Gloas:EIP7732]
         for_ops(body.proposer_slashings, process_proposer_slashing)
@@ -12044,11 +12101,11 @@
 - name: update_payload_expected_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="6a3810b9">
+    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="55907aeb">
     def update_payload_expected_withdrawals(
         state: BeaconState, withdrawals: Sequence[Withdrawal]
     ) -> None:
-        state.payload_expected_withdrawals = List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](withdrawals)
+        state.payload_expected_withdrawals = ProgressiveList[Withdrawal](withdrawals)
     </spec>
 
 - name: update_pending_partial_withdrawals#electra
@@ -12066,11 +12123,14 @@
 - name: update_proposer_boost_root#phase0
   sources: []
   spec: |
-    <spec fn="update_proposer_boost_root" fork="phase0" hash="3278de09">
+    <spec fn="update_proposer_boost_root" fork="phase0" hash="c5182f16">
     def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
         is_first_block = store.proposer_boost_root == Root()
         is_timely = store.block_timeliness[root]
-        is_same_dependent_root = get_dependent_root(store, root) == get_dependent_root(store, head)
+        epoch = get_current_store_epoch(store)
+        head_dependent_root = get_shuffling_dependent_root(store, head, epoch)
+        block_dependent_root = get_shuffling_dependent_root(store, root, epoch)
+        is_same_dependent_root = head_dependent_root == block_dependent_root
 
         # Add proposer score boost if the block is timely, not conflicting with an
         # existing block, with the same dependent root as the canonical chain head.
@@ -12081,12 +12141,15 @@
 - name: update_proposer_boost_root#gloas
   sources: []
   spec: |
-    <spec fn="update_proposer_boost_root" fork="gloas" hash="75ff4ddf">
+    <spec fn="update_proposer_boost_root" fork="gloas" hash="18e43e0c">
     def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
         is_first_block = store.proposer_boost_root == Root()
         # [Modified in Gloas:EIP7732]
         is_timely = store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]
-        is_same_dependent_root = get_dependent_root(store, root) == get_dependent_root(store, head)
+        epoch = get_current_store_epoch(store)
+        head_dependent_root = get_shuffling_dependent_root(store, head, epoch)
+        block_dependent_root = get_shuffling_dependent_root(store, root, epoch)
+        is_same_dependent_root = head_dependent_root == block_dependent_root
 
         # Add proposer score boost if the block is timely, not conflicting with an
         # existing block, with the same dependent root as the canonical chain head.
@@ -12115,6 +12178,48 @@
         # Update unrealized finalized checkpoint
         if unrealized_finalized_checkpoint.epoch > store.unrealized_finalized_checkpoint.epoch:
             store.unrealized_finalized_checkpoint = unrealized_finalized_checkpoint
+    </spec>
+
+- name: upgrade_attestation_to_gloas#gloas
+  sources:
+    - file: proto/prysm/v1alpha1/attestation.go
+      search: func AttestationElectraToGloas(
+  spec: |
+    <spec fn="upgrade_attestation_to_gloas" fork="gloas" hash="efd969bf">
+    def upgrade_attestation_to_gloas(pre: fulu.Attestation) -> Attestation:
+        return Attestation(
+            aggregation_bits=AggregationBits(list(pre.aggregation_bits)),
+            data=pre.data,
+            signature=pre.signature,
+            committee_bits=pre.committee_bits,
+        )
+    </spec>
+
+- name: upgrade_attester_slashing_to_gloas#gloas
+  sources:
+    - file: proto/prysm/v1alpha1/attestation.go
+      search: func AttesterSlashingElectraToGloas(
+  spec: |
+    <spec fn="upgrade_attester_slashing_to_gloas" fork="gloas" hash="35f9184f">
+    def upgrade_attester_slashing_to_gloas(pre: fulu.AttesterSlashing) -> AttesterSlashing:
+        return AttesterSlashing(
+            attestation_1=upgrade_indexed_attestation_to_gloas(pre.attestation_1),
+            attestation_2=upgrade_indexed_attestation_to_gloas(pre.attestation_2),
+        )
+    </spec>
+
+- name: upgrade_indexed_attestation_to_gloas#gloas
+  sources:
+    - file: proto/prysm/v1alpha1/attestation.go
+      search: func IndexedAttestationElectraToGloas(
+  spec: |
+    <spec fn="upgrade_indexed_attestation_to_gloas" fork="gloas" hash="b13fb8df">
+    def upgrade_indexed_attestation_to_gloas(pre: fulu.IndexedAttestation) -> IndexedAttestation:
+        return IndexedAttestation(
+            attesting_indices=AttestingIndices(list(pre.attesting_indices)),
+            data=pre.data,
+            signature=pre.signature,
+        )
     </spec>
 
 - name: upgrade_lc_bootstrap_to_capella#capella
@@ -12158,12 +12263,14 @@
 - name: upgrade_lc_bootstrap_to_gloas#gloas
   sources: []
   spec: |
-    <spec fn="upgrade_lc_bootstrap_to_gloas" fork="gloas" hash="d7fb2b11">
+    <spec fn="upgrade_lc_bootstrap_to_gloas" fork="gloas" hash="eae6aac6">
     def upgrade_lc_bootstrap_to_gloas(pre: electra.LightClientBootstrap) -> LightClientBootstrap:
         return LightClientBootstrap(
             header=upgrade_lc_header_to_gloas(pre.header),
             current_sync_committee=pre.current_sync_committee,
-            current_sync_committee_branch=pre.current_sync_committee_branch,
+            current_sync_committee_branch=normalize_merkle_branch(
+                pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS
+            ),
         )
     </spec>
 
@@ -12218,14 +12325,14 @@
 - name: upgrade_lc_finality_update_to_gloas#gloas
   sources: []
   spec: |
-    <spec fn="upgrade_lc_finality_update_to_gloas" fork="gloas" hash="b0e9270b">
+    <spec fn="upgrade_lc_finality_update_to_gloas" fork="gloas" hash="e918e2d2">
     def upgrade_lc_finality_update_to_gloas(
         pre: electra.LightClientFinalityUpdate,
     ) -> LightClientFinalityUpdate:
         return LightClientFinalityUpdate(
             attested_header=upgrade_lc_header_to_gloas(pre.attested_header),
             finalized_header=upgrade_lc_header_to_gloas(pre.finalized_header),
-            finality_branch=pre.finality_branch,
+            finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_GLOAS),
             sync_aggregate=pre.sync_aggregate,
             signature_slot=pre.signature_slot,
         )
@@ -12534,14 +12641,16 @@
 - name: upgrade_lc_update_to_gloas#gloas
   sources: []
   spec: |
-    <spec fn="upgrade_lc_update_to_gloas" fork="gloas" hash="bf716977">
+    <spec fn="upgrade_lc_update_to_gloas" fork="gloas" hash="b9cf5ed0">
     def upgrade_lc_update_to_gloas(pre: electra.LightClientUpdate) -> LightClientUpdate:
         return LightClientUpdate(
             attested_header=upgrade_lc_header_to_gloas(pre.attested_header),
             next_sync_committee=pre.next_sync_committee,
-            next_sync_committee_branch=pre.next_sync_committee_branch,
+            next_sync_committee_branch=normalize_merkle_branch(
+                pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX_GLOAS
+            ),
             finalized_header=upgrade_lc_header_to_gloas(pre.finalized_header),
-            finality_branch=pre.finality_branch,
+            finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_GLOAS),
             sync_aggregate=pre.sync_aggregate,
             signature_slot=pre.signature_slot,
         )
@@ -12950,7 +13059,7 @@
 - name: upgrade_to_gloas#gloas
   sources: []
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="c769e40a">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="571abe9a">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -12971,17 +13080,26 @@
             eth1_data=pre.eth1_data,
             eth1_data_votes=pre.eth1_data_votes,
             eth1_deposit_index=pre.eth1_deposit_index,
-            validators=pre.validators,
-            balances=pre.balances,
+            # [Modified in Gloas:EIP7688]
+            validators=ProgressiveList[Validator](list(pre.validators)),
+            # [Modified in Gloas:EIP7688]
+            balances=ProgressiveList[Gwei](list(pre.balances)),
             randao_mixes=pre.randao_mixes,
             slashings=pre.slashings,
-            previous_epoch_participation=pre.previous_epoch_participation,
-            current_epoch_participation=pre.current_epoch_participation,
+            # [Modified in Gloas:EIP7688]
+            previous_epoch_participation=ProgressiveList[ParticipationFlags](
+                list(pre.previous_epoch_participation)
+            ),
+            # [Modified in Gloas:EIP7688]
+            current_epoch_participation=ProgressiveList[ParticipationFlags](
+                list(pre.current_epoch_participation)
+            ),
             justification_bits=pre.justification_bits,
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
-            inactivity_scores=pre.inactivity_scores,
+            # [Modified in Gloas:EIP7688]
+            inactivity_scores=ProgressiveList[uint64](list(pre.inactivity_scores)),
             current_sync_committee=pre.current_sync_committee,
             next_sync_committee=pre.next_sync_committee,
             # [Modified in Gloas:EIP7732]
@@ -12997,9 +13115,16 @@
             earliest_exit_epoch=pre.earliest_exit_epoch,
             consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
             earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
-            pending_deposits=pre.pending_deposits,
-            pending_partial_withdrawals=pre.pending_partial_withdrawals,
-            pending_consolidations=pre.pending_consolidations,
+            # [Modified in Gloas:EIP7688]
+            pending_deposits=ProgressiveList[PendingDeposit](list(pre.pending_deposits)),
+            # [Modified in Gloas:EIP7688]
+            pending_partial_withdrawals=ProgressiveList[PendingPartialWithdrawal](
+                list(pre.pending_partial_withdrawals)
+            ),
+            # [Modified in Gloas:EIP7688]
+            pending_consolidations=ProgressiveList[PendingConsolidation](
+                list(pre.pending_consolidations)
+            ),
             proposer_lookahead=pre.proposer_lookahead,
             # [New in Gloas:EIP7732]
             builders=[],
@@ -13032,9 +13157,25 @@
 - name: upgrade_to_heze#heze
   sources: []
   spec: |
-    <spec fn="upgrade_to_heze" fork="heze" hash="c7ab4b39">
+    <spec fn="upgrade_to_heze" fork="heze" hash="390f5e3c">
     def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         epoch = gloas.get_current_epoch(pre)
+        latest_execution_payload_bid = ExecutionPayloadBid(
+            parent_block_hash=pre.latest_execution_payload_bid.parent_block_hash,
+            parent_block_root=pre.latest_execution_payload_bid.parent_block_root,
+            block_hash=pre.latest_execution_payload_bid.block_hash,
+            prev_randao=pre.latest_execution_payload_bid.prev_randao,
+            fee_recipient=pre.latest_execution_payload_bid.fee_recipient,
+            gas_limit=pre.latest_execution_payload_bid.gas_limit,
+            builder_index=pre.latest_execution_payload_bid.builder_index,
+            slot=pre.latest_execution_payload_bid.slot,
+            value=pre.latest_execution_payload_bid.value,
+            execution_payment=pre.latest_execution_payload_bid.execution_payment,
+            blob_kzg_commitments=pre.latest_execution_payload_bid.blob_kzg_commitments,
+            execution_requests_root=pre.latest_execution_payload_bid.execution_requests_root,
+            # [New in Heze:EIP7805]
+            inclusion_list_bits=Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](),
+        )
 
         post = BeaconState(
             genesis_time=pre.genesis_time,
@@ -13085,7 +13226,8 @@
             execution_payload_availability=pre.execution_payload_availability,
             builder_pending_payments=pre.builder_pending_payments,
             builder_pending_withdrawals=pre.builder_pending_withdrawals,
-            latest_execution_payload_bid=pre.latest_execution_payload_bid,
+            # [Modified in Heze:EIP7805]
+            latest_execution_payload_bid=latest_execution_payload_bid,
             payload_expected_withdrawals=pre.payload_expected_withdrawals,
             ptc_window=pre.ptc_window,
         )
@@ -14962,15 +15104,15 @@
 - name: validate_partial_data_column_sidecar_gossip#fulu
   sources: []
   spec: |
-    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="a5f4b021">
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="aaad7df2">
     def validate_partial_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         sidecar: PartialDataColumnSidecar,
-        block_root: Root,
-        column_index: ColumnIndex,
         current_time_ms: uint64,
+        group_id: PartialDataColumnGroupID,
+        column_index: ColumnIndex,
     ) -> None:
         """
         Validate a PartialDataColumnSidecar for gossip propagation on a subnet.
@@ -14984,11 +15126,11 @@
         if not (has_header or has_cells):
             raise GossipReject("partial message is semantically empty")
 
-        # [REJECT] The cell count equals the number of bits set in cells_present_bitmap
+        # [REJECT] The cell count equals the number of set bits in the bitmap
         if len(sidecar.partial_column) != num_cells_present:
             raise GossipReject("number of cells does not match number of set bits")
 
-        # [REJECT] The proof count equals the number of bits set in cells_present_bitmap
+        # [REJECT] The proof count equals the number of set bits in the bitmap
         if len(sidecar.kzg_proofs) != num_cells_present:
             raise GossipReject("number of proofs does not match number of set bits")
 
@@ -14997,13 +15139,13 @@
             block_header = header.signed_block_header.message
 
             # [REJECT] The received header MUST equal any previously validated header for this block
-            prior_header = seen.partial_data_column_headers.get(block_root)
+            prior_header = seen.partial_data_column_headers.get(group_id.beacon_block_root)
             if prior_header is not None and prior_header != header:
                 raise GossipReject("header differs from previously validated header")
 
             # [REJECT] The signed_block_header hash matches the partial message's group id
-            if hash_tree_root(block_header) != block_root:
-                raise GossipReject("header's block root does not match partial message group id")
+            if hash_tree_root(block_header) != group_id.beacon_block_root:
+                raise GossipReject("header's block root does not match group id's block root")
 
             # [REJECT] The header's kzg_commitments list is non-empty
             if len(header.kzg_commitments) == 0:
@@ -15063,11 +15205,11 @@
                 raise GossipReject("header proposer_index does not match expected proposer")
 
             # Mark this header as seen
-            seen.partial_data_column_headers[block_root] = header
+            seen.partial_data_column_headers[group_id.beacon_block_root] = header
 
         if has_cells:
             # [IGNORE] A valid corresponding PartialDataColumnHeader has been seen
-            header = seen.partial_data_column_headers.get(block_root)
+            header = seen.partial_data_column_headers.get(group_id.beacon_block_root)
             if header is None:
                 raise GossipIgnore("valid corresponding header has not been seen")
 
@@ -15085,11 +15227,11 @@
                     "corresponding header is not from a slot greater than the latest finalized slot"
                 )
 
-            # [REJECT] The cells_present_bitmap length equals the number of header kzg_commitments
+            # [REJECT] The cells present bitmap length equals the number of header commitments
             if len(sidecar.cells_present_bitmap) != len(header.kzg_commitments):
                 raise GossipReject("bitmap length does not match commitments length")
 
-            # [REJECT] The sidecar's cell and proof data is valid
+            # [REJECT] The sidecar's cell and proof data passes KZG verification
             if not verify_partial_data_column_sidecar_kzg_proofs(
                 sidecar, header.kzg_commitments, column_index
             ):
@@ -15505,11 +15647,11 @@
 - name: verify_data_column_sidecar#gloas
   sources: []
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="gloas" hash="71548b68">
+    <spec fn="verify_data_column_sidecar" fork="gloas" hash="52204844">
     def verify_data_column_sidecar(
         sidecar: DataColumnSidecar,
         # [New in Gloas:EIP7732]
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+        kzg_commitments: ProgressiveList[KZGCommitment],
     ) -> bool:
         """
         Verify if the data column sidecar is valid.

--- a/specrefs/presets.yml
+++ b/specrefs/presets.yml
@@ -8,20 +8,6 @@
     BASE_REWARD_FACTOR: uint64 = 64
     </spec>
 
-- name: BUILDER_PENDING_WITHDRAWALS_LIMIT#gloas
-  sources: []
-  spec: |
-    <spec preset_var="BUILDER_PENDING_WITHDRAWALS_LIMIT" fork="gloas" hash="40b31377">
-    BUILDER_PENDING_WITHDRAWALS_LIMIT: uint64 = 1048576
-    </spec>
-
-- name: BUILDER_REGISTRY_LIMIT#gloas
-  sources: []
-  spec: |
-    <spec preset_var="BUILDER_REGISTRY_LIMIT" fork="gloas" hash="e951ff73">
-    BUILDER_REGISTRY_LIMIT: uint64 = 1099511627776
-    </spec>
-
 - name: BYTES_PER_LOGS_BLOOM#bellatrix
   sources:
     - file: config/params/config.go
@@ -225,8 +211,8 @@
       search: MaxAttestations\s+.*yaml:"MAX_ATTESTATIONS"
       regex: true
   spec: |
-    <spec preset_var="MAX_ATTESTATIONS" fork="phase0" hash="afe55d3f">
-    MAX_ATTESTATIONS = 128
+    <spec preset_var="MAX_ATTESTATIONS" fork="phase0" hash="8ee7f084">
+    MAX_ATTESTATIONS: uint64 = 128
     </spec>
 
 - name: MAX_ATTESTATIONS_ELECTRA#electra
@@ -235,8 +221,8 @@
       search: MaxAttestationsElectra\s+.*yaml:"MAX_ATTESTATIONS_ELECTRA"
       regex: true
   spec: |
-    <spec preset_var="MAX_ATTESTATIONS_ELECTRA" fork="electra" hash="4dbaf2dd">
-    MAX_ATTESTATIONS_ELECTRA = 8
+    <spec preset_var="MAX_ATTESTATIONS_ELECTRA" fork="electra" hash="f5ced7c7">
+    MAX_ATTESTATIONS_ELECTRA: uint64 = 8
     </spec>
 
 - name: MAX_ATTESTER_SLASHINGS#phase0
@@ -245,8 +231,8 @@
       search: MaxAttesterSlashings\s+.*yaml:"MAX_ATTESTER_SLASHINGS"
       regex: true
   spec: |
-    <spec preset_var="MAX_ATTESTER_SLASHINGS" fork="phase0" hash="c1416d33">
-    MAX_ATTESTER_SLASHINGS = 2
+    <spec preset_var="MAX_ATTESTER_SLASHINGS" fork="phase0" hash="a026f81c">
+    MAX_ATTESTER_SLASHINGS: uint64 = 2
     </spec>
 
 - name: MAX_ATTESTER_SLASHINGS_ELECTRA#electra
@@ -255,8 +241,15 @@
       search: MaxAttesterSlashingsElectra\s+.*yaml:"MAX_ATTESTER_SLASHINGS_ELECTRA"
       regex: true
   spec: |
-    <spec preset_var="MAX_ATTESTER_SLASHINGS_ELECTRA" fork="electra" hash="fc70c923">
-    MAX_ATTESTER_SLASHINGS_ELECTRA = 1
+    <spec preset_var="MAX_ATTESTER_SLASHINGS_ELECTRA" fork="electra" hash="cb7ff972">
+    MAX_ATTESTER_SLASHINGS_ELECTRA: uint64 = 1
+    </spec>
+
+- name: MAX_ATTESTER_SLASHING_SIZE#gloas
+  sources: []
+  spec: |
+    <spec preset_var="MAX_ATTESTER_SLASHING_SIZE" fork="gloas" hash="35df66c7">
+    MAX_ATTESTER_SLASHING_SIZE: uint64 = 2097616
     </spec>
 
 - name: MAX_BLOB_COMMITMENTS_PER_BLOCK#deneb
@@ -275,22 +268,22 @@
       search: MaxBlsToExecutionChanges\s+.*yaml:"MAX_BLS_TO_EXECUTION_CHANGES"
       regex: true
   spec: |
-    <spec preset_var="MAX_BLS_TO_EXECUTION_CHANGES" fork="capella" hash="1eee2f2f">
-    MAX_BLS_TO_EXECUTION_CHANGES = 16
+    <spec preset_var="MAX_BLS_TO_EXECUTION_CHANGES" fork="capella" hash="a7430c88">
+    MAX_BLS_TO_EXECUTION_CHANGES: uint64 = 16
     </spec>
 
 - name: MAX_BUILDERS_PER_WITHDRAWALS_SWEEP#gloas
   sources: []
   spec: |
-    <spec preset_var="MAX_BUILDERS_PER_WITHDRAWALS_SWEEP" fork="gloas" hash="1556b314">
-    MAX_BUILDERS_PER_WITHDRAWALS_SWEEP = 16384
+    <spec preset_var="MAX_BUILDERS_PER_WITHDRAWALS_SWEEP" fork="gloas" hash="ab42a68a">
+    MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: uint64 = 16384
     </spec>
 
 - name: MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD#gloas
   sources: []
   spec: |
-    <spec preset_var="MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="81a08140">
-    MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD: uint64 = 256
+    <spec preset_var="MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="fdb8276d">
+    MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD: uint64 = 64
     </spec>
 
 - name: MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD#gloas
@@ -340,14 +333,21 @@
     MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: uint64 = 2
     </spec>
 
+- name: MAX_DATA_COLUMN_SIDECAR_SIZE#gloas
+  sources: []
+  spec: |
+    <spec preset_var="MAX_DATA_COLUMN_SIDECAR_SIZE" fork="gloas" hash="ecb9550a">
+    MAX_DATA_COLUMN_SIDECAR_SIZE: uint64 = 8585272
+    </spec>
+
 - name: MAX_DEPOSITS#phase0
   sources:
     - file: config/params/config.go
       search: MaxDeposits\s+.*yaml:"MAX_DEPOSITS"
       regex: true
   spec: |
-    <spec preset_var="MAX_DEPOSITS" fork="phase0" hash="542a0f96">
-    MAX_DEPOSITS = 16
+    <spec preset_var="MAX_DEPOSITS" fork="phase0" hash="8c07fc09">
+    MAX_DEPOSITS: uint64 = 16
     </spec>
 
 - name: MAX_DEPOSIT_REQUESTS_PER_PAYLOAD#electra
@@ -386,15 +386,22 @@
       search: MaxExtraDataBytes\s+.*yaml:"MAX_EXTRA_DATA_BYTES"
       regex: true
   spec: |
-    <spec preset_var="MAX_EXTRA_DATA_BYTES" fork="bellatrix" hash="9d278744">
-    MAX_EXTRA_DATA_BYTES = 32
+    <spec preset_var="MAX_EXTRA_DATA_BYTES" fork="bellatrix" hash="a37eed77">
+    MAX_EXTRA_DATA_BYTES: uint64 = 32
+    </spec>
+
+- name: MAX_PARTIAL_DATA_COLUMN_SIDECAR_SIZE#gloas
+  sources: []
+  spec: |
+    <spec preset_var="MAX_PARTIAL_DATA_COLUMN_SIDECAR_SIZE" fork="gloas" hash="c2570655">
+    MAX_PARTIAL_DATA_COLUMN_SIDECAR_SIZE: uint64 = 8585741
     </spec>
 
 - name: MAX_PAYLOAD_ATTESTATIONS#gloas
   sources: []
   spec: |
-    <spec preset_var="MAX_PAYLOAD_ATTESTATIONS" fork="gloas" hash="fc24e7ea">
-    MAX_PAYLOAD_ATTESTATIONS = 4
+    <spec preset_var="MAX_PAYLOAD_ATTESTATIONS" fork="gloas" hash="c91cfe07">
+    MAX_PAYLOAD_ATTESTATIONS: uint64 = 4
     </spec>
 
 - name: MAX_PENDING_DEPOSITS_PER_EPOCH#electra
@@ -423,8 +430,8 @@
       search: MaxProposerSlashings\s+.*yaml:"MAX_PROPOSER_SLASHINGS"
       regex: true
   spec: |
-    <spec preset_var="MAX_PROPOSER_SLASHINGS" fork="phase0" hash="87bfd9ed">
-    MAX_PROPOSER_SLASHINGS = 16
+    <spec preset_var="MAX_PROPOSER_SLASHINGS" fork="phase0" hash="26182947">
+    MAX_PROPOSER_SLASHINGS: uint64 = 16
     </spec>
 
 - name: MAX_SEED_LOOKAHEAD#phase0
@@ -435,6 +442,34 @@
   spec: |
     <spec preset_var="MAX_SEED_LOOKAHEAD" fork="phase0" hash="b7ae8929">
     MAX_SEED_LOOKAHEAD: uint64 = 4
+    </spec>
+
+- name: MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE#gloas
+  sources: []
+  spec: |
+    <spec preset_var="MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE" fork="gloas" hash="9dd832f2">
+    MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE: uint64 = 16829
+    </spec>
+
+- name: MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE#gloas
+  sources: []
+  spec: |
+    <spec preset_var="MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE" fork="gloas" hash="d78deb32">
+    MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE: uint64 = 196932
+    </spec>
+
+- name: MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE#heze
+  sources: []
+  spec: |
+    <spec preset_var="MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE" fork="heze" hash="718df6de">
+    MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE: uint64 = 196934
+    </spec>
+
+- name: MAX_SIGNED_INCLUSION_LIST_SIZE#heze
+  sources: []
+  spec: |
+    <spec preset_var="MAX_SIGNED_INCLUSION_LIST_SIZE" fork="heze" hash="917f47cb">
+    MAX_SIGNED_INCLUSION_LIST_SIZE: uint64 = 8348
     </spec>
 
 - name: MAX_TRANSACTIONS_PER_PAYLOAD#bellatrix
@@ -473,8 +508,8 @@
       search: MaxValidatorsPerWithdrawalsSweep\s+.*yaml:"MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP"
       regex: true
   spec: |
-    <spec preset_var="MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP" fork="capella" hash="ac61940c">
-    MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP = 16384
+    <spec preset_var="MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP" fork="capella" hash="1becfc15">
+    MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: uint64 = 16384
     </spec>
 
 - name: MAX_VOLUNTARY_EXITS#phase0
@@ -483,8 +518,8 @@
       search: MaxVoluntaryExits\s+.*yaml:"MAX_VOLUNTARY_EXITS"
       regex: true
   spec: |
-    <spec preset_var="MAX_VOLUNTARY_EXITS" fork="phase0" hash="a0a7ac5e">
-    MAX_VOLUNTARY_EXITS = 16
+    <spec preset_var="MAX_VOLUNTARY_EXITS" fork="phase0" hash="8fdacd5d">
+    MAX_VOLUNTARY_EXITS: uint64 = 16
     </spec>
 
 - name: MAX_WITHDRAWALS_PER_PAYLOAD#capella
@@ -613,8 +648,8 @@
       search: NumberOfColumns\s*=
       regex: true
   spec: |
-    <spec preset_var="NUMBER_OF_COLUMNS" fork="fulu" hash="f6441e62">
-    NUMBER_OF_COLUMNS: uint64 = 128
+    <spec preset_var="NUMBER_OF_COLUMNS" fork="fulu" hash="8b6dad29">
+    NUMBER_OF_COLUMNS = 128
     </spec>
 
 - name: PENDING_CONSOLIDATIONS_LIMIT#electra

--- a/testing/spectest/shared/fulu/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/fulu/ssz_static/ssz_static.go
@@ -67,9 +67,6 @@ func UnmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (a
 		obj = &ethpb.Deposit_Data{}
 	case "Eth1Data":
 		obj = &ethpb.Eth1Data{}
-	case "Eth1Block":
-		t.Skip("Unused type")
-		return nil, nil
 	case "Fork":
 		obj = &ethpb.Fork{}
 	case "ForkData":
@@ -154,10 +151,8 @@ func UnmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (a
 		obj = &ethpb.DataColumnSidecar{}
 	case "DataColumnsByRootIdentifier":
 		obj = &ethpb.DataColumnsByRootIdentifier{}
-	case "MatrixEntry":
+	case "MatrixEntry", "Eth1Block", "PartialDataColumnHeader", "PartialDataColumnPartsMetadata", "PartialDataColumnSidecar", "PartialDataColumnGroupID":
 		t.Skip("Unused type")
-	case "PartialDataColumnHeader", "PartialDataColumnPartsMetadata", "PartialDataColumnSidecar":
-		t.Skip("Not yet implemented")
 	default:
 		return nil, errors.New("type not found")
 	}

--- a/testing/spectest/shared/gloas/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/gloas/ssz_static/ssz_static.go
@@ -89,7 +89,7 @@ func unmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (a
 		t.Skip("Not a consensus type")
 	case "DataColumnSidecar":
 		obj = &ethpb.DataColumnSidecarGloas{}
-	case "SignedProposerPreferences", "ProposerPreferences":
+	case "SignedProposerPreferences", "ProposerPreferences", "PartialDataColumnGroupID":
 		t.Skip("p2p-only type; not part of the consensus state transition")
 
 	// Standard types that also exist in gloas
@@ -199,7 +199,7 @@ func unmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (a
 		obj = &ethpb.DataColumnsByRootIdentifier{}
 	case "MatrixEntry":
 		t.Skip("Unused type")
-	case "PartialDataColumnHeader", "PartialDataColumnPartsMetadata", "PartialDataColumnSidecar", "PartialDataColumnGroupID":
+	case "PartialDataColumnHeader", "PartialDataColumnPartsMetadata", "PartialDataColumnSidecar":
 		t.Skip("Not yet implemented")
 	default:
 		return nil, errors.New("type not found")

--- a/testing/spectest/shared/gloas/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/gloas/ssz_static/ssz_static.go
@@ -20,7 +20,7 @@ import (
 // RunSSZStaticTests executes "ssz_static" tests.
 //
 // The native-state (`custom`) HashTreeRoot uses progressive merkleization only
-// when features.EnableProgressiveSSZ is set (and version >= Gloas). That runtime
+// for Gloas types unless features.DisableProgressiveSSZ is set. That runtime
 // flag is independent of the --//tools:disable_progressive_merkleization codegen
 // flag, so when running gloas against progressive fixtures set PROGRESSIVE_SSZ=1
 // to align the native-state root with the generated one. Leave it unset for the
@@ -28,7 +28,7 @@ import (
 func RunSSZStaticTests(t *testing.T, config string) {
 	if os.Getenv("PROGRESSIVE_SSZ") != "" {
 		cfg := *features.Get() // nil-safe; copy so other flags are preserved
-		cfg.EnableProgressiveSSZ = true
+		cfg.DisableProgressiveSSZ = false
 		reset := features.InitWithReset(&cfg)
 		defer reset()
 	}


### PR DESCRIPTION
# Gloas devnet-7 spec update: progressive merkleization on by default, builder config alignment, attestation parent-slot fixes

> Part of the gloas-devnet-7 stacked series; based on `local-spectest-refactors`, diff shown against it.

This PR moves the consensus spec test pin from `v1.7.0-alpha.11` to `v1.7.0-alpha.12` and lands everything needed to pass against those fixtures. Two spec changes drive the bulk of the diff. First, the alpha.13 fixtures merkleize Gloas containers per EIP-7688, so progressive merkleization can no longer be an off-by-default experiment: the annotations are added to the Gloas types and the codegen/runtime defaults are inverted so that progressive is what you get unless you explicitly opt out. The rest is Gloas builder work: three config/preset values move to their current spec values, the builder withdrawal credential prefix is corrected and then actually enforced on deposit requests, and a builder could previously defer its own withdrawal indefinitely by topping itself up.

## Spec test pin

`WORKSPACE`: `consensus_spec_version` `v1.7.0-alpha.11` → `v1.7.0-alpha.12`, with new fixture hashes for the general/minimal/mainnet flavors and a new integrity hash for the `consensus-specs` source tarball.

## Progressive merkleization (EIP-7688) becomes the default

### Type annotations

`proto/prysm/v1alpha1/gloas.yaml` and `proto/engine/v1/engine.yaml` mark the containers and collections that EIP-7688 makes progressive:

- Progressive containers with progressive field lists: `BeaconStateGloas` (validators, balances, both participation lists, inactivity scores, pending deposits/partial withdrawals/consolidations, builders, builder pending withdrawals, payload expected withdrawals), `BeaconBlockBodyGloas` (all operation lists plus payload attestations), `AttestationGloas` (`AggregationBits` as `ProgressiveBitlist`), `IndexedAttestationGloas` (`AttestingIndices`), `ExecutionPayloadBid` (`BlobKzgCommitments`), `ExecutionPayloadGloas` (transactions as a progressive list of progressive byte lists, withdrawals, block access list), and `ExecutionRequestsGloas` (all five request lists).
- Progressive containers with no list fields: `ExecutionPayloadEnvelope`, `PayloadAttestation`.
- `DataColumnSidecarGloas` gets progressive `Column` and `KzgProofs` lists but stays a standard container.
- The base `ExecutionRequests` message is deliberately left alone, with a comment explaining why: it is the electra/fulu type, and annotating it would leak progressive merkleization into pre-Gloas forks. Gloas uses the separate `ExecutionRequestsGloas` message.

### Default flip: codegen, Bazel, feature flag

- `build/gen/ssz.go`: progressive generation now defaults to on. `SSZ_PROGRESSIVE=0` generates the bounded form (previously the default was off and `SSZ_PROGRESSIVE=1` opted in).
- `.bazelrc`: comment documenting that progressive is the build default and that `--//tools:disable_progressive_merkleization` switches to the bounded form. The `bool_flag` default in `//tools` already had progressive enabled; no rule change was needed.
- **Flag inversion**: the hidden `--enable-progressive-ssz` flag becomes `--disable-progressive-ssz`, and `features.Flags.EnableProgressiveSSZ` becomes `DisableProgressiveSSZ`. `features.ProgressiveSSZEnabled(version)` is now `version >= Gloas && !DisableProgressiveSSZ`. The flag usage string calls it an escape hatch for debugging, since Gloas mandates progressive merkleization.
- Two call sites that read the raw flag now go through `features.ProgressiveSSZEnabled` so the version gate is applied consistently: `beacon-chain/light-client/lightclient.go` (`progressiveExecutionPayloadSSZEnabled`) and `consensus-types/blocks/proofs.go` (`blockBodyListRoot`).

### Regenerated SSZ

`proto/prysm/v1alpha1/gloas{,.minimal}.ssz.go` and `proto/engine/v1/engine{,.minimal}.ssz.go` are regenerated: annotated types now expose `ProgressiveHashTreeRoot`/`ProgressiveHashTreeRootWith` (with `HashTreeRoot` delegating to them), merkleize via `MerkleizeProgressiveWithActiveFields` / `MerkleizeProgressiveWithMixin`, and use `PutProgressiveBitlist` / `ValidateProgressiveBitlist`. The bounded `ErrListTooBig` and `ValidateBitlist` checks are dropped from marshal, unmarshal, and hashing.

Note the commit split: `deb157079c` inverts the config and tests, and `8cf24656ad` commits the regenerated output, so the generated code does not match the toolchain at the intermediate commit.

### Length checks SSZ no longer provides

Because the progressive types no longer carry list limits, `ApplyParentExecutionPayload` now asserts the per-payload maxima explicitly via a new `validateExecutionRequestLengths` (withdrawal requests, consolidations, builder deposits, builder exits), matching `apply_parent_execution_payload` in the spec.

## Config and preset changes

Applied to both `config/params/mainnet_config.go` and, where relevant, `config/params/minimal_config.go`:

| Value | Before | After |
| --- | --- | --- |
| `BUILDER_WITHDRAWAL_PREFIX` | `0x03` | `0xB0` (mainnet and minimal) |
| `MIN_BUILDER_WITHDRAWABILITY_DELAY` | 8192 epochs | 64 epochs |
| `MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD` | 256 (`2**8`) | 64 (`2**6`) |
| `PAYLOAD_DUE_BPS` | 7500 | 5000 (mainnet and minimal) |

`0x03` collided with the range reserved for future credential types. The withdrawability delay change keeps an exiting builder's funds from being locked for an impractically long window. `PAYLOAD_DUE_BPS` at 5000 moves the payload deadline to the slot midpoint so builders reveal earlier and the PTC has more time to attest to timeliness; that commit notes `config/params` `TestLoadConfigFile` depends on the pinned consensus-spec config fixture, which is why it needs the spec test pin bump that is included in this same PR.

## Builder deposit and withdrawal handling

- **Prefix enforcement** (`beacon-chain/core/gloas/builder_deposit_request.go`): builder deposit requests whose withdrawal credentials lack `BUILDER_WITHDRAWAL_PREFIX` are now ignored, both when batching new registrations in `ProcessBuilderDepositRequests` and in `processBuilderDepositRequest`. Such deposits are dropped and the funds are lost, per spec.
- **Builder version** (`beacon-chain/state/state-native/setters_gloas.go`): `AddBuilderFromDeposit` registers new builders with `PAYLOAD_BUILDER_VERSION` instead of echoing `withdrawalCredentials[0]`, so a depositor can no longer influence the stored version.
- **Top-up no longer defers withdrawal**: an exited builder's `WithdrawableEpoch` was pushed out on every top-up, letting a builder with a pending balance defer its own withdrawal indefinitely. The reset now requires `Balance == 0` (actually swept) in addition to being exited, and is evaluated *before* the top-up is credited so the new deposit cannot mask a zero balance. A nil builder at a known index now returns an error rather than being dereferenced.
- **Deposit request bound removed** (`proto/engine/v1/electra.go`): Gloas drops `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` — the execution layer bounds deposit requests through the block gas limit — so `decodeExecutionRequestListGloas` raises `limits.Deposits` to the size-derived maximum. Covered by the new `TestGetDecodedExecutionRequestsGloas_NoDepositLimit`; `TestEmptyExecutionRequestsGloasHashTreeRoot` is also added.

## Spec test runner changes

- `testing/spectest/shared/gloas/ssz_static/ssz_static.go`: the `PROGRESSIVE_SSZ` env override now clears `DisableProgressiveSSZ` rather than setting the old enable flag; the comment is updated for the inverted default.
- `execution_payload_bid.go` adapts to the new `ProcessExecutionPayloadBid` signature.
- New forkchoice tests: `TestForkChoice_InsertNode_LateBlockNotRecorded` covers the new gate, and `TestForkChoice_InsertNode_RecordsFirstSeen` now sets a genesis time so the inserted block lands in the current slot.

## Behavior notes

- The alpha.12 `process_operations` pseudocode adds EIP-7688 length asserts on the block body's operation lists (proposer slashings, attester slashings, attestations, voluntary exits, BLS-to-execution changes, payload attestations). Those asserts are recorded in the spec comment but not yet mirrored in `gloasOperations`; the analogous checks for the execution request lists *are* implemented here in `ApplyParentExecutionPayload`. Worth a follow-up now that the progressive SSZ types no longer bound those lists.
- Running Gloas `ssz_static` against progressive fixtures still needs `PROGRESSIVE_SSZ=1` to align the native-state root with the generated one; the runtime feature gate and the codegen flag remain independent.

## Commits

- `37b4e29a5d` Move spectests to v1.7.0-alpha.13
- `72766adaf8` Annotate gloas types for progressive container and field merkleization
- `deb157079c` Invert config and tests to expect progressive merkleization on by default
- `8cf24656ad` Commit updated methodical codegen with progressive merkleization flipped to default-on
- `56542829cb` Enforce BUILDER_WITHDRAWAL_PREFIX on builder deposit requests
- `c7adc00b9d` Reset builder withdrawable epoch on top-up only once swept
- `a9ad3dff90` Remove the deposit request bound on Gloas request decoding
- `4f17def149` Set BUILDER_WITHDRAWAL_PREFIX to 0xB0
- `2afb3af875` Reduce Gloas builder config bounds
- `1c2bd3af27` Set PAYLOAD_DUE_BPS to 5000
- `126cc7d308` Pass the parent slot to Gloas attestation processing
- `ca26f14da7` Only record early blocks as Gloas equivocation candidates

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>