### PR TITLE
optimize recomputeProgressiveOverlay hashing

### DIFF
--- a/beacon-chain/state/fieldtrie/progressive.go
+++ b/beacon-chain/state/fieldtrie/progressive.go
@@ -194,32 +194,49 @@ func (f *FieldTrie) recomputeProgressiveOverlay(elements any, indices []uint64) 
 		return [32]byte{}, fmt.Errorf("field converters: %w", err)
 	}
 
+	// Store all dirty leaves before walking upward so shared parents are hashed only once.
+	dirtyBySubtree := make(map[int]map[uint64]bool)
 	highestSubtreeIndex := -1
 	for i, globalIndex := range chunkIndices {
 		subtreeIndex, localIndex := progressiveSubtreeForIndex(globalIndex)
 		highestSubtreeIndex = max(highestSubtreeIndex, subtreeIndex)
-		depth := progressiveSubtreeDepth(subtreeIndex)
+		if dirtyBySubtree[subtreeIndex] == nil {
+			dirtyBySubtree[subtreeIndex] = make(map[uint64]bool)
+		}
+		dirtyBySubtree[subtreeIndex][localIndex] = true
+
 		position := progressiveNodePosition{subtree: subtreeIndex, level: 0, index: localIndex}
 		f.progressiveOverridesData.nodes[position] = fieldRoots[i]
 		f.progressiveOverridesData.leaves[globalIndex] = true
+	}
 
-		currentIndex := localIndex
-		var pair [64]byte
-		hasher := hash.CustomSHA256Hasher()
+	var pair [64]byte
+	hasher := hash.CustomSHA256Hasher()
+	// Recompute each affected subtree level by level, deduplicating parents at every level.
+	for subtreeIndex, currentDirty := range dirtyBySubtree {
+		depth := progressiveSubtreeDepth(subtreeIndex)
 		for level := range depth {
-			parentIndex := currentIndex / 2
-			leftIndex := parentIndex * 2
-			left := f.readProgressiveOverlayNode(subtreeIndex, level, leftIndex)
-			right := f.readProgressiveOverlayNode(subtreeIndex, level, leftIndex+1)
-			copy(pair[:32], left[:])
-			copy(pair[32:], right[:])
-			parent := hasher(pair[:])
-			currentIndex = parentIndex
-			f.progressiveOverridesData.nodes[progressiveNodePosition{
-				subtree: subtreeIndex,
-				level:   level + 1,
-				index:   parentIndex,
-			}] = parent
+			parentDirty := make(map[uint64]bool, len(currentDirty)/2+1)
+			for currentIndex := range currentDirty {
+				parentIndex := currentIndex / 2
+				if parentDirty[parentIndex] {
+					continue
+				}
+
+				leftIndex := parentIndex * 2
+				left := f.readProgressiveOverlayNode(subtreeIndex, level, leftIndex)
+				right := f.readProgressiveOverlayNode(subtreeIndex, level, leftIndex+1)
+				copy(pair[:32], left[:])
+				copy(pair[32:], right[:])
+				parent := hasher(pair[:])
+				f.progressiveOverridesData.nodes[progressiveNodePosition{
+					subtree: subtreeIndex,
+					level:   level + 1,
+					index:   parentIndex,
+				}] = parent
+				parentDirty[parentIndex] = true
+			}
+			currentDirty = parentDirty
 		}
 	}
 	f.recomputeProgressiveOverlaySpine(highestSubtreeIndex)

--- a/beacon-chain/state/fieldtrie/progressive_test.go
+++ b/beacon-chain/state/fieldtrie/progressive_test.go
@@ -86,15 +86,22 @@ func TestProgressiveFieldTrie(t *testing.T) {
 		})
 
 		t.Run("overlay", func(t *testing.T) {
-			validators := progressiveTestValidators(6)
+			validators := progressiveTestValidators(22)
 			base := newProgressiveTestFieldTrie(t, types.Validators, types.CompositeArray, validators)
 			copied := base.CopyTrie()
 
+			validators[20].EffectiveBalance++
 			validators[5].EffectiveBalance++
+			validators[6].EffectiveBalance++
+			validators[7].EffectiveBalance++
 			validators[1].EffectiveBalance++
-			overlay, recomputedRoot, err := base.RecomputeTrie([]uint64{5, 1}, validators)
+			overlay, recomputedRoot, err := base.RecomputeTrie([]uint64{20, 5, 6, 7, 1}, validators)
 			require.NoError(t, err)
 			runtime.KeepAlive(copied)
+
+			require.Equal(t, 15, len(overlay.progressiveOverridesData.nodes))
+			require.Equal(t, 3, len(overlay.progressiveOverridesData.spine))
+			require.Equal(t, 5, len(overlay.progressiveOverridesData.leaves))
 
 			root, err := overlay.TrieRoot()
 			require.NoError(t, err)

--- a/changelog/bastin_optimize-recompute-progressive-overlay-hashing.md
+++ b/changelog/bastin_optimize-recompute-progressive-overlay-hashing.md
@@ -1,0 +1,3 @@
+### Changed
+
+- optimize recomputeProgressiveOverlay hashing.


### PR DESCRIPTION
Optimize the hashing of `fieldtrie.recomputeProgressiveOverlay()` by deduplicating parent hashings.