### PR TITLE
Recover initial sync when head is on a bad fork

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
@@ -22,9 +22,45 @@ import (
 // Blocks are stored in an ascending slot order. The first block is guaranteed to have parent
 // either in DB or initial sync cache.
 type forkData struct {
-	blocksFrom peer.ID
-	blobsFrom  peer.ID
-	bwb        []blocks.BlockWithROSidecars
+	blocksFrom    peer.ID
+	blobsFrom     peer.ID
+	bwb           []blocks.BlockWithROSidecars
+	envelopes     []interfaces.ROSignedExecutionPayloadEnvelope
+	columnsToSave []blocks.VerifiedRODataColumn
+}
+
+func (f *blocksFetcher) forkDataFromBlocks(ctx context.Context, pid peer.ID, bwb []blocks.BlockWithROSidecars) (*forkData, error) {
+	if len(bwb) == 0 {
+		return nil, errors.New("no blocks to build fork data from")
+	}
+	lastSlot := bwb[len(bwb)-1].Block.Block().Slot()
+	start := bwb[0].Block.Block().Slot()
+	if f.db != nil {
+		if parent, err := f.db.Block(ctx, bwb[0].Block.Block().ParentRoot()); err == nil && blocks.BeaconBlockIsNil(parent) == nil {
+			start = parent.Block().Slot() + 1
+		}
+	}
+	r := &fetchRequestResponse{
+		blocksFrom: pid,
+		bwb:        bwb,
+		start:      start,
+		count:      uint64(lastSlot.FlooredSubSlot(start)) + 1,
+	}
+	f.fetchPayloads(ctx, r, []peer.ID{pid})
+	if r.err != nil {
+		return nil, errors.Wrap(r.err, "fetch payloads")
+	}
+	f.fetchSidecars(ctx, r, []peer.ID{pid})
+	if r.err != nil {
+		return nil, errors.Wrap(r.err, "fetch sidecars")
+	}
+	return &forkData{
+		blocksFrom:    pid,
+		blobsFrom:     r.blobsFrom,
+		bwb:           r.bwb,
+		envelopes:     r.envelopes,
+		columnsToSave: r.columnsToSave,
+	}, nil
 }
 
 // nonSkippedSlotAfter checks slots after the given one in an attempt to find a non-empty future slot.
@@ -280,17 +316,9 @@ func (f *blocksFetcher) findForkWithPeer(ctx context.Context, pid peer.ID, slot 
 			return nil, errors.Wrap(err, "invalid blocks received in findForkWithPeer")
 		}
 
-		// We need to fetch the blobs for the given alt-chain if any exist, so that we can try to verify and import
-		// the blocks.
-		r := &fetchRequestResponse{blocksFrom: pid, bwb: bwb}
-		f.fetchSidecars(ctx, r, []peer.ID{pid})
-		if r.err != nil {
-			return nil, errors.Wrap(r.err, "fetch sidecars")
-		}
-
-		// The caller will use the BlocksWith VerifiedBlobs in bwb as the starting point for
+		// The caller will use the completed fork data as the starting point for
 		// round-robin syncing the alternate chain.
-		return &forkData{blocksFrom: pid, blobsFrom: r.blobsFrom, bwb: bwb}, nil
+		return f.forkDataFromBlocks(ctx, pid, bwb)
 	}
 	return nil, errNoAlternateBlocks
 }
@@ -306,16 +334,7 @@ func (f *blocksFetcher) findAncestor(ctx context.Context, pid peer.ID, b interfa
 			if err != nil {
 				return nil, errors.Wrap(err, "received invalid blocks in findAncestor")
 			}
-			r := &fetchRequestResponse{blocksFrom: pid, bwb: bwb}
-			f.fetchSidecars(ctx, r, []peer.ID{pid})
-			if r.err != nil {
-				return nil, errors.Wrap(r.err, "fetch sidecars")
-			}
-			return &forkData{
-				blocksFrom: pid,
-				bwb:        bwb,
-				blobsFrom:  r.blobsFrom,
-			}, nil
+			return f.forkDataFromBlocks(ctx, pid, bwb)
 		}
 		// Request block's parent.
 		req := &p2pTypes.BeaconBlockByRootsReq{parentRoot}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
@@ -35,10 +35,11 @@ func (f *blocksFetcher) forkDataFromBlocks(ctx context.Context, pid peer.ID, bwb
 	}
 	lastSlot := bwb[len(bwb)-1].Block.Block().Slot()
 	start := bwb[0].Block.Block().Slot()
-	if f.db != nil {
-		if parent, err := f.db.Block(ctx, bwb[0].Block.Block().ParentRoot()); err == nil && blocks.BeaconBlockIsNil(parent) == nil {
-			start = parent.Block().Slot() + 1
-		}
+	parentRoot := bwb[0].Block.Block().ParentRoot()
+	if slot, err := f.chain.RecentBlockSlot(parentRoot); err == nil {
+		start = slot + 1
+	} else if parent, err := f.db.Block(ctx, parentRoot); err == nil && blocks.BeaconBlockIsNil(parent) == nil {
+		start = parent.Block().Slot() + 1
 	}
 	r := &fetchRequestResponse{
 		blocksFrom: pid,

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -444,7 +444,7 @@ func (q *blocksQueue) onProcessSkippedEvent(ctx context.Context) eventHandlerFn 
 
 		// All machines are skipped, FSMs need reset.
 		startSlot := q.chain.HeadSlot() + 1
-		if q.mode == modeNonConstrained && startSlot > bestFinalizedSlot {
+		if q.mode == modeStopOnFinalizedEpoch || startSlot > bestFinalizedSlot {
 			q.staleEpochs[slots.ToEpoch(startSlot)]++
 			// If FSMs have been reset enough times, try to explore alternative forks.
 			if q.staleEpochs[slots.ToEpoch(startSlot)] >= maxResetAttempts {

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -1153,6 +1153,9 @@ func TestBlocksQueue_stuckInUnfavourableFork(t *testing.T) {
 		// Add peer that will advertise high non-finalized slot, but will not be able to support
 		// its claims with actual blocks.
 		forkedPeer := connectPeerHavingBlocks(t, p2p, chain2, finalizedSlot, p2p.Peers())
+		defer func() {
+			p2p.Peers().SetConnectionState(forkedPeer, peers.Disconnected)
+		}()
 		startSlot := mc.HeadSlot() + 1
 		blocksPerRequest := queue.blocksFetcher.blocksPerPeriod
 		machineSlots := make([]primitives.Slot, 0)
@@ -1226,6 +1229,100 @@ func TestBlocksQueue_stuckInUnfavourableFork(t *testing.T) {
 			assert.Equal(t, stateSkipped, fsm.state)
 		}
 	})
+
+	t.Run("unfavourable fork below network finalized slot", func(t *testing.T) {
+		defer hook.Reset()
+
+		// The peer's finalized slot is above our head, so the wedged branch sits below network finality.
+		peerFinalizedSlot := primitives.Slot(288)
+		forkedPeer := connectPeerHavingBlocks(t, p2p, chain2, peerFinalizedSlot, p2p.Peers())
+		defer func() {
+			p2p.Peers().SetConnectionState(forkedPeer, peers.Disconnected)
+		}()
+
+		finalizedQueue := newBlocksQueue(ctx, &blocksQueueConfig{
+			blocksFetcher:       fetcher,
+			chain:               mc,
+			highestExpectedSlot: primitives.Slot(len(chain2) - 1),
+			mode:                modeStopOnFinalizedEpoch,
+		})
+
+		startSlot := mc.HeadSlot() + 1
+		blocksPerRequest := finalizedQueue.blocksFetcher.blocksPerPeriod
+		machineSlots := make([]primitives.Slot, 0)
+		for i := startSlot; i < startSlot.Add(blocksPerRequest*lookaheadSteps); i += primitives.Slot(blocksPerRequest) {
+			finalizedQueue.smm.addStateMachine(i).setState(stateSkipped)
+			machineSlots = append(machineSlots, i)
+		}
+
+		// Update counter, and trigger backtracking.
+		finalizedQueue.staleEpochs[slots.ToEpoch(machineSlots[0])] = maxResetAttempts
+		handlerFn := finalizedQueue.onProcessSkippedEvent(ctx)
+		updatedState, err := handlerFn(finalizedQueue.smm.machines[machineSlots[len(machineSlots)-1]], nil)
+		require.NoError(t, err)
+		assert.Equal(t, stateSkipped, updatedState)
+		assert.LogsContain(t, hook, "Searching for alternative blocks")
+		assert.LogsDoNotContain(t, hook, "No alternative blocks found for peer")
+
+		// Alternative fork data must be loaded into the first machine.
+		firstFSM, ok := finalizedQueue.smm.findStateMachine(forkedSlot)
+		require.Equal(t, true, ok)
+		require.Equal(t, stateDataParsed, firstFSM.state)
+		require.Equal(t, forkedPeer, firstFSM.fetched.blocksFrom)
+		require.Equal(t, forkedSlot, firstFSM.fetched.bwb[0].Block.Block().Slot())
+	})
+}
+
+func TestBlocksQueue_resetFromForkCarriesEnvelopes(t *testing.T) {
+	beaconDB := dbtest.SetupDB(t)
+	p2p := p2pt.NewTestP2P(t)
+	chain := extendBlockSequence(t, []*eth.SignedBeaconBlock{}, 2)
+
+	st, err := util.NewBeaconState()
+	require.NoError(t, err)
+	genesisRoot, err := chain[0].Block.HashTreeRoot()
+	require.NoError(t, err)
+	mc := &mock.ChainService{
+		State:               st,
+		Root:                genesisRoot[:],
+		DB:                  beaconDB,
+		FinalizedCheckPoint: &eth.Checkpoint{},
+		Genesis:             time.Now(),
+		ValidatorsRoot:      [32]byte{},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	fetcher := newBlocksFetcher(ctx, &blocksFetcherConfig{
+		chain: mc,
+		p2p:   p2p,
+		db:    beaconDB,
+		clock: startup.NewClock(mc.Genesis, mc.ValidatorsRoot),
+	})
+	queue := newBlocksQueue(ctx, &blocksQueueConfig{
+		blocksFetcher:       fetcher,
+		chain:               mc,
+		highestExpectedSlot: 100,
+		mode:                modeNonConstrained,
+	})
+
+	wsb, err := blocks.NewSignedBeaconBlock(chain[1])
+	require.NoError(t, err)
+	ro, err := blocks.NewROBlock(wsb)
+	require.NoError(t, err)
+	env := makeEnvelope(t, ro.Block().Slot(), [32]byte{1}, [32]byte{2})
+
+	fork := &forkData{
+		blocksFrom: "peerA",
+		bwb:        []blocks.BlockWithROSidecars{{Block: ro}},
+		envelopes:  []interfaces.ROSignedExecutionPayloadEnvelope{env},
+	}
+	require.NoError(t, queue.resetFromFork(fork))
+	fsm, ok := queue.smm.findStateMachine(ro.Block().Slot())
+	require.Equal(t, true, ok)
+	require.Equal(t, stateDataParsed, fsm.state)
+	require.Equal(t, 1, len(fsm.fetched.envelopes))
+	require.Equal(t, fork.blocksFrom, fsm.fetched.blocksFrom)
 }
 
 func TestBlocksQueue_stuckWhenHeadIsSetToOrphanedBlock(t *testing.T) {

--- a/beacon-chain/sync/initial-sync/blocks_queue_utils.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_utils.go
@@ -25,6 +25,8 @@ func (q *blocksQueue) resetFromFork(fork *forkData) error {
 	}
 	fsm := q.smm.addStateMachine(firstBlock.Slot())
 	fsm.fetched.bwb = fork.bwb
+	fsm.fetched.envelopes = fork.envelopes
+	fsm.fetched.columnsToSave = fork.columnsToSave
 	fsm.fetched.blocksFrom, fsm.fetched.blobsFrom = fork.blocksFrom, fork.blobsFrom
 	fsm.state = stateDataParsed
 

--- a/changelog/terence_initial-sync-fork-recovery.md
+++ b/changelog/terence_initial-sync-fork-recovery.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Recover initial sync when the head is on a bad fork by exploring alternative branches below the network finalized slot and fetching payload envelopes for the recovered branch.


### PR DESCRIPTION
A node whose head is on a bad fork below the finalized slot can never find the correct branch, initial sync would refetch the same blocks using head + 1 repeatedly.

- Allow `findFork` in `modeStopOnFinalizedEpoch`
- Fetch payload envelopes and data columns for the recovered branch so it is processable post gloas
- Carry envelopes through `resetFromFork`