### PR TITLE
Validate block roots in BeaconBlocksByRoot to reject unsolicited resp…

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/sync/verify"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
-	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
@@ -33,19 +32,10 @@ func (s *Service) sendBeaconBlocksRequest(ctx context.Context, requests *types.B
 	ctx, cancel := context.WithTimeout(ctx, respTimeout)
 	defer cancel()
 
-	requestedRoots := make(map[[fieldparams.RootLength]byte]bool)
-	for _, root := range *requests {
-		requestedRoots[root] = true
-	}
-
 	blks, err := SendBeaconBlocksByRootRequest(ctx, s.cfg.clock, s.cfg.p2p, id, requests, func(blk interfaces.ReadOnlySignedBeaconBlock) error {
 		blkRoot, err := blk.Block().HashTreeRoot()
 		if err != nil {
 			return err
-		}
-
-		if ok := requestedRoots[blkRoot]; !ok {
-			return fmt.Errorf("received unexpected block with root %x", blkRoot)
 		}
 
 		// Verify the signature before queueing, matching the gossip path, since a matched root does not cover it.

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -331,7 +331,7 @@ func TestRecentBeaconBlocks_RPCRequestSent_IncorrectRoot(t *testing.T) {
 	})
 
 	p1.Connect(p2)
-	require.ErrorContains(t, "received unexpected block with root", r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
+	require.ErrorContains(t, "received unrequested block with root", r.sendBeaconBlocksRequest(t.Context(), &expectedRoots, p2.PeerID()))
 }
 
 func TestRecentBeaconBlocks_RPCRequestSent_InvalidSignature(t *testing.T) {

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -199,6 +199,12 @@ func SendBeaconBlocksByRootRequest(
 	}
 	defer closeStream(stream, log)
 
+	// Build a set of requested roots so each response block can be validated.
+	requestedRoots := make(map[[32]byte]bool, len(*req))
+	for _, root := range *req {
+		requestedRoots[root] = true
+	}
+
 	// Augment block processing function, if non-nil block processor is provided.
 	blocks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(*req))
 	process := func(block interfaces.ReadOnlySignedBeaconBlock) error {
@@ -221,6 +227,14 @@ func SendBeaconBlocksByRootRequest(
 		}
 		if err != nil {
 			return nil, err
+		}
+
+		blkRoot, err := blk.Block().HashTreeRoot()
+		if err != nil {
+			return nil, err
+		}
+		if !requestedRoots[blkRoot] {
+			return nil, errors.Wrapf(ErrInvalidFetchedData, "received unrequested block with root %#x", blkRoot)
 		}
 
 		if err := process(blk); err != nil {

--- a/beacon-chain/sync/rpc_send_request_test.go
+++ b/beacon-chain/sync/rpc_send_request_test.go
@@ -485,6 +485,71 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 	})
 }
 
+func TestSendBeaconBlocksByRoot_RootValidation(t *testing.T) {
+	pcl := fmt.Sprintf("%s/ssz_snappy", p2p.RPCBlocksByRootTopicV1)
+
+	blkA := util.NewBeaconBlock()
+	blkA.Block.Slot = 1
+	rootA, err := blkA.Block.HashTreeRoot()
+	require.NoError(t, err)
+
+	blkB := util.NewBeaconBlock()
+	blkB.Block.Slot = 99
+	rootB, err := blkB.Block.HashTreeRoot()
+	require.NoError(t, err)
+	require.NotEqual(t, rootA, rootB)
+
+	cases := []struct {
+		name       string
+		requested  p2ptypes.BeaconBlockByRootsReq
+		sendBlock  *ethpb.SignedBeaconBlock
+		wantErr    error
+		wantBlocks int
+	}{
+		{
+			name:       "correct root returned",
+			requested:  p2ptypes.BeaconBlockByRootsReq{rootA},
+			sendBlock:  blkA,
+			wantBlocks: 1,
+		},
+		{
+			name:       "wrong root returned",
+			requested:  p2ptypes.BeaconBlockByRootsReq{rootA},
+			sendBlock:  blkB,
+			wantErr:    ErrInvalidFetchedData,
+			wantBlocks: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			p1 := p2ptest.NewTestP2P(t)
+			p2 := p2ptest.NewTestP2P(t)
+			p1.Connect(p2)
+
+			p2.SetStreamHandler(pcl, func(stream network.Stream) {
+				defer func() { assert.NoError(t, stream.Close()) }()
+				req := new(p2ptypes.BeaconBlockByRootsReq)
+				assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+				_, err := stream.Write([]byte{0x00})
+				assert.NoError(t, err)
+				_, err = p2.Encoding().EncodeWithMaxLength(stream, c.sendBlock)
+				assert.NoError(t, err)
+			})
+
+			got, err := SendBeaconBlocksByRootRequest(ctx, startup.NewClock(time.Now(), [32]byte{}), p1, p2.PeerID(), &c.requested, nil)
+			if c.wantErr != nil {
+				require.ErrorIs(t, err, c.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, c.wantBlocks, len(got))
+		})
+	}
+}
+
 func TestBlobValidatorFromRootReq(t *testing.T) {
 	rootA := bytesutil.PadTo([]byte("valid"), 32)
 	rootB := bytesutil.PadTo([]byte("invalid"), 32)


### PR DESCRIPTION
---
**What type of PR is this?**

>Bug fix


**What does this PR do? Why is it needed?**

SendBeaconBlocksByRootRequest accepted any block returned by a peer without checking whether its root was actually requested. This meant a malicious or misbehaving peer could send back arbitrary blocks and the node would silently accept them.

Additionally, the existing root check in the sendBeaconBlocksRequest callback used fmt.Errorf instead of errors.Wrapf(ErrInvalidFetchedData, ...), so even when a wrong root was detected, the peer bad-response scorer was never incremented, the peer faced no penalty.

This PR fixes both issues:
- Validates each response block's HashTreeRoot() against the requested roots set inside SendBeaconBlocksByRootRequest, returning ErrInvalidFetchedData on mismatch to trigger peer downscoring
- Removes the now-unreachable duplicate root check in the sendBeaconBlocksRequest callback and its unused fieldparams import
- Adds a table-driven test TestSendBeaconBlocksByRoot_RootValidation covering both the happy path and the wrong-root rejection

**Which issue(s) does this PR fix?**

Fixes #17280

**Other notes for review**

The root validation is placed in SendBeaconBlocksByRootRequest rather than in the caller callback, so all callers benefit from the check automatically.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
