### PR TITLE
Release the read lock when no-keys early return for Keymanager `DeletePublicKeys` path

### DIFF
--- a/changelog/syjn99_fix-remote-web3signer-bugs.md
+++ b/changelog/syjn99_fix-remote-web3signer-bugs.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Release the read lock on the no-keys early return in the remote web3signer keymanager's `DeletePublicKeys`, which previously deadlocked all subsequent key updates.

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -880,6 +880,7 @@ func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeySt
 	km.lock.RLock()
 	originalKeysLen := len(km.providedPublicKeys)
 	if originalKeysLen == 0 {
+		km.lock.RUnlock()
 		for i := range deletedRemoteKeysStatuses {
 			deletedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
 				Status:  keymanager.StatusNotFound,

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -744,3 +744,24 @@ func TestKeymanager_DeletePublicKeys_WithFile(t *testing.T) {
 	require.Equal(t, len(keys), 1)
 	require.Equal(t, hexutil.Encode(keys[0][:]), publicKeys[1])
 }
+
+func TestKeymanager_DeletePublicKeys_NoKeysDoesNotLeakReadLock(t *testing.T) {
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(t.Context(), &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+	})
+	require.NoError(t, err)
+
+	publicKeys := []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"}
+	s, err := km.DeletePublicKeys(publicKeys)
+	require.NoError(t, err)
+	for _, status := range s {
+		require.Equal(t, keymanager.StatusNotFound, status.Status)
+	}
+
+	// The early return must not leave a read lock held, or every later writer blocks.
+	require.Equal(t, true, km.lock.TryLock(), "DeletePublicKeys returned holding a read lock")
+	km.lock.Unlock()
+}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Simple bug fix, we omits releasing a read lock in `DeletePublicKeys` for Keymanager API path.

**Which issue(s) does this PR fix?**

N/A, regression test is included.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
