### PR TITLE
Add EIP-8261 gas limit schedule support

### DIFF
--- a/beacon-chain/core/helpers/block.go
+++ b/beacon-chain/core/helpers/block.go
@@ -37,16 +37,20 @@ func ProposerDependentRootOrGenesis(ctx context.Context, db GenesisBlockRootRead
 
 // ParentTargetGasLimit returns the parent execution payload's gas limit, used
 // as the payload-attributes fallback when the proposer has no signed
-// preference. Falls back to DefaultBuilderGasLimit on pre-Gloas states or
-// when no bid is cached (e.g. at genesis).
+// preference. Falls back to the EIP-8261 scheduled gas limit, else
+// DefaultBuilderGasLimit, on pre-Gloas states or when no bid is cached
 func ParentTargetGasLimit(st state.ReadOnlyBeaconState) uint64 {
 	bid, err := st.LatestExecutionPayloadBid()
 	if err != nil || bid == nil {
+		fallback := params.BeaconConfig().DefaultBuilderGasLimit
+		if scheduled, ok := params.BeaconConfig().ScheduledGasLimit(slots.ToEpoch(st.Slot())); ok {
+			fallback = scheduled
+		}
 		// No cached bid (e.g. the gloas fork boundary): EL ratchets toward this
 		// default, briefly nudging gas limit away from the parent's value.
-		log.WithField("default", params.BeaconConfig().DefaultBuilderGasLimit).
-			Debug("No parent execution payload bid; gas limit falls back to DefaultBuilderGasLimit")
-		return params.BeaconConfig().DefaultBuilderGasLimit
+		log.WithField("default", fallback).
+			Debug("No parent execution payload bid; gas limit falls back to the default")
+		return fallback
 	}
 	return bid.GasLimit()
 }

--- a/beacon-chain/rpc/eth/config/handlers.go
+++ b/beacon-chain/rpc/eth/config/handlers.go
@@ -206,5 +206,9 @@ func shouldSkip(tField reflect.StructField) bool {
 		tField.Type == reflect.TypeOf(params.BeaconConfig().BlobSchedule) {
 		return true
 	}
+	if params.BeaconConfig().GloasForkEpoch == math.MaxUint64 &&
+		tField.Type == reflect.TypeOf(params.BeaconConfig().GasLimitSchedule) {
+		return true
+	}
 	return false
 }

--- a/beacon-chain/rpc/eth/config/handlers_test.go
+++ b/beacon-chain/rpc/eth/config/handlers_test.go
@@ -244,7 +244,7 @@ func TestGetSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
 	data, ok := resp.Data.(map[string]any)
 	require.Equal(t, true, ok)
-	assert.Equal(t, 211, len(data))
+	assert.Equal(t, 212, len(data))
 	for k, v := range data {
 		t.Run(k, func(t *testing.T) {
 			switch k {
@@ -672,6 +672,10 @@ func TestGetSpec(t *testing.T) {
 				blobSchedule, ok := v.([]any)
 				assert.Equal(t, true, ok)
 				assert.Equal(t, 2, len(blobSchedule))
+			case "GAS_LIMIT_SCHEDULE":
+				gasLimitSchedule, ok := v.([]any)
+				assert.Equal(t, true, ok)
+				assert.Equal(t, 0, len(gasLimitSchedule))
 			case "FIELD_ELEMENTS_PER_CELL":
 				assert.Equal(t, "64", v) // From fieldparams.CellsPerBlob
 			case "FIELD_ELEMENTS_PER_EXT_BLOB":
@@ -845,6 +849,66 @@ func TestGetSpec_BlobSchedule_NotFulu(t *testing.T) {
 	require.Equal(t, true, ok)
 
 	_, exists := data["BLOB_SCHEDULE"]
+	require.Equal(t, false, exists)
+}
+
+func TestGetSpec_GasLimitSchedule(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	config := params.BeaconConfig().Copy()
+	config.GloasForkEpoch = 1
+	config.GasLimitSchedule = []params.GasLimitScheduleEntry{
+		{Epoch: primitives.Epoch(100), GasLimit: 60_000_000},
+		{Epoch: primitives.Epoch(200), GasLimit: 90_000_000},
+	}
+	params.OverrideBeaconConfig(config)
+
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/config/spec", nil)
+	writer := httptest.NewRecorder()
+	writer.Body = &bytes.Buffer{}
+
+	GetSpec(writer, request)
+	require.Equal(t, http.StatusOK, writer.Code)
+	resp := structs.GetSpecResponse{}
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]any)
+	require.Equal(t, true, ok)
+
+	scheduleValue, exists := data["GAS_LIMIT_SCHEDULE"]
+	require.Equal(t, true, exists)
+	scheduleSlice, ok := scheduleValue.([]any)
+	require.Equal(t, true, ok)
+	require.Equal(t, 2, len(scheduleSlice))
+	first, ok := scheduleSlice[0].(map[string]any)
+	require.Equal(t, true, ok)
+	assert.Equal(t, "100", first["EPOCH"])
+	assert.Equal(t, "60000000", first["GAS_LIMIT"])
+	second, ok := scheduleSlice[1].(map[string]any)
+	require.Equal(t, true, ok)
+	assert.Equal(t, "200", second["EPOCH"])
+	assert.Equal(t, "90000000", second["GAS_LIMIT"])
+}
+
+func TestGetSpec_GasLimitSchedule_NotGloas(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	config := params.BeaconConfig().Copy()
+	config.GloasForkEpoch = math.MaxUint64
+	config.GasLimitSchedule = []params.GasLimitScheduleEntry{
+		{Epoch: primitives.Epoch(100), GasLimit: 60_000_000},
+	}
+	params.OverrideBeaconConfig(config)
+
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/config/spec", nil)
+	writer := httptest.NewRecorder()
+	writer.Body = &bytes.Buffer{}
+
+	GetSpec(writer, request)
+	require.Equal(t, http.StatusOK, writer.Code)
+	resp := structs.GetSpecResponse{}
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]any)
+	require.Equal(t, true, ok)
+
+	_, exists := data["GAS_LIMIT_SCHEDULE"]
 	require.Equal(t, false, exists)
 }
 

--- a/changelog/terence_eip-8261.md
+++ b/changelog/terence_eip-8261.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support the optional EIP-8261 `GAS_LIMIT_SCHEDULE` config as the epoch-based default and recommended maximum gas limit for gloas proposer preferences.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -341,6 +341,9 @@ type BeaconChainConfig struct {
 	// Blobs Values
 	BlobSchedule []BlobScheduleEntry `yaml:"BLOB_SCHEDULE" spec:"true"`
 
+	// Gas Limit Values (EIP-8261)
+	GasLimitSchedule []GasLimitScheduleEntry `yaml:"GAS_LIMIT_SCHEDULE" spec:"true"`
+
 	// Deprecated_MaxBlobsPerBlock defines the max blobs that could exist in a block.
 	// Deprecated: This field is no longer supported. Avoid using it.
 	DeprecatedMaxBlobsPerBlock int `yaml:"MAX_BLOBS_PER_BLOCK" spec:"true"`
@@ -414,6 +417,24 @@ func (e NetworkScheduleEntry) LogFields() logrus.Fields {
 
 type BlobScheduleEntry NetworkScheduleEntry
 
+type GasLimitScheduleEntry struct {
+	GasLimit uint64           `yaml:"GAS_LIMIT" json:"GAS_LIMIT"`
+	Epoch    primitives.Epoch `yaml:"EPOCH" json:"EPOCH"`
+}
+
+// ScheduledGasLimit returns the EIP-8261 recommended gas limit active at epoch, false pre-gloas or when no entry is active.
+func (b *BeaconChainConfig) ScheduledGasLimit(epoch primitives.Epoch) (uint64, bool) {
+	if epoch < b.GloasForkEpoch {
+		return 0, false
+	}
+	for i := len(b.GasLimitSchedule) - 1; i >= 0; i-- {
+		if b.GasLimitSchedule[i].Epoch <= epoch {
+			return b.GasLimitSchedule[i].GasLimit, true
+		}
+	}
+	return 0, false
+}
+
 func (b *BeaconChainConfig) ApplyOptions(opts ...Option) {
 	for _, opt := range opts {
 		opt(b)
@@ -430,6 +451,9 @@ func (b *BeaconChainConfig) InitializeForkSchedule() {
 	b.ForkVersionNames = configForkNames(b)
 	b.forkSchedule = initForkSchedule(b)
 	b.bpoSchedule = initBPOSchedule(b)
+	sort.Slice(b.GasLimitSchedule, func(i, j int) bool {
+		return b.GasLimitSchedule[i].Epoch < b.GasLimitSchedule[j].Epoch
+	})
 	combined := b.forkSchedule.merge(b.bpoSchedule)
 	if err := combined.prepare(b); err != nil {
 		log.WithError(err).Error("Failed to prepare network schedule")

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -168,6 +168,38 @@ func TestFirstBPOAtFork(t *testing.T) {
 	require.Equal(t, electraMaxBlobs+2, uint64(cfg.MaxBlobsPerBlockAtEpoch(cfg.FuluForkEpoch+2)))
 }
 
+func TestScheduledGasLimit(t *testing.T) {
+	params.SetActiveTestCleanup(t, params.MainnetBeaconConfig)
+	cfg := params.MainnetConfig()
+	cfg.GloasForkEpoch = cfg.FuluForkEpoch + 100
+	cfg.GasLimitSchedule = []params.GasLimitScheduleEntry{
+		{Epoch: cfg.GloasForkEpoch + 50, GasLimit: 90_000_000},
+		{Epoch: cfg.GloasForkEpoch, GasLimit: 60_000_000},
+	}
+	cfg.InitializeForkSchedule()
+	require.Equal(t, cfg.GloasForkEpoch, cfg.GasLimitSchedule[0].Epoch, "schedule not sorted by epoch")
+
+	_, ok := cfg.ScheduledGasLimit(cfg.GloasForkEpoch - 1)
+	require.Equal(t, false, ok)
+	gl, ok := cfg.ScheduledGasLimit(cfg.GloasForkEpoch)
+	require.Equal(t, true, ok)
+	require.Equal(t, uint64(60_000_000), gl)
+	gl, ok = cfg.ScheduledGasLimit(cfg.GloasForkEpoch + 49)
+	require.Equal(t, true, ok)
+	require.Equal(t, uint64(60_000_000), gl)
+	gl, ok = cfg.ScheduledGasLimit(cfg.GloasForkEpoch + 50)
+	require.Equal(t, true, ok)
+	require.Equal(t, uint64(90_000_000), gl)
+
+	cfg.GasLimitSchedule = []params.GasLimitScheduleEntry{{Epoch: cfg.GloasForkEpoch + 10, GasLimit: 60_000_000}}
+	_, ok = cfg.ScheduledGasLimit(cfg.GloasForkEpoch + 9)
+	require.Equal(t, false, ok)
+
+	cfg.GasLimitSchedule = nil
+	_, ok = cfg.ScheduledGasLimit(cfg.GloasForkEpoch)
+	require.Equal(t, false, ok)
+}
+
 func TestMaxBlobsNoSchedule(t *testing.T) {
 	params.SetActiveTestCleanup(t, params.MainnetBeaconConfig)
 	cfg := params.MainnetConfig()

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -317,6 +317,16 @@ func ConfigToYaml(cfg *BeaconChainConfig) []byte {
 		}
 	}
 
+	if len(cfg.GasLimitSchedule) > 0 {
+		lines = append(lines, "GAS_LIMIT_SCHEDULE:")
+		for _, entry := range cfg.GasLimitSchedule {
+			lines = append(lines,
+				"  - EPOCH: "+strconv.FormatUint(uint64(entry.Epoch), 10),
+				"    GAS_LIMIT: "+strconv.FormatUint(entry.GasLimit, 10),
+			)
+		}
+	}
+
 	yamlFile := []byte(strings.Join(lines, "\n"))
 	return yamlFile
 }

--- a/config/proposer/BUILD.bazel
+++ b/config/proposer/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//config:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "//consensus-types/validator:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1/validator-client:go_default_library",

--- a/config/proposer/loader/loader.go
+++ b/config/proposer/loader/loader.go
@@ -58,6 +58,9 @@ func WithBuilderConfig() SettingsLoaderOption {
 // WithGasLimit applies the --suggested-gas-limit flag to proposer settings
 func WithGasLimit() SettingsLoaderOption {
 	return func(cliCtx *cli.Context, psl *SettingsLoader) error {
+		if !cliCtx.IsSet(flags.BuilderGasLimitFlag.Name) {
+			return nil
+		}
 		sgl := cliCtx.String(flags.BuilderGasLimitFlag.Name)
 		if sgl != "" {
 			gl, err := strconv.ParseUint(sgl, 10, 64)

--- a/config/proposer/settings.go
+++ b/config/proposer/settings.go
@@ -2,10 +2,12 @@ package proposer
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/OffchainLabs/prysm/v7/config"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/validator"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	validatorpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1/validator-client"
@@ -315,22 +317,48 @@ func (ps *Settings) UpgradeToV2() bool {
 	return true
 }
 
-// TargetGasLimit returns the proposer preferences gas limit for pubkey from
-// the top-level fields only: the per-pubkey override, else the default config
-// value, else the chain default. Builder gas limits are registration-only and
-// intentionally not consulted.
-func (ps *Settings) TargetGasLimit(pubkey [fieldparams.BLSPubkeyLength]byte) validator.Uint64 {
-	chainDefault := validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit)
+func (ps *Settings) TargetGasLimit(pubkey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch) validator.Uint64 {
+	scheduled, active := params.BeaconConfig().ScheduledGasLimit(epoch)
+	operator, ok := ps.operatorGasLimit(pubkey)
+	if !ok {
+		if active {
+			return validator.Uint64(scheduled)
+		}
+		return validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit)
+	}
+	if active && uint64(operator) > scheduled {
+		warnGasLimitExceedsSchedule(uint64(operator), scheduled, epoch)
+	}
+	return operator
+}
+
+func (ps *Settings) operatorGasLimit(pubkey [fieldparams.BLSPubkeyLength]byte) (validator.Uint64, bool) {
 	if ps == nil {
-		return chainDefault
+		return 0, false
 	}
 	if opt, ok := ps.ProposeConfig[pubkey]; ok && opt != nil && opt.GasLimit != 0 {
-		return opt.GasLimit
+		return opt.GasLimit, true
 	}
 	if ps.DefaultConfig != nil && ps.DefaultConfig.GasLimit != 0 {
-		return ps.DefaultConfig.GasLimit
+		return ps.DefaultConfig.GasLimit, true
 	}
-	return chainDefault
+	return 0, false
+}
+
+var warnedGasLimitScheduleEpoch atomic.Uint64
+
+func warnGasLimitExceedsSchedule(operator, scheduled uint64, epoch primitives.Epoch) {
+	e := uint64(epoch) + 1
+	for {
+		prev := warnedGasLimitScheduleEpoch.Load()
+		if e <= prev {
+			return
+		}
+		if warnedGasLimitScheduleEpoch.CompareAndSwap(prev, e) {
+			break
+		}
+	}
+	log.Warnf("Configured gas limit %d exceeds the recommended maximum of %d at epoch %d", operator, scheduled, epoch)
 }
 
 // GasLimit returns the gas limit (gwei) for pubkey: the per-pubkey override,
@@ -342,7 +370,10 @@ func (ps *Settings) GasLimit(pubkey [fieldparams.BLSPubkeyLength]byte) validator
 		return chainDefault
 	}
 	if ps.isV2() {
-		return ps.TargetGasLimit(pubkey)
+		if gl, ok := ps.operatorGasLimit(pubkey); ok {
+			return gl
+		}
+		return chainDefault
 	}
 	if opt, ok := ps.ProposeConfig[pubkey]; ok && opt != nil && opt.BuilderConfig != nil && opt.BuilderConfig.GasLimit != 0 {
 		return opt.BuilderConfig.GasLimit

--- a/config/proposer/settings_test.go
+++ b/config/proposer/settings_test.go
@@ -585,7 +585,7 @@ func TestSettings_TargetGasLimit(t *testing.T) {
 
 	t.Run("nil settings returns chain default", func(t *testing.T) {
 		var ps *Settings
-		require.Equal(t, chainDefault, ps.TargetGasLimit(pk))
+		require.Equal(t, chainDefault, ps.TargetGasLimit(pk, 0))
 	})
 
 	t.Run("per-validator wins over default", func(t *testing.T) {
@@ -595,13 +595,13 @@ func TestSettings_TargetGasLimit(t *testing.T) {
 			},
 			DefaultConfig: &Option{GasLimit: validator.Uint64(42_000_000)},
 		}
-		require.Equal(t, validator.Uint64(55_000_000), ps.TargetGasLimit(pk))
+		require.Equal(t, validator.Uint64(55_000_000), ps.TargetGasLimit(pk, 0))
 	})
 
 	t.Run("falls back to default then chain default", func(t *testing.T) {
 		ps := &Settings{DefaultConfig: &Option{GasLimit: validator.Uint64(42_000_000)}}
-		require.Equal(t, validator.Uint64(42_000_000), ps.TargetGasLimit(pk))
-		require.Equal(t, chainDefault, (&Settings{}).TargetGasLimit(pk))
+		require.Equal(t, validator.Uint64(42_000_000), ps.TargetGasLimit(pk, 0))
+		require.Equal(t, chainDefault, (&Settings{}).TargetGasLimit(pk, 0))
 	})
 
 	t.Run("builder gas limits are never consulted", func(t *testing.T) {
@@ -611,6 +611,52 @@ func TestSettings_TargetGasLimit(t *testing.T) {
 			},
 			DefaultConfig: &Option{BuilderConfig: &BuilderConfig{Enabled: true, GasLimit: validator.Uint64(40_000_000)}},
 		}
-		require.Equal(t, chainDefault, ps.TargetGasLimit(pk))
+		require.Equal(t, chainDefault, ps.TargetGasLimit(pk, 0))
+	})
+}
+
+func TestSettings_TargetGasLimit_Schedule(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 100
+	cfg.GasLimitSchedule = []params.GasLimitScheduleEntry{
+		{Epoch: 100, GasLimit: 60_000_000},
+		{Epoch: 200, GasLimit: 90_000_000},
+	}
+	params.OverrideBeaconConfig(cfg)
+
+	pubkey, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+	require.NoError(t, err)
+	pk := bytesutil.ToBytes48(pubkey)
+
+	t.Run("scheduled value used when unconfigured", func(t *testing.T) {
+		var ps *Settings
+		require.Equal(t, validator.Uint64(60_000_000), ps.TargetGasLimit(pk, 100))
+		require.Equal(t, validator.Uint64(60_000_000), ps.TargetGasLimit(pk, 199))
+		require.Equal(t, validator.Uint64(90_000_000), ps.TargetGasLimit(pk, 200))
+	})
+
+	t.Run("pre-gloas ignores the schedule", func(t *testing.T) {
+		var ps *Settings
+		require.Equal(t, validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit), ps.TargetGasLimit(pk, 99))
+	})
+
+	t.Run("operator value is honored above the schedule with a warning", func(t *testing.T) {
+		hook := logtest.NewGlobal()
+		warnedGasLimitScheduleEpoch.Store(0)
+		ps := &Settings{DefaultConfig: &Option{GasLimit: validator.Uint64(100_000_000)}}
+		require.Equal(t, validator.Uint64(100_000_000), ps.TargetGasLimit(pk, 200))
+		require.LogsContain(t, hook, "exceeds the recommended maximum")
+		hook.Reset()
+		require.Equal(t, validator.Uint64(100_000_000), ps.TargetGasLimit(pk, 200))
+		require.LogsDoNotContain(t, hook, "exceeds the recommended maximum")
+	})
+
+	t.Run("operator value below the schedule is honored silently", func(t *testing.T) {
+		hook := logtest.NewGlobal()
+		warnedGasLimitScheduleEpoch.Store(0)
+		ps := &Settings{DefaultConfig: &Option{GasLimit: validator.Uint64(50_000_000)}}
+		require.Equal(t, validator.Uint64(50_000_000), ps.TargetGasLimit(pk, 200))
+		require.LogsDoNotContain(t, hook, "exceeds the recommended maximum")
 	})
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1342,7 +1342,6 @@ func (v *validator) processProposerDuties(
 			continue
 		}
 
-		feeRecipient, gasLimit := v.proposerConfigForKey(pk)
 		for _, proposalSlot := range duty.ProposerSlots {
 			// Skip slots that have passed or are too close. Preferences are
 			// submitted at mid-slot, so the proposer needs to be at least 1
@@ -1354,6 +1353,8 @@ func (v *validator) processProposerDuties(
 				continue
 			}
 
+			// Keyed on the proposal slot's own epoch, the duty store can hold next-epoch duties as current in the last slot of an epoch.
+			feeRecipient, gasLimit := v.proposerConfigForKey(pk, slots.ToEpoch(proposalSlot))
 			pref := &ethpb.ProposerPreferences{
 				DependentRoot:  dependentRoot,
 				ProposalSlot:   proposalSlot,
@@ -1410,13 +1411,10 @@ func (v *validator) releasePrefSlots(prefs []*ethpb.SignedProposerPreferences) {
 	log.WithField("proposalSlots", slots).Debug("Released proposer preference reservations for retry")
 }
 
-// proposerConfigForKey returns the fee recipient and target gas limit for pk.
-// The target gas limit comes from the top-level v2 fields only; builder gas
-// limits are registration-only.
-func (v *validator) proposerConfigForKey(pk pubkey) (common.Address, uint64) {
+func (v *validator) proposerConfigForKey(pk pubkey, epoch primitives.Epoch) (common.Address, uint64) {
 	feeRecipient := common.HexToAddress(params.BeaconConfig().EthBurnAddressHex)
 	ps := v.ProposerSettings()
-	gasLimit := uint64(ps.TargetGasLimit(pk))
+	gasLimit := uint64(ps.TargetGasLimit(pk, epoch))
 	if ps == nil {
 		return feeRecipient, gasLimit
 	}

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -3077,6 +3077,76 @@ func TestValidator_buildProposerPreferences_GasLimitSources(t *testing.T) {
 	}
 }
 
+// In the last slot of an epoch the duty store already holds next-epoch duties
+// as current, so the schedule must be resolved per proposal slot, not from the
+// wall-clock slot.
+func TestValidator_buildProposerPreferences_ScheduleUsesProposalSlotEpoch(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	cfg.GasLimitSchedule = []params.GasLimitScheduleEntry{
+		{Epoch: 0, GasLimit: 60_000_000},
+		{Epoch: 1, GasLimit: 90_000_000},
+	}
+	params.OverrideBeaconConfig(cfg)
+
+	feeRecipient := feeRecipientFromString(t, "0x1111111111111111111111111111111111111111")
+	kp := randKeypair(t)
+	km := newMockKeymanager(t, kp)
+	ctrl := gomock.NewController(t)
+	client := validatormock.NewMockValidatorClient(ctrl)
+	domainCache, err := ristretto.NewCache(&ristretto.Config[string, proto.Message]{
+		NumCounters: 1920,
+		MaxCost:     192,
+		BufferItems: 64,
+	})
+	require.NoError(t, err)
+	client.EXPECT().
+		DomainData(gomock.Any(), gomock.Any()).
+		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil).
+		AnyTimes()
+
+	lastSlotOfEpoch0 := primitives.Slot(params.BeaconConfig().SlotsPerEpoch) - 1
+	epoch1ProposerSlot := params.BeaconConfig().SlotsPerEpoch + 3
+
+	v := validator{
+		validatorClient: client,
+		domainDataCache: domainCache,
+		proposerSettings: &proposer.Settings{
+			Version: 2,
+			DefaultConfig: &proposer.Option{
+				FeeRecipientConfig: &proposer.FeeRecipientConfig{FeeRecipient: feeRecipient},
+			},
+		},
+		pubkeyToStatus: map[[fieldparams.BLSPubkeyLength]byte]*validatorStatus{
+			kp.pub: {
+				publicKey: kp.pub[:],
+				status:    &ethpb.ValidatorStatusResponse{Status: ethpb.ValidatorStatus_ACTIVE},
+				index:     1,
+			},
+		},
+		duties:             &dutyStore{},
+		submittedPrefSlots: make(map[primitives.Slot]bool),
+	}
+	root := make([]byte, fieldparams.RootLength)
+	root[0] = 1
+	var data dutyStoreData
+	data.setFromContainer(&ethpb.ValidatorDutiesContainer{
+		PrevDependentRoot: root,
+		CurrDependentRoot: root,
+		CurrentEpochDuties: []*ethpb.ValidatorDuty{{
+			PublicKey: kp.pub[:], ValidatorIndex: 1, Status: ethpb.ValidatorStatus_ACTIVE,
+			ProposerSlots: []primitives.Slot{epoch1ProposerSlot},
+		}},
+	})
+	v.duties.write(data)
+
+	prefs := v.buildProposerPreferences(t.Context(), km, lastSlotOfEpoch0, true)
+	require.Equal(t, 1, len(prefs))
+	require.Equal(t, epoch1ProposerSlot, prefs[0].Message.ProposalSlot)
+	require.Equal(t, uint64(90_000_000), prefs[0].Message.TargetGasLimit)
+}
+
 // Post-fork, PushProposerSettings must not call SubmitValidatorRegistrations
 // (builder API path is pre-Gloas only).
 func TestValidator_PushProposerSettings_SkipsBuilderRegistrationsPostGloas(t *testing.T) {


### PR DESCRIPTION
- Add optional `GAS_LIMIT_SCHEDULE` config per [EIP-8261](https://eips.ethereum.org/EIPS/eip-8261): an epoch-keyed default and recommended maximum gas limit, active post-gloas
- Unconfigured validators derive their proposer preference gas limit from the schedule at each proposal slot's epoch, and operator values are always honored with a warning when they exceed the scheduled maximum
- `--suggested-gas-limit` only counts as an operator preference when explicitly set, so the flag default no longer masks the schedule or file-provided values
- Expose the schedule via `/eth/v1/config/spec` and use it in the beacon's no-bid payload attributes fallback