### PR TITLE
Fix flaky tests (`TestRetry_On_ConnectionError` & `Test_pruneAttsFromPool_Electra`)

### DIFF
--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -122,6 +122,7 @@ func Test_pruneAttsFromPool_Electra(t *testing.T) {
 	rob, err := consensusblocks.NewSignedBeaconBlock(bl)
 	require.NoError(t, err)
 	st, _ := util.DeterministicGenesisStateElectra(t, 1024)
+	require.NoError(t, helpers.UpdateCommitteeCache(ctx, st, 0))
 	committees, err := helpers.BeaconCommittees(ctx, st, 0)
 	require.NoError(t, err)
 	// Sanity check to make sure the on-chain att will be decomposed

--- a/changelog/syjn99_flaky-tests.md
+++ b/changelog/syjn99_flaky-tests.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Fix flaky tests: `TestRetry_On_ConnectionError` & `Test_pruneAttsFromPool_Electra`

--- a/validator/client/runner_test.go
+++ b/validator/client/runner_test.go
@@ -153,7 +153,7 @@ func TestInitialize(t *testing.T) {
 
 func TestRetry_On_ConnectionError(t *testing.T) {
 	retry := 10
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx := t.Context()
 	v, vc, nc := runnerTestValidator(t, ctx)
 
 	// Each failure sends initialize() back to the top of its loop, so the steps before
@@ -180,12 +180,6 @@ func TestRetry_On_ConnectionError(t *testing.T) {
 	expectStatuses(vc, ethpb.ValidatorStatus_ACTIVE).Do(func(any, any) { activation.Add(1) }).AnyTimes()
 
 	backOffPeriod = 10 * time.Millisecond
-	go func() {
-		// each step will fail (retry times)=10 this sleep times will wait more then
-		// the time it takes for all steps to succeed before main loop.
-		time.Sleep(time.Duration(retry*6) * backOffPeriod)
-		cancel()
-	}()
 	require.NoError(t, initialize(ctx, v))
 
 	// every call will fail retry=10 times so first one will be called 2 * retry=10 + 1.


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Make these tests deterministic:

- `TestRetry_On_ConnectionError`
- `Test_pruneAttsFromPool_Electra`

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Read commit by commit as it has the context and rationale.

Example action result: https://github.com/OffchainLabs/prysm/actions/runs/31694045107/job/94427595458?pr=17347

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
