### PR TITLE
Add the `--disable-graffiti-client-append` flag.

### DIFF
--- a/beacon-chain/execution/graffiti_info.go
+++ b/beacon-chain/execution/graffiti_info.go
@@ -16,15 +16,17 @@ const (
 // GraffitiInfo holds version information for generating block graffiti.
 // It is thread-safe and can be updated by the execution service and read by the validator server.
 type GraffitiInfo struct {
-	mu       sync.RWMutex
-	elCode   string // From engine_getClientVersionV1
-	elCommit string // From engine_getClientVersionV1
-	logOnce  sync.Once
+	mu                  sync.RWMutex
+	elCode              string // From engine_getClientVersionV1
+	elCommit            string // From engine_getClientVersionV1
+	logOnce             sync.Once
+	appendClientVersion bool
 }
 
 // NewGraffitiInfo creates a new GraffitiInfo.
-func NewGraffitiInfo() *GraffitiInfo {
-	return &GraffitiInfo{}
+// When appendClientVersion is false, no client version info is appended.
+func NewGraffitiInfo(appendClientVersion bool) *GraffitiInfo {
+	return &GraffitiInfo{appendClientVersion: appendClientVersion}
 }
 
 // UpdateFromEngine updates the EL client information.
@@ -61,6 +63,11 @@ func (g *GraffitiInfo) GenerateGraffiti(userGraffiti []byte) [32]byte {
 	// Trim trailing null bytes
 	for len(userStr) > 0 && userStr[len(userStr)-1] == 0 {
 		userStr = userStr[:len(userStr)-1]
+	}
+
+	if !g.appendClientVersion {
+		copy(result[:], userStr)
+		return result
 	}
 
 	available := 32 - len(userStr)

--- a/beacon-chain/execution/graffiti_info_test.go
+++ b/beacon-chain/execution/graffiti_info_test.go
@@ -8,12 +8,13 @@ import (
 
 func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 	tests := []struct {
-		name         string
-		elCode       string
-		elCommit     string
-		userGraffiti []byte
-		wantPrefix   string // user graffiti appears first
-		wantSuffix   string // client version info appended after
+		name          string
+		elCode        string
+		elCommit      string
+		userGraffiti  []byte
+		disableAppend bool   // client version info is not appended at all
+		wantPrefix    string // user graffiti appears first
+		wantSuffix    string // client version info appended after
 	}{
 		// No EL info cases (CL info "PM" + commit still included when space allows)
 		{
@@ -179,11 +180,35 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			userGraffiti: []byte{},
 			wantPrefix:   "NMabcdPM",
 		},
+		{
+			name:          "Append disabled - empty user graffiti",
+			elCode:        "GE",
+			elCommit:      "abcd1234",
+			userGraffiti:  []byte{},
+			disableAppend: true,
+			wantPrefix:    "",
+		},
+		{
+			name:          "Append disabled - short user graffiti",
+			elCode:        "GE",
+			elCommit:      "abcd1234",
+			userGraffiti:  []byte("my validator"),
+			disableAppend: true,
+			wantPrefix:    "my validator",
+		},
+		{
+			name:          "Append disabled - input with trailing nulls",
+			elCode:        "GE",
+			elCommit:      "abcd1234",
+			userGraffiti:  append([]byte("test"), 0, 0, 0),
+			disableAppend: true,
+			wantPrefix:    "test",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGraffitiInfo()
+			g := NewGraffitiInfo(!tt.disableAppend)
 			if tt.elCode != "" {
 				g.UpdateFromEngine(tt.elCode, tt.elCommit)
 			}
@@ -191,6 +216,12 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 			result := g.GenerateGraffiti(tt.userGraffiti)
 			resultStr := string(result[:])
 			trimmed := trimNullBytes(resultStr)
+
+			if tt.disableAppend {
+				// Nothing is appended, so the result must be the user graffiti and nothing else.
+				require.Equal(t, tt.wantPrefix, trimmed, "User graffiti was not used as-is")
+				return
+			}
 
 			// Check prefix (user graffiti comes first)
 			require.Equal(t, true, len(trimmed) >= len(tt.wantPrefix), "Result too short for prefix check")
@@ -209,7 +240,7 @@ func TestGraffitiInfo_GenerateGraffiti(t *testing.T) {
 }
 
 func TestGraffitiInfo_UpdateFromEngine(t *testing.T) {
-	g := NewGraffitiInfo()
+	g := NewGraffitiInfo(true)
 
 	// Initially no EL info - should still have CL info (PM + commit)
 	result := g.GenerateGraffiti([]byte{})

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -807,7 +807,8 @@ func (b *BeaconNode) registerPOWChainService() error {
 	}
 
 	// Create GraffitiInfo for client version tracking in block graffiti
-	graffitiInfo := execution.NewGraffitiInfo()
+	appendClientVersion := !b.cliCtx.Bool(flags.DisableGraffitiClientAppend.Name)
+	graffitiInfo := execution.NewGraffitiInfo(appendClientVersion)
 
 	// skipcq: CRT-D0001
 	opts := append(

--- a/changelog/manunalepa_disable-graffiti-client-append.md
+++ b/changelog/manunalepa_disable-graffiti-client-append.md
@@ -1,0 +1,3 @@
+### Added
+
+- `--disable-graffiti-client-append` beacon node flag, to stop appending consensus and execution client version information to the block graffiti.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -374,4 +374,9 @@ var (
 		Name:  "partial-data-columns",
 		Usage: "Enable cell-level dissemination for PeerDAS data columns",
 	}
+	// DisableGraffitiClientAppend disables appending consensus and execution client version info to the block graffiti.
+	DisableGraffitiClientAppend = &cli.BoolFlag{
+		Name:  "disable-graffiti-client-append",
+		Usage: "Disables appending consensus and execution client version information to the block graffiti",
+	}
 )

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -163,6 +163,7 @@ var appFlags = []cli.Flag{
 	flags.StateDiffExponents,
 	flags.DisableEphemeralLogFile,
 	flags.PartialDataColumns,
+	flags.DisableGraffitiClientAppend,
 }
 
 func init() {

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -75,6 +75,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.BatchVerifierLimit,
 			flags.StateDiffExponents,
 			flags.PostponeShutdownForProposals,
+			flags.DisableGraffitiClientAppend,
 		},
 	},
 	{


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
Starting at:
- https://github.com/OffchainLabs/prysm/pull/16089

Prysm automatically appends, when possible, the client identification to the user graffiti.
This pull requests offers a way to de-activate this, by introducing the following flag:
```
beacon-chain OPTIONS:
   ...
   --disable-graffiti-client-append  Disables appending consensus and execution client version information to the block graffiti (default: false)
   ...
```

Kurtosis configuration file:
```yaml
participants:
  - cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    vc_extra_params:
      - --graffiti=pierogi

  - cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    cl_extra_params:
      - --disable-graffiti-client-append
    vc_extra_params:
      - --graffiti=pierogi

network_params:
  seconds_per_slot: 4

additional_services:
  - dora

global_log_level: debug
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
