### PR TITLE
Decouple `finalizedInfo.slot` with other fields in `finalizedInfo`

### DIFF
--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -889,7 +889,7 @@ func TestUpdateHead_noSavedChanges(t *testing.T) {
 
 	bellatrixState, _ := util.DeterministicGenesisStateBellatrix(t, 2)
 	require.NoError(t, beaconDB.SaveState(ctx, bellatrixState, bellatrixBlkRoot))
-	service.cfg.StateGen.SaveFinalizedState(0, bellatrixBlkRoot, bellatrixState)
+	service.cfg.StateGen.SaveFinalizedState(bellatrixBlkRoot, bellatrixState)
 
 	headRoot := service.headRoot()
 	require.Equal(t, [32]byte{}, headRoot)

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -375,7 +375,7 @@ func (s *Service) saveGenesisData(ctx context.Context, genesisState state.Beacon
 	}
 
 	s.originBlockRoot = genesisBlkRoot
-	s.cfg.StateGen.SaveFinalizedState(0 /*slot*/, genesisBlkRoot, genesisState)
+	s.cfg.StateGen.SaveFinalizedState(genesisBlkRoot, genesisState)
 
 	s.cfg.ForkChoiceStore.Lock()
 	defer s.cfg.ForkChoiceStore.Unlock()

--- a/beacon-chain/state/stategen/canonical_root_test.go
+++ b/beacon-chain/state/stategen/canonical_root_test.go
@@ -104,7 +104,8 @@ func TestMigrateToColdHdiff_OrphanAtHighestPopulatedSlot(t *testing.T) {
 	require.NotEqual(t, wantRoot, orphanRoot, "the two candidates must differ for this test to mean anything")
 
 	// Slot 64 is the only boundary in (32, 65), and is absent from the cache to force the lookup path.
-	service.finalizedInfo = &finalizedInfo{slot: 32, root: r32, state: s32.Copy()}
+	service.migratedSlot = 32
+	service.finalizedInfo = &finalizedInfo{root: r32, state: s32.Copy()}
 	require.NoError(t, service.epochBoundaryStateCache.put(r32, s32.Copy()))
 	require.NoError(t, service.MigrateToCold(ctx, r65))
 
@@ -195,7 +196,8 @@ func TestMigrateToColdHdiff_ReorgedSiblingInBoundaryCache(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, wantRoot, orphanRoot, "the two candidates must differ for this test to mean anything")
 
-	service.finalizedInfo = &finalizedInfo{slot: 32, root: r32, state: s32.Copy()}
+	service.migratedSlot = 32
+	service.finalizedInfo = &finalizedInfo{root: r32, state: s32.Copy()}
 	require.NoError(t, service.MigrateToCold(ctx, r96))
 
 	// State() resolves by the summary's slot, so any root mapped to 64 reads the tree at 64.

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -42,7 +42,6 @@ func TestStateByRoot_ColdState(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.finalizedInfo.slot = 2
 	service.slotsPerArchivedPoint = 1
 
 	b := util.NewBeaconBlock()
@@ -96,7 +95,6 @@ func TestStateByRootIfCachedNoCopy_ColdState(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 
 	service := New(beaconDB, doublylinkedtree.New())
-	service.finalizedInfo.slot = 2
 	service.slotsPerArchivedPoint = 1
 
 	b := util.NewBeaconBlock()
@@ -264,7 +262,6 @@ func TestLoadStateByRoot(t *testing.T) {
 	persistFinalizedStruct := func(r testChain, slot primitives.Slot) {
 		st := r.state(t, slot)
 		r.srv.finalizedInfo.state = st
-		r.srv.finalizedInfo.slot = st.Slot()
 		r.srv.finalizedInfo.root = r.blockRoot(t, slot)
 	}
 

--- a/beacon-chain/state/stategen/migrate.go
+++ b/beacon-chain/state/stategen/migrate.go
@@ -16,9 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// MigrateToCold advances the finalized info in between the cold and hot state sections.
-// It moves the recent finalized states from the hot section to the cold section and
-// only preserves the ones that are on archived point.
+// MigrateToCold moves finalized states to cold storage and advances the migration cursor.
 func (s *State) MigrateToCold(ctx context.Context, fRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "stateGen.MigrateToCold")
 	defer span.End()
@@ -33,9 +31,7 @@ func (s *State) MigrateToCold(ctx context.Context, fRoot [32]byte) error {
 		return s.migrateToColdHdiff(ctx, fRoot)
 	}
 
-	s.finalizedInfo.lock.RLock()
-	oldFSlot := s.finalizedInfo.slot
-	s.finalizedInfo.lock.RUnlock()
+	oldFSlot := s.migratedSlot
 
 	fBlock, err := s.beaconDB.Block(ctx, fRoot)
 	if err != nil {
@@ -125,17 +121,18 @@ func (s *State) MigrateToCold(ctx context.Context, fRoot [32]byte) error {
 		return err
 	}
 	if ok {
-		s.SaveFinalizedState(fSlot, fRoot, fInfo.state)
+		s.SaveFinalizedState(fRoot, fInfo.state)
 	}
+	// The migration can complete without the finalized state being cached. Keep
+	// finalizedInfo coherent and advance its independent migration cursor.
+	s.migratedSlot = fSlot
 
 	return nil
 }
 
 // migrateToColdHdiff saves the state-diffs for slots that are in the state diff tree after finalization
 func (s *State) migrateToColdHdiff(ctx context.Context, fRoot [32]byte) error {
-	s.finalizedInfo.lock.RLock()
-	oldFSlot := s.finalizedInfo.slot
-	s.finalizedInfo.lock.RUnlock()
+	oldFSlot := s.migratedSlot
 	fSlot, err := s.beaconDB.SlotByBlockRoot(ctx, fRoot)
 	if err != nil {
 		return errors.Wrap(err, "could not get slot by block root")
@@ -221,8 +218,11 @@ func (s *State) migrateToColdHdiff(ctx context.Context, fRoot [32]byte) error {
 		return err
 	}
 	if ok {
-		s.SaveFinalizedState(fSlot, fRoot, fInfo.state)
+		s.SaveFinalizedState(fRoot, fInfo.state)
 	}
+	// The migration can complete without the finalized state being cached. Keep
+	// finalizedInfo coherent and advance its independent migration cursor.
+	s.migratedSlot = fSlot
 	return nil
 }
 

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -32,9 +32,9 @@ func TestMigrateToCold_CanSaveFinalizedInfo(t *testing.T) {
 	require.NoError(t, service.epochBoundaryStateCache.put(br, beaconState))
 	require.NoError(t, service.MigrateToCold(ctx, br))
 
-	wanted := &finalizedInfo{state: beaconState, root: br, slot: 1}
+	wanted := &finalizedInfo{state: beaconState, root: br}
 	assert.DeepEqual(t, wanted.root, service.finalizedInfo.root)
-	assert.Equal(t, wanted.slot, service.finalizedInfo.slot)
+	assert.Equal(t, primitives.Slot(1), service.migratedSlot)
 	expectedHTR, err := wanted.state.HashTreeRoot(ctx)
 	require.NoError(t, err)
 	actualHTR, err := service.finalizedInfo.state.HashTreeRoot(ctx)
@@ -103,7 +103,6 @@ func TestMigrateToCold_RegeneratePath(t *testing.T) {
 	util.SaveBlock(t, ctx, service.beaconDB, b4)
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 4, Root: r4[:]}))
 	service.finalizedInfo = &finalizedInfo{
-		slot:  0,
 		root:  genesisStateRoot,
 		state: beaconState,
 	}
@@ -198,7 +197,6 @@ func TestMigrateToCold_ParallelCalls(t *testing.T) {
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 7, Root: r7[:]}))
 
 	service.finalizedInfo = &finalizedInfo{
-		slot:  0,
 		root:  genesisStateRoot,
 		state: genState,
 	}
@@ -272,7 +270,6 @@ func TestMigrateToColdHdiff_CanUpdateFinalizedInfo(t *testing.T) {
 
 	// Set initial finalized info at genesis.
 	service.finalizedInfo = &finalizedInfo{
-		slot:  0,
 		root:  gRoot,
 		state: beaconState,
 	}
@@ -290,7 +287,7 @@ func TestMigrateToColdHdiff_CanUpdateFinalizedInfo(t *testing.T) {
 	require.NoError(t, service.MigrateToCold(ctx, fRoot))
 
 	// Verify finalized info is updated.
-	assert.Equal(t, primitives.Slot(10), service.finalizedInfo.slot)
+	assert.Equal(t, primitives.Slot(10), service.migratedSlot)
 	assert.DeepEqual(t, fRoot, service.finalizedInfo.root)
 	expectedHTR, err := finalizedState.HashTreeRoot(ctx)
 	require.NoError(t, err)
@@ -325,10 +322,10 @@ func TestMigrateToColdHdiff_SkipsSlotsNotInDiffTree(t *testing.T) {
 
 	// Start from slot 1 to avoid slot 0 which is in the diff tree.
 	service.finalizedInfo = &finalizedInfo{
-		slot:  1,
 		root:  gRoot,
 		state: beaconState,
 	}
+	service.migratedSlot = 1
 
 	// Reset the log hook to ignore setup logs.
 	hook.Reset()
@@ -375,7 +372,6 @@ func TestMigrateToColdHdiff_MissedNonBoundarySlots(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, beaconState, gRoot))
 
 	service.finalizedInfo = &finalizedInfo{
-		slot:  0,
 		root:  gRoot,
 		state: beaconState,
 	}
@@ -447,7 +443,6 @@ func TestMigrateToColdHdiff_MissedNonBoundarySlots_BoundaryCacheMissed(t *testin
 	require.NoError(t, beaconDB.SaveState(ctx, beaconState, gRoot))
 
 	service.finalizedInfo = &finalizedInfo{
-		slot:  0,
 		root:  gRoot,
 		state: beaconState,
 	}
@@ -481,20 +476,19 @@ func TestMigrateToColdHdiff_MissedNonBoundarySlots_BoundaryCacheMissed(t *testin
 	// this makes sure the call to StateByRoot doesn't fail here.
 	service.hotStateCache.put(r96, state96)
 
-	finalizedState := beaconState.Copy()
-	require.NoError(t, finalizedState.SetSlot(128))
 	b128 := util.NewBeaconBlock()
 	b128.Block.Slot = 128
 	r128, err := b128.Block.HashTreeRoot()
 	require.NoError(t, err)
 	util.SaveBlock(t, ctx, beaconDB, b128)
-	require.NoError(t, service.epochBoundaryStateCache.put(r128, finalizedState))
-
 	require.NoError(t, service.MigrateToCold(ctx, r128))
 
 	assert.Equal(t, true, beaconDB.HasState(ctx, r32), "Did not save slot 32 checkpoint to database")
 	assert.Equal(t, true, beaconDB.HasState(ctx, r64), "Did not save slot 64 checkpoint to database")
 	assert.Equal(t, true, beaconDB.HasState(ctx, r96), "Did not save slot 96 checkpoint to database")
+	assert.Equal(t, primitives.Slot(128), service.migratedSlot)
+	assert.DeepEqual(t, gRoot, service.finalizedInfo.root)
+	assert.Equal(t, primitives.Slot(0), service.finalizedInfo.state.Slot())
 }
 
 // TestMigrateToColdHdiff_BoundaryCacheMiss_UseTargetSlotRoot verifies that a
@@ -522,7 +516,6 @@ func TestMigrateToColdHdiff_BoundaryCacheMiss_UseTargetSlotRoot(t *testing.T) {
 	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 0, Root: gRoot[:]}))
 
 	service.finalizedInfo = &finalizedInfo{
-		slot:  0,
 		root:  gRoot,
 		state: genesisState,
 	}
@@ -605,10 +598,10 @@ func TestMigrateToColdHdiff_NoOpWhenFinalizedSlotNotAdvanced(t *testing.T) {
 	finalizedState := beaconState.Copy()
 	require.NoError(t, finalizedState.SetSlot(50))
 	service.finalizedInfo = &finalizedInfo{
-		slot:  50,
 		root:  gRoot,
 		state: finalizedState,
 	}
+	service.migratedSlot = 50
 
 	// Create block at same slot 50.
 	b := util.NewBeaconBlock()

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -119,6 +119,11 @@ func TestMigrateToCold_RegeneratePath(t *testing.T) {
 	assert.Equal(t, primitives.Slot(1), lastIndex, "Did not save last archived index")
 
 	require.LogsContain(t, hook, "Saved state in DB")
+
+	// Finalized state was never cached, but the migration cursor advances.
+	assert.Equal(t, b4.Block.Slot, service.migratedSlot)
+	assert.DeepEqual(t, genesisStateRoot, service.finalizedInfo.root)
+	assert.Equal(t, primitives.Slot(0), service.finalizedInfo.state.Slot())
 }
 
 func TestMigrateToCold_StateExistsInDB(t *testing.T) {

--- a/beacon-chain/state/stategen/mock/mock.go
+++ b/beacon-chain/state/stategen/mock/mock.go
@@ -36,7 +36,7 @@ func (_ *StateManager) Resume(_ context.Context, _ state.BeaconState) (state.Bea
 }
 
 // SaveFinalizedState --
-func (_ *StateManager) SaveFinalizedState(_ primitives.Slot, _ [32]byte, _ state.BeaconState) {
+func (_ *StateManager) SaveFinalizedState(_ [32]byte, _ state.BeaconState) {
 	panic("implement me")
 }
 

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -203,13 +203,6 @@ func (s *State) SaveFinalizedState(fSlot primitives.Slot, fRoot [32]byte, fState
 	s.finalizedInfo.slot = fSlot
 }
 
-// Returns the cached and copied finalized state.
-func (s *State) FinalizedState() state.BeaconState {
-	s.finalizedInfo.lock.RLock()
-	defer s.finalizedInfo.lock.RUnlock()
-	return s.finalizedInfo.state.Copy()
-}
-
 // finalizedStateIfRoot returns a copy of the cached finalized state only if
 // the cached finalized root matches r at the moment of the read.
 func (s *State) finalizedStateIfRoot(r [32]byte) state.BeaconState {

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -44,7 +44,7 @@ type StateManager interface {
 	DeleteStateFromCaches(ctx context.Context, blockRoot [32]byte) error
 	ForceCheckpoint(ctx context.Context, root []byte) error
 	SaveState(ctx context.Context, blockRoot [32]byte, st state.BeaconState) error
-	SaveFinalizedState(fSlot primitives.Slot, fRoot [32]byte, fState state.BeaconState)
+	SaveFinalizedState(fRoot [32]byte, fState state.BeaconState)
 	MigrateToCold(ctx context.Context, fRoot [32]byte) error
 	StateByRoot(ctx context.Context, blockRoot [32]byte) (state.BeaconState, error)
 	StateByRootNoCopy(ctx context.Context, blockRoot [32]byte) (state.ReadOnlyBeaconState, error)
@@ -64,6 +64,7 @@ type State struct {
 	saveHotStateDB          *saveHotStateDbConfig
 	avb                     coverage.AvailableBlocker
 	migrationLock           *sync.Mutex
+	migratedSlot            primitives.Slot // guarded by migrationLock after initialization
 	fc                      forkchoice.ForkChoicer
 }
 
@@ -77,10 +78,8 @@ type saveHotStateDbConfig struct {
 	blockRootsOfSavedStates [][32]byte
 }
 
-// This tracks the finalized point. It's also the point where slot and the block root of
-// cold and hot sections of the DB splits.
+// finalizedInfo caches a finalized block root and its matching state for replay and balance lookups.
 type finalizedInfo struct {
-	slot  primitives.Slot
 	root  [32]byte
 	state state.BeaconState
 	lock  sync.RWMutex
@@ -102,7 +101,7 @@ func New(beaconDB db.NoHeadAccessDatabase, fc forkchoice.ForkChoicer, opts ...Op
 	s := &State{
 		beaconDB:                beaconDB,
 		hotStateCache:           newHotStateCache(),
-		finalizedInfo:           &finalizedInfo{slot: 0, root: params.BeaconConfig().ZeroHash},
+		finalizedInfo:           &finalizedInfo{root: params.BeaconConfig().ZeroHash},
 		slotsPerArchivedPoint:   params.BeaconConfig().SlotsPerArchivedPoint,
 		epochBoundaryStateCache: newBoundaryStateCache(),
 		saveHotStateDB: &saveHotStateDbConfig{
@@ -158,7 +157,8 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 		}
 	}()
 
-	s.finalizedInfo = &finalizedInfo{slot: st.Slot(), root: fRoot, state: st.Copy()}
+	s.migratedSlot = st.Slot()
+	s.finalizedInfo = &finalizedInfo{root: fRoot, state: st.Copy()}
 	populatePubkeyCache(ctx, st)
 	return st, nil
 }
@@ -192,15 +192,12 @@ func populatePubkeyCache(ctx context.Context, st state.ReadOnlyBeaconState) {
 	})
 }
 
-// SaveFinalizedState saves the finalized slot, root and state into memory to be used by state gen service.
-// This used for migration at the correct start slot and used for hot state play back to ensure
-// lower bound to start is always at the last finalized state.
-func (s *State) SaveFinalizedState(fSlot primitives.Slot, fRoot [32]byte, fState state.BeaconState) {
+// SaveFinalizedState caches a finalized block root and its matching state.
+func (s *State) SaveFinalizedState(fRoot [32]byte, fState state.BeaconState) {
 	s.finalizedInfo.lock.Lock()
 	defer s.finalizedInfo.lock.Unlock()
 	s.finalizedInfo.root = fRoot
 	s.finalizedInfo.state = fState.Copy()
-	s.finalizedInfo.slot = fSlot
 }
 
 // finalizedStateIfRoot returns a copy of the cached finalized state only if

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -32,5 +32,4 @@ func TestResume(t *testing.T) {
 	require.DeepSSZEqual(t, beaconState.ToProtoUnsafe(), resumeState.ToProtoUnsafe())
 	assert.Equal(t, params.BeaconConfig().SlotsPerEpoch, service.finalizedInfo.slot, "Did not get watned slot")
 	assert.Equal(t, service.finalizedInfo.root, root, "Did not get wanted root")
-	assert.NotNil(t, service.FinalizedState(), "Wanted a non nil finalized state")
 }

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -30,6 +30,5 @@ func TestResume(t *testing.T) {
 	resumeState, err := service.Resume(ctx, beaconState)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, beaconState.ToProtoUnsafe(), resumeState.ToProtoUnsafe())
-	assert.Equal(t, params.BeaconConfig().SlotsPerEpoch, service.finalizedInfo.slot, "Did not get watned slot")
 	assert.Equal(t, service.finalizedInfo.root, root, "Did not get wanted root")
 }

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -31,4 +31,5 @@ func TestResume(t *testing.T) {
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, beaconState.ToProtoUnsafe(), resumeState.ToProtoUnsafe())
 	assert.Equal(t, service.finalizedInfo.root, root, "Did not get wanted root")
+	assert.Equal(t, beaconState.Slot(), service.migratedSlot)
 }

--- a/changelog/syjn99_statediff-migrate-cursor.md
+++ b/changelog/syjn99_statediff-migrate-cursor.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Advance the cold-state migration cursor even when the epoch boundary cache has no state for the finalized root, so migration keeps progressing on freshly started nodes and during long non-finalization.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

This PR addresses an issue regarding cold DB migration.

### Decouple `finalizedInfo.slot` with other fields in `finalizedInfo`

We *only* caches the finalized state information when epoch boundary cache has it (`s.epochBoundaryStateCache.getByBlockRoot(fRoot)`). `finalizedInfo.slot` acts as a migration cursor though. So if the node doesn't have a cache - the migration progress cannot be saved, and it might need to do the same workload. Epoch boundary cache can be empty when the node is freshly started, or the chain is suffering from long unfinalization.

This PR moves the slot field into `migratedSlot`. Note that `migratedSlot` is safe under `migrationLock`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).
