### PR TITLE
Return the decode error from the remote web3signer client's response unmarshalling

### DIFF
--- a/changelog/syjn99_fix-unmarshal-response-web3signer.md
+++ b/changelog/syjn99_fix-unmarshal-response-web3signer.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Return the decode error from the remote web3signer client's response unmarshalling. A shadowed variable made it return `nil` on malformed responses, so `GetPublicKeys` reported zero public keys and no error.

--- a/validator/keymanager/remote-web3signer/internal/client.go
+++ b/validator/keymanager/remote-web3signer/internal/client.go
@@ -191,12 +191,12 @@ func (client *ApiClient) doRequest(ctx context.Context, httpMethod, fullPath str
 // unmarshalResponse is a utility method for unmarshalling responses.
 func unmarshalResponse(responseBody io.ReadCloser, unmarshalledResponseObject any) error {
 	defer closeBody(responseBody)
-	if err := json.NewDecoder(responseBody).Decode(&unmarshalledResponseObject); err != nil {
+	if decodeErr := json.NewDecoder(responseBody).Decode(&unmarshalledResponseObject); decodeErr != nil {
 		body, err := io.ReadAll(responseBody)
 		if err != nil {
-			return errors.Wrap(err, "failed to read response body")
+			return errors.Wrapf(decodeErr, "invalid format, unable to read response body: %v", err)
 		}
-		return errors.Wrap(err, fmt.Sprintf("invalid format, unable to read response body: %v", string(body)))
+		return errors.Wrapf(decodeErr, "invalid format, unable to read response body: %v", string(body))
 	}
 	return nil
 }

--- a/validator/keymanager/remote-web3signer/internal/client_test.go
+++ b/validator/keymanager/remote-web3signer/internal/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -182,4 +183,19 @@ func TestClient_GetServerStatus_HappyPath(t *testing.T) {
 	resp, err := cl.GetServerStatus(t.Context())
 	assert.NotNil(t, resp)
 	assert.Nil(t, err)
+}
+
+func TestClient_GetPublicKeys_MalformedJsonReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{not json`))
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	cl := internal.ApiClient{BaseURL: u, RestClient: srv.Client()}
+	keys, err := cl.GetPublicKeys(t.Context(), srv.URL+"/api/v1/eth2/publicKeys")
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(keys))
 }

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -424,7 +424,6 @@ func TestKeymanager_Sign(t *testing.T) {
 	config := &SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
-		PublicKeysURL:         "http://example2.com/api/v1/eth2/publicKeys",
 	}
 	km, err := NewKeymanager(ctx, config)
 	require.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

In `unmarshalResponse`, `err` is shadowed so `errors.Wrap(err, ...)` at line 199 returns `nil, nil`. It's interesting that this bug also surfaces what `TestKeymanager_Sign` test configuration, as `PublicKeysURL` (example2.com) actually responds with malformed JSON. See the additional comment.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Regression test is included.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
