### PR TITLE
Dedup (un)marshal methods in `validator/client/iface/validator_client.go`

### DIFF
--- a/changelog/syjn99_chore-dedup-marshal.md
+++ b/changelog/syjn99_chore-dedup-marshal.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Dedup (un)marshal methods in `validator/client/iface/validator_client.go`.

--- a/validator/client/iface/BUILD.bazel
+++ b/validator/client/iface/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//validator/keymanager:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty",
-        "@com_github_pkg_errors//:go_default_library",
     ],
 )
 

--- a/validator/client/iface/validator_client.go
+++ b/validator/client/iface/validator_client.go
@@ -2,122 +2,25 @@ package iface
 
 import (
 	"context"
-	"encoding/json"
-	"strconv"
 
 	"github.com/OffchainLabs/prysm/v7/api/client/event"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
 )
 
 type BeaconCommitteeSelection struct {
-	SelectionProof []byte
-	Slot           primitives.Slot
-	ValidatorIndex primitives.ValidatorIndex
-}
-
-type beaconCommitteeSelectionJson struct {
-	SelectionProof string `json:"selection_proof"`
-	Slot           string `json:"slot"`
-	ValidatorIndex string `json:"validator_index"`
-}
-
-func (b *BeaconCommitteeSelection) MarshalJSON() ([]byte, error) {
-	return json.Marshal(beaconCommitteeSelectionJson{
-		SelectionProof: hexutil.Encode(b.SelectionProof),
-		Slot:           strconv.FormatUint(uint64(b.Slot), 10),
-		ValidatorIndex: strconv.FormatUint(uint64(b.ValidatorIndex), 10),
-	})
-}
-
-func (b *BeaconCommitteeSelection) UnmarshalJSON(input []byte) error {
-	var bjson beaconCommitteeSelectionJson
-	err := json.Unmarshal(input, &bjson)
-	if err != nil {
-		return errors.Wrap(err, "failed to unmarshal beacon committee selection")
-	}
-
-	slot, err := strconv.ParseUint(bjson.Slot, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse slot")
-	}
-
-	vIdx, err := strconv.ParseUint(bjson.ValidatorIndex, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse validator index")
-	}
-
-	selectionProof, err := hexutil.Decode(bjson.SelectionProof)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse selection proof")
-	}
-
-	b.Slot = primitives.Slot(slot)
-	b.SelectionProof = selectionProof
-	b.ValidatorIndex = primitives.ValidatorIndex(vIdx)
-
-	return nil
+	SelectionProof hexutil.Bytes             `json:"selection_proof"`
+	Slot           primitives.Slot           `json:"slot,string"`
+	ValidatorIndex primitives.ValidatorIndex `json:"validator_index,string"`
 }
 
 type SyncCommitteeSelection struct {
-	SelectionProof    []byte
-	Slot              primitives.Slot
-	SubcommitteeIndex primitives.CommitteeIndex
-	ValidatorIndex    primitives.ValidatorIndex
-}
-
-type syncCommitteeSelectionJson struct {
-	SelectionProof    string `json:"selection_proof"`
-	Slot              string `json:"slot"`
-	SubcommitteeIndex string `json:"subcommittee_index"`
-	ValidatorIndex    string `json:"validator_index"`
-}
-
-func (s *SyncCommitteeSelection) MarshalJSON() ([]byte, error) {
-	return json.Marshal(syncCommitteeSelectionJson{
-		SelectionProof:    hexutil.Encode(s.SelectionProof),
-		Slot:              strconv.FormatUint(uint64(s.Slot), 10),
-		SubcommitteeIndex: strconv.FormatUint(uint64(s.SubcommitteeIndex), 10),
-		ValidatorIndex:    strconv.FormatUint(uint64(s.ValidatorIndex), 10),
-	})
-}
-
-func (s *SyncCommitteeSelection) UnmarshalJSON(input []byte) error {
-	var resJson syncCommitteeSelectionJson
-	err := json.Unmarshal(input, &resJson)
-	if err != nil {
-		return errors.Wrap(err, "failed to unmarshal sync committee selection")
-	}
-
-	slot, err := strconv.ParseUint(resJson.Slot, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse slot")
-	}
-
-	vIdx, err := strconv.ParseUint(resJson.ValidatorIndex, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse validator index")
-	}
-
-	subcommIdx, err := strconv.ParseUint(resJson.SubcommitteeIndex, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse subcommittee index")
-	}
-
-	selectionProof, err := hexutil.Decode(resJson.SelectionProof)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse selection proof")
-	}
-
-	s.Slot = primitives.Slot(slot)
-	s.SelectionProof = selectionProof
-	s.ValidatorIndex = primitives.ValidatorIndex(vIdx)
-	s.SubcommitteeIndex = primitives.CommitteeIndex(subcommIdx)
-
-	return nil
+	SelectionProof    hexutil.Bytes             `json:"selection_proof"`
+	Slot              primitives.Slot           `json:"slot,string"`
+	SubcommitteeIndex primitives.CommitteeIndex `json:"subcommittee_index,string"`
+	ValidatorIndex    primitives.ValidatorIndex `json:"validator_index,string"`
 }
 
 type ValidatorClient interface {


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Cleaning up - we don't need custom marshal methods.  `BeaconCommitteeSelection` and `SyncCommitteeSelection` are used only in wire that uses JSON.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
