### PR TITLE
Parallelize per-element hash tree roots for large SSZ lists

### DIFF
--- a/changelog/potuz_parallel_element_roots.md
+++ b/changelog/potuz_parallel_element_roots.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Compute per-element hash tree roots in parallel for large SSZ lists, and read the feature config atomically instead of under a mutex.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -22,7 +22,7 @@ package features
 import (
 	"fmt"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
@@ -99,18 +99,15 @@ type Flags struct {
 	BlacklistedRoots map[[32]byte]struct{} // BlacklistedRoots is a list of roots that are blacklisted from processing.
 }
 
-var featureConfig *Flags
-var featureConfigLock sync.RWMutex
+// Read on hot paths, so kept lock-free: an RWMutex read lock does not scale.
+var featureConfig atomic.Pointer[Flags]
 
 // Get retrieves feature config.
 func Get() *Flags {
-	featureConfigLock.RLock()
-	defer featureConfigLock.RUnlock()
-
-	if featureConfig == nil {
-		return &Flags{}
+	if c := featureConfig.Load(); c != nil {
+		return c
 	}
-	return featureConfig
+	return &Flags{}
 }
 
 // ProgressiveSSZEnabled reports whether progressive SSZ is enabled for the
@@ -121,19 +118,14 @@ func ProgressiveSSZEnabled(stateVersion int) bool {
 
 // Init sets the global config equal to the config that is passed in.
 func Init(c *Flags) {
-	featureConfigLock.Lock()
-	defer featureConfigLock.Unlock()
-
-	featureConfig = c
+	featureConfig.Store(c)
 }
 
 // InitWithReset sets the global config and returns function that is used to reset configuration.
 func InitWithReset(c *Flags) func() {
 	var prevConfig Flags
-	if featureConfig != nil {
-		prevConfig = *featureConfig
-	} else {
-		prevConfig = Flags{}
+	if p := featureConfig.Load(); p != nil {
+		prevConfig = *p
 	}
 	resetFunc := func() {
 		Init(&prevConfig)

--- a/encoding/ssz/BUILD.bazel
+++ b/encoding/ssz/BUILD.bazel
@@ -34,9 +34,11 @@ go_test(
         "htrutils_test.go",
         "merkleize_test.go",
         "progressive_merkleize_test.go",
+        "slice_root_bench_test.go",
     ],
     deps = [
         ":go_default_library",
+        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//crypto/hash:go_default_library",

--- a/encoding/ssz/merkleize.go
+++ b/encoding/ssz/merkleize.go
@@ -2,11 +2,15 @@ package ssz
 
 import (
 	"encoding/binary"
+	"runtime"
+	"sync"
 
 	"github.com/OffchainLabs/prysm/v7/container/trie"
 	"github.com/OffchainLabs/prysm/v7/crypto/hash/htr"
 	"github.com/pkg/errors"
 )
+
+const minSliceSizeToParallelize = 512
 
 var errInvalidNilSlice = errors.New("invalid empty slice")
 
@@ -157,16 +161,58 @@ type Hashable interface {
 	HashTreeRoot() ([32]byte, error)
 }
 
+// ElementRoots computes the root of every element, concurrently for large slices.
+func ElementRoots[T Hashable](elements []T) ([][32]byte, error) {
+	roots := make([][32]byte, len(elements))
+	if len(elements) < minSliceSizeToParallelize {
+		for i := range elements {
+			r, err := elements[i].HashTreeRoot()
+			if err != nil {
+				return nil, err
+			}
+			roots[i] = r
+		}
+		return roots, nil
+	}
+
+	n := min(runtime.GOMAXPROCS(0), len(elements))
+	groupSize := (len(elements) + n - 1) / n
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for j := range n {
+		start := j * groupSize
+		if start >= len(elements) {
+			break
+		}
+		end := min(start+groupSize, len(elements))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := start; i < end; i++ {
+				r, err := elements[i].HashTreeRoot()
+				if err != nil {
+					errs[j] = err
+					return
+				}
+				roots[i] = r
+			}
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+	return roots, nil
+}
+
 // MerkleizeVectorSSZ hashes each element in the list and then returns the HTR
 // of the corresponding list of roots
 func MerkleizeVectorSSZ[T Hashable](elements []T, length uint64) ([32]byte, error) {
-	roots := make([][32]byte, len(elements))
-	var err error
-	for i, el := range elements {
-		roots[i], err = el.HashTreeRoot()
-		if err != nil {
-			return [32]byte{}, err
-		}
+	roots, err := ElementRoots(elements)
+	if err != nil {
+		return [32]byte{}, err
 	}
 	return MerkleizeVector(roots, length), nil
 }

--- a/encoding/ssz/merkleize_test.go
+++ b/encoding/ssz/merkleize_test.go
@@ -1,6 +1,9 @@
 package ssz_test
 
 import (
+	"encoding/binary"
+	"errors"
+	"math"
 	"testing"
 
 	"github.com/OffchainLabs/go-bitfield"
@@ -132,4 +135,45 @@ func Test_MerkleizeListSSZ(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, root)
 	})
+}
+
+// countingHashable roots itself as its own index, so misordered shards show up.
+type countingHashable uint64
+
+func (c countingHashable) HashTreeRoot() ([32]byte, error) {
+	if c == errAtIndex {
+		return [32]byte{}, errors.New("boom")
+	}
+	var r [32]byte
+	binary.LittleEndian.PutUint64(r[:8], uint64(c))
+	return r, nil
+}
+
+const errAtIndex = countingHashable(math.MaxUint64)
+
+func Test_ElementRoots_ParallelMatchesSerial(t *testing.T) {
+	for _, n := range []int{0, 1, 511, 512, 513, 1000, 5000, 5001} {
+		elements := make([]countingHashable, n)
+		for i := range elements {
+			elements[i] = countingHashable(i)
+		}
+		roots, err := ssz.ElementRoots(elements)
+		require.NoError(t, err)
+		require.Equal(t, n, len(roots))
+		for i := range elements {
+			require.Equal(t, uint64(i), binary.LittleEndian.Uint64(roots[i][:8]))
+		}
+	}
+}
+
+func Test_ElementRoots_PropagatesError(t *testing.T) {
+	for _, n := range []int{1, 513, 5000} {
+		elements := make([]countingHashable, n)
+		for i := range elements {
+			elements[i] = countingHashable(i)
+		}
+		elements[n-1] = errAtIndex
+		_, err := ssz.ElementRoots(elements)
+		require.ErrorContains(t, "boom", err)
+	}
 }

--- a/encoding/ssz/progressive_merkleize.go
+++ b/encoding/ssz/progressive_merkleize.go
@@ -58,13 +58,9 @@ func MerkleizeProgressiveChunks(chunks [][32]byte) [32]byte {
 // MerkleizeVectorSSZProgressive hashes each element and computes the
 // merkleize_progressive body root over the resulting field roots.
 func MerkleizeVectorSSZProgressive[T Hashable](elements []T) ([32]byte, error) {
-	roots := make([][32]byte, len(elements))
-	for i, el := range elements {
-		r, err := el.HashTreeRoot()
-		if err != nil {
-			return [32]byte{}, err
-		}
-		roots[i] = r
+	roots, err := ElementRoots(elements)
+	if err != nil {
+		return [32]byte{}, err
 	}
 	return MerkleizeProgressiveChunks(roots), nil
 }

--- a/encoding/ssz/slice_root.go
+++ b/encoding/ssz/slice_root.go
@@ -15,13 +15,9 @@ func SliceRoot[T Hashable](slice []T, limit uint64) ([32]byte, error) {
 		return [32]byte{}, fmt.Errorf("slice exceeds max length %d", max)
 	}
 
-	roots := make([][32]byte, len(slice))
-	for i := range slice {
-		r, err := slice[i].HashTreeRoot()
-		if err != nil {
-			return [32]byte{}, errors.Wrap(err, "could not merkleize object")
-		}
-		roots[i] = r
+	roots, err := ElementRoots(slice)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "could not merkleize object")
 	}
 
 	sliceRoot, err := BitwiseMerkleize(roots, uint64(len(roots)), limit)

--- a/encoding/ssz/slice_root_bench_test.go
+++ b/encoding/ssz/slice_root_bench_test.go
@@ -1,0 +1,59 @@
+package ssz_test
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/config/features"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+const (
+	listLimit  = 1 << 20
+	bytesLimit = 1 << 30
+)
+
+type byteList []byte
+
+func (b byteList) HashTreeRoot() ([32]byte, error) {
+	return ssz.ByteSliceRoot(b, bytesLimit)
+}
+
+type progressiveByteList []byte
+
+func (b progressiveByteList) HashTreeRoot() ([32]byte, error) {
+	return ssz.ByteSliceRootProgressive(b)
+}
+
+// maxByteLists returns listLimit one-byte lists backed by one allocation.
+func maxByteLists[T ~[]byte]() []T {
+	lists := make([]T, listLimit)
+	buf := make([]byte, len(lists))
+	for i := range lists {
+		buf[i] = byte(i)
+		lists[i] = T(buf[i : i+1 : i+1])
+	}
+	return lists
+}
+
+func BenchmarkSliceRoot_MaxByteLists(b *testing.B) {
+	reset := features.InitWithReset(&features.Flags{})
+	defer reset()
+	lists := maxByteLists[byteList]()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := ssz.SliceRoot(lists, listLimit)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkSliceRootProgressive_MaxByteLists(b *testing.B) {
+	reset := features.InitWithReset(&features.Flags{})
+	defer reset()
+	lists := maxByteLists[progressiveByteList]()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := ssz.SliceRootProgressive(lists)
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Hash large lists in parallel and don't use a mutex for feature config reads.

The feature reads happens every single loop in a hash and bottlenecks on large lists. 

Parallelizing alone was a
*regression* — 2.31s to 3.48s on the benchmark below. Also it's not the GC: `GOGC=800` did not change things

```
  41.82s 46.62%  sync/atomic.(*Int32).Add
  20.61s 22.97%  sync.(*RWMutex).RUnlock   (cum)
   1.40s  1.56%  gohashtree._hash
```

Benchmark: a list of 2^20 one-byte byte-lists (`List[List[byte, 2^30], 2^20]`),
Apple M4 Pro, 14 cores, `-benchtime 5x`, identical benchmark run on
both sides:

| | develop | this PR | speedup |
|---|---|---|---|
| `SliceRoot` | 1887 ms | 468 ms | 4.0x |
| `SliceRootProgressive` | 318 ms | 90 ms | 3.5x |

Computing the leaf root dominates, this can be made better with hastree trickery but probably not worth it. 
