### PR TITLE
Implement key sets for Web3Signer public keys

### DIFF
--- a/changelog/syjn99_web3signer-keyset-sources.md
+++ b/changelog/syjn99_web3signer-keyset-sources.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Web3Signer public keys are now tracked per source (flag, public-keys URL, key file) with the validating set as their union, so one source can no longer overwrite another's keys.
+- `POST /eth/v1/remotekeys` returns `error` instead of `imported` when `--validators-external-signer-key-file` is not set, since the keys would not be persisted.
+- `DELETE /eth/v1/remotekeys` returns `error` naming the owning source for keys provided by the flag or the public-keys URL, and `not_found` for unknown keys.
+- `--validators-external-signer-key-file` no longer has the flag and URL keys written into it at startup. Those keys still validate, they are just owned by their own source instead of being adopted by the file across a restart.
+- `--validators-external-signer-poll-interval` is no longer ignored when a key file is configured. A poll now only replaces the URL's own keys, so it can run alongside the key file watcher.

--- a/changelog/syjn99_web3signer-keyset-sources.md
+++ b/changelog/syjn99_web3signer-keyset-sources.md
@@ -3,6 +3,6 @@
 - Web3Signer public keys are now tracked per source (flag, public-keys URL, key file) with the validating set as their union, so one source can no longer overwrite another's keys.
 - `GET /eth/v1/remotekeys` marks keys owned by the key file as deletable instead of read-only.
 - `POST /eth/v1/remotekeys` returns `error` instead of `imported` when `--validators-external-signer-key-file` is not set, since the keys would not be persisted.
-- `DELETE /eth/v1/remotekeys` returns `error` naming the owning source for keys provided by the flag or the public-keys URL, and `not_found` for unknown keys.
+- `DELETE /eth/v1/remotekeys` removes matching key-file entries even when the key is still provided by the flag or public-keys URL, and returns `error` explaining that the key continues validating through that source. Existing deployments should remove stale flag or URL keys copied into their key file by earlier versions.
 - `--validators-external-signer-key-file` no longer has the flag and URL keys written into it at startup. Those keys still validate, they are just owned by their own source instead of being adopted by the file across a restart.
 - `--validators-external-signer-poll-interval` is no longer ignored when a key file is configured. A poll now only replaces the URL's own keys, so it can run alongside the key file watcher.

--- a/changelog/syjn99_web3signer-keyset-sources.md
+++ b/changelog/syjn99_web3signer-keyset-sources.md
@@ -1,6 +1,7 @@
 ### Changed
 
 - Web3Signer public keys are now tracked per source (flag, public-keys URL, key file) with the validating set as their union, so one source can no longer overwrite another's keys.
+- `GET /eth/v1/remotekeys` marks keys owned by the key file as deletable instead of read-only.
 - `POST /eth/v1/remotekeys` returns `error` instead of `imported` when `--validators-external-signer-key-file` is not set, since the keys would not be persisted.
 - `DELETE /eth/v1/remotekeys` returns `error` naming the owning source for keys provided by the flag or the public-keys URL, and `not_found` for unknown keys.
 - `--validators-external-signer-key-file` no longer has the flag and URL keys written into it at startup. Those keys still validate, they are just owned by their own source instead of being adopted by the file across a restart.

--- a/validator/keymanager/remote-web3signer/BUILD.bazel
+++ b/validator/keymanager/remote-web3signer/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "helper.go",
         "key_source_file.go",
         "key_source_url.go",
         "keymanager.go",
@@ -43,6 +44,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "helper_test.go",
         "key_source_file_test.go",
         "key_source_url_test.go",
         "keymanager_test.go",

--- a/validator/keymanager/remote-web3signer/BUILD.bazel
+++ b/validator/keymanager/remote-web3signer/BUILD.bazel
@@ -55,7 +55,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//async/event:go_default_library",
-        "//config/fieldparams:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//io/file:go_default_library",

--- a/validator/keymanager/remote-web3signer/BUILD.bazel
+++ b/validator/keymanager/remote-web3signer/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "helper.go",
+        "key_sets.go",
         "key_source_file.go",
         "key_source_url.go",
         "keymanager.go",
@@ -19,6 +20,7 @@ go_library(
     deps = [
         "//api:go_default_library",
         "//async/event:go_default_library",
+        "//cmd/validator/flags:go_default_library",
         "//config/fieldparams:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
@@ -45,6 +47,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "helper_test.go",
+        "key_sets_test.go",
         "key_source_file_test.go",
         "key_source_url_test.go",
         "keymanager_test.go",

--- a/validator/keymanager/remote-web3signer/README.md
+++ b/validator/keymanager/remote-web3signer/README.md
@@ -23,6 +23,24 @@ with hex keys
 with url
 - `--validators-external-signer-public-keys=https://web3signer.com/api/v1/eth2/publicKeys`
 
+### Key sources
+
+Public keys are tracked per source and the validating set is their union. Every key has
+exactly one owner, and a source only ever replaces its own set:
+
+- `--validators-external-signer-public-keys` (flag): fixed at startup.
+- `--validators-external-signer-url` public keys endpoint: replaced whole on every poll.
+- `--validators-external-signer-key-file`: written by the operator and by the keymanager API.
+
+Because a source only replaces its own set, `--validators-external-signer-poll-interval` works
+whether or not a key file is configured: a poll swaps the URL's keys and leaves the flag and
+file keys alone.
+
+The keymanager API therefore only mutates the key file source. `POST /eth/v1/remotekeys`
+needs a key file, otherwise there is no permanent storage to import into and it reports
+`error`. `DELETE /eth/v1/remotekeys` reports `error` for keys owned by the flag or the URL,
+because they would come straight back on the next reload.
+
 ### API
 
 - Get Public keys: returns all public keys currently stored with web3signer excluding newly added keys if reload keys

--- a/validator/keymanager/remote-web3signer/helper.go
+++ b/validator/keymanager/remote-web3signer/helper.go
@@ -1,0 +1,32 @@
+package remote_web3signer
+
+import (
+	"fmt"
+
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+)
+
+// pubkey is a BLS public key in its raw form.
+type pubkey = [fieldparams.BLSPubkeyLength]byte
+
+// decodePublicKeys decodes and dedups hex-encoded BLS public keys.
+func decodePublicKeys(raw []string) ([]pubkey, error) {
+	var (
+		seen = make(map[pubkey]struct{}, len(raw))
+		keys = make([]pubkey, 0, len(raw))
+	)
+
+	for _, k := range raw {
+		b, err := bytesutil.DecodeHex48(k)
+		if err != nil {
+			return nil, fmt.Errorf("decode public key %s: %w", k, err)
+		}
+		if _, ok := seen[b]; ok {
+			continue
+		}
+		seen[b] = struct{}{}
+		keys = append(keys, b)
+	}
+	return keys, nil
+}

--- a/validator/keymanager/remote-web3signer/helper.go
+++ b/validator/keymanager/remote-web3signer/helper.go
@@ -1,7 +1,10 @@
 package remote_web3signer
 
 import (
+	"bytes"
 	"fmt"
+	"maps"
+	"slices"
 
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -9,6 +12,13 @@ import (
 
 // pubkey is a BLS public key in its raw form.
 type pubkey = [fieldparams.BLSPubkeyLength]byte
+
+// sortedKeys returns the keys of set in ascending byte order.
+func sortedKeys(set map[pubkey]struct{}) []pubkey {
+	return slices.SortedFunc(maps.Keys(set), func(a, b pubkey) int {
+		return bytes.Compare(a[:], b[:])
+	})
+}
 
 // decodePublicKeys decodes and dedups hex-encoded BLS public keys.
 func decodePublicKeys(raw []string) ([]pubkey, error) {

--- a/validator/keymanager/remote-web3signer/helper_test.go
+++ b/validator/keymanager/remote-web3signer/helper_test.go
@@ -1,0 +1,33 @@
+package remote_web3signer
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func TestDecodePublicKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		wantLen int
+		wantErr string
+	}{
+		{name: "empty input", input: nil, wantLen: 0},
+		{name: "single key", input: []string{testKeyA}, wantLen: 1},
+		{name: "dedupes repeated keys", input: []string{testKeyA, testKeyA, testKeyB}, wantLen: 2},
+		{name: "invalid hex", input: []string{"not-hex"}, wantErr: "decode public key"},
+		{name: "wrong length", input: []string{"0x1234"}, wantErr: "decode public key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodePublicKeys(tt.input)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, tt.wantErr, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantLen, len(got))
+		})
+	}
+}

--- a/validator/keymanager/remote-web3signer/helper_test.go
+++ b/validator/keymanager/remote-web3signer/helper_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
 
+func TestSortedKeys(t *testing.T) {
+	// Differs from keyA only in a later byte, so the tie is broken past the first one.
+	keyA2 := pubkey{1, 9}
+
+	t.Run("empty set", func(t *testing.T) {
+		require.Equal(t, 0, len(sortedKeys(nil)))
+	})
+
+	t.Run("ascending byte order", func(t *testing.T) {
+		set := map[pubkey]struct{}{keyC: {}, keyA2: {}, keyB: {}, keyA: {}}
+		require.DeepEqual(t, []pubkey{keyA, keyA2, keyB, keyC}, sortedKeys(set))
+	})
+
+	t.Run("stable across calls", func(t *testing.T) {
+		set := map[pubkey]struct{}{keyA: {}, keyB: {}, keyC: {}, keyA2: {}}
+		want := sortedKeys(set)
+		for range 20 {
+			require.DeepEqual(t, want, sortedKeys(set))
+		}
+	})
+}
+
 func TestDecodePublicKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/validator/keymanager/remote-web3signer/key_sets.go
+++ b/validator/keymanager/remote-web3signer/key_sets.go
@@ -2,7 +2,6 @@ package remote_web3signer
 
 import (
 	"maps"
-	"slices"
 	"sync"
 
 	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
@@ -65,7 +64,7 @@ func (k *keySets) replace(src keySource, keys []pubkey) (bool, []pubkey) {
 	}
 
 	k.union = union
-	return true, slices.Collect(maps.Keys(union))
+	return true, sortedKeys(union)
 }
 
 // get returns a copy of src's set. The copy is safe for the caller to mutate.
@@ -81,11 +80,12 @@ func (k *keySets) get(src keySource) map[pubkey]struct{} {
 }
 
 // all returns a copy of the union of every source's set.
+// Returned keys are sorted for deterministic output.
 func (k *keySets) all() []pubkey {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
-	return slices.Collect(maps.Keys(k.union))
+	return sortedKeys(k.union)
 }
 
 // owner returns the source owning key. A key present in several sets is owned by the

--- a/validator/keymanager/remote-web3signer/key_sets.go
+++ b/validator/keymanager/remote-web3signer/key_sets.go
@@ -1,0 +1,105 @@
+package remote_web3signer
+
+import (
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
+)
+
+type (
+	// keySource identifies the channel a public key came from.
+	// Every key has exactly one owner and a source may only replace its own set.
+	keySource uint8
+)
+
+const (
+	sourceFlag keySource = iota // command line; fixed at startup
+	sourceURL                   // public-keys URL; replaced whole on every poll
+	sourceFile                  // key file; written by the operator and the keymanager API
+	numKeySources
+)
+
+func (s keySource) String() string {
+	switch s {
+	case sourceFlag:
+		return "the --" + flags.Web3SignerPublicValidatorKeysFlag.Name + " flag"
+	case sourceURL:
+		return "the remote signer public keys URL"
+	case sourceFile:
+		return "the --" + flags.Web3SignerKeyFileFlag.Name + " file"
+	default:
+		return "an unknown source"
+	}
+}
+
+// keySets holds one key set per source. The validating set is their union.
+type keySets struct {
+	mu    sync.RWMutex
+	sets  [numKeySources]map[pubkey]struct{}
+	union map[pubkey]struct{}
+}
+
+// replace swaps src's set for keys and reports whether the union changed, along with
+// the new union.
+func (k *keySets) replace(src keySource, keys []pubkey) (bool, []pubkey) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	// Build a new set for src, and replace the old one.
+	set := make(map[pubkey]struct{}, len(keys))
+	for _, key := range keys {
+		set[key] = struct{}{}
+	}
+	k.sets[src] = set
+
+	// Rebuild the union of all sets.
+	union := make(map[pubkey]struct{}, len(k.union))
+	for _, s := range k.sets {
+		maps.Copy(union, s)
+	}
+
+	if maps.Equal(union, k.union) {
+		return false, nil
+	}
+
+	k.union = union
+	return true, slices.Collect(maps.Keys(union))
+}
+
+// get returns a copy of src's set. The copy is safe for the caller to mutate.
+func (k *keySets) get(src keySource) map[pubkey]struct{} {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	oldSet := k.sets[src]
+	set := make(map[pubkey]struct{}, len(oldSet))
+	maps.Copy(set, oldSet)
+
+	return set
+}
+
+// all returns a copy of the union of every source's set.
+func (k *keySets) all() []pubkey {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	return slices.Collect(maps.Keys(k.union))
+}
+
+// owner returns the source owning key. A key present in several sets is owned by the
+// first source in declaration order
+// - 1. flag, then 2. URL, then 3. file.
+func (k *keySets) owner(key pubkey) (keySource, bool) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	for src, set := range k.sets {
+		if _, ok := set[key]; ok {
+			return keySource(src), true
+		}
+	}
+
+	return 0, false
+}

--- a/validator/keymanager/remote-web3signer/key_sets_test.go
+++ b/validator/keymanager/remote-web3signer/key_sets_test.go
@@ -141,3 +141,11 @@ func TestKeySets_ReadersGetCopies(t *testing.T) {
 		require.DeepEqual(t, []pubkey{keyA}, k.all())
 	})
 }
+
+func TestKeySets_AllReturnsSortedKeys(t *testing.T) {
+	var k keySets
+	_, _ = k.replace(sourceFile, []pubkey{keyB, keyA, keyC})
+
+	all := k.all()
+	require.DeepEqual(t, []pubkey{keyA, keyB, keyC}, all)
+}

--- a/validator/keymanager/remote-web3signer/key_sets_test.go
+++ b/validator/keymanager/remote-web3signer/key_sets_test.go
@@ -1,0 +1,143 @@
+package remote_web3signer
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+var (
+	keyA = pubkey{1}
+	keyB = pubkey{2}
+	keyC = pubkey{3}
+)
+
+func TestKeySets_Replace(t *testing.T) {
+	t.Run("a source only replaces its own set", func(t *testing.T) {
+		var k keySets
+
+		changed, union := k.replace(sourceFlag, []pubkey{keyA})
+		require.Equal(t, true, changed)
+		require.Equal(t, 1, len(union))
+
+		// The file source replacing its whole set must not drop the flag key.
+		changed, union = k.replace(sourceFile, []pubkey{keyB})
+		require.Equal(t, true, changed)
+		require.Equal(t, 2, len(union))
+		require.Equal(t, true, slices.Contains(union, keyA))
+
+		// Clearing the file source falls back to the flag key.
+		changed, union = k.replace(sourceFile, nil)
+		require.Equal(t, true, changed)
+		require.DeepEqual(t, []pubkey{keyA}, union)
+	})
+
+	t.Run("the union reports a change only when it really changed", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			keys        []pubkey
+			src         keySource
+			wantChanged bool
+		}{
+			{name: "same set", src: sourceURL, keys: []pubkey{keyA, keyB}, wantChanged: false},
+			{name: "same set reordered", src: sourceURL, keys: []pubkey{keyB, keyA}, wantChanged: false},
+			{name: "same set with duplicates", src: sourceURL, keys: []pubkey{keyA, keyA, keyB}, wantChanged: false},
+			{name: "key already in the union owned elsewhere", src: sourceFile, keys: []pubkey{keyA}, wantChanged: false},
+			{name: "added key", src: sourceFile, keys: []pubkey{keyC}, wantChanged: true},
+			{name: "removed key", src: sourceURL, keys: []pubkey{keyA}, wantChanged: true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var k keySets
+				_, _ = k.replace(sourceURL, []pubkey{keyA, keyB})
+
+				changed, union := k.replace(tt.src, tt.keys)
+				require.Equal(t, tt.wantChanged, changed)
+				if !tt.wantChanged {
+					require.Equal(t, 0, len(union))
+				}
+			})
+		}
+	})
+}
+
+func TestKeySets_Owner(t *testing.T) {
+	t.Run("precedence is flag, then URL, then file", func(t *testing.T) {
+		var k keySets
+		_, _ = k.replace(sourceFlag, []pubkey{keyA})
+		_, _ = k.replace(sourceURL, []pubkey{keyB})
+		// keyA is also persisted in the file, but the flag still owns it.
+		_, _ = k.replace(sourceFile, []pubkey{keyA, keyC})
+
+		tests := []struct {
+			name  string
+			key   pubkey
+			want  keySource
+			found bool
+		}{
+			{name: "flag owned", key: keyA, want: sourceFlag, found: true},
+			{name: "url owned", key: keyB, want: sourceURL, found: true},
+			{name: "file owned", key: keyC, want: sourceFile, found: true},
+			{name: "unknown", key: pubkey{9}, found: false},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				src, ok := k.owner(tt.key)
+				require.Equal(t, tt.found, ok)
+				if tt.found {
+					require.Equal(t, tt.want, src)
+				}
+			})
+		}
+	})
+
+	t.Run("ownership transfers when the owner drops the key", func(t *testing.T) {
+		var k keySets
+		// The same key is held by all three sources at once.
+		_, _ = k.replace(sourceFlag, []pubkey{keyA})
+		_, _ = k.replace(sourceURL, []pubkey{keyA})
+		_, _ = k.replace(sourceFile, []pubkey{keyA})
+
+		src, ok := k.owner(keyA)
+		require.Equal(t, true, ok)
+		require.Equal(t, sourceFlag, src)
+
+		// Ownership falls to the next source in precedence order, and the key keeps validating.
+		_, _ = k.replace(sourceFlag, nil)
+		src, _ = k.owner(keyA)
+		require.Equal(t, sourceURL, src)
+
+		_, _ = k.replace(sourceURL, nil)
+		src, _ = k.owner(keyA)
+		require.Equal(t, sourceFile, src)
+		require.DeepEqual(t, []pubkey{keyA}, k.all())
+
+		// Once the last holder drops it the key is gone.
+		changed, union := k.replace(sourceFile, nil)
+		require.Equal(t, true, changed)
+		require.Equal(t, 0, len(union))
+		_, ok = k.owner(keyA)
+		require.Equal(t, false, ok)
+	})
+}
+
+func TestKeySets_ReadersGetCopies(t *testing.T) {
+	var k keySets
+	_, _ = k.replace(sourceFile, []pubkey{keyA})
+
+	t.Run("get", func(t *testing.T) {
+		set := k.get(sourceFile)
+		set[keyB] = struct{}{}
+		delete(set, keyA)
+
+		require.DeepEqual(t, map[pubkey]struct{}{keyA: {}}, k.get(sourceFile))
+	})
+
+	t.Run("all", func(t *testing.T) {
+		all := k.all()
+		all[0] = keyC
+
+		require.DeepEqual(t, []pubkey{keyA}, k.all())
+	})
+}

--- a/validator/keymanager/remote-web3signer/key_source_file.go
+++ b/validator/keymanager/remote-web3signer/key_source_file.go
@@ -125,6 +125,19 @@ func (km *Keymanager) readKeyFile() ([]pubkey, error) {
 	return keys, nil
 }
 
+// keyFileDirWritable reports whether the key file's directory accepts the temporary file
+// that file saving function needs to replace the key file atomically.
+func keyFileDirWritable(keyFilePath string) error {
+	f, err := os.CreateTemp(filepath.Dir(keyFilePath), "."+filepath.Base(keyFilePath)+".probe-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file in remote signer key file directory: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temporary file in remote signer key file directory: %w", err)
+	}
+	return os.Remove(f.Name())
+}
+
 // savePublicKeysToFile writes keys to the key file and makes them the file source's set.
 // The caller must hold updateLock.
 func (km *Keymanager) savePublicKeysToFile(keys []pubkey) error {

--- a/validator/keymanager/remote-web3signer/key_source_file.go
+++ b/validator/keymanager/remote-web3signer/key_source_file.go
@@ -136,9 +136,13 @@ func (km *Keymanager) savePublicKeysToFile(keys []pubkey) error {
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
+	for _, key := range keys {
+		if _, err := f.WriteString(hexutil.Encode(key[:]) + "\n"); err != nil {
+			return fmt.Errorf("error writing key %#x to file: %w", key, err)
+		}
+	}
 	// The keymanager API reports these keys as stored permanently, so flush and close before
 	// claiming so rather than discovering a write error after the response has gone out.
-	err = writePublicKeys(f, keys)
 	if syncErr := f.Sync(); err == nil {
 		err = syncErr
 	}
@@ -216,18 +220,4 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 			return nil
 		}
 	}
-}
-
-func writePublicKeys(f *os.File, keys []pubkey) error {
-	written := make(map[pubkey]struct{}, len(keys))
-	for _, key := range keys {
-		if _, ok := written[key]; ok {
-			continue
-		}
-		written[key] = struct{}{}
-		if _, err := f.WriteString(hexutil.Encode(key[:]) + "\n"); err != nil {
-			return fmt.Errorf("error writing key %#x to file: %w", key, err)
-		}
-	}
-	return nil
 }

--- a/validator/keymanager/remote-web3signer/key_source_file.go
+++ b/validator/keymanager/remote-web3signer/key_source_file.go
@@ -4,10 +4,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -42,7 +40,10 @@ func (km *Keymanager) refreshRemoteKeysFromFileChangesWithRetry(ctx context.Cont
 		if !initialized {
 			return err
 		}
-		km.updatePublicKeys(slices.Collect(maps.Values(km.flagLoadedKeysMap))) // update the keys to flag provided defaults
+
+		// drop the all file keys, the union falls back to the flag and URL keys
+		km.replaceKeys(sourceFile, nil)
+
 		km.retriesRemaining--
 		log.WithError(err).Debug("Error occurred on key refresh")
 		log.WithFields(logrus.Fields{"path": km.keyFilePath, "retriesRemaining": km.retriesRemaining, "retryDelay": retryDelay}).Warnf("Could not refresh keys. Retrying...")
@@ -54,16 +55,31 @@ func (km *Keymanager) refreshRemoteKeysFromFileChangesWithRetry(ctx context.Cont
 	}
 }
 
-func (km *Keymanager) readKeyFile() ([][48]byte, map[string][48]byte, error) {
-	km.lock.RLock()
-	defer km.lock.RUnlock()
+// reloadKeyFile re-reads the key file and makes its contents the file source's set.
+// updateLock covers the read and the replace together, so a keymanager API write cannot
+// interleave and leave the file source holding a truncated or stale set.
+func (km *Keymanager) reloadKeyFile() error {
+	km.updateLock.Lock()
+	defer km.updateLock.Unlock()
 
+	fileKeys, err := km.readKeyFile()
+	if err != nil {
+		return fmt.Errorf("read key file: %w", err)
+	}
+	if len(fileKeys) == 0 {
+		log.Warnln("Remote signer key file no longer has keys, defaulting to flag provided keys")
+	}
+	km.replaceKeysLocked(sourceFile, fileKeys)
+	return nil
+}
+
+func (km *Keymanager) readKeyFile() ([]pubkey, error) {
 	if km.keyFilePath == "" {
-		return nil, nil, errors.New("no key file path provided")
+		return nil, errors.New("no key file path provided")
 	}
 	f, err := os.Open(filepath.Clean(km.keyFilePath))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not open remote signer public key file")
+		return nil, errors.Wrap(err, "could not open remote signer public key file")
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -71,9 +87,9 @@ func (km *Keymanager) readKeyFile() ([][48]byte, map[string][48]byte, error) {
 		}
 	}()
 	// Use a map to track and skip duplicate lines
-	seenKeys := make(map[string][48]byte)
+	seenKeys := make(map[string]struct{})
 	scanner := bufio.NewScanner(f)
-	var keys [][48]byte
+	var keys []pubkey
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		pubkeyLength := (fieldparams.BLSPubkeyLength * 2) + 2
@@ -94,50 +110,49 @@ func (km *Keymanager) readKeyFile() ([][48]byte, map[string][48]byte, error) {
 		}
 		if _, found := seenKeys[line]; !found {
 			// If it's a new line, mark it as seen and process it
-			pubkey, err := hexutil.Decode(line)
+			key, err := bytesutil.DecodeHex48(line)
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "could not decode public key %s in remote signer key file", line)
+				return nil, errors.Wrapf(err, "could not decode public key %s in remote signer key file", line)
 			}
-			bPubkey := bytesutil.ToBytes48(pubkey)
-			seenKeys[line] = bPubkey
-			keys = append(keys, bPubkey)
+			seenKeys[line] = struct{}{}
+			keys = append(keys, key)
 		}
 	}
 	// Check for scanning errors
 	if err := scanner.Err(); err != nil {
-		return nil, nil, errors.Wrap(err, "could not scan remote signer public key file")
+		return nil, errors.Wrap(err, "could not scan remote signer public key file")
 	}
 	if len(keys) == 0 {
 		log.Warn("Remote signer key file: no valid public keys found. Defaulting to flag provided keys if any exist.")
 	}
-	return keys, seenKeys, nil
+	return keys, nil
 }
 
-func (km *Keymanager) savePublicKeysToFile(providedPublicKeys map[string][48]byte) error {
+// savePublicKeysToFile writes keys to the key file and makes them the file source's set.
+// The caller must hold updateLock so the watcher cannot read a half-written file.
+func (km *Keymanager) savePublicKeysToFile(keys []pubkey) error {
 	if km.keyFilePath == "" {
 		return errors.New("no key file provided")
 	}
-	pubkeys := make([][48]byte, 0)
 	// Open the file with write and truncate permissions
 	f, err := os.OpenFile(km.keyFilePath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
-	defer func(f *os.File) {
-		err := f.Close()
-		if err != nil {
-			log.WithError(err).Error("Could not close file, proceeding without closing the file")
-		}
-	}(f)
-
-	// Iterate through all lines in the slice and write them to the file
-	for key, value := range providedPublicKeys {
-		if _, err := f.WriteString(key + "\n"); err != nil {
-			return fmt.Errorf("error writing key %s to file: %w", value, err)
-		}
-		pubkeys = append(pubkeys, value)
+	// The keymanager API reports these keys as stored permanently, so flush and close before
+	// claiming so rather than discovering a write error after the response has gone out.
+	err = writePublicKeys(f, keys)
+	if syncErr := f.Sync(); err == nil {
+		err = syncErr
 	}
-	km.updatePublicKeys(pubkeys)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("write remote signer key file: %w", err)
+	}
+
+	km.replaceKeysLocked(sourceFile, keys)
 	return nil
 }
 
@@ -164,15 +179,9 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 	// Reload keys on every watcher (re)initialization: a failed refresh resets the
 	// in-memory keys to flag-provided defaults, so a recovery must restore the
 	// file-loaded set even when the flag-provided keys are not empty.
-	fileKeys, _, err := km.readKeyFile()
-	if err != nil {
-		return errors.Wrap(err, "could not read key file")
+	if err := km.reloadKeyFile(); err != nil {
+		return fmt.Errorf("reload key file: %w", err)
 	}
-	if len(fileKeys) == 0 {
-		log.Warnln("Remote signer key file no longer has keys, defaulting to flag provided keys")
-		fileKeys = slices.Collect(maps.Values(km.flagLoadedKeysMap))
-	}
-	km.updatePublicKeys(fileKeys)
 	markReady(nil)
 	for {
 		select {
@@ -194,16 +203,9 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 			}
 			if currentFileInfo.Size() != initialFileSize {
 				log.Info("Remote signer key file updated")
-				fileKeys, _, err := km.readKeyFile()
-				if err != nil {
-					return errors.New("could not read key file")
+				if err := km.reloadKeyFile(); err != nil {
+					return fmt.Errorf("reload key file: %w", err)
 				}
-				// prioritize file keys over flag keys
-				if len(fileKeys) == 0 {
-					log.Warnln("Remote signer key file no longer has keys, defaulting to flag provided keys")
-					fileKeys = slices.Collect(maps.Values(km.flagLoadedKeysMap))
-				}
-				km.updatePublicKeys(fileKeys)
 				initialFileSize = currentFileInfo.Size()
 			}
 		case err, ok := <-watcher.Errors:
@@ -217,4 +219,18 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 			return nil
 		}
 	}
+}
+
+func writePublicKeys(f *os.File, keys []pubkey) error {
+	written := make(map[pubkey]struct{}, len(keys))
+	for _, key := range keys {
+		if _, ok := written[key]; ok {
+			continue
+		}
+		written[key] = struct{}{}
+		if _, err := f.WriteString(hexutil.Encode(key[:]) + "\n"); err != nil {
+			return fmt.Errorf("error writing key %#x to file: %w", key, err)
+		}
+	}
+	return nil
 }

--- a/validator/keymanager/remote-web3signer/key_source_file.go
+++ b/validator/keymanager/remote-web3signer/key_source_file.go
@@ -126,31 +126,37 @@ func (km *Keymanager) readKeyFile() ([]pubkey, error) {
 }
 
 // savePublicKeysToFile writes keys to the key file and makes them the file source's set.
-// The caller must hold updateLock so the watcher cannot read a half-written file.
+// The caller must hold updateLock.
 func (km *Keymanager) savePublicKeysToFile(keys []pubkey) error {
 	if km.keyFilePath == "" {
 		return errors.New("no key file provided")
 	}
-	// Open the file with write and truncate permissions
-	f, err := os.OpenFile(km.keyFilePath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
+	dir := filepath.Dir(km.keyFilePath)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(km.keyFilePath)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
+		return fmt.Errorf("create temporary remote signer key file: %w", err)
 	}
+	tempPath := f.Name()
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(tempPath)
+	}()
+
 	for _, key := range keys {
 		if _, err := f.WriteString(hexutil.Encode(key[:]) + "\n"); err != nil {
-			return fmt.Errorf("error writing key %#x to file: %w", key, err)
+			return fmt.Errorf("write key %#x to temporary remote signer key file: %w", key, err)
 		}
 	}
 	// The keymanager API reports these keys as stored permanently, so flush and close before
 	// claiming so rather than discovering a write error after the response has gone out.
-	if syncErr := f.Sync(); err == nil {
-		err = syncErr
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync temporary remote signer key file: %w", err)
 	}
-	if closeErr := f.Close(); err == nil {
-		err = closeErr
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temporary remote signer key file: %w", err)
 	}
-	if err != nil {
-		return fmt.Errorf("write remote signer key file: %w", err)
+	if err := os.Rename(tempPath, km.keyFilePath); err != nil {
+		return fmt.Errorf("replace remote signer key file: %w", err)
 	}
 
 	km.replaceKeysLocked(sourceFile, keys)
@@ -167,13 +173,11 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 			log.WithError(err).Error("Could not close file watcher")
 		}
 	}()
-	initialFileInfo, err := os.Stat(km.keyFilePath)
-	if err != nil {
+	if _, err := os.Stat(km.keyFilePath); err != nil {
 		return errors.Wrap(err, "could not stat remote signer public key file")
 	}
-	initialFileSize := initialFileInfo.Size()
-	if err := watcher.Add(km.keyFilePath); err != nil {
-		return errors.Wrap(err, "could not add file to file watcher")
+	if err := watcher.Add(filepath.Dir(km.keyFilePath)); err != nil {
+		return errors.Wrap(err, "could not add key file directory to file watcher")
 	}
 	log.WithField("path", km.keyFilePath).Info("Successfully initialized file watcher")
 	km.retriesRemaining = maxRetries // reset retries to default
@@ -191,23 +195,19 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 				log.Info("Closing file watcher")
 				return nil
 			}
+			if filepath.Clean(e.Name) != filepath.Clean(km.keyFilePath) {
+				continue
+			}
 			log.WithFields(logrus.Fields{
 				"event": e.Name,
 				"op":    e.Op.String(),
 			}).Debug("Remote signer key file event triggered")
-			if e.Has(fsnotify.Remove) {
-				return errors.New("remote signer key file was removed")
-			}
-			currentFileInfo, err := os.Stat(km.keyFilePath)
-			if err != nil {
+			if _, err := os.Stat(km.keyFilePath); err != nil {
 				return errors.Wrap(err, "could not stat remote signer public key file")
 			}
-			if currentFileInfo.Size() != initialFileSize {
-				log.Info("Remote signer key file updated")
-				if err := km.reloadKeyFile(); err != nil {
-					return fmt.Errorf("reload key file: %w", err)
-				}
-				initialFileSize = currentFileInfo.Size()
+			log.Info("Remote signer key file updated")
+			if err := km.reloadKeyFile(); err != nil {
+				return fmt.Errorf("reload key file: %w", err)
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok { // Channel was closed (i.e. Watcher.Close() was called).

--- a/validator/keymanager/remote-web3signer/key_source_file.go
+++ b/validator/keymanager/remote-web3signer/key_source_file.go
@@ -67,7 +67,7 @@ func (km *Keymanager) reloadKeyFile() error {
 		return fmt.Errorf("read key file: %w", err)
 	}
 	if len(fileKeys) == 0 {
-		log.Warnln("Remote signer key file no longer has keys, defaulting to flag provided keys")
+		log.Warnln("Remote signer key file has no keys, so the key file no longer contributes any validating keys. Keys from the flag and the public keys URL are unaffected")
 	}
 	km.replaceKeysLocked(sourceFile, fileKeys)
 	return nil
@@ -121,9 +121,6 @@ func (km *Keymanager) readKeyFile() ([]pubkey, error) {
 	// Check for scanning errors
 	if err := scanner.Err(); err != nil {
 		return nil, errors.Wrap(err, "could not scan remote signer public key file")
-	}
-	if len(keys) == 0 {
-		log.Warn("Remote signer key file: no valid public keys found. Defaulting to flag provided keys if any exist.")
 	}
 	return keys, nil
 }

--- a/validator/keymanager/remote-web3signer/key_source_file_test.go
+++ b/validator/keymanager/remote-web3signer/key_source_file_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -50,7 +49,7 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 	for _, key := range all {
 		require.Equal(t, slices.Contains(wantSlice, hexutil.Encode(key[:])), true)
 	}
-	pubKeysChan := make(chan [][fieldparams.BLSPubkeyLength]byte)
+	pubKeysChan := make(chan []pubkey)
 	sub := km.SubscribeAccountChanges(pubKeysChan)
 	defer sub.Unsubscribe()
 

--- a/validator/keymanager/remote-web3signer/key_source_file_test.go
+++ b/validator/keymanager/remote-web3signer/key_source_file_test.go
@@ -94,6 +94,47 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 	}
 }
 
+func TestKeyFileWatcherSurvivesAtomicReplacements(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dir := t.TempDir()
+	keyFilePath := filepath.Join(dir, "keyfile.txt")
+	keys := []string{
+		"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820",
+		"0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055",
+		"0x800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be",
+	}
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(keys[0]+"\n")))
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+		KeyFilePath:           keyFilePath,
+	})
+	require.NoError(t, err)
+
+	updates := make(chan []pubkey, 2)
+	sub := km.SubscribeAccountChanges(updates)
+	defer sub.Unsubscribe()
+	for _, key := range keys[1:] {
+		tmp, err := os.CreateTemp(dir, ".replacement-*")
+		require.NoError(t, err)
+		_, err = tmp.WriteString(key + "\n")
+		require.NoError(t, err)
+		require.NoError(t, tmp.Close())
+		require.NoError(t, os.Rename(tmp.Name(), keyFilePath))
+
+		select {
+		case updated := <-updates:
+			require.Equal(t, 1, len(updated))
+			require.Equal(t, key, hexutil.Encode(updated[0][:]))
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for atomic key file replacement")
+		}
+	}
+}
+
 func TestReadKeyFile_PathMissing(t *testing.T) {
 	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
 	require.NoError(t, err)

--- a/validator/keymanager/remote-web3signer/key_source_file_test.go
+++ b/validator/keymanager/remote-web3signer/key_source_file_test.go
@@ -94,6 +94,33 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 	}
 }
 
+func TestNewKeymanager_WarnsOnUnwritableKeyFileDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	logHook := logTest.NewGlobal()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dir := t.TempDir()
+	keyFilePath := filepath.Join(dir, "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, []byte("0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055\n")))
+	require.NoError(t, os.Chmod(dir, 0o555))
+	defer func() { require.NoError(t, os.Chmod(dir, 0o755)) }()
+
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+		KeyFilePath:           keyFilePath,
+	})
+	// Startup succeeds and the key file's keys still validate; only API writes are lost.
+	require.NoError(t, err)
+	require.LogsContain(t, logHook, "keymanager API imports and deletions will fail")
+	require.Equal(t, 1, len(km.keys.all()))
+}
+
 func TestKeyFileWatcherSurvivesAtomicReplacements(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -281,6 +308,42 @@ func TestRefreshRemoteKeysFromFileChangesWithRetry_ctxCancelDuringRetryWait(t *t
 	case <-time.After(5 * time.Second):
 		t.Fatal("cancellation did not interrupt the retry wait")
 	}
+}
+
+func TestKeyFileDirWritable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	t.Run("writable directory", func(t *testing.T) {
+		keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+		require.NoError(t, file.WriteFile(keyFilePath, []byte("")))
+		require.NoError(t, keyFileDirWritable(keyFilePath))
+	})
+
+	t.Run("leaves no probe file behind", func(t *testing.T) {
+		dir := t.TempDir()
+		keyFilePath := filepath.Join(dir, "keyfile.txt")
+		require.NoError(t, file.WriteFile(keyFilePath, []byte("")))
+		require.NoError(t, keyFileDirWritable(keyFilePath))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(entries))
+		require.Equal(t, "keyfile.txt", entries[0].Name())
+	})
+
+	t.Run("unwritable directory", func(t *testing.T) {
+		dir := t.TempDir()
+		keyFilePath := filepath.Join(dir, "keyfile.txt")
+		require.NoError(t, file.WriteFile(keyFilePath, []byte("")))
+		// Readable and traversable, but the key file cannot be replaced in place.
+		require.NoError(t, os.Chmod(dir, 0o555))
+		// t.TempDir cleanup needs the write bit back.
+		defer func() { require.NoError(t, os.Chmod(dir, 0o755)) }()
+
+		require.ErrorContains(t, "permission denied", keyFileDirWritable(keyFilePath))
+	})
 }
 
 func logsContain(hook *logTest.Hook, substr string) bool {

--- a/validator/keymanager/remote-web3signer/key_source_file_test.go
+++ b/validator/keymanager/remote-web3signer/key_source_file_test.go
@@ -45,11 +45,10 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 	})
 	require.NoError(t, err)
 	wantSlice := []string{"0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6", "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", "0x800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be"}
-	keys := make([]string, len(km.providedPublicKeys))
-	require.Equal(t, 3, len(km.providedPublicKeys))
-	for i, key := range km.providedPublicKeys {
-		keys[i] = hexutil.Encode(key[:])
-		require.Equal(t, slices.Contains(wantSlice, keys[i]), true)
+	all := km.keys.all()
+	require.Equal(t, 3, len(all))
+	for _, key := range all {
+		require.Equal(t, slices.Contains(wantSlice, hexutil.Encode(key[:])), true)
 	}
 	pubKeysChan := make(chan [][fieldparams.BLSPubkeyLength]byte)
 	sub := km.SubscribeAccountChanges(pubKeysChan)
@@ -65,17 +64,29 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 	require.NoError(t, f.Sync())
 	require.NoError(t, f.Close())
 
-	ks, _, err := km.readKeyFile()
+	ks, err := km.readKeyFile()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(ks))
 	require.Equal(t, "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", hexutil.Encode(ks[0][:]))
 
+	// The flag key is owned by the flag source, so dropping it from the file keeps it validating.
+	want := []string{
+		"0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6",
+		"0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055",
+	}
 	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
 	for {
 		select {
 		case updatedKeys := <-pubKeysChan:
-			if len(updatedKeys) == 1 && hexutil.Encode(updatedKeys[0][:]) == "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055" {
+			if len(updatedKeys) != len(want) {
+				continue
+			}
+			matched := true
+			for _, key := range updatedKeys {
+				matched = matched && slices.Contains(want, hexutil.Encode(key[:]))
+			}
+			if matched {
 				return
 			}
 		case <-timer.C:
@@ -94,7 +105,7 @@ func TestReadKeyFile_PathMissing(t *testing.T) {
 		GenesisValidatorsRoot: root,
 	})
 	require.NoError(t, err)
-	_, _, err = km.readKeyFile()
+	_, err = km.readKeyFile()
 	require.ErrorContains(t, "no key file path provided", err)
 }
 
@@ -138,6 +149,47 @@ func startFailingWatcher(t *testing.T, ctx context.Context, km *Keymanager, keyF
 	}
 	require.NoError(t, os.Remove(keyFilePath))
 	return result
+}
+
+func TestRefreshRemoteKeysFromFileChangesWithRetry_recoveryRestoresFileKeys(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	flagKey := "0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6"
+	fileKey := "0x800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be"
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+		ProvidedPublicKeys:    []string{flagKey},
+	})
+	require.NoError(t, err)
+
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	result := startFailingWatcher(t, ctx, km, keyFilePath, time.Millisecond)
+
+	// A failed refresh drops the file keys, so putting the file back has to restore them
+	// even though the flag keys kept the validating set non-empty in the meantime.
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(fileKey+"\n")))
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		keys := km.keys.all()
+		if len(keys) == 2 && slices.Contains(encodeKeys(keys), fileKey) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the recovered watcher to restore the file keys")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// The recovered watcher is back in its event loop, so cancelling is a clean shutdown.
+	cancel()
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher did not stop on cancellation")
+	}
 }
 
 func TestRefreshRemoteKeysFromFileChangesWithRetry_maxRetryReached(t *testing.T) {

--- a/validator/keymanager/remote-web3signer/key_source_url.go
+++ b/validator/keymanager/remote-web3signer/key_source_url.go
@@ -53,7 +53,7 @@ func (km *Keymanager) pollRemoteKeysFromURL(ctx context.Context, url string, int
 				continue
 			}
 
-			km.updatePublicKeys(keys)
+			km.replaceKeys(sourceURL, keys)
 		}
 	}
 }

--- a/validator/keymanager/remote-web3signer/key_source_url.go
+++ b/validator/keymanager/remote-web3signer/key_source_url.go
@@ -2,12 +2,9 @@ package remote_web3signer
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/api"
-	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
-	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 )
 
 // urlPollTimeout bounds a single public-keys fetch so a hung request cannot stall
@@ -59,25 +56,4 @@ func (km *Keymanager) pollRemoteKeysFromURL(ctx context.Context, url string, int
 			km.updatePublicKeys(keys)
 		}
 	}
-}
-
-// decodePublicKeys decodes and dedups hex-encoded BLS public keys.
-func decodePublicKeys(raw []string) ([][fieldparams.BLSPubkeyLength]byte, error) {
-	var (
-		seen = make(map[[fieldparams.BLSPubkeyLength]byte]struct{}, len(raw))
-		keys = make([][fieldparams.BLSPubkeyLength]byte, 0, len(raw))
-	)
-
-	for _, k := range raw {
-		b, err := bytesutil.DecodeHex48(k)
-		if err != nil {
-			return nil, fmt.Errorf("decode public key %s: %w", k, err)
-		}
-		if _, ok := seen[b]; ok {
-			continue
-		}
-		seen[b] = struct{}{}
-		keys = append(keys, b)
-	}
-	return keys, nil
 }

--- a/validator/keymanager/remote-web3signer/key_source_url_test.go
+++ b/validator/keymanager/remote-web3signer/key_source_url_test.go
@@ -59,32 +59,6 @@ func newPollTestKeymanager(client internal.HttpSignerClient, initial [][fieldpar
 	}
 }
 
-func TestDecodePublicKeys(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   []string
-		wantLen int
-		wantErr string
-	}{
-		{name: "empty input", input: nil, wantLen: 0},
-		{name: "single key", input: []string{testKeyA}, wantLen: 1},
-		{name: "dedupes repeated keys", input: []string{testKeyA, testKeyA, testKeyB}, wantLen: 2},
-		{name: "invalid hex", input: []string{"not-hex"}, wantErr: "decode public key"},
-		{name: "wrong length", input: []string{"0x1234"}, wantErr: "decode public key"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := decodePublicKeys(tt.input)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, tt.wantErr, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.wantLen, len(got))
-		})
-	}
-}
-
 func TestPollRemoteKeysFromURL(t *testing.T) {
 	const interval = time.Second
 

--- a/validator/keymanager/remote-web3signer/key_source_url_test.go
+++ b/validator/keymanager/remote-web3signer/key_source_url_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/async/event"
-	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/validator/keymanager/remote-web3signer/internal"
@@ -44,14 +43,14 @@ func (c *stubSignerClient) Sign(context.Context, string, internal.SignRequestJso
 	return nil, nil
 }
 
-func decodeKeysMust(t *testing.T, hexes ...string) [][fieldparams.BLSPubkeyLength]byte {
+func decodeKeysMust(t *testing.T, hexes ...string) []pubkey {
 	t.Helper()
 	keys, err := decodePublicKeys(hexes)
 	require.NoError(t, err)
 	return keys
 }
 
-func newPollTestKeymanager(client internal.HttpSignerClient, initial [][fieldparams.BLSPubkeyLength]byte) *Keymanager {
+func newPollTestKeymanager(client internal.HttpSignerClient, initial []pubkey) *Keymanager {
 	km := &Keymanager{
 		client:              client,
 		accountsChangedFeed: new(event.Feed),
@@ -85,7 +84,7 @@ func TestPollRemoteKeysFromURL(t *testing.T) {
 				stub.set(tc.resp, tc.respErr)
 				km := newPollTestKeymanager(stub, decodeKeysMust(t, tc.seed...))
 
-				ch := make(chan [][fieldparams.BLSPubkeyLength]byte, 8)
+				ch := make(chan []pubkey, 8)
 				sub := km.SubscribeAccountChanges(ch)
 				defer sub.Unsubscribe()
 

--- a/validator/keymanager/remote-web3signer/key_source_url_test.go
+++ b/validator/keymanager/remote-web3signer/key_source_url_test.go
@@ -52,11 +52,12 @@ func decodeKeysMust(t *testing.T, hexes ...string) [][fieldparams.BLSPubkeyLengt
 }
 
 func newPollTestKeymanager(client internal.HttpSignerClient, initial [][fieldparams.BLSPubkeyLength]byte) *Keymanager {
-	return &Keymanager{
+	km := &Keymanager{
 		client:              client,
 		accountsChangedFeed: new(event.Feed),
-		providedPublicKeys:  initial,
 	}
+	km.keys.replace(sourceURL, initial)
+	return km
 }
 
 func TestPollRemoteKeysFromURL(t *testing.T) {

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -13,7 +13,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/async/event"
 	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
-	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/io/file"
@@ -193,7 +192,7 @@ func (km *Keymanager) replaceKeysLocked(src keySource, keys []pubkey) {
 }
 
 // FetchValidatingPublicKeys fetches the validating public keys
-func (km *Keymanager) FetchValidatingPublicKeys(_ context.Context) ([][fieldparams.BLSPubkeyLength]byte, error) {
+func (km *Keymanager) FetchValidatingPublicKeys(_ context.Context) ([]pubkey, error) {
 	keys := km.keys.all()
 	log.WithField("count", len(keys)).Debug("Fetched validating public keys")
 	return keys, nil
@@ -545,7 +544,7 @@ func handleRegistration(ctx context.Context, validator *validator.Validate, requ
 }
 
 // SubscribeAccountChanges returns the event subscription for changes to public keys.
-func (km *Keymanager) SubscribeAccountChanges(pubKeysChan chan [][fieldparams.BLSPubkeyLength]byte) event.Subscription {
+func (km *Keymanager) SubscribeAccountChanges(pubKeysChan chan []pubkey) event.Subscription {
 	return km.accountsChangedFeed.Subscribe(pubKeysChan)
 }
 

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -708,3 +708,9 @@ func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeySt
 
 	return statuses, nil
 }
+
+// IsReadOnly returns true if the key is not owned by the key file, meaning it is derived from the flag or the URL.
+func (km *Keymanager) IsReadOnly(key pubkey) bool {
+	src, _ := km.keys.owner(key)
+	return src != sourceFile
+}

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 
@@ -648,7 +646,7 @@ func (km *Keymanager) AddPublicKeys(pubKeys []string) ([]*keymanager.KeyStatus, 
 	}
 
 	if changed {
-		if err := km.savePublicKeysToFile(slices.Collect(maps.Keys(fileKeys))); err != nil {
+		if err := km.savePublicKeysToFile(sortedKeys(fileKeys)); err != nil {
 			return nil, fmt.Errorf("save public keys to file: %w", err)
 		}
 	}
@@ -708,7 +706,7 @@ func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeySt
 	}
 
 	if changed {
-		if err := km.savePublicKeysToFile(slices.Collect(maps.Keys(fileKeys))); err != nil {
+		if err := km.savePublicKeysToFile(sortedKeys(fileKeys)); err != nil {
 			return nil, fmt.Errorf("save public keys to file: %w", err)
 		}
 	}

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -657,8 +657,8 @@ func (km *Keymanager) AddPublicKeys(pubKeys []string) ([]*keymanager.KeyStatus, 
 }
 
 // DeletePublicKeys removes a list of public keys from the keymanager for web3signer use. Returns status with message.
-// Only keys owned by the key file can be deleted: keys derived from the flag or the URL
-// would come straight back on the next reload, so they report an error naming their owner.
+// Keys derived from the flag or URL remain validating, but any stale copy in the key file
+// is removed so it cannot take ownership if the derived source later drops the key.
 func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeyStatus, error) {
 	statuses := make([]*keymanager.KeyStatus, len(publicKeys))
 
@@ -674,16 +674,25 @@ func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeySt
 			statuses[i] = &keymanager.KeyStatus{Status: keymanager.StatusError, Message: err.Error()}
 			continue
 		}
+		_, inFile := fileKeys[key]
+		if inFile {
+			delete(fileKeys, key)
+			changed = true
+		}
 		if src, owned := km.keys.owner(key); owned && src != sourceFile {
+			message := fmt.Sprintf("Pubkey: %v is provided by %s and cannot be deleted through the keymanager API", pubkey, src)
+			if inFile {
+				message = fmt.Sprintf("Pubkey: %v was removed from the key file but is still provided by %s and continues validating", pubkey, src)
+			}
 			statuses[i] = &keymanager.KeyStatus{
 				Status:  keymanager.StatusError,
-				Message: fmt.Sprintf("Pubkey: %v is provided by %s and cannot be deleted through the keymanager API", pubkey, src),
+				Message: message,
 			}
 			continue
 		}
 		// Anything left is deletable only if the file still lists it, which also covers a
 		// key repeated within one request.
-		if _, inFile := fileKeys[key]; !inFile {
+		if !inFile {
 			statuses[i] = &keymanager.KeyStatus{
 				Status:  keymanager.StatusNotFound,
 				Message: fmt.Sprintf("Pubkey: %v not found", pubkey),
@@ -691,8 +700,6 @@ func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeySt
 			continue
 		}
 
-		delete(fileKeys, key)
-		changed = true
 		statuses[i] = &keymanager.KeyStatus{
 			Status:  keymanager.StatusDeleted,
 			Message: fmt.Sprintf("Successfully deleted pubkey: %v", pubkey),

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/async/event"
+	"github.com/OffchainLabs/prysm/v7/cmd/validator/flags"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -53,7 +54,9 @@ type SetupConfig struct {
 	ProvidedPublicKeys []string
 
 	// PollInterval makes the keymanager re-fetch the URL (PublicKeysURL) on this interval to
-	// hot-reload the validating public key set. A failed or empty response keeps the current keys.
+	// hot-reload the validating public key set. A failed or empty response keeps the current
+	// keys. Polling only replaces the URL's own keys, so it leaves the flag and key file
+	// keys alone.
 	// Note: Zero or negative disables polling.
 	PollInterval time.Duration
 }
@@ -62,15 +65,13 @@ type SetupConfig struct {
 type Keymanager struct {
 	client                internal.HttpSignerClient
 	genesisValidatorsRoot []byte
-	providedPublicKeys    [][48]byte          // (source of truth) flag loaded + file loaded + api loaded keys
-	flagLoadedKeysMap     map[string][48]byte // stores what was provided from flag ( as opposed to from file )
+	keys                  keySets
 	accountsChangedFeed   *event.Feed
 	validator             *validator.Validate
 	retriesRemaining      int
 	keyFilePath           string
-	lock                  sync.RWMutex
-	// serialize updatePublicKeys as we have multiple concurrent updaters
-	// - URL poller, file watcher, Keymanager API.
+	// serialize key set replacement and its notification across the URL poller, the file
+	// watcher and the keymanager API, so subscribers never observe them out of order.
 	updateLock sync.Mutex
 }
 
@@ -106,14 +107,18 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 		}
 	}
 
-	var ppk []string
-	// load key values
+	// Load the derived key sources:
+	// 1. From URL.
 	if cfg.PublicKeysURL != "" {
-		providedPublicKeys, err := km.client.GetPublicKeys(ctx, cfg.PublicKeysURL)
+		raw, err := km.client.GetPublicKeys(ctx, cfg.PublicKeysURL)
 		switch {
 		case err == nil:
-			ppk = providedPublicKeys
-		case cfg.PollInterval > 0 && !keyFileExists:
+			urlKeys, err := decodePublicKeys(raw)
+			if err != nil {
+				return nil, fmt.Errorf("decode public keys: %w", err)
+			}
+			km.keys.replace(sourceURL, urlKeys)
+		case cfg.PollInterval > 0:
 			// Polling will retry, so start with no keys rather than refusing to start.
 			erroredResponsesTotal.Inc()
 			log.
@@ -124,57 +129,26 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 			erroredResponsesTotal.Inc()
 			return nil, errors.Wrapf(err, "could not get public keys from remote server URL %v", api.RedactEndpoint(cfg.PublicKeysURL))
 		}
-	} else if len(cfg.ProvidedPublicKeys) != 0 {
-		ppk = cfg.ProvidedPublicKeys
-	}
-
-	// use a map to remove duplicates
-	flagLoadedKeys := make(map[string][48]byte)
-
-	// Populate the map with existing keys
-	for _, key := range ppk {
-		b, err := bytesutil.DecodeHex48(key)
-		if err != nil {
-			return nil, fmt.Errorf("decode public key %s: %w", key, err)
-		}
-		flagLoadedKeys[key] = b
-	}
-	km.flagLoadedKeysMap = flagLoadedKeys
-
-	// File-based key source is not set here. Start polling from the URL if configured, and hot-reload from file if configured.
-	if !keyFileExists {
-		// Load provided public keys in memory.
-		km.lock.Lock()
-		km.providedPublicKeys = slices.Collect(maps.Values(flagLoadedKeys))
-		km.lock.Unlock()
 
 		go km.pollRemoteKeysFromURL(ctx, cfg.PublicKeysURL, cfg.PollInterval)
+	}
 
+	// 2. From the flag.
+	if len(cfg.ProvidedPublicKeys) != 0 {
+		flagKeys, err := decodePublicKeys(cfg.ProvidedPublicKeys)
+		if err != nil {
+			return nil, fmt.Errorf("decode public keys: %w", err)
+		}
+		km.keys.replace(sourceFlag, flagKeys)
+	}
+
+	// Return early when no persistent storage is configured.
+	if !keyFileExists {
 		return km, nil
 	}
 
 	log.WithField("file", km.keyFilePath).Info("Loading keys from file")
 
-	// Notify users that poll interval flag is a no-op when a key file is provided.
-	if cfg.PollInterval > 0 {
-		log.Warn("Web3Signer key poll interval is set but key file is configured. " +
-			"The poll interval will be ignored since the key file takes precedence over the URL.")
-	}
-
-	_, fileKeys, err := km.readKeyFile()
-	if err != nil {
-		return nil, errors.Wrap(err, "could not read key file")
-	}
-	if len(flagLoadedKeys) != 0 {
-		log.WithField("flagLoadedKeyCount", len(flagLoadedKeys)).WithField("fileLoadedKeyCount", len(fileKeys)).Info("Combining flag loaded keys and file loaded keys.")
-		maps.Copy(fileKeys, flagLoadedKeys)
-		if err = km.savePublicKeysToFile(fileKeys); err != nil {
-			return nil, errors.Wrap(err, "could not save public keys to file")
-		}
-	}
-	km.lock.Lock()
-	km.providedPublicKeys = slices.Collect(maps.Values(fileKeys))
-	km.lock.Unlock()
 	watcherReady := make(chan error, 1)
 	var watcherReadyOnce sync.Once
 	markWatcherReady := func(err error) {
@@ -199,46 +173,30 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 	return km, nil
 }
 
-// equalKeySet reports whether a and b contain the same set of keys, ignoring
-// order and duplicates.
-func equalKeySet(a, b [][fieldparams.BLSPubkeyLength]byte) bool {
-	setA := make(map[[fieldparams.BLSPubkeyLength]byte]struct{}, len(a))
-	for _, k := range a {
-		setA[k] = struct{}{}
-	}
-	distinctB := make(map[[fieldparams.BLSPubkeyLength]byte]struct{}, len(b))
-	for _, k := range b {
-		if _, ok := setA[k]; !ok {
-			return false // b has a key that a does not.
-		}
-		distinctB[k] = struct{}{}
-	}
-
-	return len(setA) == len(distinctB)
-}
-
-func (km *Keymanager) updatePublicKeys(keys [][48]byte) {
+// replaceKeys swaps src's key set and notifies subscribers when the validating set changed.
+func (km *Keymanager) replaceKeys(src keySource, keys []pubkey) {
 	km.updateLock.Lock()
 	defer km.updateLock.Unlock()
 
-	km.lock.Lock()
-	if equalKeySet(km.providedPublicKeys, keys) {
-		km.lock.Unlock()
+	km.replaceKeysLocked(src, keys)
+}
+
+// replaceKeysLocked is replaceKeys for callers that already hold updateLock.
+func (km *Keymanager) replaceKeysLocked(src keySource, keys []pubkey) {
+	changed, union := km.keys.replace(src, keys)
+	if !changed {
 		return
 	}
-	km.providedPublicKeys = keys
-	km.lock.Unlock()
 
-	km.accountsChangedFeed.Send(keys)
-	log.WithField("count", len(keys)).Debug("Updated public keys")
+	km.accountsChangedFeed.Send(union)
+	log.WithField("count", len(union)).Debug("Updated public keys")
 }
 
 // FetchValidatingPublicKeys fetches the validating public keys
 func (km *Keymanager) FetchValidatingPublicKeys(_ context.Context) ([][fieldparams.BLSPubkeyLength]byte, error) {
-	km.lock.RLock()
-	defer km.lock.RUnlock()
-	log.WithField("count", len(km.providedPublicKeys)).Debug("Fetched validating public keys")
-	return km.providedPublicKeys, nil
+	keys := km.keys.all()
+	log.WithField("count", len(keys)).Debug("Fetched validating public keys")
+	return keys, nil
 }
 
 // Sign signs the message by using a remote web3signer server.
@@ -646,133 +604,108 @@ func DisplayRemotePublicKeys(validatingPubKeys [][48]byte) {
 
 // AddPublicKeys imports a list of public keys into the keymanager for web3signer use. Returns status with message.
 func (km *Keymanager) AddPublicKeys(pubKeys []string) ([]*keymanager.KeyStatus, error) {
-	importedRemoteKeysStatuses := make([]*keymanager.KeyStatus, len(pubKeys))
-	// Using a map to track both existing and new public keys efficiently
-	combinedKeys := make(map[string][48]byte)
+	statuses := make([]*keymanager.KeyStatus, len(pubKeys))
 
-	// Populate the map with existing keys
-	km.lock.RLock()
-	originalKeysLen := len(km.providedPublicKeys)
-	for _, key := range km.providedPublicKeys {
-		encodedKey := hexutil.Encode(key[:])
-		combinedKeys[encodedKey] = key
+	// Return early when no persistent storage is configured.
+	if km.keyFilePath == "" {
+		for i := range statuses {
+			statuses[i] = &keymanager.KeyStatus{
+				Status:  keymanager.StatusError,
+				Message: "no persistent storage for remote keys is configured; set --" + flags.Web3SignerKeyFileFlag.Name,
+			}
+		}
+		return statuses, nil
 	}
-	km.lock.RUnlock()
+
+	km.updateLock.Lock()
+	defer km.updateLock.Unlock()
+
+	fileKeys := km.keys.get(sourceFile)
+	changed := false
 
 	for i, pubkey := range pubKeys {
-		pubkeyBytes, err := hexutil.Decode(pubkey)
+		key, err := bytesutil.DecodeHex48(pubkey)
 		if err != nil {
-			importedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
-				Status:  keymanager.StatusError,
-				Message: err.Error(),
-			}
+			statuses[i] = &keymanager.KeyStatus{Status: keymanager.StatusError, Message: err.Error()}
 			continue
 		}
-		if len(pubkeyBytes) != fieldparams.BLSPubkeyLength {
-			importedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
-				Status:  keymanager.StatusError,
-				Message: fmt.Sprintf("pubkey byte length (%d) did not match bls pubkey byte length (%d)", len(pubkeyBytes), fieldparams.BLSPubkeyLength),
-			}
-			continue
-		}
-
-		encodedPubkey := hexutil.Encode(pubkeyBytes)
-		if _, exists := combinedKeys[encodedPubkey]; exists {
-			importedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
+		// A key owned by any source, or already staged by this request, is known to the client.
+		_, staged := fileKeys[key]
+		if _, owned := km.keys.owner(key); staged || owned {
+			statuses[i] = &keymanager.KeyStatus{
 				Status:  keymanager.StatusDuplicate,
 				Message: fmt.Sprintf("Duplicate pubkey: %v, already in use", pubkey),
 			}
 			continue
 		}
 
-		// Add the new key to the map
-		combinedKeys[encodedPubkey] = bytesutil.ToBytes48(pubkeyBytes)
-		importedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
+		fileKeys[key] = struct{}{}
+		changed = true
+		statuses[i] = &keymanager.KeyStatus{
 			Status:  keymanager.StatusImported,
 			Message: fmt.Sprintf("Successfully added pubkey: %v", pubkey),
 		}
-		log.Debug("Added pubkey to keymanager for web3signer", "pubkey", pubkey)
+		log.WithField("pubkey", pubkey).Debug("Added pubkey to keymanager for web3signer")
 	}
 
-	if originalKeysLen != len(combinedKeys) {
-		if km.keyFilePath != "" {
-			if err := km.savePublicKeysToFile(combinedKeys); err != nil {
-				return nil, err
-			}
-		} else {
-			km.updatePublicKeys(slices.Collect(maps.Values(combinedKeys)))
+	if changed {
+		if err := km.savePublicKeysToFile(slices.Collect(maps.Keys(fileKeys))); err != nil {
+			return nil, fmt.Errorf("save public keys to file: %w", err)
 		}
 	}
 
-	return importedRemoteKeysStatuses, nil
+	return statuses, nil
 }
 
 // DeletePublicKeys removes a list of public keys from the keymanager for web3signer use. Returns status with message.
+// Only keys owned by the key file can be deleted: keys derived from the flag or the URL
+// would come straight back on the next reload, so they report an error naming their owner.
 func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeyStatus, error) {
-	deletedRemoteKeysStatuses := make([]*keymanager.KeyStatus, len(publicKeys))
-	// Using a map to track both existing and new public keys efficiently
-	combinedKeys := make(map[string][48]byte)
-	km.lock.RLock()
-	originalKeysLen := len(km.providedPublicKeys)
-	if originalKeysLen == 0 {
-		km.lock.RUnlock()
-		for i := range deletedRemoteKeysStatuses {
-			deletedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
-				Status:  keymanager.StatusNotFound,
-				Message: "No pubkeys are set in validator",
-			}
-		}
-		return deletedRemoteKeysStatuses, nil
-	}
+	statuses := make([]*keymanager.KeyStatus, len(publicKeys))
 
-	// Populate the map with existing keys
-	for _, key := range km.providedPublicKeys {
-		encodedKey := hexutil.Encode(key[:])
-		combinedKeys[encodedKey] = key
-	}
-	km.lock.RUnlock()
+	km.updateLock.Lock()
+	defer km.updateLock.Unlock()
+
+	fileKeys := km.keys.get(sourceFile)
+	changed := false
 
 	for i, pubkey := range publicKeys {
-		pubkeyBytes, err := hexutil.Decode(pubkey)
+		key, err := bytesutil.DecodeHex48(pubkey)
 		if err != nil {
-			deletedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
+			statuses[i] = &keymanager.KeyStatus{Status: keymanager.StatusError, Message: err.Error()}
+			continue
+		}
+		if src, owned := km.keys.owner(key); owned && src != sourceFile {
+			statuses[i] = &keymanager.KeyStatus{
 				Status:  keymanager.StatusError,
-				Message: err.Error(),
+				Message: fmt.Sprintf("Pubkey: %v is provided by %s and cannot be deleted through the keymanager API", pubkey, src),
 			}
 			continue
 		}
-		if len(pubkeyBytes) != fieldparams.BLSPubkeyLength {
-			deletedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
-				Status:  keymanager.StatusError,
-				Message: fmt.Sprintf("pubkey byte length (%d) did not match bls pubkey byte length (%d)", len(pubkeyBytes), fieldparams.BLSPubkeyLength),
-			}
-			continue
-		}
-		_, exists := combinedKeys[pubkey]
-		if !exists {
-			deletedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
+		// Anything left is deletable only if the file still lists it, which also covers a
+		// key repeated within one request.
+		if _, inFile := fileKeys[key]; !inFile {
+			statuses[i] = &keymanager.KeyStatus{
 				Status:  keymanager.StatusNotFound,
 				Message: fmt.Sprintf("Pubkey: %v not found", pubkey),
 			}
 			continue
 		}
-		delete(combinedKeys, pubkey)
-		deletedRemoteKeysStatuses[i] = &keymanager.KeyStatus{
+
+		delete(fileKeys, key)
+		changed = true
+		statuses[i] = &keymanager.KeyStatus{
 			Status:  keymanager.StatusDeleted,
 			Message: fmt.Sprintf("Successfully deleted pubkey: %v", pubkey),
 		}
 		log.WithField("pubkey", pubkey).Debug("Deleted pubkey from keymanager for remote signer")
 	}
 
-	if originalKeysLen != len(combinedKeys) {
-		if km.keyFilePath != "" {
-			if err := km.savePublicKeysToFile(combinedKeys); err != nil {
-				return nil, err
-			}
-		} else {
-			km.updatePublicKeys(slices.Collect(maps.Values(combinedKeys)))
+	if changed {
+		if err := km.savePublicKeysToFile(slices.Collect(maps.Keys(fileKeys))); err != nil {
+			return nil, fmt.Errorf("save public keys to file: %w", err)
 		}
 	}
 
-	return deletedRemoteKeysStatuses, nil
+	return statuses, nil
 }

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -102,6 +102,14 @@ func NewKeymanager(ctx context.Context, cfg *SetupConfig) (*Keymanager, error) {
 		if !keyFileExists {
 			return nil, fmt.Errorf("no file exists in remote signer key file path %s", km.keyFilePath)
 		}
+
+		// NOTE: Warn users rather than fail as only keymanager API write path is dead.
+		if err := keyFileDirWritable(km.keyFilePath); err != nil {
+			log.
+				WithError(err).
+				WithField("dir", filepath.Dir(km.keyFilePath)).
+				Warn("Cannot create files in the remote signer key file directory, so keymanager API imports and deletions will fail. Keys already in the file still validate")
+		}
 	}
 
 	// Load the derived key sources:

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -715,7 +715,12 @@ func (km *Keymanager) DeletePublicKeys(publicKeys []string) ([]*keymanager.KeySt
 }
 
 // IsReadOnly returns true if the key is not owned by the key file, meaning it is derived from the flag or the URL.
+// If the key is not owned by any source, it is also considered read-only.
 func (km *Keymanager) IsReadOnly(key pubkey) bool {
-	src, _ := km.keys.owner(key)
+	src, owned := km.keys.owner(key)
+	if !owned {
+		return true
+	}
+
 	return src != sourceFile
 }

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -642,7 +642,9 @@ func TestKeymanager_DeletePublicKeys_URLOwnedKey(t *testing.T) {
 	defer srv.Close()
 
 	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
-	require.NoError(t, file.WriteFile(keyFilePath, nil))
+	// Older versions copied URL keys into the key file, so an upgraded deployment can
+	// legitimately have the same key in both sources.
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(urlKey+"\n")))
 	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
 	require.NoError(t, err)
 	km, err := NewKeymanager(ctx, &SetupConfig{
@@ -653,15 +655,17 @@ func TestKeymanager_DeletePublicKeys_URLOwnedKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// The URL key is not written to the key file, and the API cannot take it away.
-	fileKeys, err := km.readKeyFile()
-	require.NoError(t, err)
-	require.Equal(t, 0, len(fileKeys))
-
+	// Deleting cannot stop a URL-owned key from validating, but it must clean up the
+	// stale file copy so the key does not become file-owned if the URL later drops it.
 	statuses, err := km.DeletePublicKeys([]string{urlKey})
 	require.NoError(t, err)
 	require.Equal(t, keymanager.StatusError, statuses[0].Status)
-	require.StringContains(t, "remote signer public keys URL", statuses[0].Message)
+	require.StringContains(t, "removed from the key file", statuses[0].Message)
+	require.StringContains(t, "continues validating", statuses[0].Message)
+
+	fileKeys, err := km.readKeyFile()
+	require.NoError(t, err)
+	require.Equal(t, 0, len(fileKeys))
 
 	// Nor can it be re-imported as a file key.
 	statuses, err = km.AddPublicKeys([]string{urlKey})

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -133,8 +134,10 @@ func TestNewKeymanager(t *testing.T) {
 				BaseEndpoint:          "http://prysm.xyz/",
 				GenesisValidatorsRoot: root,
 				ProvidedPublicKeys:    []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"},
+				KeyFilePath:           filepath.Join(t.TempDir(), "good_keyfile.txt"),
 			},
-			want: []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820", "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", "0x800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be"},
+			fileContents: []string{"0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", "800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be"},
+			want:         []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820", "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", "0x800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be"},
 		},
 	}
 	for _, tt := range tests {
@@ -162,10 +165,10 @@ func TestNewKeymanager(t *testing.T) {
 				require.ErrorContains(t, tt.wantErr, err)
 				return
 			}
-			keys := make([]string, len(km.providedPublicKeys))
-			for i, key := range km.providedPublicKeys {
-				keys[i] = hexutil.Encode(key[:])
-				require.Equal(t, true, slices.Contains(tt.want, keys[i]))
+			all := km.keys.all()
+			require.Equal(t, len(tt.want), len(all))
+			for _, key := range all {
+				require.Equal(t, true, slices.Contains(tt.want, hexutil.Encode(key[:])))
 			}
 		})
 	}
@@ -204,25 +207,29 @@ func TestNewKeyManager_FileAndFlagsWithDifferentKeys(t *testing.T) {
 		ProvidedPublicKeys:    []string{"0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6"},
 	})
 	require.NoError(t, err)
+	// Both keys validate, but the file keeps holding only its own.
 	wantSlice := []string{"0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6",
 		"0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055"}
-	// provided public keys are saved to the file
-	keys, _, err := km.readKeyFile()
-	require.NoError(t, err)
-	for _, key := range keys {
+	all := km.keys.all()
+	require.Equal(t, 2, len(all))
+	for _, key := range all {
 		require.Equal(t, slices.Contains(wantSlice, hexutil.Encode(key[:])), true)
 	}
-	// wait for reading to be done
-	time.Sleep(2 * time.Second)
-	// test fall back by clearing file
-	go func() {
-		require.NoError(t, file.WriteFile(keyFilePath, []byte(" ")))
-	}()
-	// waiting for writing to be done
-	time.Sleep(2 * time.Second)
+	keys, err := km.readKeyFile()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(keys))
+	require.Equal(t, "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", hexutil.Encode(keys[0][:]))
+	// Clearing the file falls back to the flag provided keys.
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(" ")))
+	deadline := time.Now().Add(5 * time.Second)
+	for len(km.keys.all()) != 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the watcher to drop the file keys")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	require.LogsContain(t, logHook, "Remote signer key file no longer has keys, defaulting to flag provided keys")
 
-	// fall back to flag provided keys
 	keys, err = km.FetchValidatingPublicKeys(context.TODO())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
@@ -454,27 +461,106 @@ func TestKeymanager_ExternalURLUnreachable_StartsWhenPolling(t *testing.T) {
 	require.Equal(t, 0, len(keys))
 }
 
-func TestKeymanager_AddPublicKeys(t *testing.T) {
+func TestKeymanager_PollsAlongsideAKeyFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	droppedKey := "0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"
+	keptKey := "0x800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be"
+	fileKey := "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055"
+
+	var mu sync.Mutex
+	served := []string{droppedKey, keptKey}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(served))
+	}))
+	defer srv.Close()
+
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(fileKey+"\n")))
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+		PublicKeysURL:         srv.URL + "/api/v1/eth2/publicKeys",
+		KeyFilePath:           keyFilePath,
+		PollInterval:          10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, len(km.keys.all()))
+
+	// The signer drops a key, and the poll picks that up even though a key file is configured.
+	mu.Lock()
+	served = []string{keptKey}
+	mu.Unlock()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		keys, err := km.FetchValidatingPublicKeys(ctx)
+		require.NoError(t, err)
+		if len(keys) == 2 && !slices.Contains(encodeKeys(keys), droppedKey) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the poll to drop the URL key")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The file key is untouched by the poller and still deletable through the API.
+	statuses, err := km.DeletePublicKeys([]string{fileKey})
+	require.NoError(t, err)
+	require.Equal(t, keymanager.StatusDeleted, statuses[0].Status)
+}
+
+func TestKeymanager_AddPublicKeys_NoKeyFile(t *testing.T) {
 	ctx := t.Context()
 	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
 	require.NoError(t, err)
-	config := &SetupConfig{
+	km, err := NewKeymanager(ctx, &SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
-	}
-	km, err := NewKeymanager(ctx, config)
+	})
 	require.NoError(t, err)
-	publicKeys := []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"}
-	statuses, err := km.AddPublicKeys(publicKeys)
+
+	statuses, err := km.AddPublicKeys([]string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"})
 	require.NoError(t, err)
-	for _, status := range statuses {
-		require.Equal(t, keymanager.StatusImported, status.Status)
-	}
-	statuses, err = km.AddPublicKeys(publicKeys)
+	require.Equal(t, 1, len(statuses))
+	require.Equal(t, keymanager.StatusError, statuses[0].Status)
+	require.StringContains(t, "validators-external-signer-key-file", statuses[0].Message)
+
+	keys, err := km.FetchValidatingPublicKeys(ctx)
 	require.NoError(t, err)
-	for _, status := range statuses {
-		require.Equal(t, keymanager.StatusDuplicate, status.Status)
-	}
+	require.Equal(t, 0, len(keys))
+}
+
+func TestKeymanager_AddPublicKeys_DuplicateOfDerivedKey(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	flagKey := "0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6"
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, nil))
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+		KeyFilePath:           keyFilePath,
+		ProvidedPublicKeys:    []string{flagKey},
+	})
+	require.NoError(t, err)
+
+	newKey := "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055"
+	statuses, err := km.AddPublicKeys([]string{flagKey, "not-a-key", newKey, newKey})
+	require.NoError(t, err)
+	require.Equal(t, keymanager.StatusDuplicate, statuses[0].Status)
+	require.Equal(t, keymanager.StatusError, statuses[1].Status)
+	require.Equal(t, keymanager.StatusImported, statuses[2].Status)
+	// The same key twice in one request is only imported once.
+	require.Equal(t, keymanager.StatusDuplicate, statuses[3].Status)
 }
 
 func TestKeymanager_AddPublicKeys_WithFile(t *testing.T) {
@@ -505,40 +591,87 @@ func TestKeymanager_AddPublicKeys_WithFile(t *testing.T) {
 	for _, status := range statuses {
 		require.Equal(t, keymanager.StatusDuplicate, status.Status)
 	}
-	keys, _, err := km.readKeyFile()
+	keys, err := km.readKeyFile()
 	require.NoError(t, err)
 	require.Equal(t, len(keys), len(publicKeys))
 	require.Equal(t, hexutil.Encode(keys[0][:]), publicKeys[0])
 }
 
-func TestKeymanager_DeletePublicKeys(t *testing.T) {
-	ctx := t.Context()
+func TestKeymanager_DeletePublicKeys_DerivedKeysAreNotDeletable(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	flagKey := "0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6"
+	fileKey := "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055"
+	unknownKey := "0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(fileKey+"\n")))
 	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
 	require.NoError(t, err)
-	config := &SetupConfig{
+	km, err := NewKeymanager(ctx, &SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
-	}
-	km, err := NewKeymanager(ctx, config)
+		KeyFilePath:           keyFilePath,
+		ProvidedPublicKeys:    []string{flagKey},
+	})
 	require.NoError(t, err)
-	publicKeys := []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"}
-	statuses, err := km.AddPublicKeys(publicKeys)
-	require.NoError(t, err)
-	for _, status := range statuses {
-		require.Equal(t, keymanager.StatusImported, status.Status)
-	}
 
-	s, err := km.DeletePublicKeys(publicKeys)
+	statuses, err := km.DeletePublicKeys([]string{flagKey, fileKey, unknownKey, fileKey})
 	require.NoError(t, err)
-	for _, status := range s {
-		require.Equal(t, keymanager.StatusDeleted, status.Status)
-	}
+	require.Equal(t, keymanager.StatusError, statuses[0].Status)
+	require.StringContains(t, "validators-external-signer-public-keys", statuses[0].Message)
+	require.Equal(t, keymanager.StatusDeleted, statuses[1].Status)
+	require.Equal(t, keymanager.StatusNotFound, statuses[2].Status)
+	// The same key twice in one request is only deleted once.
+	require.Equal(t, keymanager.StatusNotFound, statuses[3].Status)
 
-	s, err = km.DeletePublicKeys(publicKeys)
+	// Only the file key is gone, the flag key keeps validating.
+	keys, err := km.FetchValidatingPublicKeys(ctx)
 	require.NoError(t, err)
-	for _, status := range s {
-		require.Equal(t, keymanager.StatusNotFound, status.Status)
-	}
+	require.Equal(t, 1, len(keys))
+	require.Equal(t, flagKey, hexutil.Encode(keys[0][:]))
+}
+
+func TestKeymanager_DeletePublicKeys_URLOwnedKey(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	urlKey := "0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode([]string{urlKey}))
+	}))
+	defer srv.Close()
+
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, nil))
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+		PublicKeysURL:         srv.URL + "/api/v1/eth2/publicKeys",
+		KeyFilePath:           keyFilePath,
+	})
+	require.NoError(t, err)
+
+	// The URL key is not written to the key file, and the API cannot take it away.
+	fileKeys, err := km.readKeyFile()
+	require.NoError(t, err)
+	require.Equal(t, 0, len(fileKeys))
+
+	statuses, err := km.DeletePublicKeys([]string{urlKey})
+	require.NoError(t, err)
+	require.Equal(t, keymanager.StatusError, statuses[0].Status)
+	require.StringContains(t, "remote signer public keys URL", statuses[0].Message)
+
+	// Nor can it be re-imported as a file key.
+	statuses, err = km.AddPublicKeys([]string{urlKey})
+	require.NoError(t, err)
+	require.Equal(t, keymanager.StatusDuplicate, statuses[0].Status)
+
+	keys, err := km.FetchValidatingPublicKeys(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(keys))
+	require.Equal(t, urlKey, hexutil.Encode(keys[0][:]))
 }
 
 func TestKeymanager_DeletePublicKeys_WithFile(t *testing.T) {
@@ -576,57 +709,16 @@ func TestKeymanager_DeletePublicKeys_WithFile(t *testing.T) {
 	for _, status := range s {
 		require.Equal(t, keymanager.StatusNotFound, status.Status)
 	}
-	keys, _, err := km.readKeyFile()
+	keys, err := km.readKeyFile()
 	require.NoError(t, err)
 	require.Equal(t, len(keys), 1)
 	require.Equal(t, hexutil.Encode(keys[0][:]), publicKeys[1])
 }
 
-func TestKeymanager_DeletePublicKeys_NoKeysDoesNotLeakReadLock(t *testing.T) {
-	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
-	require.NoError(t, err)
-	km, err := NewKeymanager(t.Context(), &SetupConfig{
-		BaseEndpoint:          "http://example.com",
-		GenesisValidatorsRoot: root,
-	})
-	require.NoError(t, err)
-
-	publicKeys := []string{"0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"}
-	s, err := km.DeletePublicKeys(publicKeys)
-	require.NoError(t, err)
-	for _, status := range s {
-		require.Equal(t, keymanager.StatusNotFound, status.Status)
+func encodeKeys(keys []pubkey) []string {
+	encoded := make([]string, len(keys))
+	for i, key := range keys {
+		encoded[i] = hexutil.Encode(key[:])
 	}
-
-	// The early return must not leave a read lock held, or every later writer blocks.
-	require.Equal(t, true, km.lock.TryLock(), "DeletePublicKeys returned holding a read lock")
-	km.lock.Unlock()
-}
-
-func TestEqualKeySet(t *testing.T) {
-	k1 := [48]byte{1}
-	k2 := [48]byte{2}
-
-	tests := []struct {
-		name string
-		x    [][48]byte
-		y    [][48]byte
-		want bool
-	}{
-		{name: "both empty", x: nil, y: nil, want: true},
-		{name: "equal single", x: [][48]byte{k1}, y: [][48]byte{k1}, want: true},
-		{name: "same set different order", x: [][48]byte{k1, k2}, y: [][48]byte{k2, k1}, want: true},
-		{name: "different length", x: [][48]byte{k1}, y: [][48]byte{k1, k2}, want: false},
-		{name: "same length different members", x: [][48]byte{k1}, y: [][48]byte{k2}, want: false},
-		{name: "empty vs non-empty", x: nil, y: [][48]byte{k1}, want: false},
-		{name: "duplicate entries keep same distinct set", x: [][48]byte{k1}, y: [][48]byte{k1, k1}, want: true},
-		{name: "duplicate on left is still equal", x: [][48]byte{k1, k1}, y: [][48]byte{k1}, want: true},
-		// A duplicate must not mask a removal: {k1,k2} -> {k1,k1} drops k2.
-		{name: "duplicate does not mask removal", x: [][48]byte{k1, k2}, y: [][48]byte{k1, k1}, want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, equalKeySet(tt.x, tt.y))
-		})
-	}
+	return encoded
 }

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -719,6 +719,34 @@ func TestKeymanager_DeletePublicKeys_WithFile(t *testing.T) {
 	require.Equal(t, hexutil.Encode(keys[0][:]), publicKeys[1])
 }
 
+func TestKeymanager_IsReadOnly(t *testing.T) {
+	flagKey, urlKey, fileKey := pubkey{1}, pubkey{2}, pubkey{3}
+	sharedKey := pubkey{4}
+	unknownKey := pubkey{5}
+
+	km := &Keymanager{}
+	km.keys.replace(sourceFlag, []pubkey{flagKey, sharedKey})
+	km.keys.replace(sourceURL, []pubkey{urlKey})
+	km.keys.replace(sourceFile, []pubkey{fileKey, sharedKey})
+
+	tests := []struct {
+		name string
+		key  pubkey
+		want bool
+	}{
+		{name: "flag key is read-only", key: flagKey, want: true},
+		{name: "URL key is read-only", key: urlKey, want: true},
+		{name: "file key is writable", key: fileKey, want: false},
+		{name: "key in flag and file is read-only", key: sharedKey, want: true},
+		{name: "unknown key is read-only", key: unknownKey, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, km.IsReadOnly(tt.key))
+		})
+	}
+}
+
 func encodeKeys(keys []pubkey) []string {
 	encoded := make([]string, len(keys))
 	for i, key := range keys {

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -219,7 +219,7 @@ func TestNewKeyManager_FileAndFlagsWithDifferentKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 	require.Equal(t, "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055", hexutil.Encode(keys[0][:]))
-	// Clearing the file falls back to the flag provided keys.
+	// Clearing the file empties its source, leaving only the flag provided keys.
 	require.NoError(t, file.WriteFile(keyFilePath, []byte(" ")))
 	deadline := time.Now().Add(5 * time.Second)
 	for len(km.keys.all()) != 1 {
@@ -228,7 +228,7 @@ func TestNewKeyManager_FileAndFlagsWithDifferentKeys(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	require.LogsContain(t, logHook, "Remote signer key file no longer has keys, defaulting to flag provided keys")
+	require.LogsContain(t, logHook, "Remote signer key file has no keys, so the key file no longer contributes any validating keys")
 
 	keys, err = km.FetchValidatingPublicKeys(context.TODO())
 	require.NoError(t, err)

--- a/validator/rpc/handlers_keymanager.go
+++ b/validator/rpc/handlers_keymanager.go
@@ -387,6 +387,10 @@ func (s *Server) SetVoluntaryExit(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJson(w, response)
 }
 
+type readOnlyChecker interface {
+	IsReadOnly([fieldparams.BLSPubkeyLength]byte) bool
+}
+
 // ListRemoteKeys returns a list of all public keys defined for web3signer keymanager type.
 func (s *Server) ListRemoteKeys(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "validator.keymanagerAPI.ListRemoteKeys")
@@ -400,11 +404,7 @@ func (s *Server) ListRemoteKeys(w http.ResponseWriter, r *http.Request) {
 		httputil.HandleError(w, "Prysm Wallet not initialized. Please create a new wallet.", http.StatusServiceUnavailable)
 		return
 	}
-	km, err := s.validatorService.Keymanager()
-	if err != nil {
-		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+
 	kind, _ := s.keymanagerKind()
 	if kind != keymanager.Web3Signer {
 		log.Debugf("List remote keys keymanager api expected keymanager type %s but got %s", keymanager.Web3Signer.String(), kind.String())
@@ -414,17 +414,32 @@ func (s *Server) ListRemoteKeys(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteJson(w, response)
 		return
 	}
+
+	km, err := s.validatorService.Keymanager()
+	if err != nil {
+		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	checker, ok := km.(readOnlyChecker)
+	if !ok {
+		// Should never happen.
+		httputil.HandleError(w, "Keymanager does not support read-only check", http.StatusInternalServerError)
+		return
+	}
+
 	pubKeys, err := km.FetchValidatingPublicKeys(ctx)
 	if err != nil {
 		httputil.HandleError(w, errors.Errorf("Could not retrieve public keys: %v", err).Error(), http.StatusInternalServerError)
 		return
 	}
+
 	keystoreResponse := make([]*RemoteKey, len(pubKeys))
-	for i := range pubKeys {
+	for i, pubkey := range pubKeys {
 		keystoreResponse[i] = &RemoteKey{
-			Pubkey:   hexutil.Encode(pubKeys[i][:]),
+			Pubkey:   hexutil.Encode(pubkey[:]),
 			Url:      s.validatorService.RemoteSignerConfig().BaseEndpoint,
-			Readonly: true,
+			Readonly: checker.IsReadOnly(pubkey),
 		}
 	}
 

--- a/validator/rpc/handlers_keymanager_test.go
+++ b/validator/rpc/handlers_keymanager_test.go
@@ -1501,6 +1501,33 @@ func TestServer_ImportRemoteKeys(t *testing.T) {
 			require.Equal(t, fmt.Sprintf("%v", expectedStatuses[i].Status), strings.ToLower(string(resp.Data[i].Status)))
 		}
 	})
+
+	t.Run("no key file", func(t *testing.T) {
+		config := &remoteweb3signer.SetupConfig{
+			BaseEndpoint:          "http://example.com",
+			GenesisValidatorsRoot: root,
+		}
+		km, err := remoteweb3signer.NewKeymanager(ctx, config)
+		require.NoError(t, err)
+		vs := validatormock.NewMockValidatorService(gomock.NewController(t))
+		vs.EXPECT().Keymanager().Return(km, nil).AnyTimes()
+		vs.EXPECT().RemoteSignerConfig().Return(config).AnyTimes()
+		s := &Server{walletInitialized: true, validatorService: vs}
+
+		b, err := json.Marshal(&ImportRemoteKeysRequest{RemoteKeys: []*RemoteKey{{Pubkey: pubkey}}})
+		require.NoError(t, err)
+		req := httptest.NewRequest("POST", "/eth/v1/remotekeys", bytes.NewReader(b))
+		w := httptest.NewRecorder()
+		w.Body = &bytes.Buffer{}
+		s.ImportRemoteKeys(w, req)
+
+		// Per-key statuses in a 200, never an HTTP error.
+		require.Equal(t, http.StatusOK, w.Code)
+		resp := &RemoteKeysResponse{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), resp))
+		require.Equal(t, 1, len(resp.Data))
+		require.Equal(t, keymanager.StatusError, resp.Data[0].Status)
+	})
 }
 
 func TestServer_DeleteRemoteKeys(t *testing.T) {
@@ -1552,6 +1579,40 @@ func TestServer_DeleteRemoteKeys(t *testing.T) {
 		expectedKeys, err := km.FetchValidatingPublicKeys(ctx)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(expectedKeys))
+	})
+
+	t.Run("unknown and derived keys", func(t *testing.T) {
+		unknownKey := "0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"
+		// pkey comes from the flag, not the key file, so it is not deletable.
+		keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+		require.NoError(t, file.WriteFile(keyFilePath, nil))
+		config := &remoteweb3signer.SetupConfig{
+			BaseEndpoint:          "http://example.com",
+			GenesisValidatorsRoot: root,
+			KeyFilePath:           keyFilePath,
+			ProvidedPublicKeys:    []string{pkey},
+		}
+		km, err := remoteweb3signer.NewKeymanager(ctx, config)
+		require.NoError(t, err)
+		vs := validatormock.NewMockValidatorService(gomock.NewController(t))
+		vs.EXPECT().Keymanager().Return(km, nil).AnyTimes()
+		vs.EXPECT().RemoteSignerConfig().Return(config).AnyTimes()
+		s := &Server{walletInitialized: true, validatorService: vs}
+
+		b, err := json.Marshal(&DeleteRemoteKeysRequest{Pubkeys: []string{pkey, unknownKey}})
+		require.NoError(t, err)
+		req := httptest.NewRequest("DELETE", "/eth/v1/remotekeys", bytes.NewReader(b))
+		w := httptest.NewRecorder()
+		w.Body = &bytes.Buffer{}
+		s.DeleteRemoteKeys(w, req)
+
+		// Nothing matched, but the spec still wants a 200 with statuses in request order.
+		require.Equal(t, http.StatusOK, w.Code)
+		resp := &RemoteKeysResponse{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), resp))
+		require.Equal(t, 2, len(resp.Data))
+		require.Equal(t, keymanager.StatusError, resp.Data[0].Status)
+		require.Equal(t, keymanager.StatusNotFound, resp.Data[1].Status)
 	})
 }
 

--- a/validator/rpc/handlers_keymanager_test.go
+++ b/validator/rpc/handlers_keymanager_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/validator"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	"github.com/OffchainLabs/prysm/v7/io/file"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -1453,10 +1455,12 @@ func TestServer_ImportRemoteKeys(t *testing.T) {
 	ctx := t.Context()
 	root := make([]byte, fieldparams.RootLength)
 	root[0] = 1
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, nil))
 	config := &remoteweb3signer.SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
-		ProvidedPublicKeys:    nil,
+		KeyFilePath:           keyFilePath,
 	}
 	km, err := remoteweb3signer.NewKeymanager(ctx, config)
 	require.NoError(t, err)
@@ -1504,10 +1508,12 @@ func TestServer_DeleteRemoteKeys(t *testing.T) {
 	root := make([]byte, fieldparams.RootLength)
 	root[0] = 1
 	pkey := "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(pkey+"\n")))
 	config := &remoteweb3signer.SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
-		ProvidedPublicKeys:    []string{pkey},
+		KeyFilePath:           keyFilePath,
 	}
 	km, err := remoteweb3signer.NewKeymanager(ctx, config)
 	require.NoError(t, err)

--- a/validator/rpc/handlers_keymanager_test.go
+++ b/validator/rpc/handlers_keymanager_test.go
@@ -1410,10 +1410,15 @@ func TestServer_ListRemoteKeys(t *testing.T) {
 	ctx := t.Context()
 	root := make([]byte, fieldparams.RootLength)
 	root[0] = 1
+	flagKey := "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+	fileKey := "0x800057e262bfe42413c2cfce948ff77f11efeea19721f590c8b5b2f32fecb0e164cafba987c80465878408d05b97c9be"
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(fileKey+"\n")))
 	config := &remoteweb3signer.SetupConfig{
 		BaseEndpoint:          "http://example.com",
 		GenesisValidatorsRoot: root,
-		ProvidedPublicKeys:    []string{"0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"},
+		ProvidedPublicKeys:    []string{flagKey},
+		KeyFilePath:           keyFilePath,
 	}
 	km, err := remoteweb3signer.NewKeymanager(ctx, config)
 	require.NoError(t, err)
@@ -1424,9 +1429,6 @@ func TestServer_ListRemoteKeys(t *testing.T) {
 		walletInitialized: true,
 		validatorService:  vs,
 	}
-	expectedKeys, err := km.FetchValidatingPublicKeys(ctx)
-	require.NoError(t, err)
-
 	t.Run("returns proper data with existing pub keystores", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/eth/v1/remotekeys", nil)
 		w := httptest.NewRecorder()
@@ -1435,8 +1437,12 @@ func TestServer_ListRemoteKeys(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		resp := &ListRemoteKeysResponse{}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), resp))
-		for i := 0; i < len(resp.Data); i++ {
-			require.DeepEqual(t, hexutil.Encode(expectedKeys[i][:]), resp.Data[i].Pubkey)
+		wantReadonly := map[string]bool{flagKey: true, fileKey: false}
+		require.Equal(t, len(wantReadonly), len(resp.Data))
+		for _, key := range resp.Data {
+			readonly, ok := wantReadonly[key.Pubkey]
+			require.Equal(t, true, ok)
+			require.Equal(t, readonly, key.Readonly)
 		}
 	})
 	t.Run("calling list keystores while using a remote wallet returns empty", func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Feature (with new design)

**What does this PR do? Why is it needed?**

- #17322 

The issue above describes the inherent problems that we have on remote signer key management. This PR introduces new design as I documented in the issue upon #17229.

**Which issue(s) does this PR fix?**

Fixes #17322 

**Other notes for review**

> [!IMPORTANT]
> Also, I tried to trim the commit as neat as possible. So please read commit by commit, with commit descriptions.

See full testing report by the agent [here](https://gist.github.com/syjn99/8245cb01cdb3925f28e197cc592e6c65). The essence of this PR is in `Poll replaces only the URL's keys` section.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
