### PR TITLE
Check data column duplicates before expensive validation

### DIFF
--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -155,6 +155,15 @@ func (s *Service) validateDataColumnFulu(
 	roDataColumn blocks.RODataColumn,
 	dataColumnSidecarSubTopic string,
 ) (blocks.VerifiedRODataColumn, error) {
+	// [IGNORE] The sidecar is the first sidecar for the tuple `(block_header.slot, block_header.proposer_index, sidecar.index)`.
+	proposerIndex, err := roDataColumn.ProposerIndex()
+	if err != nil {
+		return blocks.VerifiedRODataColumn{}, errors.Wrap(err, "fulu data column validation")
+	}
+	if s.hasSeenDataColumnIndex(roDataColumn.Slot(), proposerIndex, roDataColumn.Index()) {
+		return blocks.VerifiedRODataColumn{}, ignoreValidation(nil)
+	}
+
 	roDataColumns := []blocks.RODataColumn{roDataColumn}
 	verifier := s.newColumnsVerifier(roDataColumns, verification.GossipDataColumnSidecarRequirements)
 
@@ -231,16 +240,6 @@ func (s *Service) validateDataColumnFulu(
 	// [REJECT] The sidecar's column data is valid as verified by `verify_data_column_sidecar_kzg_proofs(sidecar)`.
 	if err := verifier.SidecarKzgProofVerified(); err != nil {
 		return blocks.VerifiedRODataColumn{}, errors.Wrap(err, "fulu data column validation")
-	}
-
-	// [IGNORE] The sidecar is the first sidecar for the tuple `(block_header.slot, block_header.proposer_index, sidecar.index)`
-	// with valid header signature, sidecar inclusion proof, and kzg proof.
-	proposerIndex, err := roDataColumn.ProposerIndex()
-	if err != nil {
-		return blocks.VerifiedRODataColumn{}, errors.Wrap(err, "fulu data column validation")
-	}
-	if s.hasSeenDataColumnIndex(roDataColumn.Slot(), proposerIndex, roDataColumn.Index()) {
-		return blocks.VerifiedRODataColumn{}, ignoreValidation(nil)
 	}
 
 	// [REJECT] The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -48,6 +48,11 @@ func (s *Service) validateDataColumnGloas(
 	// data_column_sidecar_{subnet_id}
 	// [Modified in Gloas:EIP7732]
 	//
+	// # [IGNORE] This is the first sidecar seen for this block root and column index
+	if s.hasSeenDataColumnRootIndex(roDataColumn.BlockRoot(), roDataColumn.Index()) {
+		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.New("data column sidecar already seen for block root"))
+	}
+
 	// [IGNORE] A valid block for the sidecar's slot has been seen (via gossip or non-gossip sources).
 	// If not yet seen, a client MUST queue the sidecar for deferred validation and possible processing once
 	// the block is received or retrieved.
@@ -99,16 +104,6 @@ func (s *Service) validateDataColumnGloas(
 	if err := verifier.VerifyDataColumnSidecarKzgProofsGloas(); err != nil {
 		return blocks.VerifiedRODataColumn{}, errors.Wrap(err, "gloas data column validation")
 	}
-
-	// [IGNORE] The sidecar is the first sidecar for the tuple
-	// (sidecar.beacon_block_root, sidecar.index) with valid kzg proof.
-	//
-	// Note: If the sidecar fails deferred validation, its forwarding peers MUST be downscored
-	// retroactively. If validation succeeds, the client MUST re-broadcast the sidecar.
-	if s.hasSeenDataColumnRootIndex(roDataColumn.BlockRoot(), roDataColumn.Index()) {
-		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.New("data column sidecar already seen for block root"))
-	}
-	verifier.SatisfyRequirement(verification.RequireNotSeenGloas)
 
 	verifiedRODataColumn, err := verifier.VerifiedRODataColumn()
 	if err != nil {

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -257,6 +257,26 @@ func TestValidateDataColumnGloas(t *testing.T) {
 		require.ErrorContains(t, "signed beacon block can't be nil", err)
 	})
 
+	t.Run("seen column ignored before block lookup and queue validation", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.DenebForkEpoch = 0
+		cfg.ElectraForkEpoch = 0
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		sidecar, _ := gloasFixture(t)
+		service, message := serviceAndMessage(t, testNewDataColumnSidecarsVerifier(verification.MockDataColumnsVerifier{}), sidecar, sidecar.Index)
+		blockRoot := bytesutil.ToBytes32(sidecar.BeaconBlockRoot)
+		service.setSeenDataColumnRootIndex(blockRoot, sidecar.Index, sidecar.Slot)
+
+		result, err := service.validateDataColumn(ctx, "aDummyPID", message)
+		require.ErrorContains(t, "data column sidecar already seen for block root", err)
+		require.Equal(t, pubsub.ValidationIgnore, result)
+		require.Equal(t, false, service.hasPendingGloasColumns(blockRoot))
+	})
+
 	t.Run("rejects oversize column on queue path", func(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		cfg := params.BeaconConfig()

--- a/beacon-chain/sync/validate_data_column_test.go
+++ b/beacon-chain/sync/validate_data_column_test.go
@@ -215,7 +215,11 @@ func TestValidateDataColumn(t *testing.T) {
 	}
 
 	t.Run("seen data column", func(t *testing.T) {
-		service, message := serviceAndMessage(t, testNewDataColumnSidecarsVerifier(verification.MockDataColumnsVerifier{}), dataColumnSidecarMsg)
+		failingVerifier := testNewDataColumnSidecarsVerifier(verification.MockDataColumnsVerifier{
+			ErrValidFields:             genericError,
+			ErrSidecarKzgProofVerified: genericError,
+		})
+		service, message := serviceAndMessage(t, failingVerifier, dataColumnSidecarMsg)
 		service.setSeenDataColumnIndex(0, 0, 0)
 		result, err := service.validateDataColumn(ctx, "aDummyPID", message)
 		require.NoError(t, err)

--- a/beacon-chain/verification/data_column_gloas.go
+++ b/beacon-chain/verification/data_column_gloas.go
@@ -18,7 +18,6 @@ var GossipDataColumnSidecarRequirementsGloas = []Requirement{
 	RequireValidFieldsGloas,
 	RequireCorrectSubnet,
 	RequireSidecarKzgProofVerifiedGloas,
-	RequireNotSeenGloas,
 }
 
 // PendingGloasColumnRequirements defines the requirements for columns queued before their block arrived.

--- a/beacon-chain/verification/requirements.go
+++ b/beacon-chain/verification/requirements.go
@@ -20,7 +20,6 @@ const (
 	RequireSlotMatchesBlockGloas
 	RequireValidFieldsGloas
 	RequireSidecarKzgProofVerifiedGloas
-	RequireNotSeenGloas
 
 	// Payload attestation specific.
 	RequireCurrentSlot

--- a/beacon-chain/verification/result.go
+++ b/beacon-chain/verification/result.go
@@ -41,8 +41,6 @@ func (r Requirement) String() string {
 		return "RequireValidFieldsGloas"
 	case RequireSidecarKzgProofVerifiedGloas:
 		return "RequireSidecarKzgProofVerifiedGloas"
-	case RequireNotSeenGloas:
-		return "RequireNotSeenGloas"
 	case RequireCurrentSlot:
 		return "RequireCurrentSlot"
 	case RequireMessageNotSeen:

--- a/changelog/syjn99_datacolumn-dup-check-order.md
+++ b/changelog/syjn99_datacolumn-dup-check-order.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Check for duplicate (already seen) data column sidecars first in Fulu and Gloas gossip validation, before KZG and other expensive checks, matching the consensus-spec ordering.


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

- https://github.com/ethereum/consensus-specs/pull/5246
- https://github.com/ethereum/consensus-specs/pull/5294

With these PRs, the ordering for gossip message validation has changed. Now it first IGNOREs when the data column sidecar is already marked "seen".

This PR reorders the validation logic as per consensus-specs.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
