### PR TITLE
REST VC: Make the SSZ publish path spec-conformant - fall back to JSON on 415

### DIFF
--- a/api/rest/multi_handler.go
+++ b/api/rest/multi_handler.go
@@ -218,16 +218,15 @@ func (m *multiHandler) Post(ctx context.Context, endpoint string, headers map[st
 	return nil
 }
 
-// PostSSZ broadcasts an SSZ-preferred POST to all nodes and returns the first
-// successful response.
-func (m *multiHandler) PostSSZ(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer) ([]byte, http.Header, error) {
+// PostSSZ broadcasts a POST with an SSZ request body to all nodes.
+// It surfaces 415 Unsupported Media Type errors from any node, otherwise succeeds as soon as one node accepts.
+func (m *multiHandler) PostSSZ(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer) error {
 	if len(m.handlers) == 1 {
-		result, header, err := m.handlers[0].PostSSZ(ctx, endpoint, headers, data)
-		if err != nil {
-			return nil, nil, fmt.Errorf("post ssz: %w", err)
+		if err := m.handlers[0].PostSSZ(ctx, endpoint, headers, data); err != nil {
+			return fmt.Errorf("post ssz: %w", err)
 		}
 
-		return result, header, nil
+		return nil
 	}
 
 	var raw []byte
@@ -235,27 +234,26 @@ func (m *multiHandler) PostSSZ(ctx context.Context, endpoint string, headers map
 		raw = data.Bytes()
 	}
 
-	post := func(ctx context.Context, h *handler) (sszResult, error) {
-		body, hdr, err := h.PostSSZ(ctx, endpoint, headers, cloneBuffer(data, raw))
-		if err != nil {
-			return sszResult{}, fmt.Errorf("post ssz: %w", err)
+	post := func(ctx context.Context, h *handler) error {
+		if err := h.PostSSZ(ctx, endpoint, headers, cloneBuffer(data, raw)); err != nil {
+			return fmt.Errorf("post ssz: %w", err)
 		}
 
-		return sszResult{body: body, header: hdr}, nil
+		return nil
 	}
 
-	vals, errs := broadcastWriteAll(ctx, m.handlers, post)
+	accepted, errs := broadcastWriteAll(ctx, m.handlers, post)
 	for _, err := range errs {
-		if errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusNotAcceptable}) {
-			return nil, nil, err
+		if errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType}) {
+			return err
 		}
 	}
 
-	if len(vals) > 0 {
-		return vals[0].body, vals[0].header, nil
+	if accepted > 0 {
+		return nil
 	}
 
-	return nil, nil, errors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 // readUntil runs round against the handlers.
@@ -556,8 +554,8 @@ func broadcastWrite[T any](ctx context.Context, handlers []*handler, fn func(con
 }
 
 // broadcastWriteAll runs fn against every handler concurrently and waits for all
-// of them, returning the successful values and the errors separately.
-func broadcastWriteAll[T any](ctx context.Context, handlers []*handler, fn func(context.Context, *handler) (T, error)) ([]T, []error) {
+// of them, returning the accepted count and the errors separately.
+func broadcastWriteAll(ctx context.Context, handlers []*handler, fn func(context.Context, *handler) error) (uint16, []error) {
 	// Detach from the caller's cancellation so writes still reach every node after we return.
 	bgCtx := context.WithoutCancel(ctx)
 
@@ -567,18 +565,12 @@ func broadcastWriteAll[T any](ctx context.Context, handlers []*handler, fn func(
 		bgCtx, cancel = context.WithDeadline(bgCtx, deadline)
 	}
 
-	type result struct {
-		val T
-		err error
-	}
-
 	// Call fn concurrently and asynchronously on every handler, sending the result to results.
 	var wg sync.WaitGroup
-	results := make(chan result, len(handlers))
+	results := make(chan error, len(handlers))
 	for _, handler := range handlers {
 		wg.Go(func() {
-			val, err := fn(bgCtx, handler)
-			results <- result{val: val, err: err}
+			results <- fn(bgCtx, handler)
 		})
 	}
 
@@ -589,43 +581,43 @@ func broadcastWriteAll[T any](ctx context.Context, handlers []*handler, fn func(
 	}()
 
 	var (
-		vals []T
-		errs []error
+		accepted uint16
+		errs     []error
 	)
 
-	collect := func(r result) {
-		if r.err != nil {
-			errs = append(errs, r.err)
+	collect := func(err error) {
+		if err != nil {
+			errs = append(errs, err)
 			return
 		}
 
-		vals = append(vals, r.val)
+		accepted++
 	}
 
 	// Collect results until every handler has returned.
 	for range handlers {
 		select {
-		case r := <-results:
-			collect(r)
+		case err := <-results:
+			collect(err)
 		case <-ctx.Done():
 			// Caller gave up waiting: drain results already in hand for successes
 			// before returning, otherwise report the context error.
 			for {
 				select {
-				case r := <-results:
-					collect(r)
+				case err := <-results:
+					collect(err)
 				default:
-					if len(vals) == 0 && len(errs) == 0 {
+					if accepted == 0 && len(errs) == 0 {
 						errs = append(errs, ctx.Err())
 					}
 
-					return vals, errs
+					return accepted, errs
 				}
 			}
 		}
 	}
 
-	return vals, errs
+	return accepted, errs
 }
 
 // cloneBuffer returns a fresh buffer over a copy of raw, or nil when the

--- a/api/rest/multi_handler_test.go
+++ b/api/rest/multi_handler_test.go
@@ -207,39 +207,32 @@ func TestMultiHandlerPostSSZ(t *testing.T) {
 		srv := sszServer(t, "accepted")
 
 		mh := multi(t, srv.URL)
-		got, header, err := mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body))
-		require.NoError(t, err)
-		assert.Equal(t, "accepted", string(got))
-		assert.Equal(t, api.OctetStreamMediaType, header.Get("Content-Type"))
+		require.NoError(t, mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body)))
 	})
 
-	t.Run("returns the first successful response across the fleet", func(t *testing.T) {
-		a := sszServer(t, "accepted")
-		b := sszServer(t, "accepted")
+	t.Run("succeeds when any node accepts", func(t *testing.T) {
+		bad := jsonServer(t, 0, http.StatusInternalServerError, nil)
+		good := sszServer(t, "accepted")
 
-		mh := multi(t, a.URL, b.URL)
-		got, _, err := mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body))
-		require.NoError(t, err)
-		assert.Equal(t, "accepted", string(got))
+		mh := multi(t, bad.URL, good.URL)
+		require.NoError(t, mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body)))
 	})
 
-	// In a mixed fleet where one node accepts SSZ and another rejects it with 406,
-	// PostSSZ must surface the 406 so the caller can re-broadcast via JSON, rather
-	// than hiding it behind the accepting node's success.
-	t.Run("surfaces a 406 so the caller can fall back to JSON", func(t *testing.T) {
+	// In a mixed fleet where one node accepts SSZ and another rejects the body with 415,
+	// PostSSZ must surface the 415 so the caller can re-broadcast via JSON, rather than
+	// hiding it behind the accepting node's success and never reaching the rejecting node.
+	t.Run("surfaces a 415 so the caller can fall back to JSON", func(t *testing.T) {
 		accepts := sszServer(t, "accepted")
 		rejects := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", api.JsonMediaType)
-			w.WriteHeader(http.StatusNotAcceptable)
-			_, _ = w.Write([]byte(`{"code":406,"message":"needs json"}`))
+			http.Error(w, "Unsupported media type: application/octet-stream", http.StatusUnsupportedMediaType)
 		}))
 		t.Cleanup(rejects.Close)
 
 		mh := multi(t, accepts.URL, rejects.URL)
-		_, _, err := mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body))
+		err := mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body))
 		require.NotNil(t, err)
-		assert.Equal(t, true, errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusNotAcceptable}),
-			"a node's 406 must surface so the caller falls back to JSON")
+		assert.Equal(t, true, errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType}),
+			"a node's 415 must surface so the caller falls back to JSON")
 	})
 
 	t.Run("returns the joined error when every node fails", func(t *testing.T) {
@@ -247,7 +240,7 @@ func TestMultiHandlerPostSSZ(t *testing.T) {
 		bad2 := jsonServer(t, 0, http.StatusBadGateway, nil)
 
 		mh := multi(t, bad1.URL, bad2.URL)
-		_, _, err := mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body))
+		err := mh.PostSSZ(context.Background(), "/publish", nil, bytes.NewBufferString(body))
 		require.NotNil(t, err)
 	})
 
@@ -263,7 +256,7 @@ func TestMultiHandlerPostSSZ(t *testing.T) {
 		cancel()
 
 		mh := multi(t, srv.URL, srv.URL)
-		_, _, err := mh.PostSSZ(ctx, "/publish", nil, bytes.NewBufferString(body))
+		err := mh.PostSSZ(ctx, "/publish", nil, bytes.NewBufferString(body))
 		assert.Equal(t, true, errors.Is(err, context.Canceled))
 	})
 }

--- a/api/rest/rest_handler.go
+++ b/api/rest/rest_handler.go
@@ -301,13 +301,15 @@ func (c *handler) PostSSZ(
 	}
 
 	// A non-JSON error body is still surfaced as a typed error so the status code survives.
+	errorJson := &httputil.DefaultJsonError{Code: httpResp.StatusCode}
 	if !strings.Contains(httpResp.Header.Get("Content-Type"), api.JsonMediaType) {
-		return &httputil.DefaultJsonError{Code: httpResp.StatusCode, Message: string(body)}
+		errorJson.Message = string(body)
+		return errorJson
 	}
 
-	errorJson := &httputil.DefaultJsonError{}
-	if err = json.NewDecoder(bytes.NewBuffer(body)).Decode(errorJson); err != nil {
-		return errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL.Redacted())
+	decoded := &httputil.DefaultJsonError{}
+	if err = json.Unmarshal(body, decoded); err == nil && decoded.Message != "" {
+		errorJson.Message = decoded.Message
 	}
 
 	return errorJson

--- a/api/rest/rest_handler.go
+++ b/api/rest/rest_handler.go
@@ -286,8 +286,12 @@ func (c *handler) PostSSZ(
 		}
 	}()
 
-	// 2XX is a success, and the body is empty by spec, so there is nothing to read.
+	// Success bodies are empty by spec, but drain any body so net/http can reuse the connection.
 	if httpResp.StatusCode/100 == 2 {
+		if _, err := io.Copy(io.Discard, httpResp.Body); err != nil {
+			return errors.Wrapf(err, "failed to drain response body for %s", httpResp.Request.URL.Redacted())
+		}
+
 		return nil
 	}
 

--- a/api/rest/rest_handler.go
+++ b/api/rest/rest_handler.go
@@ -28,7 +28,7 @@ type Handler interface {
 	GetStatusCode(ctx context.Context, endpoint string) (int, error)
 	GetSSZ(ctx context.Context, endpoint string, opts ...GetOption) ([]byte, http.Header, error)
 	Post(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer, resp any) error
-	PostSSZ(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer) ([]byte, http.Header, error)
+	PostSSZ(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer) error
 	Host() string
 }
 
@@ -252,29 +252,26 @@ func (c *handler) Post(
 	return decodeResp(httpResp, resp)
 }
 
-// PostSSZ sends a POST request and prefers an SSZ (application/octet-stream) response body.
+// PostSSZ sends a POST request with an SSZ (application/octet-stream) request body.
 func (c *handler) PostSSZ(
 	ctx context.Context,
 	apiEndpoint string,
 	headers map[string]string,
 	data *bytes.Buffer,
-) ([]byte, http.Header, error) {
+) error {
 	if data == nil {
-		return nil, nil, errors.New("data is nil")
+		return errors.New("data is nil")
 	}
 	url := c.Host() + apiEndpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, data)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to create request for endpoint %s", api.RedactEndpoint(url))
+		return errors.Wrapf(err, "failed to create request for endpoint %s", api.RedactEndpoint(url))
 	}
 
-	// Accept header: prefer octet-stream (SSZ), fall back to JSON
-	primaryAcceptType := fmt.Sprintf("%s;q=%s", api.OctetStreamMediaType, "0.95")
-	secondaryAcceptType := fmt.Sprintf("%s;q=%s", api.JsonMediaType, "0.9")
-	acceptHeaderString := fmt.Sprintf("%s,%s", primaryAcceptType, secondaryAcceptType)
-	req.Header.Set("Accept", acceptHeaderString)
+	req.Header.Set("Accept", api.JsonMediaType)
+	req.Header.Set("Content-Type", api.OctetStreamMediaType)
+	req.Header.Set("User-Agent", version.BuildData())
 
-	// User-supplied headers
 	for headerKey, headerValue := range headers {
 		req.Header.Set(headerKey, headerValue)
 	}
@@ -282,11 +279,10 @@ func (c *handler) PostSSZ(
 	for _, o := range c.reqOverrides {
 		o(req)
 	}
-	req.Header.Set("Content-Type", api.OctetStreamMediaType)
-	req.Header.Set("User-Agent", version.BuildData())
+
 	httpResp, err := c.client.Do(req)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to perform request for endpoint %s", api.RedactEndpoint(url))
+		return errors.Wrapf(err, "failed to perform request for endpoint %s", api.RedactEndpoint(url))
 	}
 	defer func() {
 		if err := httpResp.Body.Close(); err != nil {
@@ -294,33 +290,27 @@ func (c *handler) PostSSZ(
 		}
 	}()
 
-	accept := req.Header.Get("Accept")
-	contentType := httpResp.Header.Get("Content-Type")
+	// 2XX is a success, and the body is empty by spec, so there is nothing to read.
+	if httpResp.StatusCode/100 == 2 {
+		return nil
+	}
+
 	body, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to read response body for %s", httpResp.Request.URL.Redacted())
+		return errors.Wrapf(err, "failed to read response body for %s", httpResp.Request.URL.Redacted())
 	}
 
-	if !apiutil.PrimaryAcceptMatches(accept, contentType) {
-		log.WithFields(logrus.Fields{
-			"Accept":       accept,
-			"Content-Type": contentType,
-		}).Debug("Server responded with non primary accept type")
+	// A non-JSON error body is still surfaced as a typed error so the status code survives.
+	if !strings.Contains(httpResp.Header.Get("Content-Type"), api.JsonMediaType) {
+		return &httputil.DefaultJsonError{Code: httpResp.StatusCode, Message: string(body)}
 	}
 
-	// non-2XX codes are a failure
-	if !strings.HasPrefix(httpResp.Status, "2") {
-		if !strings.Contains(contentType, api.JsonMediaType) {
-			return nil, nil, &httputil.DefaultJsonError{Code: httpResp.StatusCode, Message: string(body)}
-		}
-		errorJson := &httputil.DefaultJsonError{}
-		if err = json.NewDecoder(bytes.NewBuffer(body)).Decode(errorJson); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL.Redacted())
-		}
-		return nil, nil, errorJson
+	errorJson := &httputil.DefaultJsonError{}
+	if err = json.NewDecoder(bytes.NewBuffer(body)).Decode(errorJson); err != nil {
+		return errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL.Redacted())
 	}
 
-	return body, httpResp.Header, nil
+	return errorJson
 }
 
 func decodeResp(httpResp *http.Response, resp any) error {

--- a/api/rest/rest_handler.go
+++ b/api/rest/rest_handler.go
@@ -276,10 +276,6 @@ func (c *handler) PostSSZ(
 		req.Header.Set(headerKey, headerValue)
 	}
 
-	for _, o := range c.reqOverrides {
-		o(req)
-	}
-
 	httpResp, err := c.client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to perform request for endpoint %s", api.RedactEndpoint(url))

--- a/api/rest/rest_handler_test.go
+++ b/api/rest/rest_handler_test.go
@@ -83,6 +83,19 @@ func TestPostSSZ_JSONErrorBodyIsDecoded(t *testing.T) {
 	require.Equal(t, "bad request", errJson.Message)
 }
 
+func TestPostSSZ_MalformedJSONErrorBodyKeepsStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", api.JsonMediaType)
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	c := newHandler(http.Client{}, srv.URL)
+	err := c.PostSSZ(context.Background(), "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01}))
+	require.Equal(t, true, errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType}), "expected 415 to survive, got %v", err)
+}
+
 func TestPostSSZ_DrainsSuccessBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)

--- a/api/rest/rest_handler_test.go
+++ b/api/rest/rest_handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
 
@@ -66,7 +67,7 @@ func TestGetSSZ_NonJSONErrorBodyIsTyped(t *testing.T) {
 // A JSON error body is decoded into the typed error's fields.
 func TestPostSSZ_JSONErrorBodyIsDecoded(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, api.JsonMediaType, r.Header.Get("Accept"))
+		assert.Equal(t, api.JsonMediaType, r.Header.Get("Accept"))
 		w.Header().Set("Content-Type", api.JsonMediaType)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"code":400,"message":"bad request"}`))

--- a/api/rest/rest_handler_test.go
+++ b/api/rest/rest_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"strings"
 	"sync"
 	"testing"
@@ -79,6 +80,25 @@ func TestPostSSZ_JSONErrorBodyIsDecoded(t *testing.T) {
 	require.Equal(t, true, errors.As(err, &errJson), "expected DefaultJsonError, got %T", err)
 	require.Equal(t, http.StatusBadRequest, errJson.Code)
 	require.Equal(t, "bad request", errJson.Message)
+}
+
+func TestPostSSZ_DrainsSuccessBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"message":"accepted"}`))
+	}))
+	defer srv.Close()
+
+	var reused bool
+	ctx := httptrace.WithClientTrace(t.Context(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			reused = info.Reused
+		},
+	})
+	c := newHandler(http.Client{}, srv.URL)
+	require.NoError(t, c.PostSSZ(ctx, "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01})))
+	require.NoError(t, c.PostSSZ(ctx, "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01})))
+	require.Equal(t, true, reused, "expected the second request to reuse the drained connection")
 }
 
 func TestHandler_getRaw(t *testing.T) {

--- a/api/rest/rest_handler_test.go
+++ b/api/rest/rest_handler_test.go
@@ -41,7 +41,7 @@ func TestPostSSZ_NonJSONErrorBodyIsTyped(t *testing.T) {
 	defer srv.Close()
 
 	c := newHandler(http.Client{}, srv.URL)
-	_, _, err := c.PostSSZ(context.Background(), "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01}))
+	err := c.PostSSZ(context.Background(), "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01}))
 	require.NotNil(t, err)
 	errJson := &httputil.DefaultJsonError{}
 	require.Equal(t, true, errors.As(err, &errJson), "expected DefaultJsonError, got %T", err)
@@ -64,7 +64,8 @@ func TestGetSSZ_NonJSONErrorBodyIsTyped(t *testing.T) {
 
 // A JSON error body is decoded into the typed error's fields.
 func TestPostSSZ_JSONErrorBodyIsDecoded(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, api.JsonMediaType, r.Header.Get("Accept"))
 		w.Header().Set("Content-Type", api.JsonMediaType)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"code":400,"message":"bad request"}`))
@@ -72,7 +73,7 @@ func TestPostSSZ_JSONErrorBodyIsDecoded(t *testing.T) {
 	defer srv.Close()
 
 	c := newHandler(http.Client{}, srv.URL)
-	_, _, err := c.PostSSZ(context.Background(), "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01}))
+	err := c.PostSSZ(context.Background(), "/eth/v1/test", nil, bytes.NewBuffer([]byte{0x01}))
 	require.NotNil(t, err)
 	errJson := &httputil.DefaultJsonError{}
 	require.Equal(t, true, errors.As(err, &errJson), "expected DefaultJsonError, got %T", err)

--- a/changelog/syjn99_ssz-publish-415-fallback.md
+++ b/changelog/syjn99_ssz-publish-415-fallback.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- REST VC now falls back to JSON on `415 Unsupported Media Type` — the code a beacon node actually returns when it rejects an SSZ request body — instead of on `406 Not Acceptable`.
+- REST VC's SSZ publish requests now send `Accept: application/json`. Publish endpoints never produce SSZ response bodies, so preferring `application/octet-stream` was spec-noise that could draw a spurious `406` from servers with naive `Accept`/q-value parsing.

--- a/validator/client/beacon-api/beacon_api_validator_client_test.go
+++ b/validator/client/beacon-api/beacon_api_validator_client_test.go
@@ -140,7 +140,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockValid(t *testing.T) {
 		gomock.Any(),
 		gomock.Any(),
 	).Return(
-		nil, nil, nil,
+		nil,
 	).Times(1)
 
 	validatorClient := beaconApiValidatorClient{handler: handler}
@@ -167,8 +167,8 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockError_ThenPass(t *testing.T)
 		gomock.Any(),
 		gomock.Any(),
 	).Return(
-		nil, nil, &httputil.DefaultJsonError{
-			Code:    http.StatusNotAcceptable,
+		&httputil.DefaultJsonError{
+			Code:    http.StatusUnsupportedMediaType,
 			Message: "SSZ not supported",
 		},
 	).Times(1)
@@ -310,7 +310,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockAllTypes(t *testing.T) {
 					tt.expectedPath,
 					gomock.Any(),
 					gomock.Any(),
-				).Return(nil, nil, nil).Times(1)
+				).Return(nil).Times(1)
 			}
 
 			validatorClient := beaconApiValidatorClient{handler: handler}
@@ -340,7 +340,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockHTTPErrors(t *testing.T) {
 				Code:    http.StatusAccepted,
 				Message: "block broadcast but failed validation",
 			},
-			expectJSON:   false, // No fallback for non-406 errors
+			expectJSON:   false, // No fallback for non-415 errors
 			errorMessage: "failed to submit block ssz",
 		},
 		{
@@ -349,7 +349,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockHTTPErrors(t *testing.T) {
 				Code:    http.StatusBadRequest,
 				Message: "bad request",
 			},
-			expectJSON:   false, // No fallback for non-406 errors
+			expectJSON:   false, // No fallback for non-415 errors
 			errorMessage: "failed to submit block ssz",
 		},
 	}
@@ -367,7 +367,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockHTTPErrors(t *testing.T) {
 				"/eth/v2/beacon/blocks",
 				gomock.Any(),
 				gomock.Any(),
-			).Return(nil, nil, tt.sszError).Times(1)
+			).Return(tt.sszError).Times(1)
 
 			if tt.expectJSON {
 				// When SSZ fails, it falls back to JSON
@@ -503,14 +503,14 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockJSONFallback(t *testing.T) {
 			ctx := t.Context()
 			handler := mock.NewMockHandler(ctrl)
 
-			// SSZ call fails with 406 to trigger JSON fallback
+			// SSZ call fails with 415 to trigger JSON fallback
 			handler.EXPECT().PostSSZ(
 				gomock.Any(),
 				tt.expectedPath,
 				gomock.Any(),
 				gomock.Any(),
-			).Return(nil, nil, &httputil.DefaultJsonError{
-				Code:    http.StatusNotAcceptable,
+			).Return(&httputil.DefaultJsonError{
+				Code:    http.StatusUnsupportedMediaType,
 				Message: "SSZ not supported",
 			}).Times(1)
 

--- a/validator/client/beacon-api/execution_payload_envelope.go
+++ b/validator/client/beacon-api/execution_payload_envelope.go
@@ -121,13 +121,13 @@ func envelopeHeaders(blobDataIncluded bool) map[string]string {
 	}
 }
 
-// postEnvelope publishes SSZ first; on 406 Not Acceptable falls back to JSON.
+// postEnvelope publishes SSZ first; on 415 Unsupported Media Type falls back to JSON.
 func (c *beaconApiValidatorClient) postEnvelope(ctx context.Context, endpoint string, headers map[string]string, ssz []byte, jsonFn func() ([]byte, error)) error {
-	_, _, err := c.handler.PostSSZ(ctx, endpoint, headers, bytes.NewBuffer(ssz))
+	err := c.handler.PostSSZ(ctx, endpoint, headers, bytes.NewBuffer(ssz))
 	if err == nil {
 		return nil
 	}
-	if !errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusNotAcceptable}) {
+	if !errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType}) {
 		return err
 	}
 	log.WithError(err).Warn("Envelope SSZ publish rejected, falling back to JSON")

--- a/validator/client/beacon-api/execution_payload_envelope_test.go
+++ b/validator/client/beacon-api/execution_payload_envelope_test.go
@@ -136,7 +136,7 @@ func TestPublishExecutionPayloadEnvelope_StatefulSendsBareEnvelope(t *testing.T)
 		"/eth/v1/beacon/execution_payload_envelopes",
 		expectedHeaders,
 		bytes.NewBuffer(expectedBody),
-	).Return(nil, nil, nil)
+	).Return(nil)
 
 	client := &beaconApiValidatorClient{handler: handler, envelopeCache: cache.NewExecutionPayloadEnvelopeCache()}
 	resp, err := client.publishExecutionPayloadEnvelope(t.Context(), signed)
@@ -144,7 +144,7 @@ func TestPublishExecutionPayloadEnvelope_StatefulSendsBareEnvelope(t *testing.T)
 	require.NotNil(t, resp)
 }
 
-func TestPublishExecutionPayloadEnvelope_StatefulJSONFallbackOn406(t *testing.T) {
+func TestPublishExecutionPayloadEnvelope_StatefulJSONFallbackOn415(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -161,7 +161,7 @@ func TestPublishExecutionPayloadEnvelope_StatefulJSONFallbackOn406(t *testing.T)
 	handler := mock.NewMockHandler(ctrl)
 	handler.EXPECT().PostSSZ(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-	).Return(nil, nil, &httputil.DefaultJsonError{Code: http.StatusNotAcceptable, Message: "not acceptable"})
+	).Return(&httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"})
 	handler.EXPECT().Post(
 		gomock.Any(),
 		"/eth/v1/beacon/execution_payload_envelopes",
@@ -205,7 +205,7 @@ func TestPublishExecutionPayloadEnvelope_StatelessSendsContents(t *testing.T) {
 		"/eth/v1/beacon/execution_payload_envelopes",
 		expectedHeaders,
 		bytes.NewBuffer(expectedBody),
-	).Return(nil, nil, nil)
+	).Return(nil)
 
 	client := &beaconApiValidatorClient{
 		handler:       handler,
@@ -236,7 +236,7 @@ func TestPublishExecutionPayloadEnvelope_Error(t *testing.T) {
 	handler := mock.NewMockHandler(ctrl)
 	handler.EXPECT().PostSSZ(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-	).Return(nil, nil, errors.New("server error"))
+	).Return(errors.New("server error"))
 
 	client := &beaconApiValidatorClient{handler: handler, envelopeCache: cache.NewExecutionPayloadEnvelopeCache()}
 	client.envelopeCache.Add(primitives.Slot(envelope.Payload.SlotNumber), envelope, nil, nil)

--- a/validator/client/beacon-api/mock/json_rest_handler_mock.go
+++ b/validator/client/beacon-api/mock/json_rest_handler_mock.go
@@ -127,13 +127,11 @@ func (mr *MockHandlerMockRecorder) Post(ctx, endpoint, headers, data, resp any) 
 }
 
 // PostSSZ mocks base method.
-func (m *MockHandler) PostSSZ(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer) ([]byte, http.Header, error) {
+func (m *MockHandler) PostSSZ(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostSSZ", ctx, endpoint, headers, data)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(http.Header)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // PostSSZ indicates an expected call of PostSSZ.

--- a/validator/client/beacon-api/payload_attestation.go
+++ b/validator/client/beacon-api/payload_attestation.go
@@ -56,7 +56,7 @@ func (c *beaconApiValidatorClient) submitPayloadAttestation(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal payload attestation message ssz")
 	}
-	if _, _, err = c.handler.PostSSZ(ctx, payloadAttestationsEndpoint, headers, bytes.NewBuffer(sszBody)); err == nil {
+	if err = c.handler.PostSSZ(ctx, payloadAttestationsEndpoint, headers, bytes.NewBuffer(sszBody)); err == nil {
 		return nil
 	}
 	errJson := &httputil.DefaultJsonError{}

--- a/validator/client/beacon-api/payload_attestation_test.go
+++ b/validator/client/beacon-api/payload_attestation_test.go
@@ -129,7 +129,7 @@ func TestSubmitPayloadAttestation(t *testing.T) {
 			payloadAttestationsEndpoint,
 			headers,
 			bytes.NewBuffer(sszBody),
-		).Return(nil, nil, nil).Times(1)
+		).Return(nil).Times(1)
 
 		client := &beaconApiValidatorClient{handler: handler}
 		require.NoError(t, client.submitPayloadAttestation(t.Context(), msg))
@@ -140,7 +140,7 @@ func TestSubmitPayloadAttestation(t *testing.T) {
 		defer ctrl.Finish()
 		handler := mock.NewMockHandler(ctrl)
 		handler.EXPECT().PostSSZ(gomock.Any(), payloadAttestationsEndpoint, gomock.Any(), gomock.Any()).
-			Return(nil, nil, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"}).Times(1)
+			Return(&httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"}).Times(1)
 		handler.EXPECT().Post(
 			gomock.Any(),
 			payloadAttestationsEndpoint,
@@ -158,7 +158,7 @@ func TestSubmitPayloadAttestation(t *testing.T) {
 		defer ctrl.Finish()
 		handler := mock.NewMockHandler(ctrl)
 		handler.EXPECT().PostSSZ(gomock.Any(), payloadAttestationsEndpoint, gomock.Any(), gomock.Any()).
-			Return(nil, nil, errors.New("bad request")).Times(1)
+			Return(errors.New("bad request")).Times(1)
 
 		client := &beaconApiValidatorClient{handler: handler}
 		require.ErrorContains(t, "bad request", client.submitPayloadAttestation(t.Context(), msg))

--- a/validator/client/beacon-api/propose_beacon_block.go
+++ b/validator/client/beacon-api/propose_beacon_block.go
@@ -170,9 +170,8 @@ func (c *beaconApiValidatorClient) proposeBeaconBlock(ctx context.Context, in *e
 
 	// Try PostSSZ first with SSZ data
 	if res.marshalledSSZ != nil {
-		_, _, err = c.handler.PostSSZ(ctx, endpoint, headers, bytes.NewBuffer(res.marshalledSSZ))
-		if err != nil {
-			if !errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusNotAcceptable}) || res.marshalJSON == nil {
+		if err = c.handler.PostSSZ(ctx, endpoint, headers, bytes.NewBuffer(res.marshalledSSZ)); err != nil {
+			if !errors.Is(err, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType}) || res.marshalJSON == nil {
 				return nil, errors.Wrap(err, "failed to submit block ssz")
 			}
 

--- a/validator/client/beacon-api/propose_beacon_block_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_test.go
@@ -115,10 +115,10 @@ func TestProposeBeaconBlock_SSZ_Error(t *testing.T) {
 					headers,
 					gomock.Any(),
 				).Return(
-					nil, nil, testSuite.returnedError,
+					testSuite.returnedError,
 				).Times(1)
 
-				// No JSON fallback expected for non-406 errors
+				// No JSON fallback expected for non-415 errors
 
 				validatorClient := &beaconApiValidatorClient{handler: handler}
 				_, err := validatorClient.proposeBeaconBlock(ctx, testCase.block)
@@ -177,7 +177,7 @@ func TestProposeBeaconBlock_SSZSuccess_NoFallback(t *testing.T) {
 				headers,
 				gomock.Any(),
 			).Return(
-				nil, nil, nil,
+				nil,
 			).Times(1)
 
 			// Post should NOT be called when PostSSZ succeeds
@@ -565,7 +565,7 @@ func generateSignedBlindedCapellaBlock() *ethpb.GenericSignedBeaconBlock_Blinded
 	}
 }
 
-func TestProposeBeaconBlock_SSZFails_406_FallbackToJSON(t *testing.T) {
+func TestProposeBeaconBlock_SSZFails_415_FallbackToJSON(t *testing.T) {
 	testCases := []struct {
 		name             string
 		consensusVersion string
@@ -597,8 +597,8 @@ func TestProposeBeaconBlock_SSZFails_406_FallbackToJSON(t *testing.T) {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(
-				nil, nil, &httputil.DefaultJsonError{
-					Code:    http.StatusNotAcceptable,
+				&httputil.DefaultJsonError{
+					Code:    http.StatusUnsupportedMediaType,
 					Message: "SSZ not supported",
 				},
 			).Times(1)
@@ -620,7 +620,7 @@ func TestProposeBeaconBlock_SSZFails_406_FallbackToJSON(t *testing.T) {
 	}
 }
 
-func TestProposeBeaconBlock_SSZFails_406_JSONFallbackFails(t *testing.T) {
+func TestProposeBeaconBlock_SSZFails_415_JSONFallbackFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -633,8 +633,8 @@ func TestProposeBeaconBlock_SSZFails_406_JSONFallbackFails(t *testing.T) {
 		gomock.Any(),
 		gomock.Any(),
 	).Return(
-		nil, nil, &httputil.DefaultJsonError{
-			Code:    http.StatusNotAcceptable,
+		&httputil.DefaultJsonError{
+			Code:    http.StatusUnsupportedMediaType,
 			Message: "SSZ not supported",
 		},
 	).Times(1)
@@ -656,7 +656,7 @@ func TestProposeBeaconBlock_SSZFails_406_JSONFallbackFails(t *testing.T) {
 	assert.ErrorContains(t, "failed to submit block via JSON fallback", err)
 }
 
-func TestProposeBeaconBlock_SSZFails_Non406_NoFallback(t *testing.T) {
+func TestProposeBeaconBlock_SSZFails_Non415_NoFallback(t *testing.T) {
 	testCases := []struct {
 		name             string
 		consensusVersion string
@@ -681,7 +681,7 @@ func TestProposeBeaconBlock_SSZFails_Non406_NoFallback(t *testing.T) {
 			ctx := t.Context()
 			handler := mock.NewMockHandler(ctrl)
 
-			// Expect PostSSZ to be called first and fail with non-406 error
+			// Expect PostSSZ to be called first and fail with non-415 error
 			sszHeaders := map[string]string{
 				"Eth-Consensus-Version": testCase.consensusVersion,
 			}
@@ -691,13 +691,13 @@ func TestProposeBeaconBlock_SSZFails_Non406_NoFallback(t *testing.T) {
 				sszHeaders,
 				gomock.Any(),
 			).Return(
-				nil, nil, &httputil.DefaultJsonError{
+				&httputil.DefaultJsonError{
 					Code:    http.StatusInternalServerError,
 					Message: "Internal server error",
 				},
 			).Times(1)
 
-			// Post should NOT be called for non-406 errors
+			// Post should NOT be called for non-415 errors
 			handler.EXPECT().Post(
 				gomock.Any(),
 				gomock.Any(),

--- a/validator/client/beacon-api/proposer_preferences.go
+++ b/validator/client/beacon-api/proposer_preferences.go
@@ -30,7 +30,7 @@ func (c *beaconApiValidatorClient) submitSignedProposerPreferences(ctx context.C
 	if err != nil {
 		return err
 	}
-	if _, _, err = c.handler.PostSSZ(ctx, proposerPreferencesEndpoint, headers, bytes.NewBuffer(sszBody)); err == nil {
+	if err = c.handler.PostSSZ(ctx, proposerPreferencesEndpoint, headers, bytes.NewBuffer(sszBody)); err == nil {
 		return nil
 	}
 	errJson := &httputil.DefaultJsonError{}

--- a/validator/client/beacon-api/proposer_preferences_test.go
+++ b/validator/client/beacon-api/proposer_preferences_test.go
@@ -43,7 +43,7 @@ func TestSubmitSignedProposerPreferences_Valid(t *testing.T) {
 		proposerPreferencesEndpoint,
 		map[string]string{"Eth-Consensus-Version": "gloas"},
 		bytes.NewBuffer(sszBody),
-	).Return(nil, nil, nil).Times(1)
+	).Return(nil).Times(1)
 
 	client := &beaconApiValidatorClient{handler: handler}
 	require.NoError(t, client.submitSignedProposerPreferences(t.Context(), []*ethpb.SignedProposerPreferences{pref}))
@@ -63,7 +63,7 @@ func TestSubmitSignedProposerPreferences_FallsBackToJSONOn415(t *testing.T) {
 		proposerPreferencesEndpoint,
 		gomock.Any(),
 		gomock.Any(),
-	).Return(nil, nil, &httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"}).Times(1)
+	).Return(&httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"}).Times(1)
 	handler.EXPECT().Post(
 		gomock.Any(),
 		proposerPreferencesEndpoint,
@@ -86,7 +86,7 @@ func TestSubmitSignedProposerPreferences_NonMediaTypeErrorNoFallback(t *testing.
 		proposerPreferencesEndpoint,
 		map[string]string{"Eth-Consensus-Version": "gloas"},
 		gomock.Any(),
-	).Return(nil, nil, errors.New("foo error")).Times(1)
+	).Return(errors.New("foo error")).Times(1)
 
 	client := &beaconApiValidatorClient{handler: handler}
 	err := client.submitSignedProposerPreferences(t.Context(), []*ethpb.SignedProposerPreferences{testSignedProposerPreferences()})


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Previously, `PostSSZ` method sent:

```
Accept: application/octet-stream;q=0.95,application/json;q=0.9
```

(presumably) copied from the `GetSSZ` pattern, where preferring SSZ is correct.

For the `PostSSZ`, it's incorrect. `PostSSZ` is only used for publish endpoints (e.g., VC submits a signed message to BN) and per beacon-APIs, those **never** produce an SSZ response body -  successful publish is bodiless and errors are JSON. Client doesn't need to say that "I want you to give me response encoded by SSZ" in these paths. Also it's worth noting that every caller of `PostSSZ` just discards the body and header like `_, _, err := PostSSZ`. 

Here's the result for scanning every path item in `beacon-APIs`:

| endpoint | request | response |
|---|---|---|
| `POST /eth/v2/beacon/blocks` | json + octet-stream | json only |
| `POST /eth/v2/beacon/blinded_blocks` | json + octet-stream | json only |
| `POST /eth/v1/beacon/pool/attestations` (v2) | json + octet-stream | json only |
| `POST /eth/v1/beacon/pool/payload_attestations` | json + octet-stream | json only |
| `POST /eth/v1/beacon/execution_payload_envelopes` | json + octet-stream | json only |
| `POST /eth/v1/beacon/execution_payload/bid` | json + octet-stream | json only |
| `POST /eth/v1/validator/proposer_preferences` | json + octet-stream | json only |
| `POST /eth/v1/validator/aggregate_and_proofs` (v2) | json + octet-stream | json only |
| `POST /eth/v1/validator/register_validator` | json + octet-stream | *(bodiless)* |

So this PR does following:

- `PostSSZ` sets `Accept` with `application/json`. Remove `Accept`/q-value parsing that was brought from `GetSSZ`.
- JSON fallbacks from REST VC side only key on `415`, not `406`. Make multi-handler (introduced in #17075) surface `415` instead of `406`.
- `PostSSZ` only returns `error`.

**Which issue(s) does this PR fix?**

N/A. Related to
- #17256

**Other notes for review**

`406 Not Accpetable` and `415 Unsupported Media Type` are one of a common misconception we have (I also had).

- `415`: Server-side is saying, "Hey I have no idea how to decode your request body/data. I only accept `application/json` but you sent `application/octet-stream`". This is the *only* case where the client-side should send the data differently encoded (e.g., SSZ-encoded to JSON).
- `406`: Server-side is saying, "Hey you told me to respond in `application/octet-stream` but I cannot respond you with the data type."

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
