### PR TITLE
Reconcile `SLOTS_DURATION_MS` and `SECONDS_PER_SLOT`.

### DIFF
--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -122,8 +122,8 @@ func (s *Service) shouldOverrideFCU(newHeadRoot [32]byte, proposingSlot primitiv
 		log.WithFields(logrus.Fields{
 			"root":   fmt.Sprintf("%#x", newHeadRoot),
 			"weight": headWeight,
-		}).Infof("Attempted late block reorg aborted due to attestations at %d seconds",
-			params.BeaconConfig().SecondsPerSlot)
+		}).Infof("Attempted late block reorg aborted due to attestations at %s into the slot",
+			params.BeaconConfig().SlotDuration())
 		lateBlockFailedAttemptSecondThreshold.Inc()
 	} else {
 		if s.cfg.ForkChoiceStore.ShouldOverrideFCU() {

--- a/beacon-chain/blockchain/forkchoice_update_execution_test.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution_test.go
@@ -179,9 +179,9 @@ func TestShouldOverrideFCU(t *testing.T) {
 
 	require.Equal(t, primitives.Slot(2), service.CurrentSlot())
 	require.Equal(t, true, service.shouldOverrideFCU(headRoot, 2))
-	require.LogsDoNotContain(t, hook, "12 seconds")
+	require.LogsDoNotContain(t, hook, "12s into the slot")
 	require.Equal(t, false, service.shouldOverrideFCU(parentRoot, 2))
-	require.LogsContain(t, hook, "12 seconds")
+	require.LogsContain(t, hook, "12s into the slot")
 
 	head, err := fcs.Head(ctx)
 	require.NoError(t, err)

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"math"
+	stdtime "time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
 	coregloas "github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
@@ -54,11 +55,11 @@ func (s *Service) IsBidCompatibleWithHead(bid interfaces.ROExecutionPayloadBid) 
 	return buildsOnParentPayload
 }
 
-func (s *Service) waitUntilEpoch(target primitives.Epoch, secondsPerSlot uint64) error {
+func (s *Service) waitUntilEpoch(target primitives.Epoch, slotDuration stdtime.Duration) error {
 	if slots.ToEpoch(s.CurrentSlot()) >= target {
 		return nil
 	}
-	ticker := slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
+	ticker := slots.NewSlotTicker(s.genesisTime, slotDuration)
 	defer ticker.Done()
 	for {
 		select {
@@ -81,11 +82,11 @@ func (s *Service) runLatePayloadTasks() {
 	if cfg.GloasForkEpoch == math.MaxUint64 {
 		return
 	}
-	if err := s.waitUntilEpoch(cfg.GloasForkEpoch, cfg.SecondsPerSlot); err != nil {
+	if err := s.waitUntilEpoch(cfg.GloasForkEpoch, cfg.SlotDuration()); err != nil {
 		return
 	}
 	offset := cfg.SlotComponentDuration(cfg.PayloadDueBPS)
-	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, cfg.SecondsPerSlot)
+	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, cfg.SlotDuration())
 	defer ticker.Done()
 	for {
 		select {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -820,7 +820,7 @@ func (s *Service) runLateBlockTasks() {
 		attDueBPS = cfg.AttestationDueBPSGloas
 	}
 	attThreshold := cfg.SlotComponentDuration(attDueBPS)
-	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SecondsPerSlot)
+	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SlotDuration())
 	for {
 		select {
 		case slot := <-ticker.C():
@@ -828,7 +828,7 @@ func (s *Service) runLateBlockTasks() {
 				ticker.Done()
 				attDueBPS = cfg.AttestationDueBPSGloas
 				attThreshold = cfg.SlotComponentDuration(attDueBPS)
-				ticker = slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SecondsPerSlot)
+				ticker = slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SlotDuration())
 			}
 			s.goroutineCounter.sample(slot)
 			s.lateBlockTasks(s.ctx)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -466,7 +466,7 @@ func (s *Service) areSidecarsAvailable(ctx context.Context, avs das.Availability
 			return nil
 		}
 		// Bound the wait so unavailable columns error and retry instead of stalling import.
-		daCtx, cancel := context.WithTimeout(ctx, time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second)
+		daCtx, cancel := context.WithTimeout(ctx, params.BeaconConfig().SlotDuration())
 		defer cancel()
 		if err := s.areDataColumnsAvailable(daCtx, roBlock.Root(), slot); err != nil {
 			return errors.Wrapf(err, "are data columns available for block %#x with slot %d", roBlock.Root(), slot)

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -89,7 +89,7 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 			return
 		}
 
-		reorgInterval := time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot) - reorgLateBlockCountAttestations
+		reorgInterval := params.BeaconConfig().SlotDuration() - reorgLateBlockCountAttestations
 		ticker := slots.NewSlotTickerWithIntervals(s.genesisTime, []time.Duration{0, reorgInterval})
 		for {
 			select {

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -481,7 +481,7 @@ func (s *ChainService) CurrentSlot() primitives.Slot {
 	if s.Slot != nil {
 		return *s.Slot
 	}
-	return primitives.Slot(uint64(time.Now().Unix()-s.Genesis.Unix()) / params.BeaconConfig().SecondsPerSlot)
+	return primitives.Slot(uint64(time.Since(s.Genesis).Milliseconds()) / params.BeaconConfig().SlotDurationMillis())
 }
 
 // Participation mocks the same method in the chain service.

--- a/beacon-chain/cache/subnet_ids.go
+++ b/beacon-chain/cache/subnet_ids.go
@@ -32,9 +32,9 @@ func newSubnetIDs() *subnetIDs {
 	cacheSize := int(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().MaxCommitteesPerSlot * 2)) // lint:ignore uintcast -- constant values that would panic on startup if negative.
 	attesterCache := lruwrpr.New(cacheSize)
 	aggregatorCache := lruwrpr.New(cacheSize)
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
 	subLength := epochDuration * time.Duration(params.BeaconConfig().EpochsPerRandomSubnetSubscription)
-	persistentCache := cache.New(subLength*time.Second, epochDuration*time.Second)
+	persistentCache := cache.New(subLength, epochDuration)
 	return &subnetIDs{attester: attesterCache, aggregator: aggregatorCache, persistentSubnets: persistentCache}
 }
 

--- a/beacon-chain/cache/sync_subnet_ids.go
+++ b/beacon-chain/cache/sync_subnet_ids.go
@@ -21,10 +21,10 @@ type syncSubnetIDs struct {
 var SyncSubnetIDs = newSyncSubnetIDs()
 
 func newSyncSubnetIDs() *syncSubnetIDs {
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
 	// Set the default duration of a sync subnet index as the whole sync committee period.
 	subLength := epochDuration * time.Duration(params.BeaconConfig().EpochsPerSyncCommitteePeriod)
-	persistentCache := cache.New(subLength*time.Second, epochDuration*time.Second)
+	persistentCache := cache.New(subLength, epochDuration)
 	return &syncSubnetIDs{sCommittee: persistentCache}
 }
 

--- a/beacon-chain/db/pruner/pruner.go
+++ b/beacon-chain/db/pruner/pruner.go
@@ -75,7 +75,7 @@ func New(ctx context.Context, db iface.Database, genesisTime time.Time, initSync
 		db:             db,
 		ps:             pruneStartSlotFunc(primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests) + 1), // Default retention epochs is MIN_EPOCHS_FOR_BLOCK_REQUESTS + 1 from the current slot.
 		done:           make(chan struct{}),
-		slotTicker:     slots.NewSlotTicker(slots.UnsafeStartTime(genesisTime, 0), params.BeaconConfig().SecondsPerSlot),
+		slotTicker:     slots.NewSlotTicker(slots.UnsafeStartTime(genesisTime, 0), params.BeaconConfig().SlotDuration()),
 		initSyncWaiter: initSyncWaiter,
 		backfillWaiter: backfillWaiter,
 		custody:        custody,

--- a/beacon-chain/node/shutdown_proposals.go
+++ b/beacon-chain/node/shutdown_proposals.go
@@ -32,7 +32,7 @@ func (b *BeaconNode) waitForPendingProposals(sigc <-chan os.Signal) {
 	}
 
 	// Re-evaluate the pending duties on every slot boundary.
-	ticker := slots.NewSlotTicker(genesis, params.BeaconConfig().SecondsPerSlot)
+	ticker := slots.NewSlotTicker(genesis, params.BeaconConfig().SlotDuration())
 	defer ticker.Done()
 
 	b.waitForPendingProposalsLoop(sigc, ticker.C(), genesis, chainService.HeadState, chainService.CurrentSlot)

--- a/beacon-chain/operations/attestations/kv/kv.go
+++ b/beacon-chain/operations/attestations/kv/kv.go
@@ -5,7 +5,6 @@ package kv
 
 import (
 	"sync"
-	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/operations/attestations/attmap"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -33,8 +32,8 @@ type AttCaches struct {
 // NewAttCaches initializes a new attestation pool consists of multiple KV store in cache for
 // various kind of attestations.
 func NewAttCaches() *AttCaches {
-	secsInEpoch := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	c := cache.New(2*secsInEpoch*time.Second, 2*secsInEpoch*time.Second)
+	epochDuration := params.EpochsDuration(1, params.BeaconConfig())
+	c := cache.New(2*epochDuration, 2*epochDuration)
 	pool := &AttCaches{
 		unAggregatedAtt:   make(map[attestation.Id]ethpb.Att),
 		aggregatedAtt:     make(map[attestation.Id][]ethpb.Att),

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -20,7 +20,7 @@ import (
 // every prepareForkChoiceAttsPeriod.
 func (s *Service) prepareForkChoiceAtts() {
 	intervals := features.Get().AggregateIntervals
-	slotDuration := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	slotDuration := params.BeaconConfig().SlotDuration()
 	// Adjust intervals for networks with a lower slot duration (Hive, e2e, etc)
 	for {
 		if intervals[len(intervals)-1] >= slotDuration {

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -10,9 +10,9 @@ import (
 
 // pruneExpired prunes attestations pool on every slot interval.
 func (s *Service) pruneExpired() {
-	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
-	offset := time.Duration(secondsPerSlot-1) * time.Second
-	slotTicker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, secondsPerSlot)
+	slotDuration := params.BeaconConfig().SlotDuration()
+	offset := max(slotDuration-time.Second, 0)
+	slotTicker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, slotDuration)
 	defer slotTicker.Done()
 	for {
 		select {

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -106,7 +106,7 @@ func (s *Service) expired(providedSlot primitives.Slot) bool {
 // Handles expiration of attestations before deneb.
 func (s *Service) expiredPreDeneb(slot primitives.Slot) bool {
 	expirationSlot := slot + params.BeaconConfig().SlotsPerEpoch
-	expirationTime := s.genesisTime.Add(time.Duration(expirationSlot.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second)
+	expirationTime := s.genesisTime.Add(params.SlotsDuration(expirationSlot, params.BeaconConfig()))
 	return expirationTime.Before(time.Now())
 }
 

--- a/beacon-chain/operations/attestations/service.go
+++ b/beacon-chain/operations/attestations/service.go
@@ -42,7 +42,7 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 
 	if cfg.pruneInterval == 0 {
 		// Prune expired attestations from the pool every slot interval.
-		cfg.pruneInterval = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+		cfg.pruneInterval = params.BeaconConfig().SlotDuration()
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -43,7 +43,7 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 	ctx, span := trace.StartSpan(ctx, "p2p.Broadcast")
 	defer span.End()
 
-	twoSlots := time.Duration(2*params.BeaconConfig().SecondsPerSlot) * time.Second
+	twoSlots := 2 * params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, twoSlots)
 	defer cancel()
 
@@ -73,7 +73,7 @@ func (s *Service) BroadcastForEpoch(ctx context.Context, msg proto.Message, epoc
 	ctx, span := trace.StartSpan(ctx, "p2p.BroadcastForEpoch")
 	defer span.End()
 
-	twoSlots := time.Duration(2*params.BeaconConfig().SecondsPerSlot) * time.Second
+	twoSlots := 2 * params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, twoSlots)
 	defer cancel()
 
@@ -138,7 +138,7 @@ func (s *Service) internalBroadcastAttestation(ctx context.Context, subnet uint6
 	defer span.End()
 	ctx = trace.NewContext(context.Background(), span) // clear parent context / deadline.
 
-	oneEpoch := time.Duration(1*params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+	oneEpoch := params.EpochsDuration(1, params.BeaconConfig())
 	ctx, cancel := context.WithTimeout(ctx, oneEpoch)
 	defer cancel()
 
@@ -192,7 +192,7 @@ func (s *Service) broadcastSyncCommittee(ctx context.Context, subnet uint64, sMs
 	defer span.End()
 	ctx = trace.NewContext(context.Background(), span) // clear parent context / deadline.
 
-	oneSlot := time.Duration(1*params.BeaconConfig().SecondsPerSlot) * time.Second
+	oneSlot := params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, oneSlot)
 	defer cancel()
 
@@ -265,7 +265,7 @@ func (s *Service) internalBroadcastBlob(ctx context.Context, subnet uint64, blob
 	defer span.End()
 	ctx = trace.NewContext(context.Background(), span) // clear parent context / deadline.
 
-	oneSlot := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	oneSlot := params.BeaconConfig().SlotDuration()
 	ctx, cancel := context.WithTimeout(ctx, oneSlot)
 	defer cancel()
 

--- a/beacon-chain/p2p/fork_watcher.go
+++ b/beacon-chain/p2p/fork_watcher.go
@@ -15,7 +15,7 @@ func (s *Service) forkWatcher() {
 		return
 	}
 
-	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SlotDuration())
 	var scheduleEntry params.NetworkScheduleEntry
 	for {
 		select {

--- a/beacon-chain/p2p/gossip_scoring_params.go
+++ b/beacon-chain/p2p/gossip_scoring_params.go
@@ -578,7 +578,7 @@ func defaultLightClientFinalityUpdateTopicParams() *pubsub.TopicScoreParams {
 }
 
 func oneSlotDuration() time.Duration {
-	return time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	return params.BeaconConfig().SlotDuration()
 }
 
 func oneEpochDuration() time.Duration {

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -408,7 +408,7 @@ var (
 )
 
 func (p *PartialColumnBroadcaster) loop() {
-	cleanup := time.NewTicker(time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot))
+	cleanup := time.NewTicker(params.BeaconConfig().SlotDuration())
 	for {
 		select {
 		case req := <-p.incomingReq:

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -225,7 +225,7 @@ func pubsubGossipParam() pubsub.GossipSubParams {
 // to configure our message id time-cache rather than instantiating
 // it with a router instance.
 func setPubSubParameters() {
-	seenTtl := 2 * time.Second * time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	seenTtl := 2 * params.EpochsDuration(1, params.BeaconConfig())
 	pubsub.TimeCacheDuration = seenTtl
 }
 

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -562,9 +562,7 @@ func computeSubscriptionExpirationTime(nodeID enode.ID, epoch primitives.Epoch) 
 	nodeOffset, _ := computeOffsetAndPrefix(nodeID)
 	pastEpochs := (nodeOffset + uint64(epoch)) % params.BeaconConfig().EpochsPerSubnetSubscription
 	remEpochs := params.BeaconConfig().EpochsPerSubnetSubscription - pastEpochs
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	epochTime := time.Duration(remEpochs) * epochDuration
-	return epochTime * time.Second
+	return params.EpochsDuration(primitives.Epoch(remEpochs), params.BeaconConfig())
 }
 
 func computeOffsetAndPrefix(nodeID enode.ID) (uint64, uint64) {

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -749,8 +749,7 @@ func registerSyncSubnetInternal(
 	if err != nil {
 		epochsToWatch = 0
 	}
-	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	totalDuration := epochDuration * time.Duration(epochsToWatch) * time.Second
+	totalDuration := params.EpochsDuration(1, params.BeaconConfig()) * time.Duration(epochsToWatch)
 	cache.SyncSubnetIDs.AddSyncCommitteeSubnets(pubkey, startEpoch, subs, totalDuration)
 }
 

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -210,7 +210,7 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 
 	timeout := s.EventWriteTimeout
 	if timeout == 0 {
-		timeout = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+		timeout = params.BeaconConfig().SlotDuration()
 	}
 	ka := s.KeepAliveInterval
 	if ka == 0 {

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -644,8 +644,7 @@ func (s *Server) SubmitSyncCommitteeSubscription(w http.ResponseWriter, r *http.
 		if err != nil {
 			epochsToWatch = 0
 		}
-		epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
-		totalDuration := epochDuration * time.Duration(epochsToWatch)
+		totalDuration := params.EpochsDuration(1, params.BeaconConfig()) * time.Duration(epochsToWatch)
 
 		subcommitteeSize := params.BeaconConfig().SyncCommitteeSize / params.BeaconConfig().SyncCommitteeSubnetCount
 		seen := make(map[uint64]bool)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -290,7 +290,7 @@ func (vs *Server) submitBlockToBuilder(block interfaces.ReadOnlySignedBeaconBloc
 	if vs.BlockBuilder == nil || builderURL == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), params.BeaconConfig().SlotDuration())
 	defer cancel()
 	if err := vs.BlockBuilder.SubmitSignedBeaconBlock(ctx, builderURL, block); err != nil {
 		log.WithError(err).Error("Could not submit signed beacon block to builder")

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -121,7 +121,7 @@ func (vs *Server) WaitForActivation(req *ethpb.ValidatorActivationRequest, strea
 		return status.Errorf(codes.Internal, "Could not send response over stream: %v", err)
 	}
 
-	waitTime := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	waitTime := params.BeaconConfig().SlotDuration()
 	ticker := time.NewTicker(waitTime)
 	defer ticker.Stop()
 

--- a/beacon-chain/rpc/testutil/mock_genesis_timefetcher.go
+++ b/beacon-chain/rpc/testutil/mock_genesis_timefetcher.go
@@ -17,5 +17,5 @@ func (m *MockGenesisTimeFetcher) GenesisTime() time.Time {
 }
 
 func (m *MockGenesisTimeFetcher) CurrentSlot() primitives.Slot {
-	return primitives.Slot(uint64(time.Now().Unix()-m.Genesis.Unix()) / params.BeaconConfig().SecondsPerSlot)
+	return primitives.Slot(uint64(time.Since(m.Genesis).Milliseconds()) / params.BeaconConfig().SlotDurationMillis())
 }

--- a/beacon-chain/slasher/service.go
+++ b/beacon-chain/slasher/service.go
@@ -147,10 +147,10 @@ func (s *Service) run() {
 	s.wg.Add(1)
 	go s.receiveBlocks(s.ctx, beaconBlockHeadersChan)
 
-	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
-	s.attsSlotTicker = slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
-	s.blocksSlotTicker = slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
-	s.pruningSlotTicker = slots.NewSlotTicker(s.genesisTime, secondsPerSlot)
+	slotDuration := params.BeaconConfig().SlotDuration()
+	s.attsSlotTicker = slots.NewSlotTicker(s.genesisTime, slotDuration)
+	s.blocksSlotTicker = slots.NewSlotTicker(s.genesisTime, slotDuration)
+	s.pruningSlotTicker = slots.NewSlotTicker(s.genesisTime, slotDuration)
 
 	s.wg.Add(1)
 	go s.processQueuedAttestations(s.ctx, s.attsSlotTicker.C())
@@ -213,7 +213,7 @@ func (s *Service) waitForSync(genesisTime time.Time) {
 	if slots.CurrentSlot(genesisTime) < params.BeaconConfig().SlotsPerEpoch || !s.serviceCfg.SyncChecker.Syncing() {
 		return
 	}
-	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SlotDuration())
 	defer slotTicker.Done()
 	for {
 		select {

--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -20,7 +20,7 @@ func (s *Service) p2pHandlerControlLoop() {
 	startEntry := params.GetNetworkScheduleEntry(s.cfg.clock.CurrentEpoch())
 	s.registerSubscribers(startEntry)
 
-	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	for {
 		select {
 		// In the event of a node restart, we will still end up subscribing to the correct

--- a/beacon-chain/sync/late_payload_request.go
+++ b/beacon-chain/sync/late_payload_request.go
@@ -21,7 +21,7 @@ func (s *Service) runLatePayloadRequest() {
 		return
 	}
 	offset := cfg.SlotComponentDuration(cfg.PayloadDueBPS)
-	ticker := slots.NewSlotTickerWithOffset(clock.GenesisTime(), offset, cfg.SecondsPerSlot)
+	ticker := slots.NewSlotTickerWithOffset(clock.GenesisTime(), offset, cfg.SlotDuration())
 	defer ticker.Done()
 	for {
 		select {

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -149,8 +149,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			}
 
 			// Calculate the deadline time by adding three slots duration to the current time
-			secondsPerSlot := params.BeaconConfig().SecondsPerSlot
-			threeSlotDuration := 3 * time.Duration(secondsPerSlot) * time.Second
+			threeSlotDuration := 3 * params.BeaconConfig().SlotDuration()
 			ctxWithTimeout, cancelFunction := context.WithTimeout(ctx, threeSlotDuration)
 			// Process and broadcast the block.
 			if err := s.processAndBroadcastBlock(ctxWithTimeout, b, blkRoot); err != nil {

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/OffchainLabs/prysm/v7/async"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
@@ -32,7 +31,7 @@ const maxFutureStatusHeadSlot = 1
 // maintainPeerStatuses maintains peer statuses by polling peers for their latest status twice per epoch.
 func (s *Service) maintainPeerStatuses() {
 	// Run twice per epoch.
-	interval := time.Duration(params.BeaconConfig().SlotsPerEpoch.Div(2).Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+	interval := params.SlotsDuration(params.BeaconConfig().SlotsPerEpoch.Div(2), params.BeaconConfig())
 	async.RunEvery(s.ctx, interval, func() {
 		wg := new(sync.WaitGroup)
 		for _, id := range s.cfg.p2p.Peers().Connected() {
@@ -95,9 +94,8 @@ func (s *Service) maintainPeerStatuses() {
 // resyncIfBehind checks periodically to see if we are in normal sync but have fallen behind our peers
 // by more than an epoch, in which case we attempt a resync using the initial sync method to catch up.
 func (s *Service) resyncIfBehind() {
-	millisecondsPerEpoch := params.BeaconConfig().SlotsPerEpoch.Mul(1000).Mul(params.BeaconConfig().SecondsPerSlot)
 	// Run sixteen times per epoch.
-	interval := time.Duration(millisecondsPerEpoch/16) * time.Millisecond
+	interval := params.EpochsDuration(1, params.BeaconConfig()) / 16
 	async.RunEvery(s.ctx, interval, func() {
 		if s.shouldReSync() {
 			syncedEpoch := slots.ToEpoch(s.cfg.chain.HeadSlot())

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -80,7 +80,7 @@ const (
 
 var (
 	// Seconds in one epoch.
-	pendingBlockExpTime = time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot)) * time.Second
+	pendingBlockExpTime = params.EpochsDuration(1, params.BeaconConfig())
 	// time to allow processing early blocks.
 	earlyBlockProcessingTolerance = params.BeaconConfig().MaximumGossipClockDisparityDuration()
 	// time to allow processing early attestations.

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -605,7 +605,7 @@ func (s *Service) subscribeWithParameters(p subscribeParameters) {
 	go s.logMinimumPeersPerSubnet(ctx, p)
 
 	s.trySubscribeSubnets(ctx, tracker)
-	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	defer slotTicker.Done()
 	for {
 		select {
@@ -668,7 +668,7 @@ func (s *Service) ensurePeers(ctx context.Context, tracker *subnetTracker) {
 	// Try once immediately so we don't have to wait until the next slot.
 	s.tryEnsurePeers(ctx, tracker)
 
-	oncePerSlot := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	oncePerSlot := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	defer oncePerSlot.Done()
 	for {
 		select {
@@ -681,7 +681,7 @@ func (s *Service) ensurePeers(ctx context.Context, tracker *subnetTracker) {
 }
 
 func (s *Service) tryEnsurePeers(ctx context.Context, tracker *subnetTracker) {
-	timeout := (time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second) - 100*time.Millisecond
+	timeout := params.BeaconConfig().SlotDuration() - 100*time.Millisecond
 	minPeers := flags.Get().MinimumPeersPerSubnet
 	neededSubnets := computeAllNeededSubnets(s.cfg.clock.CurrentSlot(), tracker.getSubnetsToJoin, tracker.getSubnetsRequiringPeers)
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -348,7 +348,7 @@ func (s *Service) prunePendingGloasColumns() {
 		log.WithError(err).Error("Failed to receive clock for pending Gloas columns pruning routine")
 		return
 	}
-	slotTicker := slots.NewSlotTicker(clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	slotTicker := slots.NewSlotTicker(clock.GenesisTime(), params.BeaconConfig().SlotDuration())
 	defer slotTicker.Done()
 	for {
 		select {

--- a/changelog/manu_reconcile-slot-duration.md
+++ b/changelog/manu_reconcile-slot-duration.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Derive `SECONDS_PER_SLOT` from `SLOT_DURATION_MS` (and vice versa) when a chain config file sets only one of them, and reject a file that sets both to contradictory values.

--- a/changelog/manu_slot-duration-ms-everywhere.md
+++ b/changelog/manu_slot-duration-ms-everywhere.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Compute every slot- and epoch-based duration from `SLOT_DURATION_MS` instead of `SECONDS_PER_SLOT`, via `SlotDuration()`, `SlotDurationMillis()`, `SlotsDuration()` and `EpochsDuration()`. `SECONDS_PER_SLOT` is no longer read outside `config/params`, so a chain config expressing its slot duration in milliseconds no longer has to be a whole number of seconds. `ConfigToYaml` keeps emitting the legacy `SECONDS_PER_SLOT` key for consumers that predate `SLOT_DURATION_MS`, but omits it when it cannot represent the configured duration.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -67,7 +67,7 @@ type BeaconChainConfig struct {
 	// Time parameters constants.
 	GenesisDelay                     uint64           `yaml:"GENESIS_DELAY" spec:"true"`                   // GenesisDelay is the minimum number of seconds to delay starting the Ethereum Beacon Chain genesis. Must be at least 1 second.
 	MinAttestationInclusionDelay     primitives.Slot  `yaml:"MIN_ATTESTATION_INCLUSION_DELAY" spec:"true"` // MinAttestationInclusionDelay defines how many slots validator has to wait to include attestation for beacon block.
-	SecondsPerSlot                   uint64           `yaml:"SECONDS_PER_SLOT" spec:"true"`                // SecondsPerSlot is how many seconds are in a single slot.
+	SecondsPerSlot                   uint64           `yaml:"SECONDS_PER_SLOT" spec:"true"`                // Deprecated: use SlotDuration() or SlotDurationMillis() instead.
 	SlotDurationMilliseconds         uint64           `yaml:"SLOT_DURATION_MS" spec:"true"`                // SlotDurationMilliseconds is the slot time expressed in milliseconds.
 	SlotsPerEpoch                    primitives.Slot  `yaml:"SLOTS_PER_EPOCH" spec:"true"`                 // SlotsPerEpoch is the number of slots in an epoch.
 	SqrRootSlotsPerEpoch             primitives.Slot  // SqrRootSlotsPerEpoch is a hard coded value where we take the square root of `SlotsPerEpoch` and round down.

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -25,9 +25,53 @@ func isMinimal(lines []string) bool {
 	return false
 }
 
+// reconcileSlotDuration keeps SecondsPerSlot and SlotDurationMilliseconds in agreement.
+//
+// The two fields describe one quantity: SLOT_DURATION_MS replaced SECONDS_PER_SLOT in the specification
+// config, and Prysm kept the older field because much of the codebase still reads it. A config
+// file sets one or the other, and whichever it omits keeps the value inherited from the preset
+// base.
+func reconcileSlotDuration(conf *BeaconChainConfig, hasSecondsPerSlot, hasSlotDurationMs bool) error {
+	// The only way both values are tolerated is if they represent the same duration.
+	if hasSecondsPerSlot && hasSlotDurationMs && conf.SecondsPerSlot*1000 != conf.SlotDurationMilliseconds {
+		return errors.Errorf(
+			"config sets contradictory slot durations: SECONDS_PER_SLOT: %d (%d ms) != SLOT_DURATION_MS: %d",
+			conf.SecondsPerSlot, conf.SecondsPerSlot*1000, conf.SlotDurationMilliseconds)
+	}
+
+	// Prysm still reads the slot duration at second granularity in places, so a duration that is
+	// not a whole number of seconds cannot be represented faithfully. Reject it rather than
+	// rounding, which would leave those code paths disagreeing with the millisecond value.
+	if hasSlotDurationMs && conf.SlotDurationMilliseconds%1000 != 0 {
+		return errors.Errorf(
+			"SLOT_DURATION_MS: %d is not a whole number of seconds, which Prysm does not support yet",
+			conf.SlotDurationMilliseconds)
+	}
+
+	// Derive whichever field the config file left at its preset base value. When the file sets both,
+	// they agree by now and both assignments are no-ops.
+	if hasSecondsPerSlot {
+		conf.SlotDurationMilliseconds = conf.SecondsPerSlot * 1000
+	}
+
+	if hasSlotDurationMs {
+		conf.SecondsPerSlot = conf.SlotDurationMilliseconds / 1000
+	}
+
+	// A zero slot duration stalls every ticker and divides by zero in the second-granularity paths.
+	if conf.SlotDurationMilliseconds == 0 {
+		return errors.New("slot duration cannot be zero: set SLOT_DURATION_MS to a positive whole number of seconds")
+	}
+
+	return nil
+}
+
 func UnmarshalConfig(yamlFile []byte, conf *BeaconChainConfig) (*BeaconChainConfig, error) {
 	// To track if config name is defined inside config file.
 	hasConfigName := false
+	// SECONDS_PER_SLOT and SLOT_DURATION_MS express the same value. Track which ones the file
+	// sets so the one left at its preset default can be derived from the other.
+	hasSecondsPerSlot, hasSlotDurationMs := false, false
 	// Convert 0x hex inputs to fixed bytes arrays
 	lines := strings.Split(string(yamlFile), "\n")
 	if conf == nil {
@@ -46,6 +90,12 @@ func UnmarshalConfig(yamlFile []byte, conf *BeaconChainConfig) (*BeaconChainConf
 		if strings.HasPrefix(line, "CONFIG_NAME") {
 			hasConfigName = true
 		}
+		if strings.HasPrefix(line, "SECONDS_PER_SLOT:") {
+			hasSecondsPerSlot = true
+		}
+		if strings.HasPrefix(line, "SLOT_DURATION_MS:") {
+			hasSlotDurationMs = true
+		}
 		if !strings.HasPrefix(line, "#") && strings.Contains(line, "0x") {
 			parts := ReplaceHexStringWithYAMLFormat(line)
 			lines[i] = strings.Join(parts, "\n")
@@ -62,6 +112,9 @@ func UnmarshalConfig(yamlFile []byte, conf *BeaconChainConfig) (*BeaconChainConf
 	}
 	if !hasConfigName {
 		conf.ConfigName = DevnetName
+	}
+	if err := reconcileSlotDuration(conf, hasSecondsPerSlot, hasSlotDurationMs); err != nil {
+		return nil, err
 	}
 	// recompute SqrRootSlotsPerEpoch constant to handle non-standard values of SlotsPerEpoch
 	conf.SqrRootSlotsPerEpoch = primitives.Slot(math.IntegerSquareRoot(uint64(conf.SlotsPerEpoch)))

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -28,24 +28,18 @@ func isMinimal(lines []string) bool {
 // reconcileSlotDuration keeps SecondsPerSlot and SlotDurationMilliseconds in agreement.
 //
 // The two fields describe one quantity: SLOT_DURATION_MS replaced SECONDS_PER_SLOT in the specification
-// config, and Prysm kept the older field because much of the codebase still reads it. A config
+// config, and Prysm keeps the older field so that configs still setting it keep working. A config
 // file sets one or the other, and whichever it omits keeps the value inherited from the preset
-// base.
+// base, so the omitted one has to be derived here.
+//
+// SecondsPerSlot cannot represent a sub-second slot duration, so it truncates. Nothing outside this
+// package reads it, and ConfigToYaml only writes it back out when it round-trips faithfully.
 func reconcileSlotDuration(conf *BeaconChainConfig, hasSecondsPerSlot, hasSlotDurationMs bool) error {
 	// The only way both values are tolerated is if they represent the same duration.
 	if hasSecondsPerSlot && hasSlotDurationMs && conf.SecondsPerSlot*1000 != conf.SlotDurationMilliseconds {
 		return errors.Errorf(
 			"config sets contradictory slot durations: SECONDS_PER_SLOT: %d (%d ms) != SLOT_DURATION_MS: %d",
 			conf.SecondsPerSlot, conf.SecondsPerSlot*1000, conf.SlotDurationMilliseconds)
-	}
-
-	// Prysm still reads the slot duration at second granularity in places, so a duration that is
-	// not a whole number of seconds cannot be represented faithfully. Reject it rather than
-	// rounding, which would leave those code paths disagreeing with the millisecond value.
-	if hasSlotDurationMs && conf.SlotDurationMilliseconds%1000 != 0 {
-		return errors.Errorf(
-			"SLOT_DURATION_MS: %d is not a whole number of seconds, which Prysm does not support yet",
-			conf.SlotDurationMilliseconds)
 	}
 
 	// Derive whichever field the config file left at its preset base value. When the file sets both,
@@ -58,9 +52,9 @@ func reconcileSlotDuration(conf *BeaconChainConfig, hasSecondsPerSlot, hasSlotDu
 		conf.SecondsPerSlot = conf.SlotDurationMilliseconds / 1000
 	}
 
-	// A zero slot duration stalls every ticker and divides by zero in the second-granularity paths.
+	// A zero slot duration makes every ticker panic and divides by zero in the slot arithmetic.
 	if conf.SlotDurationMilliseconds == 0 {
-		return errors.New("slot duration cannot be zero: set SLOT_DURATION_MS to a positive whole number of seconds")
+		return errors.New("slot duration cannot be zero: set a positive SLOT_DURATION_MS")
 	}
 
 	return nil
@@ -238,8 +232,7 @@ func ConfigToYaml(cfg *BeaconChainConfig) []byte {
 		fmt.Sprintf("MIN_GENESIS_TIME: %d", cfg.MinGenesisTime),
 		fmt.Sprintf("GENESIS_FORK_VERSION: %#x", cfg.GenesisForkVersion),
 		fmt.Sprintf("CHURN_LIMIT_QUOTIENT: %d", cfg.ChurnLimitQuotient),
-		fmt.Sprintf("SECONDS_PER_SLOT: %d", cfg.SecondsPerSlot),
-		fmt.Sprintf("SLOT_DURATION_MS: %d", cfg.SlotDurationMilliseconds),
+		fmt.Sprintf("SLOT_DURATION_MS: %d", cfg.SlotDurationMillis()),
 		fmt.Sprintf("SLOTS_PER_EPOCH: %d", cfg.SlotsPerEpoch),
 		fmt.Sprintf("SECONDS_PER_ETH1_BLOCK: %d", cfg.SecondsPerETH1Block),
 		fmt.Sprintf("ETH1_FOLLOW_DISTANCE: %d", cfg.Eth1FollowDistance),
@@ -308,6 +301,10 @@ func ConfigToYaml(cfg *BeaconChainConfig) []byte {
 		fmt.Sprintf("CONTRIBUTION_DUE_BPS_GLOAS: %d", cfg.ContributionDueBPSGloas),
 		fmt.Sprintf("PAYLOAD_ATTESTATION_DUE_BPS: %d", cfg.PayloadAttestationDueBPS),
 		fmt.Sprintf("PAYLOAD_DUE_BPS: %d", cfg.PayloadDueBPS),
+	}
+
+	if ms := cfg.SlotDurationMillis(); ms%1000 == 0 {
+		lines = append(lines, fmt.Sprintf("SECONDS_PER_SLOT: %d", ms/1000))
 	}
 
 	if len(cfg.BlobSchedule) > 0 {

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/build/bazel"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -443,4 +444,75 @@ func assertYamlFieldsMatch(t *testing.T, name string, fields []string, c1, c2 *p
 
 func isPlaceholderField(field string) bool {
 	return slices.Contains(placeholderFields, field)
+}
+
+func TestUnmarshalConfig_SlotDurationReconciliation(t *testing.T) {
+	// A config file may set either SECONDS_PER_SLOT or SLOT_DURATION_MS. Whichever it omits keeps
+	// the preset base value, so the omitted one has to be derived from the one that is present.
+	tests := []struct {
+		name         string
+		yaml         string
+		wantSeconds  uint64
+		wantMillis   uint64
+		wantErrParts string
+	}{
+		{
+			name:        "only SLOT_DURATION_MS, as written by the ethereum-package",
+			yaml:        "PRESET_BASE: 'mainnet'\nSLOT_DURATION_MS: 6000\n",
+			wantSeconds: 6,
+			wantMillis:  6000,
+		},
+		{
+			name:        "only SECONDS_PER_SLOT",
+			yaml:        "PRESET_BASE: 'mainnet'\nSECONDS_PER_SLOT: 6\n",
+			wantSeconds: 6,
+			wantMillis:  6000,
+		},
+		{
+			name:        "both, consistent",
+			yaml:        "PRESET_BASE: 'mainnet'\nSECONDS_PER_SLOT: 6\nSLOT_DURATION_MS: 6000\n",
+			wantSeconds: 6,
+			wantMillis:  6000,
+		},
+		{
+			name:        "neither, preset defaults kept",
+			yaml:        "PRESET_BASE: 'mainnet'\n",
+			wantSeconds: 12,
+			wantMillis:  12000,
+		},
+		{
+			name:         "non-whole second slot duration",
+			yaml:         "PRESET_BASE: 'mainnet'\nSLOT_DURATION_MS: 6500\n",
+			wantErrParts: "not a whole number of seconds",
+		},
+		{
+			name:         "zero slot duration",
+			yaml:         "PRESET_BASE: 'mainnet'\nSLOT_DURATION_MS: 0\n",
+			wantErrParts: "slot duration cannot be zero",
+		},
+		{
+			name:         "zero seconds per slot",
+			yaml:         "PRESET_BASE: 'mainnet'\nSECONDS_PER_SLOT: 0\n",
+			wantErrParts: "slot duration cannot be zero",
+		},
+		{
+			name:         "both, contradictory",
+			yaml:         "PRESET_BASE: 'mainnet'\nSECONDS_PER_SLOT: 6\nSLOT_DURATION_MS: 12000\n",
+			wantErrParts: "contradictory slot durations",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := params.UnmarshalConfig([]byte(tt.yaml), nil)
+			if tt.wantErrParts != "" {
+				require.ErrorContains(t, tt.wantErrParts, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantSeconds, cfg.SecondsPerSlot)
+			require.Equal(t, tt.wantMillis, cfg.SlotDurationMillis())
+			require.Equal(t, time.Duration(tt.wantMillis)*time.Millisecond, cfg.SlotDuration())
+		})
+	}
 }

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -481,9 +481,16 @@ func TestUnmarshalConfig_SlotDurationReconciliation(t *testing.T) {
 			wantMillis:  12000,
 		},
 		{
-			name:         "non-whole second slot duration",
-			yaml:         "PRESET_BASE: 'mainnet'\nSLOT_DURATION_MS: 6500\n",
-			wantErrParts: "not a whole number of seconds",
+			name:        "non-whole second slot duration",
+			yaml:        "PRESET_BASE: 'mainnet'\nSLOT_DURATION_MS: 6500\n",
+			wantSeconds: 6,
+			wantMillis:  6500,
+		},
+		{
+			name:        "sub-second slot duration",
+			yaml:        "PRESET_BASE: 'mainnet'\nSLOT_DURATION_MS: 250\n",
+			wantSeconds: 0,
+			wantMillis:  250,
 		},
 		{
 			name:         "zero slot duration",
@@ -515,4 +522,35 @@ func TestUnmarshalConfig_SlotDurationReconciliation(t *testing.T) {
 			require.Equal(t, time.Duration(tt.wantMillis)*time.Millisecond, cfg.SlotDuration())
 		})
 	}
+}
+
+func TestConfigToYaml_SlotDuration(t *testing.T) {
+	t.Run("whole seconds emit both keys and round-trip", func(t *testing.T) {
+		cfg := params.MainnetConfig().Copy()
+		cfg.SlotDurationMilliseconds = 6000
+		cfg.SecondsPerSlot = 6
+
+		yaml := string(params.ConfigToYaml(cfg))
+		require.StringContains(t, "SLOT_DURATION_MS: 6000", yaml)
+		require.StringContains(t, "SECONDS_PER_SLOT: 6", yaml)
+
+		got, err := params.UnmarshalConfig([]byte(yaml), nil)
+		require.NoError(t, err)
+		require.Equal(t, uint64(6000), got.SlotDurationMillis())
+	})
+
+	t.Run("sub-second omits the legacy key so the output still round-trips", func(t *testing.T) {
+		cfg := params.MainnetConfig().Copy()
+		cfg.SlotDurationMilliseconds = 500
+		cfg.SecondsPerSlot = 0
+
+		yaml := string(params.ConfigToYaml(cfg))
+		require.StringContains(t, "SLOT_DURATION_MS: 500", yaml)
+		require.Equal(t, false, strings.Contains(yaml, "SECONDS_PER_SLOT:"))
+
+		got, err := params.UnmarshalConfig([]byte(yaml), nil)
+		require.NoError(t, err)
+		require.Equal(t, uint64(500), got.SlotDurationMillis())
+		require.Equal(t, 500*time.Millisecond, got.SlotDuration())
+	})
 }

--- a/testing/endtoend/components/eth1/transactions.go
+++ b/testing/endtoend/components/eth1/transactions.go
@@ -131,7 +131,7 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 		}
 	}
 	// Broadcast Transactions every slot
-	txPeriod := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	txPeriod := params.BeaconConfig().SlotDuration()
 	ticker := time.NewTicker(txPeriod)
 	gasPrice := big.NewInt(1e11)
 	for {

--- a/testing/endtoend/evaluators/fork.go
+++ b/testing/endtoend/evaluators/fork.go
@@ -141,7 +141,7 @@ func forkOccurs(forkEpoch primitives.Epoch, expectedFork int) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), forkDeadline)
 	defer cancel()
-	ticker := time.NewTicker(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	ticker := time.NewTicker(params.BeaconConfig().SlotDuration())
 	defer ticker.Stop()
 
 	for {

--- a/testing/endtoend/evaluators/node.go
+++ b/testing/endtoend/evaluators/node.go
@@ -135,7 +135,7 @@ func finishedSyncing(_ *e2etypes.EvaluationContext, conns ...*grpc.ClientConn) e
 func waitForMidEpoch(ctx context.Context, conn *grpc.ClientConn) error {
 	beaconClient := eth.NewBeaconChainClient(conn)
 	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
-	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
+	slotDuration := params.BeaconConfig().SlotDuration()
 	midEpochSlot := slotsPerEpoch / 2
 
 	for {
@@ -150,14 +150,14 @@ func waitForMidEpoch(ctx context.Context, conn *grpc.ClientConn) error {
 		// If we're at least halfway into the epoch, we're safe
 		if slotInEpoch >= midEpochSlot {
 			// Wait 3/4 into the slot to ensure block propagation
-			if err := sleepWithContext(ctx, time.Duration(secondsPerSlot)*time.Second*3/4); err != nil {
+			if err := sleepWithContext(ctx, slotDuration*3/4); err != nil {
 				return err
 			}
 			return nil
 		}
 		// Wait for the remaining slots until mid-epoch
 		slotsToWait := midEpochSlot - slotInEpoch
-		if err := sleepWithContext(ctx, time.Duration(slotsToWait)*time.Duration(secondsPerSlot)*time.Second); err != nil {
+		if err := sleepWithContext(ctx, time.Duration(slotsToWait)*slotDuration); err != nil {
 			return err
 		}
 	}

--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -350,10 +350,9 @@ func ComponentsStarted(ctx context.Context, comps []e2etypes.ComponentRunner) er
 
 // EpochTickerStartTime calculates the best time to start epoch ticker for a given genesis time.
 func EpochTickerStartTime(genesisTime time.Time) time.Time {
-	epochSeconds := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	epochSecondsHalf := time.Duration(int64(epochSeconds*1000)/2) * time.Millisecond
+	halfEpoch := params.EpochsDuration(1, params.BeaconConfig()) / 2
 	// Adding a half slot here to ensure the requests are in the middle of an epoch.
-	middleOfEpoch := epochSecondsHalf + slots.DivideSlotBy(2 /* half a slot */)
+	middleOfEpoch := halfEpoch + slots.DivideSlotBy(2 /* half a slot */)
 	// Offsetting the ticker from genesis so it ticks in the middle of an epoch, in order to keep results consistent.
 	return genesisTime.Add(middleOfEpoch)
 }

--- a/testing/endtoend/kurtosis_e2e_helper.go
+++ b/testing/endtoend/kurtosis_e2e_helper.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/api/client/beacon"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/endtoend/kurtosis"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
@@ -82,8 +83,7 @@ func (k *KurtosisTestSuites) Run(t *testing.T) {
 
 	// Set deadline for assertoor.
 	genesisTime := fetchGenesisTime(t, ctx, client)
-	secondsPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	deadline := genesisTime.Add(time.Duration(k.epochsToRun*secondsPerEpoch) * time.Second)
+	deadline := genesisTime.Add(params.EpochsDuration(primitives.Epoch(k.epochsToRun), params.BeaconConfig()))
 
 	// Register Assertoor playbooks and wait for them to complete.
 	require.NoError(t, kw.RegisterPlaybooks(ctx), "Failed to register Assertoor playbooks")

--- a/testing/slasher/simulator/simulator.go
+++ b/testing/slasher/simulator/simulator.go
@@ -168,7 +168,7 @@ func (s *Simulator) Stop() error {
 
 func (s *Simulator) simulateBlocksAndAttestations(ctx context.Context) {
 	// Add a small offset to producing blocks and attestations a little bit after a slot starts.
-	ticker := slots.NewSlotTicker(s.genesisTime.Add(time.Millisecond*500), params.BeaconConfig().SecondsPerSlot)
+	ticker := slots.NewSlotTicker(s.genesisTime.Add(time.Millisecond*500), params.BeaconConfig().SlotDuration())
 	defer ticker.Done()
 	for {
 		select {

--- a/testing/slasher/simulator/simulator.go
+++ b/testing/slasher/simulator/simulator.go
@@ -130,6 +130,7 @@ func (s *Simulator) Start() {
 	// Override global configuration for simulation purposes.
 	config := params.BeaconConfig().Copy()
 	config.SecondsPerSlot = s.srvConfig.Params.SecondsPerSlot
+	config.SlotDurationMilliseconds = s.srvConfig.Params.SecondsPerSlot * 1000
 	config.SlotsPerEpoch = s.srvConfig.Params.SlotsPerEpoch
 	undo, err := params.SetActiveWithUndo(config)
 	if err != nil {

--- a/time/slots/slotticker.go
+++ b/time/slots/slotticker.go
@@ -75,45 +75,51 @@ func (s *SlotIntervalTicker) Done() {
 }
 
 // NewSlotTicker starts and returns a new SlotTicker instance.
-// This method panics if genesis time is zero.
+// This method panics if genesis time is zero or the slot duration is not positive.
 // lint:nopanic -- Communicated panic in godoc commentary.
-func NewSlotTicker(genesisTime time.Time, secondsPerSlot uint64) *SlotTicker {
+func NewSlotTicker(genesisTime time.Time, slotDuration time.Duration) *SlotTicker {
 	if genesisTime.IsZero() {
 		panic("zero genesis time")
+	}
+	if slotDuration <= 0 {
+		panic("non-positive slot duration")
 	}
 	ticker := &SlotTicker{
 		c:    make(chan primitives.Slot),
 		done: make(chan struct{}),
 	}
-	ticker.start(genesisTime, secondsPerSlot, prysmTime.Since, prysmTime.Until, time.After)
+	ticker.start(genesisTime, slotDuration, prysmTime.Since, prysmTime.Until, time.After)
 	return ticker
 }
 
 // NewSlotTickerWithOffset starts and returns a SlotTicker instance that allows a offset of time from genesis,
-// entering a offset greater than secondsPerSlot is not allowed.
-// This method will panic if genesis time is zero or the offset is less than seconds per slot.
+// entering a offset greater than the slot duration is not allowed.
+// This method will panic if genesis time is zero, the slot duration is not positive, or the offset
+// exceeds the slot duration.
 // lint:nopanic -- Communicated panic in godoc commentary.
-func NewSlotTickerWithOffset(genesisTime time.Time, offset time.Duration, secondsPerSlot uint64) *SlotTicker {
+func NewSlotTickerWithOffset(genesisTime time.Time, offset, slotDuration time.Duration) *SlotTicker {
 	if genesisTime.Unix() == 0 {
 		panic("zero genesis time")
 	}
-	if offset > time.Duration(secondsPerSlot)*time.Second {
+	if slotDuration <= 0 {
+		panic("non-positive slot duration")
+	}
+	if offset > slotDuration {
 		panic("invalid ticker offset")
 	}
 	ticker := &SlotTicker{
 		c:    make(chan primitives.Slot),
 		done: make(chan struct{}),
 	}
-	ticker.start(genesisTime.Add(offset), secondsPerSlot, prysmTime.Since, prysmTime.Until, time.After)
+	ticker.start(genesisTime.Add(offset), slotDuration, prysmTime.Since, prysmTime.Until, time.After)
 	return ticker
 }
 
 func (s *SlotTicker) start(
 	genesisTime time.Time,
-	secondsPerSlot uint64,
+	d time.Duration,
 	since, until func(time.Time) time.Duration,
 	after func(time.Duration) <-chan time.Time) {
-	d := time.Duration(secondsPerSlot) * time.Second
 
 	go func() {
 		sinceGenesis := since(genesisTime)
@@ -189,7 +195,7 @@ func NewSlotTickerWithIntervals(genesisTime time.Time, intervals []time.Duration
 	if len(intervals) == 0 {
 		panic("at least one interval has to be entered")
 	}
-	slotDuration := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	slotDuration := params.BeaconConfig().SlotDuration()
 	lastOffset := time.Duration(0)
 	for _, offset := range intervals {
 		if offset < lastOffset {

--- a/time/slots/slotticker_test.go
+++ b/time/slots/slotticker_test.go
@@ -35,7 +35,7 @@ func TestSlotTicker(t *testing.T) {
 	}
 
 	genesisTime := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
-	secondsPerSlot := uint64(8)
+	slotDuration := 8 * time.Second
 
 	// Test when the ticker starts immediately after genesis time.
 	sinceDuration = 1 * time.Second
@@ -43,7 +43,7 @@ func TestSlotTicker(t *testing.T) {
 	// Make this a buffered channel to prevent a deadlock since
 	// the other goroutine calls a function in this goroutine.
 	tick = make(chan time.Time, 2)
-	ticker.start(genesisTime, secondsPerSlot, since, until, after)
+	ticker.start(genesisTime, slotDuration, since, until, after)
 
 	// Tick once.
 	tick <- time.Now()
@@ -90,7 +90,7 @@ func TestSlotTickerGenesis(t *testing.T) {
 	}
 
 	genesisTime := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
-	secondsPerSlot := uint64(8)
+	slotDuration := 8 * time.Second
 
 	// Test when the ticker starts before genesis time.
 	sinceDuration = -1 * time.Second
@@ -98,7 +98,7 @@ func TestSlotTickerGenesis(t *testing.T) {
 	// Make this a buffered channel to prevent a deadlock since
 	// the other goroutine calls a function in this goroutine.
 	tick = make(chan time.Time, 2)
-	ticker.start(genesisTime, secondsPerSlot, since, until, after)
+	ticker.start(genesisTime, slotDuration, since, until, after)
 
 	// Tick once.
 	tick <- time.Now()
@@ -118,12 +118,12 @@ func TestSlotTickerGenesis(t *testing.T) {
 func TestGetSlotTickerWithOffset_OK(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		genesisTime := time.Now()
-		secondsPerSlot := uint64(4)
-		offset := time.Duration(secondsPerSlot/2) * time.Second
+		slotDuration := 4 * time.Second
+		offset := slotDuration / 2
 
-		offsetTicker := NewSlotTickerWithOffset(genesisTime, offset, secondsPerSlot)
+		offsetTicker := NewSlotTickerWithOffset(genesisTime, offset, slotDuration)
 		defer offsetTicker.Done()
-		normalTicker := NewSlotTicker(genesisTime, secondsPerSlot)
+		normalTicker := NewSlotTicker(genesisTime, slotDuration)
 		defer normalTicker.Done()
 
 		firstTicked := 0
@@ -147,12 +147,12 @@ func TestGetSlotTickerWithOffset_OK(t *testing.T) {
 func TestGetSlotTickerWitIntervals(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		genesisTime := time.Now()
-		offset := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second / 3
+		offset := params.BeaconConfig().SlotDuration() / 3
 		intervals := []time.Duration{offset, 2 * offset}
 
 		intervalTicker := NewSlotTickerWithIntervals(genesisTime, intervals)
 		defer intervalTicker.Done()
-		normalTicker := NewSlotTicker(genesisTime, params.BeaconConfig().SecondsPerSlot)
+		normalTicker := NewSlotTicker(genesisTime, params.BeaconConfig().SlotDuration())
 		defer normalTicker.Done()
 
 		firstTicked := 0
@@ -176,7 +176,7 @@ func TestGetSlotTickerWitIntervals(t *testing.T) {
 
 func TestSlotTickerWithIntervalsInputValidation(t *testing.T) {
 	var genesisTime time.Time
-	offset := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second / 3
+	offset := params.BeaconConfig().SlotDuration() / 3
 	intervals := make([]time.Duration, 0)
 	panicCall := func() {
 		NewSlotTickerWithIntervals(genesisTime, intervals)

--- a/time/slots/slottime_test.go
+++ b/time/slots/slottime_test.go
@@ -653,8 +653,8 @@ func TestToForkVersion(t *testing.T) {
 
 func TestSlotTickerReplayBehaviour(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		secondsPerslot := uint64(1)
-		st := NewSlotTicker(time.Unix(time.Now().Unix(), 0), secondsPerslot) // 1-second period
+		slotDuration := time.Second
+		st := NewSlotTicker(time.Unix(time.Now().Unix(), 0), slotDuration) // 1-second period
 		const ticks = 5
 
 		ctx, cancel := context.WithTimeout(t.Context(), 6*time.Second) // make the timeout very close
@@ -665,7 +665,7 @@ func TestSlotTickerReplayBehaviour(t *testing.T) {
 		for counter < ticks {
 			select {
 			case <-st.C(): // simulate ticks faster than supposed iteration due to replaying old ticks
-				assert.Equal(t, true, time.Now().Sub(prevTime) < time.Duration(secondsPerslot)*time.Second)
+				assert.Equal(t, true, time.Now().Sub(prevTime) < slotDuration)
 				counter++
 				prevTime = time.Now()
 			case <-ctx.Done(): // timed out before enough ticks arrived

--- a/tools/bootnode/bootnode.go
+++ b/tools/bootnode/bootnode.go
@@ -124,8 +124,7 @@ func main() {
 	}
 
 	// Update metrics once per slot.
-	slotDuration := time.Duration(params.BeaconConfig().SecondsPerSlot)
-	async.RunEvery(context.Background(), slotDuration*time.Second, func() {
+	async.RunEvery(context.Background(), params.BeaconConfig().SlotDuration(), func() {
 		updateMetrics(listener)
 	})
 

--- a/tools/forkchecker/forkchecker.go
+++ b/tools/forkchecker/forkchecker.go
@@ -54,7 +54,7 @@ func main() {
 		clients[endpt] = pb.NewBeaconChainClient(conn)
 	}
 
-	ticker := time.NewTicker(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+	ticker := time.NewTicker(params.BeaconConfig().SlotDuration())
 	go func() {
 		for range ticker.C {
 			if *compare {

--- a/validator/client/health_monitor.go
+++ b/validator/client/health_monitor.go
@@ -90,8 +90,7 @@ func (m *healthMonitor) performHealthCheck() {
 
 func (m *healthMonitor) loop() {
 	log.Debug("Starting health check routine for beacon node apis")
-	interval := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(params.BeaconConfig().SlotDuration())
 
 	for ; true; <-ticker.C { // check immediately
 		if m.ctx.Err() != nil {

--- a/validator/client/health_monitor_test.go
+++ b/validator/client/health_monitor_test.go
@@ -207,10 +207,10 @@ func TestHealthMonitor_HealthyChan_ReceivesUpdates(t *testing.T) {
 	mockValidator := validatormock.NewMockValidator(ctrl)
 	monitorCtx, monitorCancelFunc := context.WithCancel(context.Background())
 
-	originalSecPerSlot := params.BeaconConfig().SecondsPerSlot
-	params.BeaconConfig().SecondsPerSlot = 1 // 1 sec interval for test
+	originalSlotDurationMs := params.BeaconConfig().SlotDurationMilliseconds
+	params.BeaconConfig().SlotDurationMilliseconds = 1000 // 1 sec interval for test
 	defer func() {
-		params.BeaconConfig().SecondsPerSlot = originalSecPerSlot
+		params.BeaconConfig().SlotDurationMilliseconds = originalSlotDurationMs
 		monitorCancelFunc() // Ensure monitor context is cleaned up
 	}()
 

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -135,7 +135,7 @@ func (fv *FakeValidator) SlasherReady(_ context.Context) error {
 func (fv *FakeValidator) SlotDeadline(_ primitives.Slot) time.Time {
 	fv.SlotDeadlineCalled = true
 	if fv.IsRegularDeadline {
-		return prysmTime.Now().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
+		return prysmTime.Now().Add(params.BeaconConfig().SlotDuration())
 	}
 	return prysmTime.Now()
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -369,7 +369,7 @@ func (v *validator) SetTicker() {
 	}
 	// Once the ChainStart log is received, we update the genesis time of the validator client
 	// and begin a slot ticker used to track the current slot the beacon node is in.
-	v.ticker = slots.NewSlotTicker(v.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	v.ticker = slots.NewSlotTicker(v.genesisTime, params.BeaconConfig().SlotDuration())
 	log.WithField("genesisTime", v.genesisTime).Info("Beacon chain started")
 }
 
@@ -452,8 +452,7 @@ func (v *validator) NextSlot() <-chan primitives.Slot {
 
 // SlotDeadline is the start time of the next slot.
 func (v *validator) SlotDeadline(slot primitives.Slot) time.Time {
-	secs := time.Duration((slot + 1).Mul(params.BeaconConfig().SecondsPerSlot))
-	return v.genesisTime.Add(secs * time.Second)
+	return v.genesisTime.Add(params.SlotsDuration(slot+1, params.BeaconConfig()))
 }
 
 // CheckDoppelGanger checks if the current actively provided keys have


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Starting at:
- https://github.com/OffchainLabs/prysm/pull/15999

Prysm uses both `SLOTS_DURATION_MS` and `SECONDS_PER_SLOT`.
It is also allowed to use contradictory values without any check or warning, which leads to +/- silent bugs.

On the other hand, starting at:
- https://github.com/ethpandaops/ethereum-genesis-generator/pull/268

Kurtosis deprecated `SECONDS_PER_SLOT` in favor of `SLOT_DURATION_MS`.

==> Using 

```yaml
network_params:
  seconds_per_slot: <xxx>
```

leads to the previously mentioned issue.

This PR:
1. Implements `reconcileSlotDuration`, ensuring that both  `SECONDS_PER_SLOT` and `SLOT_DURATION_MS` are allowed to be overwritten only if these both values are consistent.
2. Modifies the usage of `SECONDS_PER_SLOT` to `SLOT_DURATION_MS` (excepted in test related files, where everything is already working and does not specifically needs to be changed)
3. Deprecates `SecondsPerSlot`, so every new usage is warned with this: 
<img width="800" height="203" alt="image" src="https://github.com/user-attachments/assets/97468a15-9020-4075-92c9-d15045658d57" />

How to test it?

With the following Kurtosis configuration file:
```yaml
participants:
  - cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    count: 3

network_params:
  gloas_fork_epoch: 1
  heze_fork_epoch: 2
  seconds_per_slot: 4

additional_services:
  - dora
  - spamoor

spamoor_params:
  image: ethpandaops/spamoor:master
  spammers:
    - scenario: eoatx
      config:
        throughput: 10
    - scenario: blobs
      config:
        throughput: 6

dora_params:
  image: ethpandaops/dora:glamsterdam-devnet-7

global_log_level: debug
```

1. On **develop**, comment the `seconds_per_slot: 4` line  ==> Should be OK
2. On **develop**, uncomment the `seconds_per_slot: 4` ==> Should fail within one epoch
3. On **this branch**, run again the with `seconds_per_slot: 4` uncomment ==> Should be OK.


**Other notes for review**
Please read commit by commit, with commit messages.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
