### PR TITLE
fix(validator): reload Web3Signer keys after same-size file updates

### DIFF
--- a/changelog/questfever_fix-web3signer-same-size-reload.md
+++ b/changelog/questfever_fix-web3signer-same-size-reload.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Reload Web3Signer validator public keys when the configured key file changes without changing size.

--- a/validator/keymanager/remote-web3signer/keymanager.go
+++ b/validator/keymanager/remote-web3signer/keymanager.go
@@ -309,11 +309,9 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 			log.WithError(err).Error("Could not close file watcher")
 		}
 	}()
-	initialFileInfo, err := os.Stat(km.keyFilePath)
-	if err != nil {
+	if _, err := os.Stat(km.keyFilePath); err != nil {
 		return errors.Wrap(err, "could not stat remote signer public key file")
 	}
-	initialFileSize := initialFileInfo.Size()
 	if err := watcher.Add(km.keyFilePath); err != nil {
 		return errors.Wrap(err, "could not add file to file watcher")
 	}
@@ -352,29 +350,22 @@ func (km *Keymanager) refreshRemoteKeysFromFileChanges(ctx context.Context, mark
 			if e.Has(fsnotify.Remove) {
 				return errors.New("remote signer key file was removed")
 			}
-			currentFileInfo, err := os.Stat(km.keyFilePath)
+			fileKeys, _, err := km.readKeyFile()
 			if err != nil {
-				return errors.Wrap(err, "could not stat remote signer public key file")
+				return errors.New("could not read key file")
 			}
-			if currentFileInfo.Size() != initialFileSize {
+			// prioritize file keys over flag keys
+			if len(fileKeys) == 0 {
+				log.Warnln("Remote signer key file no longer has keys, defaulting to flag provided keys")
+				fileKeys = slices.Collect(maps.Values(km.flagLoadedKeysMap))
+			}
+			currentKeys, err := km.FetchValidatingPublicKeys(ctx)
+			if err != nil {
+				return errors.Wrap(err, "could not fetch current keys")
+			}
+			if !slices.Equal(currentKeys, fileKeys) {
 				log.Info("Remote signer key file updated")
-				fileKeys, _, err := km.readKeyFile()
-				if err != nil {
-					return errors.New("could not read key file")
-				}
-				// prioritize file keys over flag keys
-				if len(fileKeys) == 0 {
-					log.Warnln("Remote signer key file no longer has keys, defaulting to flag provided keys")
-					fileKeys = slices.Collect(maps.Values(km.flagLoadedKeysMap))
-				}
-				currentKeys, err := km.FetchValidatingPublicKeys(ctx)
-				if err != nil {
-					return errors.Wrap(err, "could not fetch current keys")
-				}
-				if !slices.Equal(currentKeys, fileKeys) {
-					km.updatePublicKeys(fileKeys)
-				}
-				initialFileSize = currentFileInfo.Size()
+				km.updatePublicKeys(fileKeys)
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok { // Channel was closed (i.e. Watcher.Close() was called).

--- a/validator/keymanager/remote-web3signer/keymanager_test.go
+++ b/validator/keymanager/remote-web3signer/keymanager_test.go
@@ -253,6 +253,53 @@ func TestNewKeyManager_ChangingFileCreated(t *testing.T) {
 	}
 }
 
+func TestNewKeyManager_ReloadsSameSizeKeyFileUpdate(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	const keyA = "0x800077e04f8d7496099b3d30ac5430aea64873a45e5bcfe004d2095babcbf55e21138ff0d5691abc29da190aa32755c6"
+	const keyB = "0x8000a9a6d3f5e22d783eefaadbcf0298146adb5d95b04db910a0d4e16976b30229d0b1e7b9cda6c7e0bfa11f72efe055"
+	keyFilePath := filepath.Join(t.TempDir(), "keyfile.txt")
+	require.NoError(t, file.WriteFile(keyFilePath, []byte(keyA+"\n")))
+
+	root, err := hexutil.Decode("0x270d43e74ce340de4bca2b1936beca0f4f5408d9e78aec4850920baf659d5b69")
+	require.NoError(t, err)
+	km, err := NewKeymanager(ctx, &SetupConfig{
+		BaseEndpoint:          "http://example.com",
+		GenesisValidatorsRoot: root,
+		KeyFilePath:           keyFilePath,
+	})
+	require.NoError(t, err)
+
+	before, err := os.Stat(keyFilePath)
+	require.NoError(t, err)
+	pubKeysChan := make(chan [][fieldparams.BLSPubkeyLength]byte, 1)
+	sub := km.SubscribeAccountChanges(pubKeysChan)
+	defer sub.Unsubscribe()
+
+	// Do not truncate the file: overwrite it in place so its size never changes.
+	f, err := os.OpenFile(keyFilePath, os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	_, err = f.WriteString(keyB + "\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Sync())
+	require.NoError(t, f.Close())
+
+	after, err := os.Stat(keyFilePath)
+	require.NoError(t, err)
+	require.Equal(t, before.Size(), after.Size())
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case updatedKeys := <-pubKeysChan:
+		require.Equal(t, 1, len(updatedKeys))
+		require.Equal(t, keyB, hexutil.Encode(updatedKeys[0][:]))
+	case <-timer.C:
+		t.Fatal("timed out waiting for the same-size key file update")
+	}
+}
+
 func TestNewKeyManager_FileAndFlagsWithDifferentKeys(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**

The Web3Signer key-file watcher currently uses a change in file size as a proxy for a change in file contents.

Validator public keys have a fixed width. Replacing one key with another while preserving the number of keys and formatting therefore leaves the file size unchanged. Although fsnotify reports the write, Prysm skips re-reading the file and keeps the previous key set in `providedPublicKeys`.

For example, replacing an equal-length key A with key B does not reload the configured validators until another size-changing update occurs, the watcher is reinitialized, or the validator client is restarted.

This PR removes the file-size gate and re-reads the key file after relevant watcher events. The existing key comparison prevents `providedPublicKeys` and account-change subscribers from being updated when the parsed keys have not changed.

A regression test performs an in-place overwrite from key A to an equal-length key B, verifies that the file size remains unchanged, and asserts that `SubscribeAccountChanges` receives key B.



**Which issue(s) does this PR fix?**

Related to #17322.

This PR fixes only the same-size key-file reload bug described there and does not close the broader key-source management proposal.


**Other notes for review**

- Added a regression test for an equal-size in-place key-file update.
- Verified that the test times out before the fix.
- Verified that the test receives key B after removing the size gate.
- `go test ./validator/keymanager/remote-web3signer`

**Acknowledgements**


- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
