### PR TITLE
Remove (frozen) `slotsPerArchivedPoint` field in favor of config read

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -125,7 +125,7 @@ type NoHeadAccessDatabase interface {
 	SaveExecutionPayloadEnvelope(ctx context.Context, envelope *ethpb.SignedExecutionPayloadEnvelope) error
 	DeleteExecutionPayloadEnvelope(ctx context.Context, blockRoot [32]byte) error
 
-	CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint primitives.Slot) error
+	CleanUpDirtyStates(ctx context.Context) error
 	DeleteHistoricalDataBeforeSlot(ctx context.Context, slot primitives.Slot, batchSize int) (int, error)
 
 	// Genesis operations.

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	statenative "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
 	"github.com/OffchainLabs/prysm/v7/config/features"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -1004,7 +1005,7 @@ func createStateIndicesFromStateSlot(ctx context.Context, slot primitives.Slot) 
 // 3.) state with current finalized root
 // 4.) unfinalized States
 // 5.) not origin root
-func (s *Store) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint primitives.Slot) error {
+func (s *Store) CleanUpDirtyStates(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB. CleanUpDirtyStates")
 	defer span.End()
 
@@ -1024,6 +1025,8 @@ func (s *Store) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint pr
 		// Use zero hash which will never match any actual state root
 		return err
 	}
+
+	slotsPerArchivedPoint := params.BeaconConfig().SlotsPerArchivedPoint
 
 	err = s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(stateSlotIndicesBucket)

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -695,6 +695,12 @@ func TestStore_GenesisState_CanGetHighestBelow(t *testing.T) {
 }
 
 func TestStore_CleanUpDirtyStates_AboveThreshold(t *testing.T) {
+	slotsPerArchivedPoint := primitives.Slot(128)
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = slotsPerArchivedPoint
+	params.OverrideBeaconConfig(cfg)
+
 	db := setupDB(t)
 
 	genesisState, err := util.NewBeaconState()
@@ -705,7 +711,6 @@ func TestStore_CleanUpDirtyStates_AboveThreshold(t *testing.T) {
 	require.NoError(t, db.SaveOriginCheckpointBlockRoot(t.Context(), [32]byte{'a'}))
 
 	bRoots := make([][32]byte, 0)
-	slotsPerArchivedPoint := primitives.Slot(128)
 	prevRoot := genesisRoot
 	for i := primitives.Slot(1); i <= slotsPerArchivedPoint; i++ {
 		b := util.NewBeaconBlock()
@@ -729,7 +734,7 @@ func TestStore_CleanUpDirtyStates_AboveThreshold(t *testing.T) {
 		Root:  bRoots[len(bRoots)-1][:],
 		Epoch: primitives.Epoch(slotsPerArchivedPoint / params.BeaconConfig().SlotsPerEpoch),
 	}))
-	require.NoError(t, db.CleanUpDirtyStates(t.Context(), slotsPerArchivedPoint))
+	require.NoError(t, db.CleanUpDirtyStates(t.Context()))
 
 	for i, root := range bRoots {
 		if primitives.Slot(i) >= slotsPerArchivedPoint.SubSlot(slotsPerArchivedPoint.Div(3)) {
@@ -741,6 +746,11 @@ func TestStore_CleanUpDirtyStates_AboveThreshold(t *testing.T) {
 }
 
 func TestStore_CleanUpDirtyStates_Finalized(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = cfg.SlotsPerEpoch
+	params.OverrideBeaconConfig(cfg)
+
 	db := setupDB(t)
 
 	genesisState, err := util.NewBeaconState()
@@ -766,11 +776,16 @@ func TestStore_CleanUpDirtyStates_Finalized(t *testing.T) {
 	}
 
 	require.NoError(t, db.SaveFinalizedCheckpoint(t.Context(), &ethpb.Checkpoint{Root: genesisRoot[:]}))
-	require.NoError(t, db.CleanUpDirtyStates(t.Context(), params.BeaconConfig().SlotsPerEpoch))
+	require.NoError(t, db.CleanUpDirtyStates(t.Context()))
 	require.Equal(t, true, db.HasState(t.Context(), genesisRoot))
 }
 
 func TestStore_CleanUpDirtyStates_OriginRoot(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = cfg.SlotsPerEpoch
+	params.OverrideBeaconConfig(cfg)
+
 	db := setupDB(t)
 
 	genesisState, err := util.NewBeaconState()
@@ -795,11 +810,16 @@ func TestStore_CleanUpDirtyStates_OriginRoot(t *testing.T) {
 	}
 
 	require.NoError(t, db.SaveOriginCheckpointBlockRoot(t.Context(), r))
-	require.NoError(t, db.CleanUpDirtyStates(t.Context(), params.BeaconConfig().SlotsPerEpoch))
+	require.NoError(t, db.CleanUpDirtyStates(t.Context()))
 	require.Equal(t, true, db.HasState(t.Context(), r))
 }
 
 func TestStore_CleanUpDirtyStates_DontDeleteNonFinalized(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = cfg.SlotsPerEpoch
+	params.OverrideBeaconConfig(cfg)
+
 	db := setupDB(t)
 
 	genesisState, err := util.NewBeaconState()
@@ -827,7 +847,7 @@ func TestStore_CleanUpDirtyStates_DontDeleteNonFinalized(t *testing.T) {
 	}
 
 	require.NoError(t, db.SaveFinalizedCheckpoint(t.Context(), &ethpb.Checkpoint{Root: genesisRoot[:]}))
-	require.NoError(t, db.CleanUpDirtyStates(t.Context(), params.BeaconConfig().SlotsPerEpoch))
+	require.NoError(t, db.CleanUpDirtyStates(t.Context()))
 
 	for _, rt := range unfinalizedRoots {
 		require.Equal(t, true, db.HasState(t.Context(), rt))
@@ -1290,6 +1310,12 @@ func BenchmarkState_CheckStateReadTime_10(b *testing.B) { checkStateReadTime(b, 
 func TestStore_CleanUpDirtyStates_NoOriginRoot(t *testing.T) {
 	// This test verifies that CleanUpDirtyStates does not fail when the origin block root is not set,
 	// which can happen when starting from genesis or in certain fork scenarios like Fulu.
+	slotsPerArchivedPoint := primitives.Slot(128)
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = slotsPerArchivedPoint
+	params.OverrideBeaconConfig(cfg)
+
 	db := setupDB(t)
 	genesisState, err := util.NewBeaconState()
 	require.NoError(t, err)
@@ -1298,7 +1324,6 @@ func TestStore_CleanUpDirtyStates_NoOriginRoot(t *testing.T) {
 	require.NoError(t, db.SaveState(t.Context(), genesisState, genesisRoot))
 	// Note: We intentionally do NOT call SaveOriginCheckpointBlockRoot here
 	// to simulate the scenario where origin block root is not set
-	slotsPerArchivedPoint := primitives.Slot(128)
 	bRoots := make([][fieldparams.RootLength]byte, 0)
 	prevRoot := genesisRoot
 	for i := primitives.Slot(1); i <= slotsPerArchivedPoint; i++ { // skip slot 0
@@ -1322,7 +1347,7 @@ func TestStore_CleanUpDirtyStates_NoOriginRoot(t *testing.T) {
 		Epoch: primitives.Epoch(slotsPerArchivedPoint / params.BeaconConfig().SlotsPerEpoch),
 	}))
 	// This should not fail even though origin block root is not set
-	err = db.CleanUpDirtyStates(t.Context(), slotsPerArchivedPoint)
+	err = db.CleanUpDirtyStates(t.Context())
 	require.NoError(t, err)
 	// Verify that cleanup still works correctly
 	for i, root := range bRoots {

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -43,7 +43,6 @@ func TestStateByRoot_ColdState(t *testing.T) {
 
 	service := New(beaconDB, doublylinkedtree.New())
 	service.finalizedInfo.slot = 2
-	service.slotsPerArchivedPoint = 1
 
 	b := util.NewBeaconBlock()
 	b.Block.Slot = 1
@@ -97,7 +96,6 @@ func TestStateByRootIfCachedNoCopy_ColdState(t *testing.T) {
 
 	service := New(beaconDB, doublylinkedtree.New())
 	service.finalizedInfo.slot = 2
-	service.slotsPerArchivedPoint = 1
 
 	b := util.NewBeaconBlock()
 	b.Block.Slot = 1

--- a/beacon-chain/state/stategen/migrate.go
+++ b/beacon-chain/state/stategen/migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/features"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -46,19 +47,21 @@ func (s *State) MigrateToCold(ctx context.Context, fRoot [32]byte) error {
 		return nil
 	}
 
+	slotsPerArchivedPoint := params.BeaconConfig().SlotsPerArchivedPoint
+
 	// Calculate the first archived point slot >= oldFSlot (but > 0).
 	// This avoids iterating through every slot and only visits archived points directly.
 	var startSlot primitives.Slot
 	if oldFSlot == 0 {
-		startSlot = s.slotsPerArchivedPoint
+		startSlot = slotsPerArchivedPoint
 	} else {
 		// Round up to the next archived point
-		startSlot = (oldFSlot + s.slotsPerArchivedPoint - 1) / s.slotsPerArchivedPoint * s.slotsPerArchivedPoint
+		startSlot = (oldFSlot + slotsPerArchivedPoint - 1) / slotsPerArchivedPoint * slotsPerArchivedPoint
 	}
 
 	// Start at the first archived point after old finalized slot, stop before current finalized slot.
 	// Jump directly between archived points.
-	for slot := startSlot; slot < fSlot; slot += s.slotsPerArchivedPoint {
+	for slot := startSlot; slot < fSlot; slot += slotsPerArchivedPoint {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v7/config/features"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -43,12 +44,16 @@ func TestMigrateToCold_CanSaveFinalizedInfo(t *testing.T) {
 }
 
 func TestMigrateToCold_HappyPath(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = 1
+	params.OverrideBeaconConfig(cfg)
+
 	hook := logTest.NewGlobal()
 	ctx := t.Context()
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.slotsPerArchivedPoint = 1
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
 	stateSlot := primitives.Slot(1)
 	require.NoError(t, beaconState.SetSlot(stateSlot))
@@ -63,7 +68,7 @@ func TestMigrateToCold_HappyPath(t *testing.T) {
 	gotState, err := service.beaconDB.State(ctx, fRoot)
 	require.NoError(t, err)
 	assert.DeepSSZEqual(t, beaconState.ToProtoUnsafe(), gotState.ToProtoUnsafe(), "Did not save state")
-	gotRoot := service.beaconDB.ArchivedPointRoot(ctx, stateSlot/service.slotsPerArchivedPoint)
+	gotRoot := service.beaconDB.ArchivedPointRoot(ctx, stateSlot/params.BeaconConfig().SlotsPerArchivedPoint)
 	assert.Equal(t, fRoot, gotRoot, "Did not save archived root")
 	lastIndex, err := service.beaconDB.LastArchivedSlot(ctx)
 	require.NoError(t, err)
@@ -73,12 +78,16 @@ func TestMigrateToCold_HappyPath(t *testing.T) {
 }
 
 func TestMigrateToCold_RegeneratePath(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = 1
+	params.OverrideBeaconConfig(cfg)
+
 	hook := logTest.NewGlobal()
 	ctx := t.Context()
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.slotsPerArchivedPoint = 1
 	beaconState, pks := util.DeterministicGenesisState(t, 32)
 	genesisStateRoot, err := beaconState.HashTreeRoot(ctx)
 	require.NoError(t, err)
@@ -113,7 +122,7 @@ func TestMigrateToCold_RegeneratePath(t *testing.T) {
 	s1, err := service.beaconDB.State(ctx, r1)
 	require.NoError(t, err)
 	assert.Equal(t, s1.Slot(), primitives.Slot(1), "Did not save state")
-	gotRoot := service.beaconDB.ArchivedPointRoot(ctx, 1/service.slotsPerArchivedPoint)
+	gotRoot := service.beaconDB.ArchivedPointRoot(ctx, 1/params.BeaconConfig().SlotsPerArchivedPoint)
 	assert.Equal(t, r1, gotRoot, "Did not save archived root")
 	lastIndex, err := service.beaconDB.LastArchivedSlot(ctx)
 	require.NoError(t, err)
@@ -123,12 +132,16 @@ func TestMigrateToCold_RegeneratePath(t *testing.T) {
 }
 
 func TestMigrateToCold_StateExistsInDB(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = 1
+	params.OverrideBeaconConfig(cfg)
+
 	hook := logTest.NewGlobal()
 	ctx := t.Context()
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.slotsPerArchivedPoint = 1
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
 	stateSlot := primitives.Slot(1)
 	require.NoError(t, beaconState.SetSlot(stateSlot))
@@ -147,12 +160,16 @@ func TestMigrateToCold_StateExistsInDB(t *testing.T) {
 }
 
 func TestMigrateToCold_ParallelCalls(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.SlotsPerArchivedPoint = 1
+	params.OverrideBeaconConfig(cfg)
+
 	hook := logTest.NewGlobal()
 	ctx := t.Context()
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.slotsPerArchivedPoint = 1
 	beaconState, pks := util.DeterministicGenesisState(t, 32)
 	genState := beaconState.Copy()
 	genesisStateRoot, err := beaconState.HashTreeRoot(ctx)
@@ -218,7 +235,7 @@ func TestMigrateToCold_ParallelCalls(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, s4.Slot(), primitives.Slot(4), "Did not save state")
 
-	gotRoot := service.beaconDB.ArchivedPointRoot(ctx, 1/service.slotsPerArchivedPoint)
+	gotRoot := service.beaconDB.ArchivedPointRoot(ctx, 1/params.BeaconConfig().SlotsPerArchivedPoint)
 	assert.Equal(t, r1, gotRoot, "Did not save archived root")
 	gotRoot = service.beaconDB.ArchivedPointRoot(ctx, 4)
 	assert.Equal(t, r4, gotRoot, "Did not save archived root")

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -57,7 +57,6 @@ type StateManager interface {
 // State is a concrete implementation of StateManager.
 type State struct {
 	beaconDB                db.NoHeadAccessDatabase
-	slotsPerArchivedPoint   primitives.Slot
 	hotStateCache           *hotStateCache
 	finalizedInfo           *finalizedInfo
 	epochBoundaryStateCache *epochBoundaryState
@@ -103,7 +102,6 @@ func New(beaconDB db.NoHeadAccessDatabase, fc forkchoice.ForkChoicer, opts ...Op
 		beaconDB:                beaconDB,
 		hotStateCache:           newHotStateCache(),
 		finalizedInfo:           &finalizedInfo{slot: 0, root: params.BeaconConfig().ZeroHash},
-		slotsPerArchivedPoint:   params.BeaconConfig().SlotsPerArchivedPoint,
 		epochBoundaryStateCache: newBoundaryStateCache(),
 		saveHotStateDB: &saveHotStateDbConfig{
 			duration: defaultHotStateDBInterval,
@@ -153,7 +151,7 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 	}
 
 	go func() {
-		if err := s.beaconDB.CleanUpDirtyStates(ctx, s.slotsPerArchivedPoint); err != nil {
+		if err := s.beaconDB.CleanUpDirtyStates(ctx); err != nil {
 			log.WithError(err).Error("Could not clean up dirty states")
 		}
 	}()

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -20,7 +20,6 @@ func TestSaveState_HotStateCanBeSaved(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.slotsPerArchivedPoint = 1
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
 	// This goes to hot section, verify it can save on epoch boundary.
 	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch))
@@ -41,7 +40,6 @@ func TestSaveState_HotStateCached(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.slotsPerArchivedPoint = 1
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
 	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch))
 

--- a/changelog/syjn99_refactor-frozen-archived-point.md
+++ b/changelog/syjn99_refactor-frozen-archived-point.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Remove (frozen) `slotsPerArchivedPoint` field in favor of config read.


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Small refactor. StateManager holds `slotsPerArchivedPoint` which is fixed in the runtime as `params.BeaconConfig().SlotsPerArchivedPoint`, and there's no mutation on this field. Rather than holding it and passing it as arguments, just read the global configuration value.

For the testing side, like what we have been doing, mutate the config like:

```go
	slotsPerArchivedPoint := primitives.Slot(128)
	params.SetupTestConfigCleanup(t)
	cfg := params.BeaconConfig().Copy()
	cfg.SlotsPerArchivedPoint = slotsPerArchivedPoint
	params.OverrideBeaconConfig(cfg)
```

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

No functional behavior changes.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
