### PR TITLE
Remove Bazel: Phase 5/9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+#
+# This docker file builds a FAST, non-hermetic image for local iteration (Kurtosis / devnets / ...).
+# It is NOT suitable for releases.
+# To build a hermetic, reproducible image for releases, use `make dist`.
+#
+# Usage:
+#   docker build [--build-arg BIN=beacon-chain|validator|prysmctl] -t <name> .
+#   Default BIN is beacon-chain.
+
+FROM golang:1.26-bookworm AS build
+ARG BIN=beacon-chain
+ARG TAG=dev
+
+WORKDIR /src
+
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=1 CGO_CFLAGS="-D__BLST_PORTABLE__" \
+  go build \
+  -ldflags "-X github.com/OffchainLabs/prysm/v7/runtime/version.gitTag=$TAG" \
+  -o "/out/$BIN" "./cmd/$BIN"
+
+FROM gcr.io/distroless/cc-debian12
+ARG BIN=beacon-chain
+LABEL org.opencontainers.image.source="https://github.com/prysmaticlabs/prysm"
+COPY --from=build /out/${BIN} /entrypoint
+ENTRYPOINT ["/entrypoint"]

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ TAGFLAG := $(if $(TAGS),-tags=$(TAGS),)
 
 flags ?=
 
-ALLOWED_VARS := GO DIST TAGS flags mode platform SOURCE_DATE_EPOCH
+ALLOWED_VARS := GO DIST TAGS flags mode platform SOURCE_DATE_EPOCH DOCKER_REGISTRY DOCKER_TAG
 BAD_VARS := $(strip $(foreach v,$(.VARIABLES),$(if $(filter command line,$(origin $(v))),$(filter-out $(ALLOWED_VARS),$(v)))))
 ifneq ($(BAD_VARS),)
 $(error unknown variable(s): $(BAD_VARS)  (allowed: $(ALLOWED_VARS)))
@@ -141,6 +141,13 @@ CROSS_TARGETS := \
 
 CROSS_PLATFORMS := $(foreach t,$(CROSS_TARGETS),$(word 1,$(subst /,$(space),$(t)))/$(word 2,$(subst /,$(space),$(t))))
 
+DOCKER_IMAGES  := beacon-chain validator prysmctl
+DOCKER_REGISTRY ?= gcr.io/offchainlabs/prysm
+DOCKER_TAG      ?= $(GIT_TAG)
+LINUX_ARCHES   := $(foreach t,$(filter linux/%,$(CROSS_TARGETS)),$(word 2,$(subst /,$(space),$(t))))
+DOCKER_PLATFORMS := $(foreach a,$(LINUX_ARCHES),docker/$(a))
+ALL_PLATFORMS  := $(CROSS_PLATFORMS) $(DOCKER_PLATFORMS)
+
 # linux/arm64 C optimization flags.
 CGO_CFLAGS_LINUX_ARM64 := -ftree-vectorize -funsafe-math-optimizations -fomit-frame-pointer
 
@@ -178,32 +185,39 @@ DIST_BAD  := $(filter-out $(CROSS_BINARIES),$(DIST_ARGS))
 DIST_BINS := $(or $(strip $(filter $(CROSS_BINARIES),$(DIST_ARGS))),$(CROSS_BINARIES))
 
 # Which run-targets `make dist` builds: empty platform= means all, otherwise platform= is one
-# or a space/comma list of exact <os>/<arch> values from CROSS_PLATFORMS (each maps to its
-# CROSS_TARGETS entry). DIST_PLAT_BAD collects any selector that isn't a known platform.
+# or a space/comma list of exact values from ALL_PLATFORMS: an <os>/<arch> from CROSS_PLATFORMS
+# (each maps to its CROSS_TARGETS entry), or a docker/<arch> that also packages an OCI image
+# (and implies its linux/<arch> binaries). DIST_PLAT_BAD collects any unknown selector.
 platform ?=
 ifeq ($(strip $(platform)),)
-DIST_TARGETS  := $(CROSS_TARGETS)
-DIST_PLAT_BAD :=
+DIST_PLAT_SEL := $(ALL_PLATFORMS)
 else
 DIST_PLAT_SEL := $(subst $(comma),$(space),$(platform))
-DIST_PLAT_BAD := $(filter-out $(CROSS_PLATFORMS),$(DIST_PLAT_SEL))
-DIST_TARGETS  := $(foreach s,$(filter $(CROSS_PLATFORMS),$(DIST_PLAT_SEL)),$(filter $(s)/%,$(CROSS_TARGETS)))
 endif
 
-# Env for the in-container dist build (build/crossdocker -> build/cross). dist is always a
-# release build: stamped + stripped (-s -w) + PGO'd. crossbuild reads PGO_beacon_chain
-# (underscore) and applies it only to beacon-chain.
+DIST_PLAT_BAD := $(filter-out $(ALL_PLATFORMS),$(DIST_PLAT_SEL))
+DIST_DOCKER_ARCHES := $(sort $(foreach s,$(filter $(DOCKER_PLATFORMS),$(DIST_PLAT_SEL)),$(word 2,$(subst /,$(space),$(s)))))
+DIST_BIN_PLATS := $(sort $(filter $(CROSS_PLATFORMS),$(DIST_PLAT_SEL)) $(foreach a,$(DIST_DOCKER_ARCHES),linux/$(a)))
+DIST_TARGETS   := $(foreach s,$(DIST_BIN_PLATS),$(filter $(s)/%,$(CROSS_TARGETS)))
+
 DIST_LDFLAGS := $(LDFLAGS_STAMPED) -s -w
 BUILD_CROSS_ENV = GO="$(GO)" DIST="$(DIST)" GIT_TAG="$(GIT_TAG)" \
 	CGO_CFLAGS_LINUX_ARM64="$(CGO_CFLAGS_LINUX_ARM64)" BLST_PORTABLE="$(BLST_PORTABLE)" \
 	LDFLAGS="$(DIST_LDFLAGS)" TAGFLAG="$(TAGFLAG)" PGO_beacon_chain="$(PGO_beacon-chain)" \
 	BUILD_MODE="release"
 
+DIST_DOCKER      := $(strip $(DIST_DOCKER_ARCHES))
+DIST_DOCKER_BINS := $(filter $(DOCKER_IMAGES),$(DIST_BINS))
+DIST_DOCKER_ENV   = GO="$(GO)" DIST="$(DIST)" GIT_TAG="$(GIT_TAG)" \
+	DOCKER_TAG="$(DOCKER_TAG)" DOCKER_REGISTRY="$(DOCKER_REGISTRY)" \
+	DOCKER_BINARIES="$(strip $(DIST_DOCKER_BINS))" DOCKER_ARCHES="$(strip $(DIST_DOCKER_ARCHES))"
+
 .PHONY: dist
 dist:
 	@$(if $(DIST_BAD),echo "❌ dist: unknown binary(ies): $(DIST_BAD)  (one of: $(CROSS_BINARIES))" >&2; exit 1;) \
-	$(if $(DIST_PLAT_BAD),echo "❌ dist: unknown platform(s): $(DIST_PLAT_BAD)  (valid: $(CROSS_PLATFORMS))" >&2; exit 1;) \
-	$(BUILD_CROSS_ENV) CROSS_BINARIES="$(DIST_BINS)" CROSS_TARGETS="$(strip $(DIST_TARGETS))" $(GO) run ./build/crossdocker
+	$(if $(DIST_PLAT_BAD),echo "❌ dist: unknown platform(s): $(DIST_PLAT_BAD)  (valid: $(ALL_PLATFORMS))" >&2; exit 1;) \
+	$(BUILD_CROSS_ENV) CROSS_BINARIES="$(DIST_BINS)" CROSS_TARGETS="$(strip $(DIST_TARGETS))" $(GO) run ./build/crossdocker \
+	$(if $(DIST_DOCKER),&& $(DIST_DOCKER_ENV) $(GO) run ./build/docker,)
 
 # ---------------------------------------------------------------------------
 # Help (default target)
@@ -222,7 +236,7 @@ help: ## Show this help
 	@printf "  \033[36m%-44s\033[0m %s\n" "make gen [<kind>...] [mode=force|no-force]" "Create generated code (default: all,no-force)"
 	@printf "  \033[36m%-44s\033[0m %s\n" "make test [<kind>...] [mode=no-race|race]"  "Run unit tests (default: all,no-race)"
 	@printf "  \033[36m%-44s\033[0m %s\n" "make e2e [<scenario>|<suite>...]"           "Run end-to-end tests (default: presubmit)"
-	@printf "  \033[36m%-44s\033[0m %s\n" "make dist [<bin>...] [platform=...]"        "Build official release binaries (default: all binaries,all platforms)"
+	@printf "  \033[36m%-44s\033[0m %s\n" "make dist [<bin>...] [platform=...]"        "Build official release binaries (docker/<arch> also packages an OCI image)"
 	@printf "  \033[36m%-44s\033[0m %s\n" "make testdata"                              "Pre-fetch external spec-test data"
 	@printf "  \033[36m%-44s\033[0m %s\n" "make clean"                                 "Clean everything"
 	@printf "  \033[36m%-44s\033[0m %s\n" "make help"                                  "Show this help"
@@ -237,7 +251,7 @@ help: ## Show this help
 	@printf "    \033[36m%-16s\033[0m %s\n" "postsubmit:"     "$(E2E_SUITE_postsubmit)"
 	@printf "    \033[36m%-16s\033[0m %s\n" "scenario_tests:" "$(E2E_SUITE_scenario_tests)"
 	@printf "  \033[36m%-16s\033[0m %s\n" "dist <bin>:"     "$(CROSS_BINARIES)"
-	@printf "  \033[36m%-16s\033[0m %s\n" "dist platform:"  "$(CROSS_PLATFORMS)  (give one, or a space/comma list)"
+	@printf "  \033[36m%-16s\033[0m %s\n" "dist platform:"  "$(ALL_PLATFORMS)"
 	@echo ""
 	@printf '\033[1mNotes:\033[0m\n'
 	@echo "  After '--', pass '--flag value' (not '--flag=value')"

--- a/build/docker/BUILD.bazel
+++ b/build/docker/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/OffchainLabs/prysm/v7/build/docker",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "docker",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/build/docker/main.go
+++ b/build/docker/main.go
@@ -1,0 +1,147 @@
+// Command docker assembles the Prysm OCI container images.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	dockerfile = "tools/docker/Dockerfile"
+	builder    = "prysm-builder"
+
+	beaconChain = "beacon-chain"
+	validator   = "validator"
+	prysmctl    = "prysmctl"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "❌ docker:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	dist := env("DIST", "dist")
+	binTag := env("GIT_TAG", gitDescribe())
+	imageTag := env("DOCKER_TAG", binTag)
+	registry := env("DOCKER_REGISTRY", "gcr.io/offchainlabs/prysm")
+	binaries := strings.Fields(env("DOCKER_BINARIES", beaconChain+" validator prysmctl"))
+	arches := strings.Fields(env("DOCKER_ARCHES", "amd64 arm64"))
+
+	if err := ensureBuilder(); err != nil {
+		return fmt.Errorf("ensure builder: %w", err)
+	}
+
+	total := len(binaries) * len(arches)
+	n := 0
+	for _, arch := range arches {
+		for _, bin := range binaries {
+			n++
+
+			binPath := filepath.Join(dist, fmt.Sprintf("%s-%s-linux-%s", bin, binTag, arch))
+			if _, err := os.Stat(binPath); err != nil {
+				return fmt.Errorf("os stat: %w", err)
+			}
+
+			repo, err := repoFor(bin)
+			if err != nil {
+				return fmt.Errorf("repo for: %w", err)
+			}
+
+			ref := registry + "/" + repo + ":" + imageTag
+			out := filepath.Join(dist, fmt.Sprintf("%s-%s-linux-%s.tar", bin, binTag, arch))
+
+			args := []string{
+				"buildx", "--builder", builder, "build",
+				"--platform", "linux/" + arch,
+				"--build-arg", "BIN=" + bin,
+				"--build-arg", "TAG=" + binTag,
+				"-t", ref,
+			}
+
+			if bin == beaconChain {
+				args = append(args, "-t", registry+"/"+repo+":"+imageTag+"-portable")
+			}
+
+			args = append(args,
+				"--output", "type=docker,dest="+out,
+				"-f", dockerfile, ".",
+			)
+
+			fmt.Fprintf(os.Stderr, "[%d/%d] → docker/%s  %s  → %s\n", n, total, arch, bin, out)
+
+			// #nosec G204 -- build-time tooling: the image tag, registry and binary/arch names come from the Makefile environment.
+			cmd := exec.Command("docker", args...)
+			cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("docker buildx %s (linux/%s): %w%s", bin, arch, err, emulationHint(arch))
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "✅ docker: wrote %d image(s) -> %s/  (docker load -i <file>)\n", n, dist)
+	return nil
+}
+
+func ensureBuilder() error {
+	if exec.Command("docker", "buildx", "inspect", builder).Run() == nil {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "docker: creating buildx builder %q (docker-container driver)\n", builder)
+	cmd := exec.Command("docker", "buildx", "create", "--name", builder, "--driver", "docker-container")
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cmd run: %w", err)
+	}
+
+	return nil
+}
+
+func repoFor(bin string) (string, error) {
+	switch bin {
+	case beaconChain:
+		return beaconChain, nil
+	case validator:
+		return validator, nil
+	case prysmctl:
+		// This inconsistency is here to maintain the inconsistency we had in the past using Bazel.
+		return "cmd/" + prysmctl, nil
+	default:
+		return "", fmt.Errorf("no image repo defined for %q", bin)
+	}
+}
+
+func emulationHint(arch string) string {
+	if arch == runtime.GOARCH {
+		return ""
+	}
+
+	return fmt.Sprintf("\n\nbuilding linux/%s on a %s host runs the image's rootfs stage under "+
+		"emulation. If you see \"exec format error\", register QEMU once with:\n"+
+		"    docker run --privileged --rm tonistiigi/binfmt --install %s", arch, runtime.GOARCH, arch)
+}
+
+func gitDescribe() string {
+	out, err := exec.Command("git", "describe", "--tags", "--abbrev=0").Output()
+	if err != nil {
+		return "Unknown"
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+
+	return fallback
+}

--- a/tools/cross-toolchain/Dockerfile.builder
+++ b/tools/cross-toolchain/Dockerfile.builder
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
 #
 # Cross-toolchain builder image
+# -----------------------------
+#
+# This docker file builds a cross-toolchain builder image that can be used to build binaries for multiple architectures.
 
 FROM golang:1.26-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651 AS builder
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+#
+# Docker image build stage
+# ------------------------
+#
+# This Dockerfile builds a hermetic, reproducible and distroless Docker image for the Prysm client.
+
+ARG BASE=gcr.io/prysmaticlabs/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
+
+FROM debian:bullseye-slim AS rootfs
+ARG BIN
+ARG TARGETARCH
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY tools/docker/debian-pkgs.sh /usr/local/bin/debian-pkgs.sh
+RUN /usr/local/bin/debian-pkgs.sh "$TARGETARCH" /rootfs
+RUN set -eu; \
+    mkdir -p /rootfs/etc /rootfs/bin "/rootfs/app/cmd/$BIN"; \
+    printf 'root:x:0:0:root:/root:/bin/bash\nnonroot:x:1001:1001:nonroot:/home/nonroot:/bin/bash\n' > /rootfs/etc/passwd; \
+    ln -sf /bin/bash /rootfs/bin/sh; \
+    ln -sf "/$BIN" "/rootfs/app/cmd/$BIN/$BIN"; \
+    ln -sf "/$BIN" /rootfs/entrypoint
+
+FROM ${BASE}
+ARG BIN
+ARG TAG
+ARG TARGETARCH
+LABEL org.opencontainers.image.source="https://github.com/prysmaticlabs/prysm"
+COPY --from=rootfs /rootfs/ /
+COPY dist/${BIN}-${TAG}-linux-${TARGETARCH} /${BIN}
+ENTRYPOINT ["/entrypoint"]

--- a/tools/docker/Dockerfile.cross
+++ b/tools/docker/Dockerfile.cross
@@ -1,8 +1,10 @@
 # syntax=docker/dockerfile:1
 #
 # Cross-compile stage
-
-# Uses the latest prysm-cross-builder image to build the prysm binaries for all supported platforms.
+# -------------------
+#
+# This docker file hermetically and reproducibly cross builds all the prysm binaries for all supported platforms.
+# It uses the prysm-cross-builder image to build the binaries and then copies them to a scratch image for distribution.
 ARG BUILDER=prysm-cross-builder:latest
 
 FROM ${BUILDER} AS crossbuild

--- a/tools/docker/Dockerfile.dockerignore
+++ b/tools/docker/Dockerfile.dockerignore
@@ -1,4 +1,5 @@
-dist/
 bazel-*
 .git
 third_party/testdata/
+dist/*.tar
+dist/*.deb

--- a/tools/docker/debian-pkgs.sh
+++ b/tools/docker/debian-pkgs.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# debian-pkgs.sh <amd64|arm64> <rootfs-dir>
+#
+# Download, checksum-verify, and extract Debian-11 userland packages
+set -euo pipefail
+
+arch="${1:?usage: debian-pkgs.sh <amd64|arm64> <rootfs-dir>}"
+rootfs="${2:?usage: debian-pkgs.sh <amd64|arm64> <rootfs-dir>}"
+
+SNAP="https://snapshot.debian.org/archive/debian/20231214T085654Z/pool/main"
+MIRROR="https://prysmaticlabs.com/uploads"
+
+# Each entry: "<sha256>  <pool/sub/path/file.deb>" (mirror URL uses the basename).
+case "$arch" in
+  amd64) pkgs=(
+    "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377  b/bash/bash_5.1-2+deb11u1_amd64.deb"                   # /bin/bash: the image's only shell (/bin/sh -> /bin/bash)
+    "96ed58b8fd656521e08549c763cd18da6cff1b7801a3a22f29678701a95d7e7b  n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb"  # libtinfo.so.6: needed by bash
+    "3558a412ab51eee4b60641327cb145bb91415f127769823b68f9335585b308d4  c/coreutils/coreutils_8.32-4+b1_amd64.deb"             # ls, cp, mv, cat, mkdir, chown, ... (~100 tools)
+    "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897  libs/libselinux/libselinux1_3.1-3_amd64.deb"           # libselinux.so.1: needed by coreutils
+    "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064  p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb"        # libpcre2-8.so.0: needed by libselinux1
+    "af3c3562eb2802481a2b9558df1b389f3c6d9b1bf3b4219e000e05131372ebaf  a/attr/libattr1_2.4.48-6_amd64.deb"                    # libattr.so.1: needed by coreutils (cp, mv, install)
+    "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a  a/acl/libacl1_2.2.53-10_amd64.deb"                     # libacl.so.1: needed by coreutils (cp, mv, install)
+  ) ;;
+  arm64) pkgs=(
+    "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b  b/bash/bash_5.1-2+deb11u1_arm64.deb"                   # /bin/bash: the image's only shell (/bin/sh -> /bin/bash)
+    "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27  n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb"  # libtinfo.so.6: needed by bash
+    "6210c84d6ff84b867dc430f661f22f536e1704c27bdb79de38e26f75b853d9c0  c/coreutils/coreutils_8.32-4_arm64.deb"                # ls, cp, mv, cat, mkdir, chown, ... (~100 tools)
+    "da98279a47dabaa46a83514142f5c691c6a71fa7e582661a3a3db6887ad3e9d1  libs/libselinux/libselinux1_3.1-3_arm64.deb"           # libselinux.so.1: needed by coreutils
+    "27a4362a4793cb67a8ae571bd8c3f7e8654dc2e56d99088391b87af1793cca9c  p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb"        # libpcre2-8.so.0: needed by libselinux1
+    "cb9b59be719a6fdbaabaa60e22aa6158b2de7a68c88ccd7c3fb7f41a25fb43d0  a/attr/libattr1_2.4.48-6_arm64.deb"                    # libattr.so.1: needed by coreutils (cp, mv, install)
+    "f164c48192cb47746101de6c59afa3f97777c8fc821e5a30bb890df1f4cb4cfd  a/acl/libacl1_2.2.53-10_arm64.deb"                     # libacl.so.1: needed by coreutils (cp, mv, install)
+  ) ;;
+  *) echo "debian-pkgs: unsupported arch '$arch' (want amd64|arm64)" >&2; exit 1 ;;
+esac
+
+mkdir -p "$rootfs"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+for entry in "${pkgs[@]}"; do
+  sha="${entry%% *}"; path="${entry##* }"; file="$(basename "$path")"
+  out="$tmp/$file"; ok=0
+
+  for url in "$SNAP/$path" "$MIRROR/$file"; do
+    if curl -fsSL "$url" -o "$out" 2>/dev/null && echo "$sha  $out" | sha256sum -c - >/dev/null 2>&1; then
+      ok=1; break
+    fi
+  done
+  
+  if [ "$ok" -ne 1 ]; then echo "debian-pkgs: failed to fetch/verify $file" >&2; exit 1; fi
+  dpkg-deb -x "$out" "$rootfs"
+  echo "debian-pkgs: extracted $file" >&2
+done


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR implements **Phase 5: Implement hermetic release docker image build** of:
- https://github.com/OffchainLabs/prysm/issues/16982

The new `make help` is now:
```
Prysm - Ethereum consensus client

Commands:
  make run <bin> [flags=...] [-- <args>]       Run a binary
  make build [<bin>...] [flags=...]            Build a binary (default: all)
  make gen [<kind>...] [mode=force|no-force]   Create generated code (default: all,no-force)
  make test [<kind>...] [mode=no-race|race]    Run unit tests (default: all,no-race)
  make e2e [<scenario>|<suite>...]             Run end-to-end tests (default: presubmit)
  make dist [<bin>...] [platform=...]          Build official release binaries (docker/<arch> also packages an OCI image)
  make testdata                                Pre-fetch external spec-test data
  make clean                                   Clean everything
  make help                                    Show this help

Options:
  <bin>:           beacon-chain client-stats prysmctl validator
  gen <kind>:      proto ssz mocks
  test <kind>:     mainnet mainnet-spectest minimal minimal-spectest
  e2e <scenario>:  minimal builder web3signer slasher slashing scenario scenario-multiclient postmerge statediff mainnet multiclient
  e2e <suite>:
    presubmit:       minimal statediff slashing slasher
    postsubmit:      builder postmerge mainnet multiclient
    scenario_tests:  scenario scenario-multiclient
  dist <bin>:      beacon-chain validator client-stats prysmctl
  dist platform:   linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 docker/amd64 docker/arm64

Notes:
  After '--', pass '--flag value' (not '--flag=value')
  'make dist SOURCE_DATE_EPOCH=<unix-seconds>' pins the build timestamp (reproducible build)
```

With the important line being:
```
  dist platform:   linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 docker/amd64 docker/arm64
```

`docker/arm64` and `docker/amd64` Docker images can be built using:
```
make dist platform=docker/amd64,docker/arm64
```

Using
```
make dist
```

without any parameters builds all binaries as previously + the Docker images.

Docker images are written in the `dist` directory, as following:
```
beacon-chain-v7.1.8-linux-amd64.tar beacon-chain-v7.1.8-linux-arm64.tar prysmctl-v7.1.8-linux-amd64.tar     prysmctl-v7.1.8-linux-arm64.tar     validator-v7.1.8-linux-amd64.tar    validator-v7.1.8-linux-arm64.tar
```

To load the docker images in the local registry, use the `docker load` command.
Example:
```
docker load -i dist/beacon-chain-v7.1.8-linux-arm64.tar
422a511108d9: Loading layer [==================================================>]  10.32MB/10.32MB
db88fd86fa06: Loading layer [==================================================>]  24.89MB/24.89MB
Loaded image: gcr.io/offchainlabs/prysm/beacon-chain:v7.1.8
Loaded image: gcr.io/offchainlabs/prysm/beacon-chain:v7.1.8-portable
```

And then:
```
docker run gcr.io/offchainlabs/prysm/beacon-chain:v7.1.8
```

To test the reproducibility of the builds you can pin `SOURCE_DATE_EPOCH`, build 2 times and run the `diff` command against the 2 generated `dist` directories. They should contain no difference.
Example
```
SOURCE_DATE_EPOCH=1781515081 make dist platform=docker/amd64,docker/arm64
```

Finally, to build a "convenience" docker image (not suitable for releases, but fast to build), you can use:

```
docker build [--build-arg BIN=beacon-chain|validator|prysmctl] -t <name>
```

Default BIN is `beacon-chain`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
