### PR TITLE
Use slot duration helper function instead of `SecondsPerSlot`

### DIFF
--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -122,8 +122,8 @@ func (s *Service) shouldOverrideFCU(newHeadRoot [32]byte, proposingSlot primitiv
 		log.WithFields(logrus.Fields{
 			"root":   fmt.Sprintf("%#x", newHeadRoot),
 			"weight": headWeight,
-		}).Infof("Attempted late block reorg aborted due to attestations at %d seconds",
-			params.BeaconConfig().SecondsPerSlot)
+		}).Infof("Attempted late block reorg aborted due to attestations at %s into the slot",
+			params.BeaconConfig().SlotDuration())
 		lateBlockFailedAttemptSecondThreshold.Inc()
 	} else {
 		if s.cfg.ForkChoiceStore.ShouldOverrideFCU() {

--- a/beacon-chain/blockchain/forkchoice_update_execution_test.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution_test.go
@@ -179,9 +179,9 @@ func TestShouldOverrideFCU(t *testing.T) {
 
 	require.Equal(t, primitives.Slot(2), service.CurrentSlot())
 	require.Equal(t, true, service.shouldOverrideFCU(headRoot, 2))
-	require.LogsDoNotContain(t, hook, "12 seconds")
+	require.LogsDoNotContain(t, hook, "12s into the slot")
 	require.Equal(t, false, service.shouldOverrideFCU(parentRoot, 2))
-	require.LogsContain(t, hook, "12 seconds")
+	require.LogsContain(t, hook, "12s into the slot")
 
 	head, err := fcs.Head(ctx)
 	require.NoError(t, err)

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -3,11 +3,12 @@ package blockchain
 import (
 	"context"
 	"math"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
 	coregloas "github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/time"
+	coreTime "github.com/OffchainLabs/prysm/v7/beacon-chain/core/time"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/features"
@@ -54,11 +55,11 @@ func (s *Service) IsBidCompatibleWithHead(bid interfaces.ROExecutionPayloadBid) 
 	return buildsOnParentPayload
 }
 
-func (s *Service) waitUntilEpoch(target primitives.Epoch, secondsPerSlot uint64) error {
+func (s *Service) waitUntilEpoch(target primitives.Epoch, slotDuration time.Duration) error {
 	if slots.ToEpoch(s.CurrentSlot()) >= target {
 		return nil
 	}
-	ticker := slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
+	ticker := slots.NewSlotTicker(s.genesisTime, slotDuration)
 	defer ticker.Done()
 	for {
 		select {
@@ -81,11 +82,11 @@ func (s *Service) runLatePayloadTasks() {
 	if cfg.GloasForkEpoch == math.MaxUint64 {
 		return
 	}
-	if err := s.waitUntilEpoch(cfg.GloasForkEpoch, cfg.SecondsPerSlot); err != nil {
+	if err := s.waitUntilEpoch(cfg.GloasForkEpoch, cfg.SlotDuration()); err != nil {
 		return
 	}
 	offset := cfg.SlotComponentDuration(cfg.PayloadDueBPS)
-	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, cfg.SecondsPerSlot)
+	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, cfg.SlotDuration())
 	defer ticker.Done()
 	for {
 		select {
@@ -164,7 +165,7 @@ func (s *Service) getLatePayloadAttribute(ctx context.Context, st state.ReadOnly
 		return emptyAttri
 	}
 
-	prevRando, err := helpers.RandaoMix(st, time.CurrentEpoch(st))
+	prevRando, err := helpers.RandaoMix(st, coreTime.CurrentEpoch(st))
 	if err != nil {
 		log.WithError(err).Error("Could not get randao mix to get payload attribute")
 		return emptyAttri

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -776,7 +776,7 @@ func TestPostPayloadTasks_BetsAgainstLatePayload(t *testing.T) {
 
 	root := bytesutil.ToBytes32([]byte("late-head"))
 	blockHash := bytesutil.ToBytes32([]byte("hash1"))
-	service.SetGenesisTime(time.Now().Add(-time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second))
+	service.SetGenesisTime(time.Now().Add(-params.BeaconConfig().SlotDuration()))
 	blockSlot := service.CurrentSlot()
 
 	base, blk := testGloasState(t, blockSlot, params.BeaconConfig().ZeroHash, blockHash)
@@ -823,7 +823,7 @@ func TestLatePayloadTasks_ReturnsEarlyWhenBlockLate(t *testing.T) {
 		slot:  1,
 	}
 	// Set genesis time so CurrentSlot > HeadSlot.
-	service.SetGenesisTime(time.Now().Add(-2 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second))
+	service.SetGenesisTime(time.Now().Add(-2 * params.BeaconConfig().SlotDuration()))
 
 	service.latePayloadTasks(tr.ctx)
 	require.LogsDoNotContain(t, logHook, "Could not notify forkchoice update")
@@ -860,7 +860,7 @@ func TestLatePayloadTasks_SendsFCU(t *testing.T) {
 		slot:  1,
 	}
 	// CurrentSlot == HeadSlot == 1: place genesis 1.5 slots ago so we're solidly in slot 1.
-	service.SetGenesisTime(time.Now().Add(-3 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second / 2))
+	service.SetGenesisTime(time.Now().Add(-3 * params.BeaconConfig().SlotDuration() / 2))
 	service.SetForkChoiceGenesisTime(service.genesisTime)
 
 	service.latePayloadTasks(tr.ctx)
@@ -898,7 +898,7 @@ func TestLatePayloadTasks_SendsFCUWhilePayloadSyncing(t *testing.T) {
 		state: st,
 		slot:  1,
 	}
-	service.SetGenesisTime(time.Now().Add(-3 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second / 2))
+	service.SetGenesisTime(time.Now().Add(-3 * params.BeaconConfig().SlotDuration() / 2))
 	service.SetForkChoiceGenesisTime(service.genesisTime)
 
 	// The envelope validating past the 9s mark must not starve the proposer of the empty build.
@@ -936,7 +936,7 @@ func TestLateBlockTasks_GloasFCU(t *testing.T) {
 	}
 
 	// Set genesis time so CurrentSlot > HeadSlot, triggering late block logic.
-	service.SetGenesisTime(time.Now().Add(-2 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second))
+	service.SetGenesisTime(time.Now().Add(-2 * params.BeaconConfig().SlotDuration()))
 	service.SetForkChoiceGenesisTime(service.genesisTime)
 
 	service.lateBlockTasks(tr.ctx)
@@ -984,7 +984,7 @@ func TestLateBlockTasks_GloasForkBoundary_PreforkBidUsesHeadRoot(t *testing.T) {
 	}
 
 	// Trigger late block logic: CurrentSlot > HeadSlot.
-	service.SetGenesisTime(time.Now().Add(-2 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second))
+	service.SetGenesisTime(time.Now().Add(-2 * params.BeaconConfig().SlotDuration()))
 	service.SetForkChoiceGenesisTime(service.genesisTime)
 
 	service.lateBlockTasks(tr.ctx)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -820,7 +820,7 @@ func (s *Service) runLateBlockTasks() {
 		attDueBPS = cfg.AttestationDueBPSGloas
 	}
 	attThreshold := cfg.SlotComponentDuration(attDueBPS)
-	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SecondsPerSlot)
+	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SlotDuration())
 	for {
 		select {
 		case slot := <-ticker.C():
@@ -828,7 +828,7 @@ func (s *Service) runLateBlockTasks() {
 				ticker.Done()
 				attDueBPS = cfg.AttestationDueBPSGloas
 				attThreshold = cfg.SlotComponentDuration(attDueBPS)
-				ticker = slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SecondsPerSlot)
+				ticker = slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SlotDuration())
 			}
 			s.goroutineCounter.sample(slot)
 			s.lateBlockTasks(s.ctx)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -466,7 +466,7 @@ func (s *Service) areSidecarsAvailable(ctx context.Context, avs das.Availability
 			return nil
 		}
 		// Bound the wait so unavailable columns error and retry instead of stalling import.
-		daCtx, cancel := context.WithTimeout(ctx, time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second)
+		daCtx, cancel := context.WithTimeout(ctx, params.BeaconConfig().SlotDuration())
 		defer cancel()
 		if err := s.areDataColumnsAvailable(daCtx, roBlock.Root(), slot); err != nil {
 			return errors.Wrapf(err, "are data columns available for block %#x with slot %d", roBlock.Root(), slot)

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2250,7 +2250,7 @@ func TestFillMissingBlockPayloadId_PrepareAllPayloads(t *testing.T) {
 // boost. It alters the genesisTime tracked by the store.
 func driftGenesisTime(s *Service, slot primitives.Slot, delay time.Duration) {
 	now := time.Now()
-	slotDuration := time.Duration(slot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	slotDuration := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	genesis := now.Add(-slotDuration - delay)
 	s.SetGenesisTime(genesis)
 	s.cfg.ForkChoiceStore.SetGenesisTime(genesis)
@@ -3030,7 +3030,7 @@ func TestIsDataAvailable_InitSync(t *testing.T) {
 			done <- service.isDataAvailable(ctx, roBlock)
 		}()
 
-		bound := time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + 2*time.Second
+		bound := params.BeaconConfig().SlotDuration() + 2*time.Second
 		select {
 		case err := <-done:
 			require.NotNil(t, err)

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -89,7 +89,7 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 			return
 		}
 
-		reorgInterval := time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot) - reorgLateBlockCountAttestations
+		reorgInterval := params.BeaconConfig().SlotDuration() - reorgLateBlockCountAttestations
 		ticker := slots.NewSlotTickerWithIntervals(s.genesisTime, []time.Duration{0, reorgInterval})
 		for {
 			select {

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -89,10 +89,6 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 			return
 		}
 
-		// Slots shorter than reorgLateBlockCountAttestations would give a negative offset, which
-		// NewSlotTickerWithIntervals panics on. Clamp to zero: the late-block branch is keyed on
-		// Interval > 0, so a zero offset disables late-block attestation counting rather than
-		// crashing the node on an accelerated devnet.
 		reorgInterval := max(params.BeaconConfig().SlotDuration()-reorgLateBlockCountAttestations, 0)
 		ticker := slots.NewSlotTickerWithIntervals(s.genesisTime, []time.Duration{0, reorgInterval})
 		for {

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -89,7 +89,11 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 			return
 		}
 
-		reorgInterval := params.BeaconConfig().SlotDuration() - reorgLateBlockCountAttestations
+		// Slots shorter than reorgLateBlockCountAttestations would give a negative offset, which
+		// NewSlotTickerWithIntervals panics on. Clamp to zero: the late-block branch is keyed on
+		// Interval > 0, so a zero offset disables late-block attestation counting rather than
+		// crashing the node on an accelerated devnet.
+		reorgInterval := max(params.BeaconConfig().SlotDuration()-reorgLateBlockCountAttestations, 0)
 		ticker := slots.NewSlotTickerWithIntervals(s.genesisTime, []time.Duration{0, reorgInterval})
 		for {
 			select {

--- a/beacon-chain/blockchain/receive_attestation_test.go
+++ b/beacon-chain/blockchain/receive_attestation_test.go
@@ -68,9 +68,9 @@ func TestProcessAttestations_Ok(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := tr.ctx
 
-	service.genesisTime = prysmTime.Now().Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	service.genesisTime = prysmTime.Now().Add(-1 * params.BeaconConfig().SlotDuration())
 	genesisState, pks := util.DeterministicGenesisState(t, 64)
-	require.NoError(t, genesisState.SetGenesisTime(time.Now().Add(-1*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second)))
+	require.NoError(t, genesisState.SetGenesisTime(time.Now().Add(-1*params.BeaconConfig().SlotDuration())))
 	require.NoError(t, service.saveGenesisData(ctx, genesisState))
 	atts, err := util.GenerateAttestations(genesisState, pks, 1, 0, false)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestService_ProcessAttestationsAndUpdateHead(t *testing.T) {
 	service, tr := minimalTestService(t)
 	ctx, fcs := tr.ctx, tr.fcs
 
-	service.genesisTime = prysmTime.Now().Add(-2 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	service.genesisTime = prysmTime.Now().Add(-2 * params.BeaconConfig().SlotDuration())
 	genesisState, pks := util.DeterministicGenesisState(t, 64)
 	require.NoError(t, service.saveGenesisData(ctx, genesisState))
 	ojc := &ethpb.Checkpoint{Epoch: 0, Root: service.originBlockRoot[:]}
@@ -159,7 +159,7 @@ func TestService_UpdateHead_NoAtts(t *testing.T) {
 	service, tr := minimalTestService(t)
 	ctx, fcs := tr.ctx, tr.fcs
 
-	service.genesisTime = prysmTime.Now().Add(-2 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	service.genesisTime = prysmTime.Now().Add(-2 * params.BeaconConfig().SlotDuration())
 	genesisState, pks := util.DeterministicGenesisState(t, 64)
 	require.NoError(t, service.saveGenesisData(ctx, genesisState))
 	require.NoError(t, fcs.UpdateJustifiedCheckpoint(ctx, &forkchoicetypes.Checkpoint{Epoch: 0, Root: service.originBlockRoot}))

--- a/beacon-chain/blockchain/testing/BUILD.bazel
+++ b/beacon-chain/blockchain/testing/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//encoding/bytesutil:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//time/slots:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -30,6 +30,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
 
@@ -481,7 +482,7 @@ func (s *ChainService) CurrentSlot() primitives.Slot {
 	if s.Slot != nil {
 		return *s.Slot
 	}
-	return primitives.Slot(uint64(time.Now().Unix()-s.Genesis.Unix()) / params.BeaconConfig().SecondsPerSlot)
+	return slots.CurrentSlot(s.Genesis)
 }
 
 // Participation mocks the same method in the chain service.

--- a/beacon-chain/cache/subnet_ids.go
+++ b/beacon-chain/cache/subnet_ids.go
@@ -32,9 +32,9 @@ func newSubnetIDs() *subnetIDs {
 	cacheSize := int(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().MaxCommitteesPerSlot * 2)) // lint:ignore uintcast -- constant values that would panic on startup if negative.
 	attesterCache := lruwrpr.New(cacheSize)
 	aggregatorCache := lruwrpr.New(cacheSize)
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
 	subLength := epochDuration * time.Duration(params.BeaconConfig().EpochsPerRandomSubnetSubscription)
-	persistentCache := cache.New(subLength*time.Second, epochDuration*time.Second)
+	persistentCache := cache.New(subLength, epochDuration)
 	return &subnetIDs{attester: attesterCache, aggregator: aggregatorCache, persistentSubnets: persistentCache}
 }
 

--- a/beacon-chain/cache/sync_subnet_ids.go
+++ b/beacon-chain/cache/sync_subnet_ids.go
@@ -21,10 +21,10 @@ type syncSubnetIDs struct {
 var SyncSubnetIDs = newSyncSubnetIDs()
 
 func newSyncSubnetIDs() *syncSubnetIDs {
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
 	// Set the default duration of a sync subnet index as the whole sync committee period.
 	subLength := epochDuration * time.Duration(params.BeaconConfig().EpochsPerSyncCommitteePeriod)
-	persistentCache := cache.New(subLength*time.Second, epochDuration*time.Second)
+	persistentCache := cache.New(subLength, epochDuration)
 	return &syncSubnetIDs{sCommittee: persistentCache}
 }
 

--- a/beacon-chain/core/altair/sync_committee_test.go
+++ b/beacon-chain/core/altair/sync_committee_test.go
@@ -309,7 +309,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			name: "sync_message.slot == current_slot",
 			args: args{
 				syncMessageSlot: 15,
-				genesisTime:     prysmTime.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime:     prysmTime.Now().Add(-15 * params.BeaconConfig().SlotDuration()),
 			},
 		},
 		{
@@ -317,7 +317,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			args: args{
 				syncMessageSlot: 15,
 				genesisTime: prysmTime.Now().Add(
-					-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+					-15 * params.BeaconConfig().SlotDuration(),
 				).Add(-(time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second)),
 			},
 		},
@@ -326,7 +326,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			args: args{
 				syncMessageSlot: 16,
 				genesisTime: prysmTime.Now().Add(
-					-16 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+					-16 * params.BeaconConfig().SlotDuration(),
 				).Add(-200 * time.Millisecond),
 			},
 		},
@@ -334,7 +334,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			name: "sync_message.slot > current_slot",
 			args: args{
 				syncMessageSlot: 16,
-				genesisTime:     prysmTime.Now().Add(-(15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)),
+				genesisTime:     prysmTime.Now().Add(-(15 * params.BeaconConfig().SlotDuration())),
 			},
 			wantedErr: "(message slot 16) not within allowable range of",
 		},
@@ -342,7 +342,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			name: "sync_message.slot == current_slot+CLOCK_DISPARITY",
 			args: args{
 				syncMessageSlot: 100,
-				genesisTime:     prysmTime.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second - params.BeaconConfig().MaximumGossipClockDisparityDuration())),
+				genesisTime:     prysmTime.Now().Add(-(100*params.BeaconConfig().SlotDuration() - params.BeaconConfig().MaximumGossipClockDisparityDuration())),
 			},
 			wantedErr: "",
 		},
@@ -350,7 +350,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			name: "sync_message.slot == current_slot+CLOCK_DISPARITY-1000ms",
 			args: args{
 				syncMessageSlot: 100,
-				genesisTime:     prysmTime.Now().Add(-(100 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second) + params.BeaconConfig().MaximumGossipClockDisparityDuration() + 1000*time.Millisecond),
+				genesisTime:     prysmTime.Now().Add(-(100 * params.BeaconConfig().SlotDuration()) + params.BeaconConfig().MaximumGossipClockDisparityDuration() + 1000*time.Millisecond),
 			},
 			wantedErr: "(message slot 100) not within allowable range of",
 		},
@@ -358,7 +358,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			name: "sync_message.slot == current_slot-CLOCK_DISPARITY",
 			args: args{
 				syncMessageSlot: 100,
-				genesisTime:     prysmTime.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + params.BeaconConfig().MaximumGossipClockDisparityDuration())),
+				genesisTime:     prysmTime.Now().Add(-(100*params.BeaconConfig().SlotDuration() + params.BeaconConfig().MaximumGossipClockDisparityDuration())),
 			},
 			wantedErr: "",
 		},
@@ -366,7 +366,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			name: "sync_message.slot > current_slot+CLOCK_DISPARITY",
 			args: args{
 				syncMessageSlot: 101,
-				genesisTime:     prysmTime.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + params.BeaconConfig().MaximumGossipClockDisparityDuration())),
+				genesisTime:     prysmTime.Now().Add(-(100*params.BeaconConfig().SlotDuration() + params.BeaconConfig().MaximumGossipClockDisparityDuration())),
 			},
 			wantedErr: "(message slot 101) not within allowable range of",
 		},
@@ -374,7 +374,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 			name: "sync_message.slot is well beyond current slot",
 			args: args{
 				syncMessageSlot: 1 << 32,
-				genesisTime:     prysmTime.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime:     prysmTime.Now().Add(-15 * params.BeaconConfig().SlotDuration()),
 			},
 			wantedErr: "which exceeds max allowed value relative to the local clock",
 		},

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -128,7 +128,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			name: "attestation.slot == current_slot",
 			args: args{
 				attSlot:     15,
-				genesisTime: prysmTime.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-15 * params.BeaconConfig().SlotDuration()),
 			},
 		},
 		{
@@ -136,7 +136,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			args: args{
 				attSlot: 15,
 				genesisTime: prysmTime.Now().Add(
-					-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+					-15 * params.BeaconConfig().SlotDuration(),
 				).Add(-(time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second)),
 			},
 		},
@@ -145,7 +145,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			args: args{
 				attSlot: 16,
 				genesisTime: prysmTime.Now().Add(
-					-16 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+					-16 * params.BeaconConfig().SlotDuration(),
 				).Add(-200 * time.Millisecond),
 			},
 		},
@@ -153,7 +153,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			name: "attestation.slot > current_slot",
 			args: args{
 				attSlot:     16,
-				genesisTime: prysmTime.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-15 * params.BeaconConfig().SlotDuration()),
 			},
 			wantedErr: "not within attestation propagation range",
 		},
@@ -161,7 +161,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			name: "attestation.slot < current_slot-ATTESTATION_PROPAGATION_SLOT_RANGE",
 			args: args{
 				attSlot:     100 - params.BeaconConfig().AttestationPropagationSlotRange - 1,
-				genesisTime: prysmTime.Now().Add(-100 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-100 * params.BeaconConfig().SlotDuration()),
 			},
 			wantedErr: "not within attestation propagation range",
 		},
@@ -169,7 +169,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			name: "attestation.slot = current_slot-ATTESTATION_PROPAGATION_SLOT_RANGE",
 			args: args{
 				attSlot:     100 - params.BeaconConfig().AttestationPropagationSlotRange,
-				genesisTime: prysmTime.Now().Add(-100 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-100 * params.BeaconConfig().SlotDuration()),
 			},
 		},
 		{
@@ -177,7 +177,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			args: args{
 				attSlot: 100 - params.BeaconConfig().AttestationPropagationSlotRange,
 				genesisTime: prysmTime.Now().Add(
-					-100 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+					-100 * params.BeaconConfig().SlotDuration(),
 				).Add(200 * time.Millisecond),
 			},
 		},
@@ -185,14 +185,14 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			name: "attestation.slot < current_slot-ATTESTATION_PROPAGATION_SLOT_RANGE in deneb",
 			args: args{
 				attSlot:     300 - params.BeaconConfig().AttestationPropagationSlotRange - 1,
-				genesisTime: prysmTime.Now().Add(-300 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-300 * params.BeaconConfig().SlotDuration()),
 			},
 		},
 		{
 			name: "attestation.slot = current_slot-ATTESTATION_PROPAGATION_SLOT_RANGE in deneb",
 			args: args{
 				attSlot:     300 - params.BeaconConfig().AttestationPropagationSlotRange,
-				genesisTime: prysmTime.Now().Add(-300 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-300 * params.BeaconConfig().SlotDuration()),
 			},
 		},
 		{
@@ -200,7 +200,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			args: args{
 				attSlot: 300 - params.BeaconConfig().AttestationPropagationSlotRange,
 				genesisTime: prysmTime.Now().Add(
-					-300 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+					-300 * params.BeaconConfig().SlotDuration(),
 				).Add(200 * time.Millisecond),
 			},
 		},
@@ -209,7 +209,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			args: args{
 				attSlot: 300 - params.BeaconConfig().AttestationPropagationSlotRange,
 				genesisTime: prysmTime.Now().Add(
-					-500 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+					-500 * params.BeaconConfig().SlotDuration(),
 				).Add(200 * time.Millisecond),
 			},
 			wantedErr: "attestation epoch 8 not within current epoch 15 or previous epoch",
@@ -218,7 +218,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 			name: "attestation.slot is well beyond current slot",
 			args: args{
 				attSlot:     1024,
-				genesisTime: time.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: time.Now().Add(-15 * params.BeaconConfig().SlotDuration()),
 			},
 			wantedErr: "attestation slot 1024 not within attestation propagation range of 0 to 15 (current slot)",
 		},

--- a/beacon-chain/db/pruner/pruner.go
+++ b/beacon-chain/db/pruner/pruner.go
@@ -75,7 +75,7 @@ func New(ctx context.Context, db iface.Database, genesisTime time.Time, initSync
 		db:             db,
 		ps:             pruneStartSlotFunc(primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests) + 1), // Default retention epochs is MIN_EPOCHS_FOR_BLOCK_REQUESTS + 1 from the current slot.
 		done:           make(chan struct{}),
-		slotTicker:     slots.NewSlotTicker(slots.UnsafeStartTime(genesisTime, 0), params.BeaconConfig().SecondsPerSlot),
+		slotTicker:     slots.NewSlotTicker(slots.UnsafeStartTime(genesisTime, 0), params.BeaconConfig().SlotDuration()),
 		initSyncWaiter: initSyncWaiter,
 		backfillWaiter: backfillWaiter,
 		custody:        custody,

--- a/beacon-chain/node/shutdown_proposals.go
+++ b/beacon-chain/node/shutdown_proposals.go
@@ -32,7 +32,7 @@ func (b *BeaconNode) waitForPendingProposals(sigc <-chan os.Signal) {
 	}
 
 	// Re-evaluate the pending duties on every slot boundary.
-	ticker := slots.NewSlotTicker(genesis, params.BeaconConfig().SecondsPerSlot)
+	ticker := slots.NewSlotTicker(genesis, params.BeaconConfig().SlotDuration())
 	defer ticker.Done()
 
 	b.waitForPendingProposalsLoop(sigc, ticker.C(), genesis, chainService.HeadState, chainService.CurrentSlot)

--- a/beacon-chain/operations/attestations/kv/kv.go
+++ b/beacon-chain/operations/attestations/kv/kv.go
@@ -5,7 +5,6 @@ package kv
 
 import (
 	"sync"
-	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/operations/attestations/attmap"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -33,8 +32,8 @@ type AttCaches struct {
 // NewAttCaches initializes a new attestation pool consists of multiple KV store in cache for
 // various kind of attestations.
 func NewAttCaches() *AttCaches {
-	secsInEpoch := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	c := cache.New(2*secsInEpoch*time.Second, 2*secsInEpoch*time.Second)
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
+	c := cache.New(2*epochDuration, 2*epochDuration)
 	pool := &AttCaches{
 		unAggregatedAtt:   make(map[attestation.Id]ethpb.Att),
 		aggregatedAtt:     make(map[attestation.Id][]ethpb.Att),

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -20,7 +20,7 @@ import (
 // every prepareForkChoiceAttsPeriod.
 func (s *Service) prepareForkChoiceAtts() {
 	intervals := features.Get().AggregateIntervals
-	slotDuration := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	slotDuration := params.BeaconConfig().SlotDuration()
 	// Adjust intervals for networks with a lower slot duration (Hive, e2e, etc)
 	for {
 		if intervals[len(intervals)-1] >= slotDuration {

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -10,9 +10,9 @@ import (
 
 // pruneExpired prunes attestations pool on every slot interval.
 func (s *Service) pruneExpired() {
-	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
-	offset := time.Duration(secondsPerSlot-1) * time.Second
-	slotTicker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, secondsPerSlot)
+	slotDuration := params.BeaconConfig().SlotDuration()
+	offset := slotDuration - time.Second
+	slotTicker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, slotDuration)
 	defer slotTicker.Done()
 	for {
 		select {

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -106,7 +106,7 @@ func (s *Service) expired(providedSlot primitives.Slot) bool {
 // Handles expiration of attestations before deneb.
 func (s *Service) expiredPreDeneb(slot primitives.Slot) bool {
 	expirationSlot := slot + params.BeaconConfig().SlotsPerEpoch
-	expirationTime := s.genesisTime.Add(time.Duration(expirationSlot.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second)
+	expirationTime := s.genesisTime.Add(time.Duration(expirationSlot) * params.BeaconConfig().SlotDuration())
 	return expirationTime.Before(time.Now())
 }
 

--- a/beacon-chain/operations/attestations/prune_expired_test.go
+++ b/beacon-chain/operations/attestations/prune_expired_test.go
@@ -49,7 +49,7 @@ func TestPruneExpired_Ticker(t *testing.T) {
 	}
 
 	// Rewind back one epoch worth of time.
-	s.genesisTime = time.Now().Add(-1 * time.Duration(params.BeaconConfig().SlotsPerEpoch) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	s.genesisTime = time.Now().Add(-1 * time.Duration(params.BeaconConfig().SlotsPerEpoch) * params.BeaconConfig().SlotDuration())
 
 	go s.pruneExpired()
 
@@ -102,7 +102,7 @@ func TestPruneExpired_PruneExpiredAtts(t *testing.T) {
 	}
 
 	// Rewind back one epoch worth of time.
-	s.genesisTime = time.Now().Add(-1 * time.Duration(params.BeaconConfig().SlotsPerEpoch) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	s.genesisTime = time.Now().Add(-1 * time.Duration(params.BeaconConfig().SlotsPerEpoch) * params.BeaconConfig().SlotDuration())
 
 	s.pruneExpiredAtts()
 	// All the attestations on slot 0 should be pruned.
@@ -123,7 +123,7 @@ func TestPruneExpired_Expired(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rewind back one epoch worth of time.
-	s.genesisTime = time.Now().Add(-1 * time.Duration(params.BeaconConfig().SlotsPerEpoch) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	s.genesisTime = time.Now().Add(-1 * time.Duration(params.BeaconConfig().SlotsPerEpoch) * params.BeaconConfig().SlotDuration())
 	assert.Equal(t, true, s.expired(0), "Should be expired")
 	assert.Equal(t, false, s.expired(1), "Should not be expired")
 }
@@ -138,7 +138,7 @@ func TestPruneExpired_ExpiredDeneb(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rewind back 4 epochs + 10 slots worth of time.
-	s.genesisTime = time.Now().Add(-4*time.Duration(params.BeaconConfig().SlotsPerEpoch*primitives.Slot(params.BeaconConfig().SecondsPerSlot))*time.Second - 10*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second)
+	s.genesisTime = time.Now().Add(-4*time.Duration(params.BeaconConfig().SlotsPerEpoch*primitives.Slot(params.BeaconConfig().SecondsPerSlot))*time.Second - 10*params.BeaconConfig().SlotDuration())
 	secondEpochStart := primitives.Slot(2 * uint64(params.BeaconConfig().SlotsPerEpoch))
 	thirdEpochStart := primitives.Slot(3 * uint64(params.BeaconConfig().SlotsPerEpoch))
 

--- a/beacon-chain/operations/attestations/service.go
+++ b/beacon-chain/operations/attestations/service.go
@@ -42,7 +42,7 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 
 	if cfg.pruneInterval == 0 {
 		// Prune expired attestations from the pool every slot interval.
-		cfg.pruneInterval = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+		cfg.pruneInterval = params.BeaconConfig().SlotDuration()
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -43,7 +43,7 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 	ctx, span := trace.StartSpan(ctx, "p2p.Broadcast")
 	defer span.End()
 
-	twoSlots := time.Duration(2*params.BeaconConfig().SecondsPerSlot) * time.Second
+	twoSlots := 2 * params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, twoSlots)
 	defer cancel()
 
@@ -73,7 +73,7 @@ func (s *Service) BroadcastForEpoch(ctx context.Context, msg proto.Message, epoc
 	ctx, span := trace.StartSpan(ctx, "p2p.BroadcastForEpoch")
 	defer span.End()
 
-	twoSlots := time.Duration(2*params.BeaconConfig().SecondsPerSlot) * time.Second
+	twoSlots := 2 * params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, twoSlots)
 	defer cancel()
 
@@ -138,7 +138,7 @@ func (s *Service) internalBroadcastAttestation(ctx context.Context, subnet uint6
 	defer span.End()
 	ctx = trace.NewContext(context.Background(), span) // clear parent context / deadline.
 
-	oneEpoch := time.Duration(1*params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+	oneEpoch := params.EpochsDuration(1, params.BeaconConfig())
 	ctx, cancel := context.WithTimeout(ctx, oneEpoch)
 	defer cancel()
 
@@ -192,7 +192,7 @@ func (s *Service) broadcastSyncCommittee(ctx context.Context, subnet uint64, sMs
 	defer span.End()
 	ctx = trace.NewContext(context.Background(), span) // clear parent context / deadline.
 
-	oneSlot := time.Duration(1*params.BeaconConfig().SecondsPerSlot) * time.Second
+	oneSlot := params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, oneSlot)
 	defer cancel()
 
@@ -265,7 +265,7 @@ func (s *Service) internalBroadcastBlob(ctx context.Context, subnet uint64, blob
 	defer span.End()
 	ctx = trace.NewContext(context.Background(), span) // clear parent context / deadline.
 
-	oneSlot := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	oneSlot := params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, oneSlot)
 	defer cancel()
 

--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -43,7 +43,7 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 	ctx, span := trace.StartSpan(ctx, "p2p.Broadcast")
 	defer span.End()
 
-	twoSlots := 2 * params.BeaconConfig().SlotDuration()
+	twoSlots := params.SlotsDuration(2, params.BeaconConfig())
 	ctx, cancel := context.WithTimeout(ctx, twoSlots)
 	defer cancel()
 
@@ -73,7 +73,7 @@ func (s *Service) BroadcastForEpoch(ctx context.Context, msg proto.Message, epoc
 	ctx, span := trace.StartSpan(ctx, "p2p.BroadcastForEpoch")
 	defer span.End()
 
-	twoSlots := 2 * params.BeaconConfig().SlotDuration()
+	twoSlots := params.SlotsDuration(2, params.BeaconConfig())
 	ctx, cancel := context.WithTimeout(ctx, twoSlots)
 	defer cancel()
 

--- a/beacon-chain/p2p/broadcaster_test.go
+++ b/beacon-chain/p2p/broadcaster_test.go
@@ -566,7 +566,7 @@ func TestService_BroadcastLightClientOptimisticUpdate(t *testing.T) {
 		pubsub:                p1.PubSub(),
 		joinedTopics:          map[string]*pubsub.Topic{},
 		cfg:                   &Config{},
-		genesisTime:           time.Now().Add(-33 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), // the signature slot of the mock update is 33
+		genesisTime:           time.Now().Add(-33 * params.BeaconConfig().SlotDuration()), // the signature slot of the mock update is 33
 		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
 		subnetsLock:           make(map[uint64]*sync.RWMutex),
 		subnetsLockLock:       sync.Mutex{},
@@ -643,7 +643,7 @@ func TestService_BroadcastLightClientFinalityUpdate(t *testing.T) {
 		pubsub:                p1.PubSub(),
 		joinedTopics:          map[string]*pubsub.Topic{},
 		cfg:                   &Config{},
-		genesisTime:           time.Now().Add(-33 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), // the signature slot of the mock update is 33
+		genesisTime:           time.Now().Add(-33 * params.BeaconConfig().SlotDuration()), // the signature slot of the mock update is 33
 		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
 		subnetsLock:           make(map[uint64]*sync.RWMutex),
 		subnetsLockLock:       sync.Mutex{},

--- a/beacon-chain/p2p/custody_test.go
+++ b/beacon-chain/p2p/custody_test.go
@@ -188,7 +188,7 @@ func TestUpdateEarliestAvailableSlot(t *testing.T) {
 
 		service := &Service{
 			// Set genesis time in the past so currentSlot is the "current" slot
-			genesisTime: time.Now().Add(-time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			genesisTime: time.Now().Add(-time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()),
 			custodyInfo: &custodyInfo{
 				earliestAvailableSlot: initialSlot,
 				groupCount:            groupCount,
@@ -234,7 +234,7 @@ func TestUpdateEarliestAvailableSlot(t *testing.T) {
 		attemptedSlot := minRequiredSlot + 1000 // Within the mandatory retention period
 
 		service := &Service{
-			genesisTime: time.Now().Add(-time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			genesisTime: time.Now().Add(-time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()),
 			custodyInfo: &custodyInfo{
 				earliestAvailableSlot: minRequiredSlot - 100, // Current value is before the min required
 				groupCount:            5,
@@ -259,7 +259,7 @@ func TestUpdateEarliestAvailableSlot(t *testing.T) {
 		attemptedSlot := primitives.Slot(minRequiredEpoch)*primitives.Slot(params.BeaconConfig().SlotsPerEpoch) + 8
 
 		service := &Service{
-			genesisTime: time.Now().Add(-time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			genesisTime: time.Now().Add(-time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()),
 			custodyInfo: &custodyInfo{
 				earliestAvailableSlot: storedEarliestSlot,
 				groupCount:            5,
@@ -284,7 +284,7 @@ func TestUpdateEarliestAvailableSlot(t *testing.T) {
 		attemptedSlot := primitives.Slot(1000)
 
 		service := &Service{
-			genesisTime: time.Now().Add(-time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			genesisTime: time.Now().Add(-time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()),
 			custodyInfo: &custodyInfo{
 				earliestAvailableSlot: currentEarliestSlot,
 				groupCount:            5,

--- a/beacon-chain/p2p/fork_watcher.go
+++ b/beacon-chain/p2p/fork_watcher.go
@@ -15,7 +15,7 @@ func (s *Service) forkWatcher() {
 		return
 	}
 
-	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SlotDuration())
 	var scheduleEntry params.NetworkScheduleEntry
 	for {
 		select {

--- a/beacon-chain/p2p/gossip_scoring_params.go
+++ b/beacon-chain/p2p/gossip_scoring_params.go
@@ -578,7 +578,7 @@ func defaultLightClientFinalityUpdateTopicParams() *pubsub.TopicScoreParams {
 }
 
 func oneSlotDuration() time.Duration {
-	return time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	return params.BeaconConfig().SlotDuration()
 }
 
 func oneEpochDuration() time.Duration {

--- a/beacon-chain/p2p/gossip_scoring_params.go
+++ b/beacon-chain/p2p/gossip_scoring_params.go
@@ -582,7 +582,7 @@ func oneSlotDuration() time.Duration {
 }
 
 func oneEpochDuration() time.Duration {
-	return time.Duration(params.BeaconConfig().SlotsPerEpoch) * oneSlotDuration()
+	return params.EpochsDuration(1, params.BeaconConfig())
 }
 
 // determines the decay rate from the provided time period till

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -408,7 +408,7 @@ var (
 )
 
 func (p *PartialColumnBroadcaster) loop() {
-	cleanup := time.NewTicker(time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot))
+	cleanup := time.NewTicker(params.BeaconConfig().SlotDuration())
 	for {
 		select {
 		case req := <-p.incomingReq:

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -225,7 +225,7 @@ func pubsubGossipParam() pubsub.GossipSubParams {
 // to configure our message id time-cache rather than instantiating
 // it with a router instance.
 func setPubSubParameters() {
-	seenTtl := 2 * time.Second * time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	seenTtl := 2 * params.EpochsDuration(1, params.BeaconConfig())
 	pubsub.TimeCacheDuration = seenTtl
 }
 

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -562,9 +562,8 @@ func computeSubscriptionExpirationTime(nodeID enode.ID, epoch primitives.Epoch) 
 	nodeOffset, _ := computeOffsetAndPrefix(nodeID)
 	pastEpochs := (nodeOffset + uint64(epoch)) % params.BeaconConfig().EpochsPerSubnetSubscription
 	remEpochs := params.BeaconConfig().EpochsPerSubnetSubscription - pastEpochs
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	epochTime := time.Duration(remEpochs) * epochDuration
-	return epochTime * time.Second
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
+	return time.Duration(remEpochs) * epochDuration
 }
 
 func computeOffsetAndPrefix(nodeID enode.ID) (uint64, uint64) {

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -749,8 +749,8 @@ func registerSyncSubnetInternal(
 	if err != nil {
 		epochsToWatch = 0
 	}
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	totalDuration := epochDuration * time.Duration(epochsToWatch) * time.Second
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
+	totalDuration := epochDuration * time.Duration(epochsToWatch)
 	cache.SyncSubnetIDs.AddSyncCommitteeSubnets(pubkey, startEpoch, subs, totalDuration)
 }
 

--- a/beacon-chain/rpc/core/validator_test.go
+++ b/beacon-chain/rpc/core/validator_test.go
@@ -37,8 +37,8 @@ func TestRegisterSyncSubnetProto(t *testing.T) {
 	coms, _, ok, exp := cache.SyncSubnetIDs.GetSyncCommitteeSubnets(k, 0)
 	require.Equal(t, true, ok, "No cache entry found for validator")
 	assert.Equal(t, uint64(1), uint64(len(coms)))
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	totalTime := time.Duration(params.BeaconConfig().EpochsPerSyncCommitteePeriod) * epochDuration * time.Second
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
+	totalTime := time.Duration(params.BeaconConfig().EpochsPerSyncCommitteePeriod) * epochDuration
 	receivedTime := time.Until(exp.Round(time.Second)).Round(time.Second)
 	if receivedTime < totalTime {
 		t.Fatalf("Expiration time of %f was less than expected duration of %f ", receivedTime.Seconds(), totalTime.Seconds())
@@ -59,8 +59,8 @@ func TestRegisterSyncSubnet(t *testing.T) {
 	coms, _, ok, exp := cache.SyncSubnetIDs.GetSyncCommitteeSubnets(k, 0)
 	require.Equal(t, true, ok, "No cache entry found for validator")
 	assert.Equal(t, uint64(1), uint64(len(coms)))
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	totalTime := time.Duration(params.BeaconConfig().EpochsPerSyncCommitteePeriod) * epochDuration * time.Second
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
+	totalTime := time.Duration(params.BeaconConfig().EpochsPerSyncCommitteePeriod) * epochDuration
 	receivedTime := time.Until(exp.Round(time.Second)).Round(time.Second)
 	if receivedTime < totalTime {
 		t.Fatalf("Expiration time of %f was less than expected duration of %f ", receivedTime.Seconds(), totalTime.Seconds())
@@ -76,7 +76,7 @@ func pubKey(i uint64) []byte {
 
 func TestService_SubmitSignedAggregateSelectionProof(t *testing.T) {
 	slot := primitives.Slot(0)
-	mock := &mockChain.ChainService{Slot: &slot, Genesis: time.Now().Add(-75 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)}
+	mock := &mockChain.ChainService{Slot: &slot, Genesis: time.Now().Add(-75 * params.BeaconConfig().SlotDuration())}
 	s := &Service{GenesisTimeFetcher: mock}
 	var err error
 	t.Run("Happy path electra", func(t *testing.T) {

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -210,7 +210,7 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 
 	timeout := s.EventWriteTimeout
 	if timeout == 0 {
-		timeout = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+		timeout = params.BeaconConfig().SlotDuration()
 	}
 	ka := s.KeepAliveInterval
 	if ka == 0 {

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -644,7 +644,7 @@ func (s *Server) SubmitSyncCommitteeSubscription(w http.ResponseWriter, r *http.
 		if err != nil {
 			epochsToWatch = 0
 		}
-		epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+		epochDuration := params.EpochsDuration(1, params.BeaconConfig())
 		totalDuration := epochDuration * time.Duration(epochsToWatch)
 
 		subcommitteeSize := params.BeaconConfig().SyncCommitteeSize / params.BeaconConfig().SyncCommitteeSubnetCount

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -1178,7 +1178,7 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1252,7 +1252,7 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1386,7 +1386,7 @@ func TestGetAttestationData(t *testing.T) {
 
 	t.Run("invalid slot", func(t *testing.T) {
 		slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1444,7 +1444,7 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1497,7 +1497,7 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 		require.NoError(t, err)
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1572,7 +1572,7 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 		require.NoError(t, err)
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1667,7 +1667,7 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1761,7 +1761,7 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
 			Genesis:                    time.Now().Add(-1 * offset),
@@ -1840,7 +1840,7 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(slot, params.BeaconConfig())
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
 			Genesis:                    time.Now().Add(-1 * offset),

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -618,7 +618,7 @@ func TestSubmitContributionAndProofs(t *testing.T) {
 
 func TestSubmitAggregateAndProofsV2(t *testing.T) {
 	slot := primitives.Slot(0)
-	mock := &mockChain.ChainService{Slot: &slot, Genesis: time.Now().Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)}
+	mock := &mockChain.ChainService{Slot: &slot, Genesis: time.Now().Add(-1 * params.BeaconConfig().SlotDuration())}
 	s := &Server{
 		CoreService: &core.Service{GenesisTimeFetcher: mock},
 		TimeFetcher: mock,
@@ -1178,10 +1178,10 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			Root:                       blockRoot[:],
 			CurrentJustifiedCheckPoint: justifiedCheckpoint,
 			TargetRoot:                 blockRoot,
@@ -1252,10 +1252,10 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			Root:                       blockRoot[:],
 			CurrentJustifiedCheckPoint: justifiedCheckpoint,
 			TargetRoot:                 blockRoot,
@@ -1386,10 +1386,10 @@ func TestGetAttestationData(t *testing.T) {
 
 	t.Run("invalid slot", func(t *testing.T) {
 		slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			CurrentJustifiedCheckPoint: &ethpbalpha.Checkpoint{},
 		}
 
@@ -1444,10 +1444,10 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			CurrentJustifiedCheckPoint: justifiedCheckpoint,
 			TargetRoot:                 blockRoot2,
 		}
@@ -1497,10 +1497,10 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 		require.NoError(t, err)
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			CurrentJustifiedCheckPoint: justifiedCheckpt,
 			TargetRoot:                 blockRoot,
 			State:                      beaconState,
@@ -1572,10 +1572,10 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 		require.NoError(t, err)
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			CurrentJustifiedCheckPoint: justifiedCheckpt,
 			TargetRoot:                 blockRoot,
 			State:                      beaconState,
@@ -1667,10 +1667,10 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			CurrentJustifiedCheckPoint: justifiedCheckpt,
 			TargetRoot:                 blockRoot,
 			State:                      beaconState,
@@ -1761,10 +1761,10 @@ func TestGetAttestationData(t *testing.T) {
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpt))
 
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Root:                       blockRoot[:],
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			CurrentJustifiedCheckPoint: justifiedCheckpt,
 			TargetRoot:                 blockRoot,
 			State:                      beaconState,
@@ -1840,10 +1840,10 @@ func TestGetAttestationData(t *testing.T) {
 			Root:  justifiedRoot[:],
 		}
 		require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 		chain := &mockChain.ChainService{
 			Optimistic:                 false,
-			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Genesis:                    time.Now().Add(-1 * offset),
 			Root:                       blockRoot[:],
 			CurrentJustifiedCheckPoint: justifiedCheckpoint,
 			TargetRoot:                 blockRoot,

--- a/beacon-chain/rpc/lookup/blocker_test.go
+++ b/beacon-chain/rpc/lookup/blocker_test.go
@@ -1236,7 +1236,7 @@ func TestGetDataColumns(t *testing.T) {
 
 		// Mock genesis time to make current slot much later than the block slot
 		// This simulates being outside retention period
-		genesisTime := time.Now().Add(-time.Duration(fuluForkSlot+1000) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+		genesisTime := time.Now().Add(-time.Duration(fuluForkSlot+1000) * params.BeaconConfig().SlotDuration())
 		blocker := &BeaconDbBlocker{
 			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
 				Genesis: genesisTime,

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/committees_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/committees_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"math"
 	"testing"
-	"time"
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
@@ -34,7 +33,7 @@ func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	ctx := t.Context()
 	headState := setupActiveValidators(t, numValidators)
 
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	m := &mock.ChainService{
 		Genesis: prysmTime.Now().Add(-1 * offset),
 	}
@@ -109,7 +108,7 @@ func TestServer_ListBeaconCommittees_PreviousEpoch(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.SaveState(ctx, headState, gRoot))
 
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	m := &mock.ChainService{
 		State:   headState,
 		Genesis: prysmTime.Now().Add(-1 * offset),

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/committees_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/committees_test.go
@@ -34,9 +34,9 @@ func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	ctx := t.Context()
 	headState := setupActiveValidators(t, numValidators)
 
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	m := &mock.ChainService{
-		Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+		Genesis: prysmTime.Now().Add(-1 * offset),
 	}
 	bs := &Server{
 		HeadFetcher:        m,
@@ -109,10 +109,10 @@ func TestServer_ListBeaconCommittees_PreviousEpoch(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.SaveState(ctx, headState, gRoot))
 
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	m := &mock.ChainService{
 		State:   headState,
-		Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+		Genesis: prysmTime.Now().Add(-1 * offset),
 	}
 	bs := &Server{
 		HeadFetcher:        m,

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
@@ -1862,7 +1862,7 @@ func TestGetValidatorPerformance_OK(t *testing.T) {
 	}
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
@@ -1925,7 +1925,7 @@ func TestGetValidatorPerformance_Indices(t *testing.T) {
 		},
 	}
 	require.NoError(t, headState.SetValidators(validators))
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
@@ -1997,7 +1997,7 @@ func TestGetValidatorPerformance_IndicesPubkeys(t *testing.T) {
 	}
 	require.NoError(t, headState.SetValidators(validators))
 
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
@@ -2075,7 +2075,7 @@ func TestGetValidatorPerformanceAltair_OK(t *testing.T) {
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
@@ -2145,7 +2145,7 @@ func TestGetValidatorPerformanceBellatrix_OK(t *testing.T) {
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
@@ -2215,7 +2215,7 @@ func TestGetValidatorPerformanceCapella_OK(t *testing.T) {
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
@@ -1548,14 +1548,14 @@ func TestServer_GetValidatorParticipation_CurrentAndPrevEpoch(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, headState, params.BeaconConfig().ZeroHash))
 
 	m := &mock.ChainService{State: headState}
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := params.EpochsDuration(1, params.BeaconConfig())
 	bs := &Server{
 		BeaconDB: beaconDB,
 		StateGen: stategen.New(beaconDB, doublylinkedtree.New()),
 		CoreService: &core.Service{
 			HeadFetcher: m,
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: prysmTime.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher: &mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 100}},
 		},
@@ -1629,14 +1629,14 @@ func TestServer_GetValidatorParticipation_OrphanedUntilGenesis(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, headState, params.BeaconConfig().ZeroHash))
 
 	m := &mock.ChainService{State: headState}
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := params.EpochsDuration(1, params.BeaconConfig())
 	bs := &Server{
 		BeaconDB: beaconDB,
 		StateGen: stategen.New(beaconDB, doublylinkedtree.New()),
 		CoreService: &core.Service{
 			HeadFetcher: m,
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: prysmTime.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher: &mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 100}},
 		},
@@ -1747,12 +1747,12 @@ func runGetValidatorParticipationCurrentAndPrevEpoch(t *testing.T, genState stat
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, gRoot))
 
 	m := &mock.ChainService{State: genState}
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := params.EpochsDuration(1, params.BeaconConfig())
 	bs := &Server{
 		BeaconDB: beaconDB,
 		CoreService: &core.Service{
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: prysmTime.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher: &mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 100}},
 		},
@@ -1862,13 +1862,13 @@ func TestGetValidatorPerformance_OK(t *testing.T) {
 	}
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
 				State: headState,
 			},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			SyncChecker:        &mockSync.Sync{IsSyncing: false},
 		},
 	}
@@ -1925,7 +1925,7 @@ func TestGetValidatorPerformance_Indices(t *testing.T) {
 		},
 	}
 	require.NoError(t, headState.SetValidators(validators))
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
@@ -1933,7 +1933,7 @@ func TestGetValidatorPerformance_Indices(t *testing.T) {
 				State: headState,
 			},
 			SyncChecker:        &mockSync.Sync{IsSyncing: false},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		},
 	}
 	c := headState.Copy()
@@ -1997,7 +1997,7 @@ func TestGetValidatorPerformance_IndicesPubkeys(t *testing.T) {
 	}
 	require.NoError(t, headState.SetValidators(validators))
 
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
@@ -2005,7 +2005,7 @@ func TestGetValidatorPerformance_IndicesPubkeys(t *testing.T) {
 				State: headState,
 			},
 			SyncChecker:        &mockSync.Sync{IsSyncing: false},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		},
 	}
 	c := headState.Copy()
@@ -2075,13 +2075,13 @@ func TestGetValidatorPerformanceAltair_OK(t *testing.T) {
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
 				State: headState,
 			},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			SyncChecker:        &mockSync.Sync{IsSyncing: false},
 		},
 	}
@@ -2145,13 +2145,13 @@ func TestGetValidatorPerformanceBellatrix_OK(t *testing.T) {
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
 				State: headState,
 			},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			SyncChecker:        &mockSync.Sync{IsSyncing: false},
 		},
 	}
@@ -2215,13 +2215,13 @@ func TestGetValidatorPerformanceCapella_OK(t *testing.T) {
 	require.NoError(t, headState.SetValidators(validators))
 	require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 	require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-	offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 	bs := &Server{
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{
 				State: headState,
 			},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			SyncChecker:        &mockSync.Sync{IsSyncing: false},
 		},
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
@@ -50,7 +50,7 @@ func TestServer_GetBlock(t *testing.T) {
 func TestServer_GetAttestationInclusionSlot(t *testing.T) {
 	db := dbTest.SetupDB(t)
 	ctx := t.Context()
-	offset := 2 * params.EpochsDuration(1, params.BeaconConfig())
+	offset := params.EpochsDuration(2, params.BeaconConfig())
 	bs := &Server{
 		BeaconDB:           db,
 		StateGen:           stategen.New(db, doublylinkedtree.New()),

--- a/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
@@ -50,11 +50,11 @@ func TestServer_GetBlock(t *testing.T) {
 func TestServer_GetAttestationInclusionSlot(t *testing.T) {
 	db := dbTest.SetupDB(t)
 	ctx := t.Context()
-	offset := int64(2 * params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := 2 * params.EpochsDuration(1, params.BeaconConfig())
 	bs := &Server{
 		BeaconDB:           db,
 		StateGen:           stategen.New(db, doublylinkedtree.New()),
-		GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 	}
 
 	s, _ := util.DeterministicGenesisState(t, 2048)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_mainnet_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_mainnet_test.go
@@ -60,15 +60,15 @@ func TestAttestationDataAtSlot_HandlesFarAwayJustifiedEpoch(t *testing.T) {
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
 
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		CoreService: &core.Service{
 			AttestationCache:      cache.NewAttestationDataCache(),
 			HeadFetcher:           &mock.ChainService{TargetRoot: blockRoot, Root: blockRoot[:], State: beaconState},
-			GenesisTimeFetcher:    &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher:    &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 			OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		},

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_mainnet_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_mainnet_test.go
@@ -60,7 +60,7 @@ func TestAttestationDataAtSlot_HandlesFarAwayJustifiedEpoch(t *testing.T) {
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
 
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
@@ -295,7 +295,7 @@ func TestGetAttestationData_OK(t *testing.T) {
 		Root:  justifiedRoot[:],
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
@@ -360,7 +360,7 @@ func TestGetAttestationData_CachedDataFromPreviousHead(t *testing.T) {
 	require.NoError(t, beaconState.SetSlot(slot))
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
 
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	genesis := time.Now().Add(-1 * offset)
 
 	// A server whose head is headRoot, serving attestation data out of attCache.
@@ -431,7 +431,7 @@ func BenchmarkGetAttestationDataConcurrent(b *testing.B) {
 		Epoch: 2,
 		Root:  justifiedRoot[:],
 	}
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
@@ -520,7 +520,7 @@ func TestServer_GetAttestationData_InvalidRequestSlot(t *testing.T) {
 	ctx := t.Context()
 
 	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
@@ -562,7 +562,7 @@ func TestServer_GetAttestationData_RequestSlotIsDifferentThanCurrentSlot(t *test
 		Epoch: 2,
 		Root:  justifiedRoot[:],
 	}
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
@@ -609,7 +609,7 @@ func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
 
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
@@ -678,7 +678,7 @@ func TestGetAttestationData_CommitteeIndexIsZeroPostElectra(t *testing.T) {
 		Root:  justifiedRoot[:],
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
@@ -747,7 +747,7 @@ func TestGetAttestationData_CommitteeIndexGloas(t *testing.T) {
 		Root:  justifiedRoot[:],
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slot, params.BeaconConfig())
 
 	t.Run("full payload returns index 1", func(t *testing.T) {
 		headSlot := slot

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
@@ -295,15 +295,15 @@ func TestGetAttestationData_OK(t *testing.T) {
 		Root:  justifiedRoot[:],
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{TargetRoot: targetRoot, Root: blockRoot[:], State: beaconState},
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: time.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 			AttestationCache:      cache.NewAttestationDataCache(),
@@ -360,8 +360,8 @@ func TestGetAttestationData_CachedDataFromPreviousHead(t *testing.T) {
 	require.NoError(t, beaconState.SetSlot(slot))
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
 
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-	genesis := time.Now().Add(time.Duration(-1*offset) * time.Second)
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
+	genesis := time.Now().Add(-1 * offset)
 
 	// A server whose head is headRoot, serving attestation data out of attCache.
 	newServer := func(attCache *cache.AttestationDataCache) *Server {
@@ -431,16 +431,16 @@ func BenchmarkGetAttestationDataConcurrent(b *testing.B) {
 		Epoch: 2,
 		Root:  justifiedRoot[:],
 	}
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		CoreService: &core.Service{
 			AttestationCache: cache.NewAttestationDataCache(),
 			HeadFetcher:      &mock.ChainService{TargetRoot: targetRoot, Root: blockRoot[:]},
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: time.Now().Add(-1 * offset),
 			},
 			OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 			FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
@@ -520,13 +520,13 @@ func TestServer_GetAttestationData_InvalidRequestSlot(t *testing.T) {
 	ctx := t.Context()
 
 	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		CoreService: &core.Service{
-			GenesisTimeFetcher:    &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher:    &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		},
 	}
@@ -562,14 +562,14 @@ func TestServer_GetAttestationData_RequestSlotIsDifferentThanCurrentSlot(t *test
 		Epoch: 2,
 		Root:  justifiedRoot[:],
 	}
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		CoreService: &core.Service{
 			HeadFetcher:           &mock.ChainService{TargetRoot: blockRoot2, Root: blockRoot[:]},
-			GenesisTimeFetcher:    &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher:    &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			StateGen:              stategen.New(db, doublylinkedtree.New()),
 			FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 			OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
@@ -609,17 +609,17 @@ func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
 
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second)},
+		TimeFetcher:           &mock.ChainService{Genesis: prysmTime.Now().Add(-1 * offset)},
 		CoreService: &core.Service{
 			AttestationCache: cache.NewAttestationDataCache(),
 			HeadFetcher: &mock.ChainService{
 				TargetRoot: targetRoot, Root: blockRoot[:], State: beaconState,
 			},
-			GenesisTimeFetcher:    &mock.ChainService{Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second)},
+			GenesisTimeFetcher:    &mock.ChainService{Genesis: prysmTime.Now().Add(-1 * offset)},
 			FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 			OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		},
@@ -678,15 +678,15 @@ func TestGetAttestationData_CommitteeIndexIsZeroPostElectra(t *testing.T) {
 		Root:  justifiedRoot[:],
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 		CoreService: &core.Service{
 			HeadFetcher: &mock.ChainService{TargetRoot: targetRoot, Root: blockRoot[:], State: beaconState},
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: time.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 			AttestationCache:      cache.NewAttestationDataCache(),
@@ -747,14 +747,14 @@ func TestGetAttestationData_CommitteeIndexGloas(t *testing.T) {
 		Root:  justifiedRoot[:],
 	}
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(justifiedCheckpoint))
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := time.Duration(slot) * params.BeaconConfig().SlotDuration()
 
 	t.Run("full payload returns index 1", func(t *testing.T) {
 		headSlot := slot
 		attesterServer := &Server{
 			SyncChecker:           &mockSync.Sync{IsSyncing: false},
 			OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-			TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
 					TargetRoot:   targetRoot,
@@ -767,7 +767,7 @@ func TestGetAttestationData_CommitteeIndexGloas(t *testing.T) {
 					MockCanonicalFull:  map[primitives.Slot]bool{slot: true},
 				},
 				GenesisTimeFetcher: &mock.ChainService{
-					Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+					Genesis: time.Now().Add(-1 * offset),
 				},
 				FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 				AttestationCache:      cache.NewAttestationDataCache(),
@@ -787,7 +787,7 @@ func TestGetAttestationData_CommitteeIndexGloas(t *testing.T) {
 		attesterServer := &Server{
 			SyncChecker:           &mockSync.Sync{IsSyncing: false},
 			OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-			TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+			TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
 					TargetRoot:   targetRoot,
@@ -799,7 +799,7 @@ func TestGetAttestationData_CommitteeIndexGloas(t *testing.T) {
 					MockCanonicalRoots: map[primitives.Slot][32]byte{slot: blockRoot},
 				},
 				GenesisTimeFetcher: &mock.ChainService{
-					Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+					Genesis: time.Now().Add(-1 * offset),
 				},
 				FinalizedFetcher:      &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 				AttestationCache:      cache.NewAttestationDataCache(),

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/exit_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/exit_test.go
@@ -38,8 +38,8 @@ func TestProposeExit_Notification(t *testing.T) {
 	require.NoError(t, err, "Could not get signing root")
 
 	// Set genesis time to be 100 epochs ago.
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	genesisTime := time.Now().Add(time.Duration(-100*offset) * time.Second)
+	offset := params.EpochsDuration(1, params.BeaconConfig())
+	genesisTime := time.Now().Add(-100 * offset)
 	mockChainService := &mockChain.ChainService{State: beaconState, Root: genesisRoot[:], Genesis: genesisTime}
 	server := &Server{
 		HeadFetcher:       mockChainService,
@@ -105,8 +105,8 @@ func TestProposeExit_NoPanic(t *testing.T) {
 	require.NoError(t, err, "Could not get signing root")
 
 	// Set genesis time to be 100 epochs ago.
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	genesisTime := time.Now().Add(time.Duration(-100*offset) * time.Second)
+	offset := params.EpochsDuration(1, params.BeaconConfig())
+	genesisTime := time.Now().Add(-100 * offset)
 	mockChainService := &mockChain.ChainService{State: beaconState, Root: genesisRoot[:], Genesis: genesisTime}
 	server := &Server{
 		HeadFetcher:       mockChainService,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -761,7 +761,7 @@ func TestServer_setExecutionData(t *testing.T) {
 }
 
 func TestServer_getPayloadHeader(t *testing.T) {
-	genesis := time.Now().Add(-time.Duration(params.BeaconConfig().SlotsPerEpoch) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	genesis := time.Now().Add(-time.Duration(params.BeaconConfig().SlotsPerEpoch) * params.BeaconConfig().SlotDuration())
 	params.SetupTestConfigCleanup(t)
 	bc := params.BeaconConfig()
 	bc.BellatrixForkEpoch = 1

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -761,7 +761,7 @@ func TestServer_setExecutionData(t *testing.T) {
 }
 
 func TestServer_getPayloadHeader(t *testing.T) {
-	genesis := time.Now().Add(-time.Duration(params.BeaconConfig().SlotsPerEpoch) * params.BeaconConfig().SlotDuration())
+	genesis := time.Now().Add(-params.EpochsDuration(1, params.BeaconConfig()))
 	params.SetupTestConfigCleanup(t)
 	bc := params.BeaconConfig()
 	bc.BellatrixForkEpoch = 1

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -290,7 +290,7 @@ func (vs *Server) submitBlockToBuilder(block interfaces.ReadOnlySignedBeaconBloc
 	if vs.BlockBuilder == nil || builderURL == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), params.BeaconConfig().SlotDuration())
 	defer cancel()
 	if err := vs.BlockBuilder.SubmitSignedBeaconBlock(ctx, builderURL, block); err != nil {
 		log.WithError(err).Error("Could not submit signed beacon block to builder")

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -121,7 +121,7 @@ func (vs *Server) WaitForActivation(req *ethpb.ValidatorActivationRequest, strea
 		return status.Errorf(codes.Internal, "Could not send response over stream: %v", err)
 	}
 
-	waitTime := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	waitTime := params.BeaconConfig().SlotDuration()
 	ticker := time.NewTicker(waitTime)
 	defer ticker.Stop()
 

--- a/beacon-chain/rpc/prysm/validator/handlers_test.go
+++ b/beacon-chain/rpc/prysm/validator/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/OffchainLabs/go-bitfield"
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
@@ -120,7 +119,7 @@ func TestServer_GetValidatorParticipation_CurrentAndPrevEpoch(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, headState, params.BeaconConfig().ZeroHash))
 
 	m := &mock.ChainService{State: headState}
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := params.EpochsDuration(1, params.BeaconConfig())
 
 	var st state.BeaconState
 	st, _ = util.DeterministicGenesisState(t, 4)
@@ -134,7 +133,7 @@ func TestServer_GetValidatorParticipation_CurrentAndPrevEpoch(t *testing.T) {
 			HeadFetcher: m,
 			StateGen:    stategen.New(beaconDB, doublylinkedtree.New()),
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: prysmTime.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher: &mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 100}},
 		},
@@ -221,7 +220,7 @@ func TestServer_GetValidatorParticipation_OrphanedUntilGenesis(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, headState, params.BeaconConfig().ZeroHash))
 
 	m := &mock.ChainService{State: headState}
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := params.EpochsDuration(1, params.BeaconConfig())
 
 	var st state.BeaconState
 	st, _ = util.DeterministicGenesisState(t, 4)
@@ -234,7 +233,7 @@ func TestServer_GetValidatorParticipation_OrphanedUntilGenesis(t *testing.T) {
 			HeadFetcher: m,
 			StateGen:    stategen.New(beaconDB, doublylinkedtree.New()),
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: prysmTime.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher: &mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 100}},
 		},
@@ -358,7 +357,7 @@ func runGetValidatorParticipationCurrentEpoch(t *testing.T, genState state.Beaco
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, gRoot))
 
 	m := &mock.ChainService{State: genState}
-	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	offset := params.EpochsDuration(1, params.BeaconConfig())
 
 	s := &Server{
 		BeaconDB: beaconDB,
@@ -369,7 +368,7 @@ func runGetValidatorParticipationCurrentEpoch(t *testing.T, genState state.Beaco
 			HeadFetcher: m,
 			StateGen:    stategen.New(beaconDB, doublylinkedtree.New()),
 			GenesisTimeFetcher: &mock.ChainService{
-				Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second),
+				Genesis: prysmTime.Now().Add(-1 * offset),
 			},
 			FinalizedFetcher: &mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 100}},
 		},

--- a/beacon-chain/rpc/prysm/validator/validator_performance_test.go
+++ b/beacon-chain/rpc/prysm/validator/validator_performance_test.go
@@ -57,13 +57,13 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 		headState = setHeadState(t, headState, publicKeys)
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
 
-		offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
 					State: headState,
 				},
-				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 				SyncChecker:        &mockSync.Sync{IsSyncing: false},
 			},
 		}
@@ -113,7 +113,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 		require.NoError(t, err)
 		headState = setHeadState(t, headState, publicKeys)
 
-		offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
@@ -121,7 +121,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 					State: headState,
 				},
 				SyncChecker:        &mockSync.Sync{IsSyncing: false},
-				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			},
 		}
 		c := headState.Copy()
@@ -178,7 +178,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 		require.NoError(t, err)
 		headState = setHeadState(t, headState, publicKeys)
 
-		offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
@@ -186,7 +186,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 					State: headState,
 				},
 				SyncChecker:        &mockSync.Sync{IsSyncing: false},
-				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 			},
 		}
 		c := headState.Copy()
@@ -249,13 +249,13 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 
 		require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-		offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
 					State: headState,
 				},
-				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 				SyncChecker:        &mockSync.Sync{IsSyncing: false},
 			},
 		}
@@ -311,13 +311,13 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 
 		require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-		offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
 					State: headState,
 				},
-				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 				SyncChecker:        &mockSync.Sync{IsSyncing: false},
 			},
 		}
@@ -373,13 +373,13 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 
 		require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-		offset := int64(headState.Slot().Mul(params.BeaconConfig().SecondsPerSlot))
+		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
 					State: headState,
 				},
-				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+				GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(-1 * offset)},
 				SyncChecker:        &mockSync.Sync{IsSyncing: false},
 			},
 		}

--- a/beacon-chain/rpc/prysm/validator/validator_performance_test.go
+++ b/beacon-chain/rpc/prysm/validator/validator_performance_test.go
@@ -57,7 +57,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 		headState = setHeadState(t, headState, publicKeys)
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
 
-		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
@@ -113,7 +113,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 		require.NoError(t, err)
 		headState = setHeadState(t, headState, publicKeys)
 
-		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
@@ -178,7 +178,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 		require.NoError(t, err)
 		headState = setHeadState(t, headState, publicKeys)
 
-		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
@@ -249,7 +249,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 
 		require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
@@ -311,7 +311,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 
 		require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{
@@ -373,7 +373,7 @@ func TestServer_GetValidatorPerformance(t *testing.T) {
 
 		require.NoError(t, headState.SetInactivityScores([]uint64{0, 0, 0}))
 		require.NoError(t, headState.SetBalances([]uint64{100, 101, 102}))
-		offset := time.Duration(headState.Slot()) * params.BeaconConfig().SlotDuration()
+		offset := params.SlotsDuration(headState.Slot(), params.BeaconConfig())
 		vs := &Server{
 			CoreService: &core.Service{
 				HeadFetcher: &mock.ChainService{

--- a/beacon-chain/rpc/testutil/BUILD.bazel
+++ b/beacon-chain/rpc/testutil/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//beacon-chain/rpc/core:go_default_library",
         "//beacon-chain/rpc/options:go_default_library",
         "//beacon-chain/state:go_default_library",
-        "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/rpc/testutil/mock_genesis_timefetcher.go
+++ b/beacon-chain/rpc/testutil/mock_genesis_timefetcher.go
@@ -3,8 +3,8 @@ package testutil
 import (
 	"time"
 
-	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
 // MockGenesisTimeFetcher is a fake implementation of the blockchain.TimeFetcher
@@ -17,5 +17,5 @@ func (m *MockGenesisTimeFetcher) GenesisTime() time.Time {
 }
 
 func (m *MockGenesisTimeFetcher) CurrentSlot() primitives.Slot {
-	return primitives.Slot(uint64(time.Now().Unix()-m.Genesis.Unix()) / params.BeaconConfig().SecondsPerSlot)
+	return slots.CurrentSlot(m.Genesis)
 }

--- a/beacon-chain/slasher/service.go
+++ b/beacon-chain/slasher/service.go
@@ -147,10 +147,10 @@ func (s *Service) run() {
 	s.wg.Add(1)
 	go s.receiveBlocks(s.ctx, beaconBlockHeadersChan)
 
-	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
-	s.attsSlotTicker = slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
-	s.blocksSlotTicker = slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
-	s.pruningSlotTicker = slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
+	slotDuration := params.BeaconConfig().SlotDuration()
+	s.attsSlotTicker = slots.NewSlotTicker(s.genesisTime, slotDuration)
+	s.blocksSlotTicker = slots.NewSlotTicker(s.genesisTime, slotDuration)
+	s.pruningSlotTicker = slots.NewSlotTicker(s.genesisTime, slotDuration)
 
 	s.wg.Add(1)
 	go s.processQueuedAttestations(s.ctx, s.attsSlotTicker.C())
@@ -213,7 +213,7 @@ func (s *Service) waitForSync(genesisTime time.Time) {
 	if slots.CurrentSlot(genesisTime) < params.BeaconConfig().SlotsPerEpoch || !s.serviceCfg.SyncChecker.Syncing() {
 		return
 	}
-	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SlotDuration())
 	defer slotTicker.Done()
 	for {
 		select {

--- a/beacon-chain/startup/clock_test.go
+++ b/beacon-chain/startup/clock_test.go
@@ -41,7 +41,7 @@ func TestClock(t *testing.T) {
 }
 
 func testInterval(nSlots primitives.Slot) (time.Time, time.Time) {
-	oneSlot := time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot)
+	oneSlot := params.BeaconConfig().SlotDuration()
 	var start uint64 = 23
 	endOffset := oneSlot * time.Duration(nSlots)
 	startTime := time.Unix(int64(start), 0)

--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -20,7 +20,7 @@ func (s *Service) p2pHandlerControlLoop() {
 	startEntry := params.GetNetworkScheduleEntry(s.cfg.clock.CurrentEpoch())
 	s.registerSubscribers(startEntry)
 
-	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	for {
 		select {
 		// In the event of a node restart, we will still end up subscribing to the correct

--- a/beacon-chain/sync/fork_watcher_test.go
+++ b/beacon-chain/sync/fork_watcher_test.go
@@ -248,7 +248,7 @@ func attachSpawner(s *Service) *sync.WaitGroup {
 
 // oneEpoch returns the duration of one epoch.
 func oneEpoch() time.Duration {
-	return time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+	return params.EpochsDuration(1, params.BeaconConfig())
 }
 
 type fakePartialBroadcaster struct {

--- a/beacon-chain/sync/fork_watcher_test.go
+++ b/beacon-chain/sync/fork_watcher_test.go
@@ -246,11 +246,6 @@ func attachSpawner(s *Service) *sync.WaitGroup {
 	return wg
 }
 
-// oneEpoch returns the duration of one epoch.
-func oneEpoch() time.Duration {
-	return params.EpochsDuration(1, params.BeaconConfig())
-}
-
 type fakePartialBroadcaster struct {
 	mu           sync.Mutex
 	unsubscribed []string

--- a/beacon-chain/sync/late_payload_request.go
+++ b/beacon-chain/sync/late_payload_request.go
@@ -21,7 +21,7 @@ func (s *Service) runLatePayloadRequest() {
 		return
 	}
 	offset := cfg.SlotComponentDuration(cfg.PayloadDueBPS)
-	ticker := slots.NewSlotTickerWithOffset(clock.GenesisTime(), offset, cfg.SecondsPerSlot)
+	ticker := slots.NewSlotTickerWithOffset(clock.GenesisTime(), offset, cfg.SlotDuration())
 	defer ticker.Done()
 	for {
 		select {

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -298,7 +298,7 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAttElectra_VerifyAlreadySeen
 	p1 := p2ptest.NewTestP2P(t)
 	validators := uint64(256)
 	currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
-	genesisOffset := time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	genesisOffset := time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()
 	clock := startup.NewClock(time.Now().Add(-1*genesisOffset), params.BeaconConfig().GenesisValidatorsRoot)
 
 	// Create genesis state and associated keys.

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -298,7 +298,7 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAttElectra_VerifyAlreadySeen
 	p1 := p2ptest.NewTestP2P(t)
 	validators := uint64(256)
 	currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
-	genesisOffset := time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()
+	genesisOffset := params.SlotsDuration(currentSlot, params.BeaconConfig())
 	clock := startup.NewClock(time.Now().Add(-1*genesisOffset), params.BeaconConfig().GenesisValidatorsRoot)
 
 	// Create genesis state and associated keys.

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -149,8 +149,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			}
 
 			// Calculate the deadline time by adding three slots duration to the current time
-			secondsPerSlot := params.BeaconConfig().SecondsPerSlot
-			threeSlotDuration := 3 * time.Duration(secondsPerSlot) * time.Second
+			threeSlotDuration := 3 * params.BeaconConfig().SlotDuration()
 			ctxWithTimeout, cancelFunction := context.WithTimeout(ctx, threeSlotDuration)
 			// Process and broadcast the block.
 			if err := s.processAndBroadcastBlock(ctxWithTimeout, b, blkRoot); err != nil {

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -149,7 +149,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			}
 
 			// Calculate the deadline time by adding three slots duration to the current time
-			threeSlotDuration := 3 * params.BeaconConfig().SlotDuration()
+			threeSlotDuration := params.SlotsDuration(3, params.BeaconConfig())
 			ctxWithTimeout, cancelFunction := context.WithTimeout(ctx, threeSlotDuration)
 			// Process and broadcast the block.
 			if err := s.processAndBroadcastBlock(ctxWithTimeout, b, blkRoot); err != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -679,7 +679,7 @@ func TestRPCBeaconBlocksByRange_RPCHandlerRateLimitOverflow(t *testing.T) {
 
 func TestRPCBeaconBlocksByRange_validateRangeRequest(t *testing.T) {
 	slotsSinceGenesis := primitives.Slot(1000)
-	offset := time.Duration(slotsSinceGenesis) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(slotsSinceGenesis, params.BeaconConfig())
 	clock := startup.NewClock(time.Now().Add(-offset), [32]byte{})
 
 	tests := []struct {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -679,8 +679,8 @@ func TestRPCBeaconBlocksByRange_RPCHandlerRateLimitOverflow(t *testing.T) {
 
 func TestRPCBeaconBlocksByRange_validateRangeRequest(t *testing.T) {
 	slotsSinceGenesis := primitives.Slot(1000)
-	offset := int64(slotsSinceGenesis.Mul(params.BeaconConfig().SecondsPerSlot))
-	clock := startup.NewClock(time.Now().Add(time.Second*time.Duration(-1*offset)), [32]byte{})
+	offset := time.Duration(slotsSinceGenesis) * params.BeaconConfig().SlotDuration()
+	clock := startup.NewClock(time.Now().Add(-offset), [32]byte{})
 
 	tests := []struct {
 		name          string

--- a/beacon-chain/sync/rpc_metadata_test.go
+++ b/beacon-chain/sync/rpc_metadata_test.go
@@ -108,8 +108,7 @@ func TestMetadataRPCHandler_SendMetadataRequest(t *testing.T) {
 	params.OverrideBeaconConfig(beaconChainConfig)
 	params.BeaconConfig().InitializeForkSchedule()
 
-	// Compute the number of seconds in an epoch.
-	secondsPerEpoch := oneEpoch()
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
 
 	testCases := []struct {
 		name                                             string
@@ -278,8 +277,8 @@ func TestMetadataRPCHandler_SendMetadataRequest(t *testing.T) {
 			require.Equal(t, 1, peersCount, "Expected peers to be connected")
 
 			// Setup sync services.
-			genesisPeer1 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer1) * secondsPerEpoch)
-			genesisPeer2 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer2) * secondsPerEpoch)
+			genesisPeer1 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer1) * epochDuration)
+			genesisPeer2 := time.Now().Add(-time.Duration(tc.epochsSinceGenesisPeer2) * epochDuration)
 
 			chainPeer1 := &mock.ChainService{Genesis: genesisPeer1, ValidatorsRoot: [32]byte{}}
 			chainPeer2 := &mock.ChainService{Genesis: genesisPeer2, ValidatorsRoot: [32]byte{}}
@@ -336,7 +335,7 @@ func TestMetadataRPCHandler_SendsMetadataQUIC(t *testing.T) {
 
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
-	chain := &mock.ChainService{Genesis: time.Now().Add(-5 * oneEpoch()), ValidatorsRoot: [32]byte{}}
+	chain := &mock.ChainService{Genesis: time.Now().Add(-params.EpochsDuration(5, params.BeaconConfig())), ValidatorsRoot: [32]byte{}}
 	r := &Service{
 		cfg: &config{
 			beaconDB: d,
@@ -347,7 +346,7 @@ func TestMetadataRPCHandler_SendsMetadataQUIC(t *testing.T) {
 		rateLimiter: newRateLimiter(p1),
 	}
 
-	chain2 := &mock.ChainService{Genesis: time.Now().Add(-5 * oneEpoch()), ValidatorsRoot: [32]byte{}}
+	chain2 := &mock.ChainService{Genesis: time.Now().Add(-params.EpochsDuration(5, params.BeaconConfig())), ValidatorsRoot: [32]byte{}}
 	r2 := &Service{
 		cfg: &config{
 			beaconDB: d,

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/OffchainLabs/prysm/v7/async"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
@@ -32,7 +31,7 @@ const maxFutureStatusHeadSlot = 1
 // maintainPeerStatuses maintains peer statuses by polling peers for their latest status twice per epoch.
 func (s *Service) maintainPeerStatuses() {
 	// Run twice per epoch.
-	interval := time.Duration(params.BeaconConfig().SlotsPerEpoch.Div(2).Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+	interval := params.EpochsDuration(1, params.BeaconConfig()) / 2
 	async.RunEvery(s.ctx, interval, func() {
 		wg := new(sync.WaitGroup)
 		for _, id := range s.cfg.p2p.Peers().Connected() {
@@ -95,9 +94,9 @@ func (s *Service) maintainPeerStatuses() {
 // resyncIfBehind checks periodically to see if we are in normal sync but have fallen behind our peers
 // by more than an epoch, in which case we attempt a resync using the initial sync method to catch up.
 func (s *Service) resyncIfBehind() {
-	millisecondsPerEpoch := params.BeaconConfig().SlotsPerEpoch.Mul(1000).Mul(params.BeaconConfig().SecondsPerSlot)
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
 	// Run sixteen times per epoch.
-	interval := time.Duration(millisecondsPerEpoch/16) * time.Millisecond
+	interval := epochDuration / 16
 	async.RunEvery(s.ctx, interval, func() {
 		if s.shouldReSync() {
 			syncedEpoch := slots.ToEpoch(s.cfg.chain.HeadSlot())

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -1122,7 +1122,7 @@ func TestShouldResync(t *testing.T) {
 			name: "two epochs behind, resync ok",
 			args: args{
 				headSlot: 31,
-				genesis:  prysmTime.Now().Add(-1 * 96 * params.BeaconConfig().SlotDuration()),
+				genesis:  prysmTime.Now().Add(-params.EpochsDuration(3, params.BeaconConfig())),
 				syncing:  false,
 			},
 			want: true,
@@ -1131,7 +1131,7 @@ func TestShouldResync(t *testing.T) {
 			name: "two epochs behind, already syncing",
 			args: args{
 				headSlot: 31,
-				genesis:  prysmTime.Now().Add(-1 * 96 * params.BeaconConfig().SlotDuration()),
+				genesis:  prysmTime.Now().Add(-params.EpochsDuration(3, params.BeaconConfig())),
 				syncing:  true,
 			},
 			want: false,

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -1122,7 +1122,7 @@ func TestShouldResync(t *testing.T) {
 			name: "two epochs behind, resync ok",
 			args: args{
 				headSlot: 31,
-				genesis:  prysmTime.Now().Add(-1 * 96 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesis:  prysmTime.Now().Add(-1 * 96 * params.BeaconConfig().SlotDuration()),
 				syncing:  false,
 			},
 			want: true,
@@ -1131,7 +1131,7 @@ func TestShouldResync(t *testing.T) {
 			name: "two epochs behind, already syncing",
 			args: args{
 				headSlot: 31,
-				genesis:  prysmTime.Now().Add(-1 * 96 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesis:  prysmTime.Now().Add(-1 * 96 * params.BeaconConfig().SlotDuration()),
 				syncing:  true,
 			},
 			want: false,

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -79,8 +79,8 @@ const (
 )
 
 var (
-	// Seconds in one epoch.
-	pendingBlockExpTime = time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+	// Duration of one epoch.
+	pendingBlockExpTime = params.EpochsDuration(1, params.BeaconConfig())
 	// time to allow processing early blocks.
 	earlyBlockProcessingTolerance = params.BeaconConfig().MaximumGossipClockDisparityDuration()
 	// time to allow processing early attestations.

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -681,7 +681,7 @@ func (s *Service) ensurePeers(ctx context.Context, tracker *subnetTracker) {
 }
 
 func (s *Service) tryEnsurePeers(ctx context.Context, tracker *subnetTracker) {
-	timeout := (time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second) - 100*time.Millisecond
+	timeout := (params.BeaconConfig().SlotDuration()) - 100*time.Millisecond
 	minPeers := flags.Get().MinimumPeersPerSubnet
 	neededSubnets := computeAllNeededSubnets(s.cfg.clock.CurrentSlot(), tracker.getSubnetsToJoin, tracker.getSubnetsRequiringPeers)
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -605,7 +605,7 @@ func (s *Service) subscribeWithParameters(p subscribeParameters) {
 	go s.logMinimumPeersPerSubnet(ctx, p)
 
 	s.trySubscribeSubnets(ctx, tracker)
-	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	defer slotTicker.Done()
 	for {
 		select {
@@ -668,7 +668,7 @@ func (s *Service) ensurePeers(ctx context.Context, tracker *subnetTracker) {
 	// Try once immediately so we don't have to wait until the next slot.
 	s.tryEnsurePeers(ctx, tracker)
 
-	oncePerSlot := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	oncePerSlot := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	defer oncePerSlot.Done()
 	for {
 		select {

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -455,7 +455,7 @@ func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
 	require.NoError(t, beaconState.SetGenesisTime(time.Now()))
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
+	chain := &mock.ChainService{Genesis: time.Now().Add(-params.EpochsDuration(1, params.BeaconConfig())),
 		Optimistic:       true,
 		DB:               db,
 		State:            beaconState,
@@ -557,7 +557,7 @@ func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	chain := &mock.ChainService{Genesis: time.Now().Add(-oneEpoch()),
+	chain := &mock.ChainService{Genesis: time.Now().Add(-params.EpochsDuration(1, params.BeaconConfig())),
 		DB:               db,
 		ValidatorsRoot:   [32]byte{'A'},
 		State:            beaconState,

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -315,7 +315,7 @@ func TestService_validateCommitteeIndexBeaconAttestationElectra(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	db := dbtest.SetupDB(t)
 	currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
-	genesisOffset := time.Duration(currentSlot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	genesisOffset := time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()
 	chain := &mockChain.ChainService{
 		Genesis:          time.Now().Add(-1 * genesisOffset),
 		ValidatorsRoot:   params.BeaconConfig().GenesisValidatorsRoot,

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -315,7 +315,7 @@ func TestService_validateCommitteeIndexBeaconAttestationElectra(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	db := dbtest.SetupDB(t)
 	currentSlot := 1 + (primitives.Slot(params.BeaconConfig().ElectraForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
-	genesisOffset := time.Duration(currentSlot) * params.BeaconConfig().SlotDuration()
+	genesisOffset := params.SlotsDuration(currentSlot, params.BeaconConfig())
 	chain := &mockChain.ChainService{
 		Genesis:          time.Now().Add(-1 * genesisOffset),
 		ValidatorsRoot:   params.BeaconConfig().GenesisValidatorsRoot,

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -584,8 +584,8 @@ func TestValidateBeaconBlockPubSub_WithLookahead(t *testing.T) {
 	require.NoError(t, err)
 
 	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
+	offset := time.Duration(blkSlot) * params.BeaconConfig().SlotDuration()
+	chainService := &mock.ChainService{Genesis: time.Now().Add(-offset),
 		DB:    db,
 		State: beaconState,
 		FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -668,8 +668,8 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 	require.NoError(t, err)
 
 	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := int64(blkSlot.Mul(params.BeaconConfig().SecondsPerSlot))
-	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-offset, 0),
+	offset := time.Duration(blkSlot) * params.BeaconConfig().SlotDuration()
+	chainService := &mock.ChainService{Genesis: time.Now().Add(-offset),
 		DB:    db,
 		State: beaconState,
 		FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -1561,7 +1561,7 @@ func TestValidateBeaconBlockPubSub_ValidExecutionPayload(t *testing.T) {
 	require.NoError(t, err)
 
 	stateGen := stategen.New(db, doublylinkedtree.New())
-	chainService := &mock.ChainService{Genesis: now.Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+	chainService := &mock.ChainService{Genesis: now.Add(-1 * params.BeaconConfig().SlotDuration()),
 		ValidatorsRoot: params.BeaconConfig().GenesisValidatorsRoot,
 		DB:             db,
 		FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -1756,7 +1756,7 @@ func Test_validateBellatrixBeaconBlockParentValidation(t *testing.T) {
 	msg.Block.ParentRoot = bRoot[:]
 	msg.Block.Slot = 1
 	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
+	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(params.BeaconConfig().SlotDuration()).Unix())
 	msg.Block.Body.ExecutionPayload.GasUsed = 10
 	msg.Block.Body.ExecutionPayload.GasLimit = 11
 	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
@@ -1815,7 +1815,7 @@ func Test_validateBeaconBlockProcessingWhenParentIsOptimistic(t *testing.T) {
 	msg.Block.ParentRoot = bRoot[:]
 	msg.Block.Slot = 1
 	msg.Block.ProposerIndex = proposerIdx
-	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix())
+	msg.Block.Body.ExecutionPayload.Timestamp = uint64(beaconState.GenesisTime().Add(params.BeaconConfig().SlotDuration()).Unix())
 	msg.Block.Body.ExecutionPayload.GasUsed = 10
 	msg.Block.Body.ExecutionPayload.GasLimit = 11
 	msg.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("blockHash"), 32)
@@ -2226,7 +2226,7 @@ func TestDetectAndBroadcastEquivocation(t *testing.T) {
 		slotStart, err := slots.StartTime(genesis, 1)
 		require.NoError(t, err)
 		// Past the early deadline (75% of slot at default mainnet config).
-		lateReceived := slotStart.Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+		lateReceived := slotStart.Add(params.BeaconConfig().SlotDuration())
 		require.NoError(t, r.detectAndBroadcastEquivocation(ctx, signedNewBlock, lateReceived))
 
 		require.Equal(t, 0, len(chainService.RecordedEquivocations))

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -584,7 +584,7 @@ func TestValidateBeaconBlockPubSub_WithLookahead(t *testing.T) {
 	require.NoError(t, err)
 
 	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := time.Duration(blkSlot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(blkSlot, params.BeaconConfig())
 	chainService := &mock.ChainService{Genesis: time.Now().Add(-offset),
 		DB:    db,
 		State: beaconState,
@@ -668,7 +668,7 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 	require.NoError(t, err)
 
 	stateGen := stategen.New(db, doublylinkedtree.New())
-	offset := time.Duration(blkSlot) * params.BeaconConfig().SlotDuration()
+	offset := params.SlotsDuration(blkSlot, params.BeaconConfig())
 	chainService := &mock.ChainService{Genesis: time.Now().Add(-offset),
 		DB:    db,
 		State: beaconState,

--- a/beacon-chain/sync/validate_bls_to_execution_change_test.go
+++ b/beacon-chain/sync/validate_bls_to_execution_change_test.go
@@ -208,7 +208,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.SlotsDuration(10, params.BeaconConfig())), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -246,7 +246,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.SlotsDuration(10, params.BeaconConfig())), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -287,7 +287,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.SlotsDuration(10, params.BeaconConfig())), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -336,7 +336,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.SlotsDuration(10, params.BeaconConfig())), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -380,7 +380,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.SlotsDuration(10, params.BeaconConfig())), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB

--- a/beacon-chain/sync/validate_bls_to_execution_change_test.go
+++ b/beacon-chain/sync/validate_bls_to_execution_change_test.go
@@ -208,7 +208,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -246,7 +246,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -287,7 +287,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -336,7 +336,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB
@@ -380,7 +380,7 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 				WithBlsToExecPool(blstoexec.NewPool()),
 				WithStateNotifier(chainService.StateNotifier()),
 			},
-			clock: startup.NewClock(time.Now().Add(-time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Duration(10)), [32]byte{'A'}),
+			clock: startup.NewClock(time.Now().Add(-params.BeaconConfig().SlotDuration()*time.Duration(10)), [32]byte{'A'}),
 			setupSvc: func(s *Service, msg *ethpb.SignedBLSToExecutionChange, topic string) (*Service, string) {
 				s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
 				s.cfg.beaconDB = beaconDB

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -348,7 +348,7 @@ func (s *Service) prunePendingGloasColumns() {
 		log.WithError(err).Error("Failed to receive clock for pending Gloas columns pruning routine")
 		return
 	}
-	slotTicker := slots.NewSlotTicker(clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	defer slotTicker.Done()
 	for {
 		select {

--- a/beacon-chain/sync/validate_sync_committee_message_test.go
+++ b/beacon-chain/sync/validate_sync_committee_message_test.go
@@ -179,7 +179,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				incorrectRoot := [32]byte{0xBB}
 				msg.BlockRoot = incorrectRoot[:]
 
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(10))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(10))
 				return s, topic, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -220,7 +220,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				msg.ValidatorIndex = primitives.ValidatorIndex(chosenVal)
 				msg.Slot = slots.PrevSlot(hState.Slot())
 
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(slots.ToEpoch(clock.CurrentSlot()))
@@ -266,7 +266,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				msg.ValidatorIndex = primitives.ValidatorIndex(chosenVal)
 				msg.Slot = slots.PrevSlot(hState.Slot())
 
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(clock.CurrentEpoch())
@@ -320,7 +320,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				}
 
 				// Set Topic and Subnet
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(slots.ToEpoch(clock.CurrentSlot()))
@@ -378,7 +378,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				msg.Slot = slots.PrevSlot(hState.Slot())
 
 				// Set Topic and Subnet
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(slots.ToEpoch(clock.CurrentSlot()))

--- a/beacon-chain/sync/validate_sync_committee_message_test.go
+++ b/beacon-chain/sync/validate_sync_committee_message_test.go
@@ -179,7 +179,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				incorrectRoot := [32]byte{0xBB}
 				msg.BlockRoot = incorrectRoot[:]
 
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(10))
+				gt := time.Now().Add(-params.SlotsDuration(10, params.BeaconConfig()))
 				return s, topic, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -220,7 +220,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				msg.ValidatorIndex = primitives.ValidatorIndex(chosenVal)
 				msg.Slot = slots.PrevSlot(hState.Slot())
 
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.SlotsDuration(slots.PrevSlot(hState.Slot()), params.BeaconConfig()))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(slots.ToEpoch(clock.CurrentSlot()))
@@ -266,7 +266,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				msg.ValidatorIndex = primitives.ValidatorIndex(chosenVal)
 				msg.Slot = slots.PrevSlot(hState.Slot())
 
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.SlotsDuration(slots.PrevSlot(hState.Slot()), params.BeaconConfig()))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(clock.CurrentEpoch())
@@ -320,7 +320,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				}
 
 				// Set Topic and Subnet
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.SlotsDuration(slots.PrevSlot(hState.Slot()), params.BeaconConfig()))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(slots.ToEpoch(clock.CurrentSlot()))
@@ -378,7 +378,7 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 				msg.Slot = slots.PrevSlot(hState.Slot())
 
 				// Set Topic and Subnet
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(slots.PrevSlot(hState.Slot())))
+				gt := time.Now().Add(-params.SlotsDuration(slots.PrevSlot(hState.Slot()), params.BeaconConfig()))
 				vr := [32]byte{'A'}
 				clock := startup.NewClock(gt, vr)
 				digest := params.ForkDigest(slots.ToEpoch(clock.CurrentSlot()))

--- a/beacon-chain/sync/validate_sync_contribution_proof_test.go
+++ b/beacon-chain/sync/validate_sync_contribution_proof_test.go
@@ -185,7 +185,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 
 				s.setSyncContributionIndexSlotSeen(1, 1, 1)
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -226,7 +226,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 				msg.Message.Contribution.SubcommitteeIndex = 20
 
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -268,7 +268,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.SelectionProof = incorrectProof[:]
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -328,7 +328,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					}
 				}
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -391,7 +391,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 
 				s.initCaches()
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -469,7 +469,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				}
 
 				s.initCaches()
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -549,7 +549,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				}
 
 				s.initCaches()
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -631,7 +631,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					Genesis:                     time.Now(),
 				}
 				s.initCaches()
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -725,7 +725,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					Genesis:                     time.Now(),
 				}
 				s.initCaches()
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -820,7 +820,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					SyncCommitteePubkeys:        pubkeys,
 					Genesis:                     time.Now(),
 				}
-				gt := time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
 
 				s.initCaches()
 				return s, startup.NewClock(gt, [32]byte{'A'})
@@ -976,7 +976,7 @@ func TestValidateSyncContributionAndProof(t *testing.T) {
 	subCommitteeSize := params.BeaconConfig().SyncCommitteeSize / params.BeaconConfig().SyncCommitteeSubnetCount
 	s.cfg.chain = &mockChain.ChainService{
 		ValidatorsRoot:              [32]byte{'A'},
-		Genesis:                     time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(msg.Message.Contribution.Slot)),
+		Genesis:                     time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot)),
 		SyncCommitteeIndices:        []primitives.CommitteeIndex{primitives.CommitteeIndex(msg.Message.Contribution.SubcommitteeIndex * subCommitteeSize)},
 		PublicKey:                   bytesutil.ToBytes48(keys[msg.Message.AggregatorIndex].PublicKey().Marshal()),
 		SyncSelectionProofDomain:    pd,

--- a/beacon-chain/sync/validate_sync_contribution_proof_test.go
+++ b/beacon-chain/sync/validate_sync_contribution_proof_test.go
@@ -185,7 +185,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 
 				s.setSyncContributionIndexSlotSeen(1, 1, 1)
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -226,7 +226,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 				msg.Message.Contribution.SubcommitteeIndex = 20
 
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -268,7 +268,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.SelectionProof = incorrectProof[:]
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -328,7 +328,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					}
 				}
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -391,7 +391,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				msg.Message.Contribution.AggregationBits.SetBitAt(1, true)
 
 				s.initCaches()
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -469,7 +469,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				}
 
 				s.initCaches()
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -549,7 +549,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 				}
 
 				s.initCaches()
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -631,7 +631,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					Genesis:                     time.Now(),
 				}
 				s.initCaches()
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -725,7 +725,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					Genesis:                     time.Now(),
 				}
 				s.initCaches()
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 				return s, startup.NewClock(gt, [32]byte{'A'})
 			},
 			args: args{
@@ -820,7 +820,7 @@ func TestService_ValidateSyncContributionAndProof(t *testing.T) {
 					SyncCommitteePubkeys:        pubkeys,
 					Genesis:                     time.Now(),
 				}
-				gt := time.Now().Add(-params.BeaconConfig().SlotDuration() * time.Duration(msg.Message.Contribution.Slot))
+				gt := time.Now().Add(-params.SlotsDuration(msg.Message.Contribution.Slot, params.BeaconConfig()))
 
 				s.initCaches()
 				return s, startup.NewClock(gt, [32]byte{'A'})

--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -45,7 +45,7 @@ func TestBlobIndexInBounds(t *testing.T) {
 func TestSlotNotTooEarly(t *testing.T) {
 	now := time.Now()
 	// make genesis 1 slot in the past
-	genesis := now.Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	genesis := now.Add(-1 * params.BeaconConfig().SlotDuration())
 
 	_, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 0, 1)
 	b := blobs[0]

--- a/beacon-chain/verification/execution_payload_bid_test.go
+++ b/beacon-chain/verification/execution_payload_bid_test.go
@@ -378,7 +378,7 @@ func signBidForState(t *testing.T, sk bls.SecretKey, bid *ethpb.ExecutionPayload
 func testClockAtSlot(t *testing.T, slot primitives.Slot) *startup.Clock {
 	t.Helper()
 
-	secondsPerSlot := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	secondsPerSlot := params.BeaconConfig().SlotDuration()
 	genesis := time.Now().Add(-time.Duration(slot)*secondsPerSlot - secondsPerSlot/2)
 	return startup.NewClock(genesis, [32]byte{})
 }

--- a/beacon-chain/verification/payload_attestation_test.go
+++ b/beacon-chain/verification/payload_attestation_test.go
@@ -24,7 +24,7 @@ import (
 func TestPayloadAttestationVerifyCurrentSlot(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	now := time.Unix(1000, 0)
-	genesis := now.Add(-time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	genesis := now.Add(-params.BeaconConfig().SlotDuration())
 	clock := startup.NewClock(genesis, [32]byte{}, startup.WithNower(func() time.Time { return now }))
 	ini := &Initializer{shared: &sharedResources{clock: clock}}
 

--- a/changelog/syjn99_slot-duration-ms-timers.md
+++ b/changelog/syjn99_slot-duration-ms-timers.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Derive the remaining slot- and epoch-length timers from `SLOT_DURATION_MS` instead of the raw `SECONDS_PER_SLOT` field. Broadcast and RPC timeouts, subnet/attestation cache TTLs, peer status and resync intervals, the pending-block queue deadline and the attestation pruning interval all computed their durations from `SecondsPerSlot`, which a config that only sets `SLOT_DURATION_MS` leaves at its preset default. They now run at the configured slot rate. The `SECONDS_PER_SLOT` config key itself is unchanged and still backs `SlotDuration()` when `SLOT_DURATION_MS` is absent.

--- a/changelog/syjn99_slot-duration-ms-timers.md
+++ b/changelog/syjn99_slot-duration-ms-timers.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Derive the remaining slot- and epoch-length timers from `SLOT_DURATION_MS` instead of the raw `SECONDS_PER_SLOT` field. Broadcast and RPC timeouts, subnet/attestation cache TTLs, peer status and resync intervals, the pending-block queue deadline and the attestation pruning interval all computed their durations from `SecondsPerSlot`, which a config that only sets `SLOT_DURATION_MS` leaves at its preset default. They now run at the configured slot rate. The `SECONDS_PER_SLOT` config key itself is unchanged and still backs `SlotDuration()` when `SLOT_DURATION_MS` is absent.

--- a/changelog/syjn99_slot-duration.md
+++ b/changelog/syjn99_slot-duration.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Derive the remaining slot- and epoch-length timers from `SLOT_DURATION_MS` instead of the raw `SECONDS_PER_SLOT` field.
+- Drive slot tickers from `SLOT_DURATION_MS` instead of the raw `SECONDS_PER_SLOT` field.

--- a/changelog/syjn99_slot-ticker-slot-duration-ms.md
+++ b/changelog/syjn99_slot-ticker-slot-duration-ms.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Drive slot tickers from `SLOT_DURATION_MS` instead of the raw `SECONDS_PER_SLOT` field. Configs that only set `SLOT_DURATION_MS` (as ethereum-genesis-generator v6.1.5+ now generates) left `SecondsPerSlot` at its preset default, so `slots.NewSlotTicker` ran at the wrong rate while `time/slots` slot-time math used the correct duration. On a network with a non-default slot time this made the validator client propose blocks early and drift, and the beacon node rejected every one of them as "could not process slot from the future". `NewSlotTicker` and `NewSlotTickerWithOffset` now take a `time.Duration`.

--- a/changelog/syjn99_slot-ticker-slot-duration-ms.md
+++ b/changelog/syjn99_slot-ticker-slot-duration-ms.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Drive slot tickers from `SLOT_DURATION_MS` instead of the raw `SECONDS_PER_SLOT` field. Configs that only set `SLOT_DURATION_MS` (as ethereum-genesis-generator v6.1.5+ now generates) left `SecondsPerSlot` at its preset default, so `slots.NewSlotTicker` ran at the wrong rate while `time/slots` slot-time math used the correct duration. On a network with a non-default slot time this made the validator client propose blocks early and drift, and the beacon node rejected every one of them as "could not process slot from the future". `NewSlotTicker` and `NewSlotTickerWithOffset` now take a `time.Duration`.

--- a/testing/endtoend/components/eth1/transactions.go
+++ b/testing/endtoend/components/eth1/transactions.go
@@ -131,7 +131,7 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 		}
 	}
 	// Broadcast Transactions every slot
-	txPeriod := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	txPeriod := params.BeaconConfig().SlotDuration()
 	ticker := time.NewTicker(txPeriod)
 	gasPrice := big.NewInt(1e11)
 	for {

--- a/testing/endtoend/evaluators/fork.go
+++ b/testing/endtoend/evaluators/fork.go
@@ -141,7 +141,7 @@ func forkOccurs(forkEpoch primitives.Epoch, expectedFork int) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), forkDeadline)
 	defer cancel()
-	ticker := time.NewTicker(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	ticker := time.NewTicker(params.BeaconConfig().SlotDuration())
 	defer ticker.Stop()
 
 	for {

--- a/testing/endtoend/evaluators/node.go
+++ b/testing/endtoend/evaluators/node.go
@@ -135,7 +135,7 @@ func finishedSyncing(_ *e2etypes.EvaluationContext, conns ...*grpc.ClientConn) e
 func waitForMidEpoch(ctx context.Context, conn *grpc.ClientConn) error {
 	beaconClient := eth.NewBeaconChainClient(conn)
 	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
-	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
+	slotDuration := params.BeaconConfig().SlotDuration()
 	midEpochSlot := slotsPerEpoch / 2
 
 	for {
@@ -150,14 +150,14 @@ func waitForMidEpoch(ctx context.Context, conn *grpc.ClientConn) error {
 		// If we're at least halfway into the epoch, we're safe
 		if slotInEpoch >= midEpochSlot {
 			// Wait 3/4 into the slot to ensure block propagation
-			if err := sleepWithContext(ctx, time.Duration(secondsPerSlot)*time.Second*3/4); err != nil {
+			if err := sleepWithContext(ctx, slotDuration*3/4); err != nil {
 				return err
 			}
 			return nil
 		}
 		// Wait for the remaining slots until mid-epoch
 		slotsToWait := midEpochSlot - slotInEpoch
-		if err := sleepWithContext(ctx, time.Duration(slotsToWait)*time.Duration(secondsPerSlot)*time.Second); err != nil {
+		if err := sleepWithContext(ctx, time.Duration(slotsToWait)*slotDuration); err != nil {
 			return err
 		}
 	}

--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -350,10 +350,9 @@ func ComponentsStarted(ctx context.Context, comps []e2etypes.ComponentRunner) er
 
 // EpochTickerStartTime calculates the best time to start epoch ticker for a given genesis time.
 func EpochTickerStartTime(genesisTime time.Time) time.Time {
-	epochSeconds := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	epochSecondsHalf := time.Duration(int64(epochSeconds*1000)/2) * time.Millisecond
+	halfEpoch := params.EpochsDuration(1, params.BeaconConfig()) / 2
 	// Adding a half slot here to ensure the requests are in the middle of an epoch.
-	middleOfEpoch := epochSecondsHalf + slots.DivideSlotBy(2 /* half a slot */)
+	middleOfEpoch := halfEpoch + slots.DivideSlotBy(2 /* half a slot */)
 	// Offsetting the ticker from genesis so it ticks in the middle of an epoch, in order to keep results consistent.
 	return genesisTime.Add(middleOfEpoch)
 }

--- a/testing/endtoend/kurtosis_e2e_helper.go
+++ b/testing/endtoend/kurtosis_e2e_helper.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/api/client/beacon"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/endtoend/kurtosis"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
@@ -82,8 +83,7 @@ func (k *KurtosisTestSuites) Run(t *testing.T) {
 
 	// Set deadline for assertoor.
 	genesisTime := fetchGenesisTime(t, ctx, client)
-	secondsPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	deadline := genesisTime.Add(time.Duration(k.epochsToRun*secondsPerEpoch) * time.Second)
+	deadline := genesisTime.Add(params.EpochsDuration(primitives.Epoch(k.epochsToRun), params.BeaconConfig()))
 
 	// Register Assertoor playbooks and wait for them to complete.
 	require.NoError(t, kw.RegisterPlaybooks(ctx), "Failed to register Assertoor playbooks")

--- a/testing/slasher/simulator/simulator.go
+++ b/testing/slasher/simulator/simulator.go
@@ -168,7 +168,7 @@ func (s *Simulator) Stop() error {
 
 func (s *Simulator) simulateBlocksAndAttestations(ctx context.Context) {
 	// Add a small offset to producing blocks and attestations a little bit after a slot starts.
-	ticker := slots.NewSlotTicker(s.genesisTime.Add(time.Millisecond*500), params.BeaconConfig().SecondsPerSlot)
+	ticker := slots.NewSlotTicker(s.genesisTime.Add(time.Millisecond*500), params.BeaconConfig().SlotDuration())
 	defer ticker.Done()
 	for {
 		select {

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -59,14 +59,15 @@ func NewBuilder(t testing.TB, initialState state.BeaconState, initialBlock inter
 // Tick resets the genesis time to now()-tick and adjusts the slot to the appropriate value.
 func (bb *Builder) Tick(t testing.TB, tick int64) {
 	bb.service.SetGenesisTime(time.Unix(time.Now().Unix()-tick, 0))
-	lastSlot := uint64(bb.lastTick) / params.BeaconConfig().SecondsPerSlot
-	currentSlot := uint64(tick) / params.BeaconConfig().SecondsPerSlot
+	slotDuration := params.BeaconConfig().SlotDuration()
+	lastSlot := uint64(time.Duration(bb.lastTick) * time.Second / slotDuration)
+	currentSlot := uint64(time.Duration(tick) * time.Second / slotDuration)
 	for lastSlot < currentSlot {
 		lastSlot++
-		bb.service.SetForkChoiceGenesisTime(time.Now().Add(-1 * time.Duration(params.BeaconConfig().SecondsPerSlot*lastSlot) * time.Second))
+		bb.service.SetForkChoiceGenesisTime(time.Now().Add(-1 * time.Duration(lastSlot) * slotDuration))
 		require.NoError(t, bb.service.NewSlot(t.Context(), primitives.Slot(lastSlot)))
 	}
-	if tick > int64(params.BeaconConfig().SecondsPerSlot*lastSlot) {
+	if time.Duration(tick)*time.Second > time.Duration(lastSlot)*slotDuration {
 		bb.service.SetForkChoiceGenesisTime(time.Now().Add(-1 * time.Duration(tick) * time.Second))
 	}
 	bb.lastTick = tick

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
@@ -134,10 +133,11 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 						// A 1-second buffer has proven insufficient during parallel spec test runs, as the likelihood of missing the proposer boost increases significantly,
 						// often extending to 4 seconds. Starting 2 seconds into the slot ensures close to a 100% pass rate.
 						if slices.Contains(proposerBoostTests3s, folder.Name()) {
-							// Spec test ticks have second granularity.
-							slotSeconds := uint64(params.BeaconConfig().SlotDuration() / time.Second)
-							deadline := slotSeconds / params.BeaconConfig().IntervalsPerSlot
-							if uint64(tick)%slotSeconds == deadline-1 {
+							// Spec test ticks have second granularity; work in milliseconds so a
+							// sub-second slot duration does not truncate to a zero divisor.
+							slotMillis := params.BeaconConfig().SlotDurationMillis()
+							deadline := slotMillis / params.BeaconConfig().IntervalsPerSlot
+							if uint64(tick)*1000%slotMillis == deadline-1000 {
 								tick--
 							}
 						}

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
@@ -133,8 +134,10 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 						// A 1-second buffer has proven insufficient during parallel spec test runs, as the likelihood of missing the proposer boost increases significantly,
 						// often extending to 4 seconds. Starting 2 seconds into the slot ensures close to a 100% pass rate.
 						if slices.Contains(proposerBoostTests3s, folder.Name()) {
-							deadline := params.BeaconConfig().SecondsPerSlot / params.BeaconConfig().IntervalsPerSlot
-							if uint64(tick)%params.BeaconConfig().SecondsPerSlot == deadline-1 {
+							// Spec test ticks have second granularity.
+							slotSeconds := uint64(params.BeaconConfig().SlotDuration() / time.Second)
+							deadline := slotSeconds / params.BeaconConfig().IntervalsPerSlot
+							if uint64(tick)%slotSeconds == deadline-1 {
 								tick--
 							}
 						}

--- a/time/slots/slotticker.go
+++ b/time/slots/slotticker.go
@@ -77,7 +77,7 @@ func (s *SlotIntervalTicker) Done() {
 // NewSlotTicker starts and returns a new SlotTicker instance.
 // This method panics if genesis time is zero.
 // lint:nopanic -- Communicated panic in godoc commentary.
-func NewSlotTicker(genesisTime time.Time, secondsPerSlot uint64) *SlotTicker {
+func NewSlotTicker(genesisTime time.Time, slotDuration time.Duration) *SlotTicker {
 	if genesisTime.IsZero() {
 		panic("zero genesis time")
 	}
@@ -85,36 +85,34 @@ func NewSlotTicker(genesisTime time.Time, secondsPerSlot uint64) *SlotTicker {
 		c:    make(chan primitives.Slot),
 		done: make(chan struct{}),
 	}
-	ticker.start(genesisTime, secondsPerSlot, prysmTime.Since, prysmTime.Until, time.After)
+	ticker.start(genesisTime, slotDuration, prysmTime.Since, prysmTime.Until, time.After)
 	return ticker
 }
 
 // NewSlotTickerWithOffset starts and returns a SlotTicker instance that allows a offset of time from genesis,
-// entering a offset greater than secondsPerSlot is not allowed.
-// This method will panic if genesis time is zero or the offset is less than seconds per slot.
+// entering a offset greater than the slot duration is not allowed.
+// This method will panic if genesis time is zero or the offset exceeds the slot duration.
 // lint:nopanic -- Communicated panic in godoc commentary.
-func NewSlotTickerWithOffset(genesisTime time.Time, offset time.Duration, secondsPerSlot uint64) *SlotTicker {
+func NewSlotTickerWithOffset(genesisTime time.Time, offset, slotDuration time.Duration) *SlotTicker {
 	if genesisTime.Unix() == 0 {
 		panic("zero genesis time")
 	}
-	if offset > time.Duration(secondsPerSlot)*time.Second {
+	if offset > slotDuration {
 		panic("invalid ticker offset")
 	}
 	ticker := &SlotTicker{
 		c:    make(chan primitives.Slot),
 		done: make(chan struct{}),
 	}
-	ticker.start(genesisTime.Add(offset), secondsPerSlot, prysmTime.Since, prysmTime.Until, time.After)
+	ticker.start(genesisTime.Add(offset), slotDuration, prysmTime.Since, prysmTime.Until, time.After)
 	return ticker
 }
 
 func (s *SlotTicker) start(
 	genesisTime time.Time,
-	secondsPerSlot uint64,
+	d time.Duration,
 	since, until func(time.Time) time.Duration,
 	after func(time.Duration) <-chan time.Time) {
-	d := time.Duration(secondsPerSlot) * time.Second
-
 	go func() {
 		sinceGenesis := since(genesisTime)
 
@@ -146,7 +144,7 @@ func (s *SlotTicker) start(
 
 // startWithIntervals starts a ticker that emits a tick every slot at the
 // prescribed intervals. The caller is responsible to make these intervals increasing and
-// less than secondsPerSlot
+// less than the slot duration
 func (s *SlotIntervalTicker) startWithIntervals(
 	genesisTime time.Time,
 	until func(time.Time) time.Duration,
@@ -179,7 +177,7 @@ func (s *SlotIntervalTicker) startWithIntervals(
 // NewSlotTickerWithIntervals starts and returns a SlotTicker instance that allows
 // several offsets of time from genesis,
 // Caller is responsible to input the intervals in increasing order and none bigger or equal than
-// SecondsPerSlot
+// the slot duration
 // This method will panic if genesis time is zero, intervals is 0 length, or offsets are invalid.
 // lint:nopanic -- Communicated panic in godoc commentary.
 func NewSlotTickerWithIntervals(genesisTime time.Time, intervals []time.Duration) *SlotIntervalTicker {
@@ -189,7 +187,7 @@ func NewSlotTickerWithIntervals(genesisTime time.Time, intervals []time.Duration
 	if len(intervals) == 0 {
 		panic("at least one interval has to be entered")
 	}
-	slotDuration := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	slotDuration := params.BeaconConfig().SlotDuration()
 	lastOffset := time.Duration(0)
 	for _, offset := range intervals {
 		if offset < lastOffset {

--- a/time/slots/slotticker_test.go
+++ b/time/slots/slotticker_test.go
@@ -35,7 +35,7 @@ func TestSlotTicker(t *testing.T) {
 	}
 
 	genesisTime := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
-	secondsPerSlot := uint64(8)
+	slotDuration := 8 * time.Second
 
 	// Test when the ticker starts immediately after genesis time.
 	sinceDuration = 1 * time.Second
@@ -43,7 +43,7 @@ func TestSlotTicker(t *testing.T) {
 	// Make this a buffered channel to prevent a deadlock since
 	// the other goroutine calls a function in this goroutine.
 	tick = make(chan time.Time, 2)
-	ticker.start(genesisTime, secondsPerSlot, since, until, after)
+	ticker.start(genesisTime, slotDuration, since, until, after)
 
 	// Tick once.
 	tick <- time.Now()
@@ -90,7 +90,7 @@ func TestSlotTickerGenesis(t *testing.T) {
 	}
 
 	genesisTime := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
-	secondsPerSlot := uint64(8)
+	slotDuration := 8 * time.Second
 
 	// Test when the ticker starts before genesis time.
 	sinceDuration = -1 * time.Second
@@ -98,7 +98,7 @@ func TestSlotTickerGenesis(t *testing.T) {
 	// Make this a buffered channel to prevent a deadlock since
 	// the other goroutine calls a function in this goroutine.
 	tick = make(chan time.Time, 2)
-	ticker.start(genesisTime, secondsPerSlot, since, until, after)
+	ticker.start(genesisTime, slotDuration, since, until, after)
 
 	// Tick once.
 	tick <- time.Now()
@@ -118,12 +118,12 @@ func TestSlotTickerGenesis(t *testing.T) {
 func TestGetSlotTickerWithOffset_OK(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		genesisTime := time.Now()
-		secondsPerSlot := uint64(4)
-		offset := time.Duration(secondsPerSlot/2) * time.Second
+		slotDuration := 4 * time.Second
+		offset := slotDuration / 2
 
-		offsetTicker := NewSlotTickerWithOffset(genesisTime, offset, secondsPerSlot)
+		offsetTicker := NewSlotTickerWithOffset(genesisTime, offset, slotDuration)
 		defer offsetTicker.Done()
-		normalTicker := NewSlotTicker(genesisTime, secondsPerSlot)
+		normalTicker := NewSlotTicker(genesisTime, slotDuration)
 		defer normalTicker.Done()
 
 		firstTicked := 0
@@ -152,7 +152,7 @@ func TestGetSlotTickerWitIntervals(t *testing.T) {
 
 		intervalTicker := NewSlotTickerWithIntervals(genesisTime, intervals)
 		defer intervalTicker.Done()
-		normalTicker := NewSlotTicker(genesisTime, params.BeaconConfig().SecondsPerSlot)
+		normalTicker := NewSlotTicker(genesisTime, params.BeaconConfig().SlotDuration())
 		defer normalTicker.Done()
 
 		firstTicked := 0

--- a/time/slots/slotticker_test.go
+++ b/time/slots/slotticker_test.go
@@ -147,7 +147,7 @@ func TestGetSlotTickerWithOffset_OK(t *testing.T) {
 func TestGetSlotTickerWitIntervals(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		genesisTime := time.Now()
-		offset := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second / 3
+		offset := params.BeaconConfig().SlotDuration() / 3
 		intervals := []time.Duration{offset, 2 * offset}
 
 		intervalTicker := NewSlotTickerWithIntervals(genesisTime, intervals)
@@ -176,7 +176,7 @@ func TestGetSlotTickerWitIntervals(t *testing.T) {
 
 func TestSlotTickerWithIntervalsInputValidation(t *testing.T) {
 	var genesisTime time.Time
-	offset := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second / 3
+	offset := params.BeaconConfig().SlotDuration() / 3
 	intervals := make([]time.Duration, 0)
 	panicCall := func() {
 		NewSlotTickerWithIntervals(genesisTime, intervals)

--- a/time/slots/slottime_test.go
+++ b/time/slots/slottime_test.go
@@ -653,8 +653,8 @@ func TestToForkVersion(t *testing.T) {
 
 func TestSlotTickerReplayBehaviour(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		secondsPerslot := uint64(1)
-		st := NewSlotTicker(time.Unix(time.Now().Unix(), 0), secondsPerslot) // 1-second period
+		slotDuration := time.Second
+		st := NewSlotTicker(time.Unix(time.Now().Unix(), 0), slotDuration) // 1-second period
 		const ticks = 5
 
 		ctx, cancel := context.WithTimeout(t.Context(), 6*time.Second) // make the timeout very close
@@ -665,7 +665,7 @@ func TestSlotTickerReplayBehaviour(t *testing.T) {
 		for counter < ticks {
 			select {
 			case <-st.C(): // simulate ticks faster than supposed iteration due to replaying old ticks
-				assert.Equal(t, true, time.Now().Sub(prevTime) < time.Duration(secondsPerslot)*time.Second)
+				assert.Equal(t, true, time.Now().Sub(prevTime) < slotDuration)
 				counter++
 				prevTime = time.Now()
 			case <-ctx.Done(): // timed out before enough ticks arrived

--- a/time/slots/slottime_test.go
+++ b/time/slots/slottime_test.go
@@ -264,14 +264,14 @@ func TestVerifySlotTime(t *testing.T) {
 		{
 			name: "Past slot",
 			args: args{
-				genesisTime: prysmTime.Now().Add(-1 * 5 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-1 * 5 * params.BeaconConfig().SlotDuration()),
 				slot:        3,
 			},
 		},
 		{
 			name: "within tolerance",
 			args: args{
-				genesisTime:   prysmTime.Now().Add(-1 * 5 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Add(20 * time.Millisecond),
+				genesisTime:   prysmTime.Now().Add(-1 * 5 * params.BeaconConfig().SlotDuration()).Add(20 * time.Millisecond),
 				slot:          5,
 				timeTolerance: 20 * time.Millisecond,
 			},
@@ -279,7 +279,7 @@ func TestVerifySlotTime(t *testing.T) {
 		{
 			name: "future slot",
 			args: args{
-				genesisTime: prysmTime.Now().Add(-1 * 5 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-1 * 5 * params.BeaconConfig().SlotDuration()),
 				slot:        6,
 			},
 			wantedErr: "could not process slot from the future",
@@ -295,7 +295,7 @@ func TestVerifySlotTime(t *testing.T) {
 		{
 			name: "max future slot",
 			args: args{
-				genesisTime: prysmTime.Now().Add(-1 * 5 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesisTime: prysmTime.Now().Add(-1 * 5 * params.BeaconConfig().SlotDuration()),
 				slot:        primitives.Slot(MaxSlotBuffer + 6),
 			},
 			wantedErr: "exceeds max allowed value relative to the local clock",
@@ -303,7 +303,7 @@ func TestVerifySlotTime(t *testing.T) {
 		{
 			name: "evil future slot",
 			args: args{
-				genesisTime: prysmTime.Now().Add(-1 * 24 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), // 24 slots in the past
+				genesisTime: prysmTime.Now().Add(-1 * 24 * params.BeaconConfig().SlotDuration()), // 24 slots in the past
 				// Gets multiplied with slot duration, and results in an overflow. Wraps around to a valid time.
 				// Lower than max signed int. And chosen specifically to wrap to a valid slot 24
 				slot: primitives.Slot((^uint64(0))/params.BeaconConfig().SecondsPerSlot) + 24,
@@ -324,7 +324,7 @@ func TestVerifySlotTime(t *testing.T) {
 }
 
 func TestValidateSlotClock_HandlesBadSlot(t *testing.T) {
-	genTime := prysmTime.Now().Add(-1 * time.Duration(MaxSlotBuffer) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	genTime := prysmTime.Now().Add(-1 * time.Duration(MaxSlotBuffer) * params.BeaconConfig().SlotDuration())
 
 	assert.NoError(t, ValidateClock(primitives.Slot(MaxSlotBuffer), genTime), "unexpected error validating slot")
 	assert.NoError(t, ValidateClock(primitives.Slot(2*MaxSlotBuffer), genTime), "unexpected error validating slot")
@@ -409,7 +409,7 @@ func TestSinceSlotStart(t *testing.T) {
 		wantedErr bool
 	}{
 		{slot: 1, timeStamp: now.Add(-1 * time.Hour), wantedErr: true},
-		{slot: 1, timeStamp: now.Add(2 * time.Second).Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second), wanted: 2 * time.Second},
+		{slot: 1, timeStamp: now.Add(2 * time.Second).Add(params.BeaconConfig().SlotDuration()), wanted: 2 * time.Second},
 	}
 	for i, test := range tests {
 		t.Logf("testing scenario %d", i)
@@ -424,7 +424,7 @@ func TestSinceSlotStart(t *testing.T) {
 }
 
 func TestDuration(t *testing.T) {
-	oneSlot := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	oneSlot := params.BeaconConfig().SlotDuration()
 	cases := []struct {
 		name     string
 		start    time.Time
@@ -545,7 +545,7 @@ func TestCurrentSlot(t *testing.T) {
 		{
 			name: "post-genesis",
 			args: args{
-				genesis: prysmTime.Now().Add(-5 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+				genesis: prysmTime.Now().Add(-5 * params.BeaconConfig().SlotDuration()),
 			},
 			want: 5,
 		},
@@ -565,7 +565,7 @@ func TestCurrentSlot_iterative(t *testing.T) {
 }
 
 func testCurrentSlot(t testing.TB, slot primitives.Slot) {
-	genesis := time.Now().Add(-1 * time.Duration(slot) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	genesis := time.Now().Add(-1 * time.Duration(slot) * params.BeaconConfig().SlotDuration())
 	cs := CurrentSlot(genesis)
 	require.Equal(t, slot, cs)
 }

--- a/tools/bootnode/bootnode.go
+++ b/tools/bootnode/bootnode.go
@@ -124,8 +124,7 @@ func main() {
 	}
 
 	// Update metrics once per slot.
-	slotDuration := time.Duration(params.BeaconConfig().SecondsPerSlot)
-	async.RunEvery(context.Background(), slotDuration*time.Second, func() {
+	async.RunEvery(context.Background(), params.BeaconConfig().SlotDuration(), func() {
 		updateMetrics(listener)
 	})
 

--- a/tools/forkchecker/forkchecker.go
+++ b/tools/forkchecker/forkchecker.go
@@ -54,7 +54,7 @@ func main() {
 		clients[endpt] = pb.NewBeaconChainClient(conn)
 	}
 
-	ticker := time.NewTicker(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	ticker := time.NewTicker(params.BeaconConfig().SlotDuration())
 	go func() {
 		for range ticker.C {
 			if *compare {

--- a/validator/client/attest_test.go
+++ b/validator/client/attest_test.go
@@ -712,7 +712,7 @@ func TestSignAttestation(t *testing.T) {
 func TestServer_WaitToSlotOneThird_CanWait(t *testing.T) {
 	currentTime := time.Now()
 	currentSlot := primitives.Slot(4)
-	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot) * params.BeaconConfig().SlotDuration())
+	genesisTime := currentTime.Add(-params.SlotsDuration(currentSlot, params.BeaconConfig()))
 
 	v := &validator{
 		genesisTime: genesisTime,
@@ -731,7 +731,7 @@ func TestServer_WaitToSlotOneThird_CanWait(t *testing.T) {
 func TestServer_WaitToSlotOneThird_SameReqSlot(t *testing.T) {
 	currentTime := time.Now()
 	currentSlot := primitives.Slot(4)
-	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot) * params.BeaconConfig().SlotDuration())
+	genesisTime := currentTime.Add(-params.SlotsDuration(currentSlot, params.BeaconConfig()))
 
 	v := &validator{
 		genesisTime:      genesisTime,
@@ -752,7 +752,7 @@ func TestServer_WaitToSlotOneThird_ReceiveBlockSlot(t *testing.T) {
 
 	currentTime := time.Now()
 	currentSlot := primitives.Slot(4)
-	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot) * params.BeaconConfig().SlotDuration())
+	genesisTime := currentTime.Add(-params.SlotsDuration(currentSlot, params.BeaconConfig()))
 
 	v := &validator{
 		genesisTime: genesisTime,

--- a/validator/client/attest_test.go
+++ b/validator/client/attest_test.go
@@ -712,7 +712,7 @@ func TestSignAttestation(t *testing.T) {
 func TestServer_WaitToSlotOneThird_CanWait(t *testing.T) {
 	currentTime := time.Now()
 	currentSlot := primitives.Slot(4)
-	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second)
+	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot) * params.BeaconConfig().SlotDuration())
 
 	v := &validator{
 		genesisTime: genesisTime,
@@ -731,7 +731,7 @@ func TestServer_WaitToSlotOneThird_CanWait(t *testing.T) {
 func TestServer_WaitToSlotOneThird_SameReqSlot(t *testing.T) {
 	currentTime := time.Now()
 	currentSlot := primitives.Slot(4)
-	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second)
+	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot) * params.BeaconConfig().SlotDuration())
 
 	v := &validator{
 		genesisTime:      genesisTime,
@@ -752,7 +752,7 @@ func TestServer_WaitToSlotOneThird_ReceiveBlockSlot(t *testing.T) {
 
 	currentTime := time.Now()
 	currentSlot := primitives.Slot(4)
-	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second)
+	genesisTime := currentTime.Add(-1 * time.Duration(currentSlot) * params.BeaconConfig().SlotDuration())
 
 	v := &validator{
 		genesisTime: genesisTime,

--- a/validator/client/duties_test.go
+++ b/validator/client/duties_test.go
@@ -1347,7 +1347,7 @@ func TestEnsureNextEpochDuties(t *testing.T) {
 		v, client, keys := setup(t)
 		// Genesis far enough back that SlotDeadline(0) already passed: the retry ctx
 		// is born expired, so even a hung fetch unblocks immediately.
-		v.genesisTime = time.Now().Add(-2 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+		v.genesisTime = time.Now().Add(-2 * params.BeaconConfig().SlotDuration())
 		seed(v, keys, missingNextPtc)
 
 		client.EXPECT().PTCDuties(gomock.Any(), epoch+1, gomock.Any()).DoAndReturn(

--- a/validator/client/duties_test.go
+++ b/validator/client/duties_test.go
@@ -1347,7 +1347,7 @@ func TestEnsureNextEpochDuties(t *testing.T) {
 		v, client, keys := setup(t)
 		// Genesis far enough back that SlotDeadline(0) already passed: the retry ctx
 		// is born expired, so even a hung fetch unblocks immediately.
-		v.genesisTime = time.Now().Add(-2 * params.BeaconConfig().SlotDuration())
+		v.genesisTime = time.Now().Add(-params.SlotsDuration(2, params.BeaconConfig()))
 		seed(v, keys, missingNextPtc)
 
 		client.EXPECT().PTCDuties(gomock.Any(), epoch+1, gomock.Any()).DoAndReturn(

--- a/validator/client/health_monitor.go
+++ b/validator/client/health_monitor.go
@@ -90,8 +90,7 @@ func (m *healthMonitor) performHealthCheck() {
 
 func (m *healthMonitor) loop() {
 	log.Debug("Starting health check routine for beacon node apis")
-	interval := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(params.BeaconConfig().SlotDuration())
 
 	for ; true; <-ticker.C { // check immediately
 		if m.ctx.Err() != nil {

--- a/validator/client/health_monitor_test.go
+++ b/validator/client/health_monitor_test.go
@@ -207,10 +207,10 @@ func TestHealthMonitor_HealthyChan_ReceivesUpdates(t *testing.T) {
 	mockValidator := validatormock.NewMockValidator(ctrl)
 	monitorCtx, monitorCancelFunc := context.WithCancel(context.Background())
 
-	originalSecPerSlot := params.BeaconConfig().SecondsPerSlot
-	params.BeaconConfig().SecondsPerSlot = 1 // 1 sec interval for test
+	originalSlotDuration := params.BeaconConfig().SlotDurationMilliseconds
+	params.BeaconConfig().SlotDurationMilliseconds = 1000 // 1 sec interval for test
 	defer func() {
-		params.BeaconConfig().SecondsPerSlot = originalSecPerSlot
+		params.BeaconConfig().SlotDurationMilliseconds = originalSlotDuration
 		monitorCancelFunc() // Ensure monitor context is cleaned up
 	}()
 

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -135,7 +135,7 @@ func (fv *FakeValidator) SlasherReady(_ context.Context) error {
 func (fv *FakeValidator) SlotDeadline(_ primitives.Slot) time.Time {
 	fv.SlotDeadlineCalled = true
 	if fv.IsRegularDeadline {
-		return prysmTime.Now().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+		return prysmTime.Now().Add(params.BeaconConfig().SlotDuration())
 	}
 	return prysmTime.Now()
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -369,7 +369,7 @@ func (v *validator) SetTicker() {
 	}
 	// Once the ChainStart log is received, we update the genesis time of the validator client
 	// and begin a slot ticker used to track the current slot the beacon node is in.
-	v.ticker = slots.NewSlotTicker(v.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	v.ticker = slots.NewSlotTicker(v.genesisTime, params.BeaconConfig().SlotDuration())
 	log.WithField("genesisTime", v.genesisTime).Info("Beacon chain started")
 }
 
@@ -452,8 +452,7 @@ func (v *validator) NextSlot() <-chan primitives.Slot {
 
 // SlotDeadline is the start time of the next slot.
 func (v *validator) SlotDeadline(slot primitives.Slot) time.Time {
-	secs := time.Duration((slot + 1).Mul(params.BeaconConfig().SecondsPerSlot))
-	return v.genesisTime.Add(secs * time.Second)
+	return v.genesisTime.Add(time.Duration(slot+1) * params.BeaconConfig().SlotDuration())
 }
 
 // CheckDoppelGanger checks if the current actively provided keys have

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -452,7 +452,7 @@ func (v *validator) NextSlot() <-chan primitives.Slot {
 
 // SlotDeadline is the start time of the next slot.
 func (v *validator) SlotDeadline(slot primitives.Slot) time.Time {
-	return v.genesisTime.Add(time.Duration(slot+1) * params.BeaconConfig().SlotDuration())
+	return v.genesisTime.Add(params.SlotsDuration(slot+1, params.BeaconConfig()))
 }
 
 // CheckDoppelGanger checks if the current actively provided keys have


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

While testing my [Kurtosis+E2E PR](https://github.com/OffchainLabs/prysm/pull/17239/), I found some parts in our validator client still rely on `SecondsPerSlot` which is already deprecated in `ethereum-package` and `ethereum-genesis-generator`:

- https://github.com/ethpandaops/ethereum-genesis-generator/pull/268

This change doesn't affect to the normal case but if we want to adjust seconds per slot, the chain cannot proceed because of `could not process slot from the future` error.

This PR switches all production usage for `SecondsPerSlot` in favor of the more robust helper function `SlotDuration()`. Also most of the diff come from the testing file changes to be more consistent with the change of production path.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Kurtosis configuration:

```yaml
participants:
  - el_type: geth
    cl_type: lighthouse
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    use_separate_vc: true
    count: 1
    vc_extra_params:
      - --enable-beacon-rest-api
      - --verbosity=debug

  - el_type: geth
    cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    vc_image: prysm-vc-custom-image:latest
    count: 1
    vc_extra_params:
      - --enable-beacon-rest-api
      - --beacon-rest-api-provider=http://cl-2-prysm-geth:3500
      - --verbosity=debug

  - el_type: geth
    cl_type: lighthouse
    count: 2
    supernode: true

network_params:
  genesis_delay: 40
  # The point of the run: 4s slots against the mainnet preset default of 12.
  slot_duration_ms: 4000

additional_services:
  - dora
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
