### PR TITLE
Send SSZ request body for `aggregate_and_proofs` using `PostSSZWithFallback`

### DIFF
--- a/changelog/syjn99_vc-aggregate-proof-ssz.md
+++ b/changelog/syjn99_vc-aggregate-proof-ssz.md
@@ -1,0 +1,3 @@
+### Added
+
+- The REST VC now submits `POST /eth/v2/validator/aggregate_and_proofs` with an SSZ request body, falling back to JSON when the beacon node rejects SSZ.

--- a/encoding/ssz/list.go
+++ b/encoding/ssz/list.go
@@ -6,6 +6,21 @@ import (
 	fssz "github.com/prysmaticlabs/fastssz"
 )
 
+// MarshalVariableList joins the SSZ encodings of variable-size elements into the SSZ List encoding:
+// a vector of 4-byte offsets followed by the elements. It is the inverse of SplitVariableList.
+func MarshalVariableList(elements ...[]byte) []byte {
+	var offsets, data []byte
+
+	offset := 4 * len(elements)
+	for _, e := range elements {
+		offsets = fssz.WriteOffset(offsets, offset)
+		offset += len(e)
+		data = append(data, e...)
+	}
+
+	return append(offsets, data...)
+}
+
 // SplitVariableList splits the SSZ List encoding of variable-size elements into the encodings of its
 // elements, without decoding them. It bounds the element count and should be the limit the list type declares.
 func SplitVariableList(b []byte, maxLen int) ([][]byte, error) {

--- a/encoding/ssz/list_test.go
+++ b/encoding/ssz/list_test.go
@@ -6,39 +6,42 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
-	fssz "github.com/prysmaticlabs/fastssz"
 )
 
-// variableList builds the SSZ List encoding of variable-size elements: a vector of 4-byte offsets
-// followed by the elements.
-func variableList(elements ...[]byte) []byte {
-	var offsets, data []byte
-	offset := 4 * len(elements)
-	for _, e := range elements {
-		offsets = fssz.WriteOffset(offsets, offset)
-		offset += len(e)
-		data = append(data, e...)
-	}
-	return append(offsets, data...)
+func TestMarshalVariableList(t *testing.T) {
+	t.Run("single element", func(t *testing.T) {
+		// One 4-byte offset, so the element starts at 4.
+		expected := append([]byte{4, 0, 0, 0}, []byte("only")...)
+		assert.DeepEqual(t, expected, ssz.MarshalVariableList([]byte("only")))
+	})
+	t.Run("several elements", func(t *testing.T) {
+		// Three 4-byte offsets, so the elements start at 12, 13 and 15.
+		expected := []byte{12, 0, 0, 0, 13, 0, 0, 0, 15, 0, 0, 0}
+		expected = append(expected, []byte("abbccc")...)
+		assert.DeepEqual(t, expected, ssz.MarshalVariableList([]byte("a"), []byte("bb"), []byte("ccc")))
+	})
+	t.Run("no elements", func(t *testing.T) {
+		assert.Equal(t, 0, len(ssz.MarshalVariableList()))
+	})
 }
 
 func TestSplitVariableList(t *testing.T) {
 	t.Run("splits every element", func(t *testing.T) {
-		b := variableList([]byte("a"), []byte("bb"), []byte("ccc"))
+		b := ssz.MarshalVariableList([]byte("a"), []byte("bb"), []byte("ccc"))
 
 		elements, err := ssz.SplitVariableList(b, 10)
 		require.NoError(t, err)
 		assert.DeepEqual(t, [][]byte{[]byte("a"), []byte("bb"), []byte("ccc")}, elements)
 	})
 	t.Run("single element", func(t *testing.T) {
-		b := variableList([]byte("only"))
+		b := ssz.MarshalVariableList([]byte("only"))
 
 		elements, err := ssz.SplitVariableList(b, 10)
 		require.NoError(t, err)
 		assert.DeepEqual(t, [][]byte{[]byte("only")}, elements)
 	})
 	t.Run("zero-length elements", func(t *testing.T) {
-		b := variableList([]byte{}, []byte{})
+		b := ssz.MarshalVariableList([]byte{}, []byte{})
 
 		elements, err := ssz.SplitVariableList(b, 10)
 		require.NoError(t, err)
@@ -52,7 +55,7 @@ func TestSplitVariableList(t *testing.T) {
 		assert.Equal(t, 0, len(elements))
 	})
 	t.Run("element count over maxLength", func(t *testing.T) {
-		b := variableList([]byte("a"), []byte("b"), []byte("c"))
+		b := ssz.MarshalVariableList([]byte("a"), []byte("b"), []byte("c"))
 
 		_, err := ssz.SplitVariableList(b, 2)
 		assert.NotNil(t, err)

--- a/validator/client/beacon-api/BUILD.bazel
+++ b/validator/client/beacon-api/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//encoding/ssz:go_default_library",
         "//network/httputil:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/validator/client/beacon-api/submit_signed_aggregate_proof.go
+++ b/validator/client/beacon-api/submit_signed_aggregate_proof.go
@@ -1,25 +1,33 @@
 package beacon_api
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
 
+const aggregateAndProofsEndpoint = "/eth/v2/validator/aggregate_and_proofs"
+
 func (c *beaconApiValidatorClient) submitSignedAggregateSelectionProof(ctx context.Context, in *ethpb.SignedAggregateSubmitRequest) (*ethpb.SignedAggregateSubmitResponse, error) {
-	body, err := json.Marshal([]*structs.SignedAggregateAttestationAndProof{jsonifySignedAggregateAndProof(in.SignedAggregateAndProof)})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal SignedAggregateAttestationAndProof")
-	}
 	headers := map[string]string{"Eth-Consensus-Version": version.String(in.SignedAggregateAndProof.Version())}
-	err = c.handler.Post(ctx, "/eth/v2/validator/aggregate_and_proofs", headers, bytes.NewBuffer(body), nil)
-	if err != nil {
+	jsonFn := func() ([]byte, error) {
+		return json.Marshal([]*structs.SignedAggregateAttestationAndProof{jsonifySignedAggregateAndProof(in.SignedAggregateAndProof)})
+	}
+	sszFn := func() ([]byte, error) {
+		elem, err := in.SignedAggregateAndProof.MarshalSSZ()
+		if err != nil {
+			return nil, err
+		}
+		return ssz.MarshalVariableList(elem), nil
+	}
+
+	if err := c.handler.PostSSZWithFallback(ctx, aggregateAndProofsEndpoint, headers, sszFn, jsonFn); err != nil {
 		return nil, err
 	}
 
@@ -32,14 +40,21 @@ func (c *beaconApiValidatorClient) submitSignedAggregateSelectionProof(ctx conte
 }
 
 func (c *beaconApiValidatorClient) submitSignedAggregateSelectionProofElectra(ctx context.Context, in *ethpb.SignedAggregateSubmitElectraRequest) (*ethpb.SignedAggregateSubmitResponse, error) {
-	body, err := json.Marshal([]*structs.SignedAggregateAttestationAndProofElectra{jsonifySignedAggregateAndProofElectra(in.SignedAggregateAndProof)})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal SignedAggregateAttestationAndProofElectra")
-	}
 	dataSlot := in.SignedAggregateAndProof.Message.Aggregate.Data.Slot
 	consensusVersion := version.String(slots.ToForkVersion(dataSlot))
 	headers := map[string]string{"Eth-Consensus-Version": consensusVersion}
-	if err = c.handler.Post(ctx, "/eth/v2/validator/aggregate_and_proofs", headers, bytes.NewBuffer(body), nil); err != nil {
+	jsonFn := func() ([]byte, error) {
+		return json.Marshal([]*structs.SignedAggregateAttestationAndProofElectra{jsonifySignedAggregateAndProofElectra(in.SignedAggregateAndProof)})
+	}
+	sszFn := func() ([]byte, error) {
+		elem, err := in.SignedAggregateAndProof.MarshalSSZ()
+		if err != nil {
+			return nil, err
+		}
+		return ssz.MarshalVariableList(elem), nil
+	}
+
+	if err := c.handler.PostSSZWithFallback(ctx, aggregateAndProofsEndpoint, headers, sszFn, jsonFn); err != nil {
 		return nil, err
 	}
 

--- a/validator/client/beacon-api/submit_signed_aggregate_proof_test.go
+++ b/validator/client/beacon-api/submit_signed_aggregate_proof_test.go
@@ -3,10 +3,13 @@ package beacon_api
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
+	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -23,18 +26,19 @@ func TestSubmitSignedAggregateSelectionProof_Valid(t *testing.T) {
 	defer ctrl.Finish()
 
 	signedAggregateAndProof := generateSignedAggregateAndProofJson()
-	marshalledSignedAggregateSignedAndProof, err := json.Marshal([]*structs.SignedAggregateAttestationAndProof{jsonifySignedAggregateAndProof(signedAggregateAndProof)})
+	elem, err := signedAggregateAndProof.MarshalSSZ()
 	require.NoError(t, err)
+	sszBody := ssz.MarshalVariableList(elem)
 
 	ctx := t.Context()
 	headers := map[string]string{"Eth-Consensus-Version": version.String(signedAggregateAndProof.Message.Version())}
 	handler := mock.NewMockHandler(ctrl)
-	handler.EXPECT().Post(
+	expectPostSSZWithFallback(handler)
+	handler.EXPECT().PostSSZ(
 		gomock.Any(),
 		"/eth/v2/validator/aggregate_and_proofs",
 		headers,
-		bytes.NewBuffer(marshalledSignedAggregateSignedAndProof),
-		nil,
+		bytes.NewBuffer(sszBody),
 	).Return(
 		nil,
 	).Times(1)
@@ -50,7 +54,7 @@ func TestSubmitSignedAggregateSelectionProof_Valid(t *testing.T) {
 	assert.DeepEqual(t, attestationDataRoot[:], resp.AttestationDataRoot)
 }
 
-func TestSubmitSignedAggregateSelectionProof_BadRequest(t *testing.T) {
+func TestSubmitSignedAggregateSelectionProof_JsonFallback(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -61,6 +65,10 @@ func TestSubmitSignedAggregateSelectionProof_BadRequest(t *testing.T) {
 	ctx := t.Context()
 	headers := map[string]string{"Eth-Consensus-Version": version.String(signedAggregateAndProof.Message.Version())}
 	handler := mock.NewMockHandler(ctrl)
+	expectPostSSZWithFallback(handler)
+	handler.EXPECT().PostSSZ(gomock.Any(), "/eth/v2/validator/aggregate_and_proofs", headers, gomock.Any()).Return(
+		&httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"},
+	).Times(1)
 	handler.EXPECT().Post(
 		gomock.Any(),
 		"/eth/v2/validator/aggregate_and_proofs",
@@ -68,11 +76,37 @@ func TestSubmitSignedAggregateSelectionProof_BadRequest(t *testing.T) {
 		bytes.NewBuffer(marshalledSignedAggregateSignedAndProof),
 		nil,
 	).Return(
-		errors.New("bad request"),
+		nil,
 	).Times(1)
 
 	validatorClient := &beaconApiValidatorClient{handler: handler}
 	_, err = validatorClient.submitSignedAggregateSelectionProof(ctx, &ethpb.SignedAggregateSubmitRequest{
+		SignedAggregateAndProof: signedAggregateAndProof,
+	})
+	require.NoError(t, err)
+}
+
+func TestSubmitSignedAggregateSelectionProof_BadRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	signedAggregateAndProof := generateSignedAggregateAndProofJson()
+
+	ctx := t.Context()
+	headers := map[string]string{"Eth-Consensus-Version": version.String(signedAggregateAndProof.Message.Version())}
+	handler := mock.NewMockHandler(ctrl)
+	expectPostSSZWithFallback(handler)
+	handler.EXPECT().PostSSZ(
+		gomock.Any(),
+		"/eth/v2/validator/aggregate_and_proofs",
+		headers,
+		gomock.Any(),
+	).Return(
+		errors.New("bad request"),
+	).Times(1)
+
+	validatorClient := &beaconApiValidatorClient{handler: handler}
+	_, err := validatorClient.submitSignedAggregateSelectionProof(ctx, &ethpb.SignedAggregateSubmitRequest{
 		SignedAggregateAndProof: signedAggregateAndProof,
 	})
 	assert.ErrorContains(t, "bad request", err)
@@ -87,19 +121,20 @@ func TestSubmitSignedAggregateSelectionProofElectra_Valid(t *testing.T) {
 	defer ctrl.Finish()
 
 	signedAggregateAndProofElectra := generateSignedAggregateAndProofElectraJson()
-	marshalledSignedAggregateSignedAndProofElectra, err := json.Marshal([]*structs.SignedAggregateAttestationAndProofElectra{jsonifySignedAggregateAndProofElectra(signedAggregateAndProofElectra)})
+	elem, err := signedAggregateAndProofElectra.MarshalSSZ()
 	require.NoError(t, err)
+	sszBody := ssz.MarshalVariableList(elem)
 
 	ctx := t.Context()
 	expectedVersion := version.String(slots.ToForkVersion(signedAggregateAndProofElectra.Message.Aggregate.Data.Slot))
 	headers := map[string]string{"Eth-Consensus-Version": expectedVersion}
 	handler := mock.NewMockHandler(ctrl)
-	handler.EXPECT().Post(
+	expectPostSSZWithFallback(handler)
+	handler.EXPECT().PostSSZ(
 		gomock.Any(),
 		"/eth/v2/validator/aggregate_and_proofs",
 		headers,
-		bytes.NewBuffer(marshalledSignedAggregateSignedAndProofElectra),
-		nil,
+		bytes.NewBuffer(sszBody),
 	).Return(
 		nil,
 	).Times(1)
@@ -115,7 +150,7 @@ func TestSubmitSignedAggregateSelectionProofElectra_Valid(t *testing.T) {
 	assert.DeepEqual(t, attestationDataRoot[:], resp.AttestationDataRoot)
 }
 
-func TestSubmitSignedAggregateSelectionProofElectra_BadRequest(t *testing.T) {
+func TestSubmitSignedAggregateSelectionProofElectra_JsonFallback(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	params.BeaconConfig().ElectraForkEpoch = 0
 	params.BeaconConfig().FuluForkEpoch = 100
@@ -131,6 +166,10 @@ func TestSubmitSignedAggregateSelectionProofElectra_BadRequest(t *testing.T) {
 	expectedVersion := version.String(slots.ToForkVersion(signedAggregateAndProofElectra.Message.Aggregate.Data.Slot))
 	headers := map[string]string{"Eth-Consensus-Version": expectedVersion}
 	handler := mock.NewMockHandler(ctrl)
+	expectPostSSZWithFallback(handler)
+	handler.EXPECT().PostSSZ(gomock.Any(), "/eth/v2/validator/aggregate_and_proofs", headers, gomock.Any()).Return(
+		&httputil.DefaultJsonError{Code: http.StatusUnsupportedMediaType, Message: "unsupported media type"},
+	).Times(1)
 	handler.EXPECT().Post(
 		gomock.Any(),
 		"/eth/v2/validator/aggregate_and_proofs",
@@ -138,11 +177,42 @@ func TestSubmitSignedAggregateSelectionProofElectra_BadRequest(t *testing.T) {
 		bytes.NewBuffer(marshalledSignedAggregateSignedAndProofElectra),
 		nil,
 	).Return(
-		errors.New("bad request"),
+		nil,
 	).Times(1)
 
 	validatorClient := &beaconApiValidatorClient{handler: handler}
 	_, err = validatorClient.submitSignedAggregateSelectionProofElectra(ctx, &ethpb.SignedAggregateSubmitElectraRequest{
+		SignedAggregateAndProof: signedAggregateAndProofElectra,
+	})
+	require.NoError(t, err)
+}
+
+func TestSubmitSignedAggregateSelectionProofElectra_BadRequest(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	params.BeaconConfig().ElectraForkEpoch = 0
+	params.BeaconConfig().FuluForkEpoch = 100
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	signedAggregateAndProofElectra := generateSignedAggregateAndProofElectraJson()
+
+	ctx := t.Context()
+	expectedVersion := version.String(slots.ToForkVersion(signedAggregateAndProofElectra.Message.Aggregate.Data.Slot))
+	headers := map[string]string{"Eth-Consensus-Version": expectedVersion}
+	handler := mock.NewMockHandler(ctrl)
+	expectPostSSZWithFallback(handler)
+	handler.EXPECT().PostSSZ(
+		gomock.Any(),
+		"/eth/v2/validator/aggregate_and_proofs",
+		headers,
+		gomock.Any(),
+	).Return(
+		errors.New("bad request"),
+	).Times(1)
+
+	validatorClient := &beaconApiValidatorClient{handler: handler}
+	_, err := validatorClient.submitSignedAggregateSelectionProofElectra(ctx, &ethpb.SignedAggregateSubmitElectraRequest{
 		SignedAggregateAndProof: signedAggregateAndProofElectra,
 	})
 	assert.ErrorContains(t, "bad request", err)
@@ -157,19 +227,20 @@ func TestSubmitSignedAggregateSelectionProofElectra_FuluVersion(t *testing.T) {
 	defer ctrl.Finish()
 
 	signedAggregateAndProofElectra := generateSignedAggregateAndProofElectraJson()
-	marshalledSignedAggregateSignedAndProofElectra, err := json.Marshal([]*structs.SignedAggregateAttestationAndProofElectra{jsonifySignedAggregateAndProofElectra(signedAggregateAndProofElectra)})
+	elem, err := signedAggregateAndProofElectra.MarshalSSZ()
 	require.NoError(t, err)
+	sszBody := ssz.MarshalVariableList(elem)
 
 	ctx := t.Context()
 	expectedVersion := version.String(slots.ToForkVersion(signedAggregateAndProofElectra.Message.Aggregate.Data.Slot))
 	headers := map[string]string{"Eth-Consensus-Version": expectedVersion}
 	handler := mock.NewMockHandler(ctrl)
-	handler.EXPECT().Post(
+	expectPostSSZWithFallback(handler)
+	handler.EXPECT().PostSSZ(
 		gomock.Any(),
 		"/eth/v2/validator/aggregate_and_proofs",
 		headers,
-		bytes.NewBuffer(marshalledSignedAggregateSignedAndProofElectra),
-		nil,
+		bytes.NewBuffer(sszBody),
 	).Return(
 		nil,
 	).Times(1)


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Follow up of #17318. Now Prysm BN supports to accept SSZ-encoded body for `POST /eth/v2/validator/aggregate_and_proofs`. This PR makes Prysm VC to send the request with SSZ-encoded, so with this PR Prysm BN + VC communicates on SSZ on `aggregate_and_proofs`.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

Kurtosis configuration

```yaml
participants:
  - el_type: geth
    cl_type: lighthouse
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    use_separate_vc: true
    count: 1
    vc_extra_params:
      - --verbosity=debug

  - el_type: geth
    cl_type: prysm
    cl_image: prysm-bn-custom-image:latest
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    use_separate_vc: true
    count: 1
    cl_extra_params:
      - --verbosity=debug
    vc_extra_params:
      - --enable-beacon-rest-api
      - --verbosity=debug

  - el_type: geth
    cl_type: teku
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    use_separate_vc: true
    count: 1
    vc_extra_params:
      - --verbosity=debug

  - el_type: geth
    cl_type: lodestar
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    use_separate_vc: true
    count: 1
    vc_extra_params:
      - --verbosity=debug

  - el_type: geth
    cl_type: nimbus
    vc_type: prysm
    vc_image: prysm-vc-custom-image:latest
    use_separate_vc: true
    count: 1
    vc_extra_params:
      - --verbosity=debug

network_params:
  genesis_delay: 40

additional_services:
  - dora
```

Note that (current) Lighthouse doesn't support SSZ for this endpoint, so it proves that #17256 works well. `falling back to JSON` should only appear once in a day:

```
> docker logs -f vc-1-geth-lighthouse-prysm--1ad205ac905c434d9e0a560fc478dc41 | grep -i "falling back to JSON"
[2026-08-17 07:03:42.02]  WARN rest: Beacon node does not accept SSZ request bodies, falling back to JSON endpoint=/eth/v2/validator/aggregate_and_proofs error=HTTP request unsuccessful (415: UNSUPPORTED_MEDIA_TYPE) host=http://cl-1-lighthouse-geth:4000
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
