### PR TITLE
fix(sync): cap data column range database batches

### DIFF
--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
+	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
@@ -15,6 +16,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	pb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/pkg/errors"
 
@@ -251,6 +253,11 @@ func validateDataColumnsByRange(request *pb.DataColumnSidecarsByRangeRequest, cu
 		return nil, errors.Wrap(p2ptypes.ErrInvalidRequest, "overflow end - start + 1")
 	}
 
-	rangeParameters := &rangeParams{start: startSlot, end: endSlot, size: uint64(size)}
+	// Keep the complete request range while limiting the slot width of each database read.
+	batchLimit := min(
+		uint64(flags.Get().BlockBatchLimit),
+		params.MaxRequestBlock(slots.ToEpoch(currentSlot)),
+	)
+	rangeParameters := &rangeParams{start: startSlot, end: endSlot, size: min(uint64(size), batchLimit)}
 	return rangeParameters, nil
 }

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range_test.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -431,11 +432,11 @@ func TestValidateDataColumnsByRange(t *testing.T) {
 			expectErr:   false,
 		},
 		{
-			name:        "range exceeds limits",
+			name:        "range is split at the block batch limit",
 			startSlot:   0,
 			count:       10_000,
 			currentSlot: 400,
-			expected:    &rangeParams{start: 320, end: 400, size: 81},
+			expected:    &rangeParams{start: 320, end: 400, size: uint64(flags.Get().BlockBatchLimit)},
 			expectErr:   false,
 		},
 	}

--- a/changelog/exocognosis_cap-data-column-range-batches.md
+++ b/changelog/exocognosis_cap-data-column-range-batches.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Bound data column sidecar range database reads to the configured block batch size.


### PR DESCRIPTION
## Problem

`validateDataColumnsByRange` preserves the full normalized request width in `rangeParams.size`. The shared `blockRangeBatcher` interprets that value as the slot width for each database lookup, so a request spanning thousands of slots can cause one large synchronous `db.Blocks` read before response quotas stop stream writes.

The block and blob range handlers already separate the full request range from the size of each database batch. The data column handler did not apply an equivalent bound.

## Solution

- Preserve the normalized `start` and `end` slots so valid requests still cover their complete range.
- Clamp the per-read `size` to the configured block batch limit.
- Also bound the batch width by the fork-aware maximum block request size.
- Let the existing range batcher iterate across the remaining range in bounded database reads.
- Add regression coverage showing that a normalized 81-slot range uses the configured 64-slot batch size.
- Add the required changelog fragment.

## Impact

This prevents large data column range requests from creating a single wide block database read. It does not reject valid requests, change their normalized range, or reduce the response quota. It only bounds the amount of block data loaded by each batch iteration.

## Validation

- `go test ./beacon-chain/sync -run '^TestValidateDataColumnsByRange$' -count=1`
- `go test ./beacon-chain/sync -count=1`
- `gofmt` on the modified Go files
- `git diff --check`

Closes #17314
