### PR TITLE
add progressive state schema

### DIFF
--- a/beacon-chain/state/state-native/BUILD.bazel
+++ b/beacon-chain/state/state-native/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "beacon_state.go",
         "doc.go",
         "error.go",
+        "fields.go",
         "getters_attestation.go",
         "getters_block.go",
         "getters_checkpoint.go",
@@ -97,6 +98,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "fields_test.go",
         "getters_attestation_test.go",
         "getters_block_test.go",
         "getters_checkpoint_test.go",

--- a/beacon-chain/state/state-native/fields.go
+++ b/beacon-chain/state/state-native/fields.go
@@ -215,15 +215,15 @@ func newProgressiveStateFieldsSchema(allFields []types.FieldIndex, inactiveField
 	return schema, nil
 }
 
-func (schema *ProgressiveStateSchema) GetFieldIndex(field types.FieldIndex) (int, bool) {
-	index, ok := schema.fieldIndex[field]
+func (s *ProgressiveStateSchema) GetFieldIndex(field types.FieldIndex) (int, bool) {
+	index, ok := s.fieldIndex[field]
 	return index, ok
 }
 
-func (schema *ProgressiveStateSchema) ActiveFields() []bool {
-	return schema.activeFields
+func (s *ProgressiveStateSchema) ActiveFields() []bool {
+	return s.activeFields
 }
 
-func (schema *ProgressiveStateSchema) Fields() []types.FieldIndex {
-	return schema.fields
+func (s *ProgressiveStateSchema) Fields() []types.FieldIndex {
+	return s.fields
 }

--- a/beacon-chain/state/state-native/fields.go
+++ b/beacon-chain/state/state-native/fields.go
@@ -115,7 +115,7 @@ var (
 		types.PTCWindow,
 	}
 
-	gloasProgressiveSchema *progressiveStateSchema
+	gloasProgressiveSchema *ProgressiveStateSchema
 	gloasFields            []types.FieldIndex
 )
 
@@ -139,7 +139,7 @@ func init() {
 	gloasFields = gloasProgressiveSchema.fields
 }
 
-func progressiveStateSchemaForVersion(v int) (*progressiveStateSchema, bool) {
+func ProgressiveStateSchemaForVersion(v int) (*ProgressiveStateSchema, bool) {
 	switch v {
 	case version.Gloas:
 		return gloasProgressiveSchema, true
@@ -148,7 +148,7 @@ func progressiveStateSchemaForVersion(v int) (*progressiveStateSchema, bool) {
 	}
 }
 
-type progressiveStateSchema struct {
+type ProgressiveStateSchema struct {
 	// activeFields uses stable, append-only field positions and retains false
 	// entries for fields removed in later forks.
 	activeFields []bool
@@ -158,7 +158,7 @@ type progressiveStateSchema struct {
 	fieldIndex map[types.FieldIndex]int
 }
 
-func newProgressiveStateFieldsSchema(allFields []types.FieldIndex, inactiveFields []types.FieldIndex, forkFieldCount int) (*progressiveStateSchema, error) {
+func newProgressiveStateFieldsSchema(allFields []types.FieldIndex, inactiveFields []types.FieldIndex, forkFieldCount int) (*ProgressiveStateSchema, error) {
 	if len(allFields) == 0 {
 		return nil, fmt.Errorf("progressive state schema requires at least one field")
 	}
@@ -206,7 +206,7 @@ func newProgressiveStateFieldsSchema(allFields []types.FieldIndex, inactiveField
 		return nil, fmt.Errorf("fields count does not match expected count: got %d, expected %d", len(fields), forkFieldCount)
 	}
 
-	schema := &progressiveStateSchema{
+	schema := &ProgressiveStateSchema{
 		activeFields: activeFields,
 		fields:       fields,
 		fieldIndex:   fieldIndex,
@@ -215,7 +215,15 @@ func newProgressiveStateFieldsSchema(allFields []types.FieldIndex, inactiveField
 	return schema, nil
 }
 
-func (schema *progressiveStateSchema) getFieldIndex(field types.FieldIndex) (int, bool) {
+func (schema *ProgressiveStateSchema) GetFieldIndex(field types.FieldIndex) (int, bool) {
 	index, ok := schema.fieldIndex[field]
 	return index, ok
+}
+
+func (schema *ProgressiveStateSchema) ActiveFields() []bool {
+	return schema.activeFields
+}
+
+func (schema *ProgressiveStateSchema) Fields() []types.FieldIndex {
+	return schema.fields
 }

--- a/beacon-chain/state/state-native/fields.go
+++ b/beacon-chain/state/state-native/fields.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 )
-
-const maxProgressiveStateFields = 256
 
 var (
 	phase0Fields = []types.FieldIndex{
@@ -163,8 +162,8 @@ func newProgressiveStateFieldsSchema(allFields []types.FieldIndex, inactiveField
 	if len(allFields) == 0 {
 		return nil, fmt.Errorf("progressive state schema requires at least one field")
 	}
-	if len(allFields) > maxProgressiveStateFields {
-		return nil, fmt.Errorf("progressive state schema has %d fields, maximum is %d", len(allFields), maxProgressiveStateFields)
+	if len(allFields) > ssz.MaxProgressiveActiveFields {
+		return nil, fmt.Errorf("progressive state schema has %d fields, maximum is %d", len(allFields), ssz.MaxProgressiveActiveFields)
 	}
 
 	knownFields := make(map[types.FieldIndex]struct{}, len(allFields))

--- a/beacon-chain/state/state-native/fields.go
+++ b/beacon-chain/state/state-native/fields.go
@@ -1,0 +1,222 @@
+package state_native
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
+)
+
+const maxProgressiveStateFields = 256
+
+var (
+	phase0Fields = []types.FieldIndex{
+		types.GenesisTime,
+		types.GenesisValidatorsRoot,
+		types.Slot,
+		types.Fork,
+		types.LatestBlockHeader,
+		types.BlockRoots,
+		types.StateRoots,
+		types.HistoricalRoots,
+		types.Eth1Data,
+		types.Eth1DataVotes,
+		types.Eth1DepositIndex,
+		types.Validators,
+		types.Balances,
+		types.RandaoMixes,
+		types.Slashings,
+		types.PreviousEpochAttestations,
+		types.CurrentEpochAttestations,
+		types.JustificationBits,
+		types.PreviousJustifiedCheckpoint,
+		types.CurrentJustifiedCheckpoint,
+		types.FinalizedCheckpoint,
+	}
+
+	altairFields = []types.FieldIndex{
+		types.GenesisTime,
+		types.GenesisValidatorsRoot,
+		types.Slot,
+		types.Fork,
+		types.LatestBlockHeader,
+		types.BlockRoots,
+		types.StateRoots,
+		types.HistoricalRoots,
+		types.Eth1Data,
+		types.Eth1DataVotes,
+		types.Eth1DepositIndex,
+		types.Validators,
+		types.Balances,
+		types.RandaoMixes,
+		types.Slashings,
+		types.PreviousEpochParticipationBits,
+		types.CurrentEpochParticipationBits,
+		types.JustificationBits,
+		types.PreviousJustifiedCheckpoint,
+		types.CurrentJustifiedCheckpoint,
+		types.FinalizedCheckpoint,
+		types.InactivityScores,
+		types.CurrentSyncCommittee,
+		types.NextSyncCommittee,
+	}
+
+	bellatrixFields = append(altairFields, types.LatestExecutionPayloadHeader)
+
+	withdrawalAndHistoricalSummaryFields = []types.FieldIndex{
+		types.NextWithdrawalIndex,
+		types.NextWithdrawalValidatorIndex,
+		types.HistoricalSummaries,
+	}
+
+	capellaFields = slices.Concat(
+		altairFields,
+		[]types.FieldIndex{types.LatestExecutionPayloadHeaderCapella},
+		withdrawalAndHistoricalSummaryFields,
+	)
+
+	denebFields = slices.Concat(
+		altairFields,
+		[]types.FieldIndex{types.LatestExecutionPayloadHeaderDeneb},
+		withdrawalAndHistoricalSummaryFields,
+	)
+
+	electraAdditionalFields = []types.FieldIndex{
+		types.DepositRequestsStartIndex,
+		types.DepositBalanceToConsume,
+		types.ExitBalanceToConsume,
+		types.EarliestExitEpoch,
+		types.ConsolidationBalanceToConsume,
+		types.EarliestConsolidationEpoch,
+		types.PendingDeposits,
+		types.PendingPartialWithdrawals,
+		types.PendingConsolidations,
+	}
+
+	electraFields = slices.Concat(
+		denebFields,
+		electraAdditionalFields,
+	)
+
+	fuluFields = append(
+		electraFields,
+		types.ProposerLookahead,
+	)
+
+	gloasAdditionalFields = []types.FieldIndex{
+		types.Builders,
+		types.NextWithdrawalBuilderIndex,
+		types.ExecutionPayloadAvailability,
+		types.BuilderPendingPayments,
+		types.BuilderPendingWithdrawals,
+		types.LatestExecutionPayloadBid,
+		types.PayloadExpectedWithdrawals,
+		types.PTCWindow,
+	}
+
+	gloasProgressiveSchema *progressiveStateSchema
+	gloasFields            []types.FieldIndex
+)
+
+func init() {
+	var err error
+	gloasProgressiveSchema, err = newProgressiveStateFieldsSchema(
+		slices.Concat(
+			altairFields,
+			[]types.FieldIndex{types.LatestBlockHash},
+			withdrawalAndHistoricalSummaryFields,
+			electraAdditionalFields,
+			[]types.FieldIndex{types.ProposerLookahead},
+			gloasAdditionalFields,
+		),
+		nil,
+		params.BeaconConfig().BeaconStateGloasFieldCount,
+	)
+	if err != nil {
+		panic(err)
+	}
+	gloasFields = gloasProgressiveSchema.fields
+}
+
+func progressiveStateSchemaForVersion(v int) (*progressiveStateSchema, bool) {
+	switch v {
+	case version.Gloas:
+		return gloasProgressiveSchema, true
+	default:
+		return nil, false
+	}
+}
+
+type progressiveStateSchema struct {
+	// activeFields uses stable, append-only field positions and retains false
+	// entries for fields removed in later forks.
+	activeFields []bool
+	// fields and fieldIndex describe the dense, active field roots used by the
+	// progressive Merkle tree for this fork.
+	fields     []types.FieldIndex
+	fieldIndex map[types.FieldIndex]int
+}
+
+func newProgressiveStateFieldsSchema(allFields []types.FieldIndex, inactiveFields []types.FieldIndex, forkFieldCount int) (*progressiveStateSchema, error) {
+	if len(allFields) == 0 {
+		return nil, fmt.Errorf("progressive state schema requires at least one field")
+	}
+	if len(allFields) > maxProgressiveStateFields {
+		return nil, fmt.Errorf("progressive state schema has %d fields, maximum is %d", len(allFields), maxProgressiveStateFields)
+	}
+
+	knownFields := make(map[types.FieldIndex]struct{}, len(allFields))
+	for _, field := range allFields {
+		if _, exists := knownFields[field]; exists {
+			return nil, fmt.Errorf("progressive state schema contains duplicate field %s", field.String())
+		}
+		knownFields[field] = struct{}{}
+	}
+
+	inactive := make(map[types.FieldIndex]struct{}, len(inactiveFields))
+	for _, field := range inactiveFields {
+		if _, exists := knownFields[field]; !exists {
+			return nil, fmt.Errorf("inactive field %s is not present in progressive state schema", field.String())
+		}
+		if _, exists := inactive[field]; exists {
+			return nil, fmt.Errorf("progressive state schema contains duplicate inactive field %s", field.String())
+		}
+		inactive[field] = struct{}{}
+	}
+
+	fields := make([]types.FieldIndex, 0, len(allFields)-len(inactiveFields))
+	fieldIndex := make(map[types.FieldIndex]int, len(allFields)-len(inactiveFields))
+	activeFields := make([]bool, 0, len(allFields))
+
+	for _, field := range allFields {
+		if _, isInactive := inactive[field]; isInactive {
+			activeFields = append(activeFields, false)
+			continue
+		}
+		fields = append(fields, field)
+		fieldIndex[field] = len(fields) - 1
+		activeFields = append(activeFields, true)
+	}
+
+	if !activeFields[len(activeFields)-1] {
+		return nil, fmt.Errorf("progressive state schema active fields must not end with an inactive field")
+	}
+	if len(fields) != forkFieldCount {
+		return nil, fmt.Errorf("fields count does not match expected count: got %d, expected %d", len(fields), forkFieldCount)
+	}
+
+	schema := &progressiveStateSchema{
+		activeFields: activeFields,
+		fields:       fields,
+		fieldIndex:   fieldIndex,
+	}
+
+	return schema, nil
+}
+
+func (schema *progressiveStateSchema) getFieldIndex(field types.FieldIndex) (int, bool) {
+	index, ok := schema.fieldIndex[field]
+	return index, ok
+}

--- a/beacon-chain/state/state-native/fields_test.go
+++ b/beacon-chain/state/state-native/fields_test.go
@@ -1,0 +1,175 @@
+package state_native
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func TestGloasProgressiveStateSchema(t *testing.T) {
+	schema, ok := progressiveStateSchemaForVersion(version.Gloas)
+	require.Equal(t, true, ok)
+	require.Equal(t, params.BeaconConfig().BeaconStateGloasFieldCount, len(schema.fields))
+	require.Equal(t, len(schema.fields), len(schema.activeFields))
+	require.Equal(t, len(schema.fields), len(schema.fieldIndex))
+	require.DeepEqual(t, gloasFields, schema.fields)
+
+	for i, field := range schema.fields {
+		require.Equal(t, true, schema.activeFields[i], "field %s should be active", field.String())
+		require.Equal(t, i, field.RealPosition(), "unexpected Gloas position for field %s", field.String())
+
+		index, found := schema.getFieldIndex(field)
+		require.Equal(t, true, found, "field %s should have an index", field.String())
+		require.Equal(t, i, index, "unexpected index for field %s", field.String())
+	}
+}
+
+func TestNewProgressiveStateFieldsSchema(t *testing.T) {
+	t.Run("MaximumFields", func(t *testing.T) {
+		allFields := make([]types.FieldIndex, maxProgressiveStateFields)
+		for i := range allFields {
+			allFields[i] = types.FieldIndex(i)
+		}
+
+		schema, err := newProgressiveStateFieldsSchema(allFields, nil, len(allFields))
+		require.NoError(t, err)
+		require.Equal(t, maxProgressiveStateFields, len(schema.activeFields))
+		require.Equal(t, maxProgressiveStateFields, len(schema.fields))
+		require.Equal(t, maxProgressiveStateFields, len(schema.fieldIndex))
+		for i, active := range schema.activeFields {
+			require.Equal(t, true, active, "field position %d should be active", i)
+		}
+	})
+
+	t.Run("InactiveFields", func(t *testing.T) {
+		allFields := []types.FieldIndex{
+			types.GenesisTime,
+			types.Slot,
+			types.Validators,
+			types.Balances,
+			types.PTCWindow,
+		}
+		inactiveFields := []types.FieldIndex{
+			types.Slot,
+			types.Validators,
+		}
+
+		schema, err := newProgressiveStateFieldsSchema(allFields, inactiveFields, 3)
+		require.NoError(t, err)
+		require.DeepEqual(t, []bool{true, false, false, true, true}, schema.activeFields)
+		require.DeepEqual(t, []types.FieldIndex{
+			types.GenesisTime,
+			types.Balances,
+			types.PTCWindow,
+		}, schema.fields)
+		require.Equal(t, 3, len(schema.fieldIndex))
+
+		tests := []struct {
+			field types.FieldIndex
+			index int
+			found bool
+		}{
+			{field: types.GenesisTime, index: 0, found: true},
+			{field: types.Slot, index: 0, found: false},
+			{field: types.Validators, index: 0, found: false},
+			{field: types.Balances, index: 1, found: true},
+			{field: types.PTCWindow, index: 2, found: true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.field.String(), func(t *testing.T) {
+				index, found := schema.getFieldIndex(tt.field)
+				require.Equal(t, tt.found, found)
+				require.Equal(t, tt.index, index)
+			})
+		}
+	})
+
+	t.Run("CopiesInputs", func(t *testing.T) {
+		allFields := []types.FieldIndex{types.GenesisTime, types.Slot, types.Balances}
+		inactiveFields := []types.FieldIndex{types.Slot}
+
+		schema, err := newProgressiveStateFieldsSchema(allFields, inactiveFields, 2)
+		require.NoError(t, err)
+
+		allFields[0] = types.Fork
+		inactiveFields[0] = types.Balances
+
+		require.DeepEqual(t, []bool{true, false, true}, schema.activeFields)
+		require.DeepEqual(t, []types.FieldIndex{types.GenesisTime, types.Balances}, schema.fields)
+		index, found := schema.getFieldIndex(types.GenesisTime)
+		require.Equal(t, true, found)
+		require.Equal(t, 0, index)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		tooManyFields := make([]types.FieldIndex, maxProgressiveStateFields+1)
+
+		tests := []struct {
+			name           string
+			allFields      []types.FieldIndex
+			inactiveFields []types.FieldIndex
+			forkFieldCount int
+			want           string
+		}{
+			{
+				name: "NoFields",
+				want: "requires at least one field",
+			},
+			{
+				name:           "TooManyFields",
+				allFields:      tooManyFields,
+				forkFieldCount: len(tooManyFields),
+				want:           "maximum is 256",
+			},
+			{
+				name:           "DuplicateField",
+				allFields:      []types.FieldIndex{types.GenesisTime, types.Slot, types.Slot},
+				forkFieldCount: 3,
+				want:           "duplicate field slot",
+			},
+			{
+				name:           "UnknownInactiveField",
+				allFields:      []types.FieldIndex{types.GenesisTime, types.Slot},
+				inactiveFields: []types.FieldIndex{types.Validators},
+				forkFieldCount: 2,
+				want:           "inactive field validators is not present",
+			},
+			{
+				name:           "DuplicateInactiveField",
+				allFields:      []types.FieldIndex{types.GenesisTime, types.Slot, types.Balances},
+				inactiveFields: []types.FieldIndex{types.Slot, types.Slot},
+				forkFieldCount: 2,
+				want:           "duplicate inactive field slot",
+			},
+			{
+				name:           "TrailingInactiveField",
+				allFields:      []types.FieldIndex{types.GenesisTime, types.Slot},
+				inactiveFields: []types.FieldIndex{types.Slot},
+				forkFieldCount: 1,
+				want:           "must not end with an inactive field",
+			},
+			{
+				name:           "FieldCountMismatch",
+				allFields:      []types.FieldIndex{types.GenesisTime, types.Slot},
+				forkFieldCount: 1,
+				want:           "fields count does not match expected count: got 2, expected 1",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				schema, err := newProgressiveStateFieldsSchema(tt.allFields, tt.inactiveFields, tt.forkFieldCount)
+				require.IsNil(t, schema)
+				require.ErrorContains(t, tt.want, err)
+			})
+		}
+	})
+}
+
+func TestProgressiveStateSchemaForVersion_Unsupported(t *testing.T) {
+	schema, ok := progressiveStateSchemaForVersion(version.Gloas + 1)
+	require.Equal(t, false, ok)
+	require.IsNil(t, schema)
+}

--- a/beacon-chain/state/state-native/fields_test.go
+++ b/beacon-chain/state/state-native/fields_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
@@ -29,16 +30,16 @@ func TestGloasProgressiveStateSchema(t *testing.T) {
 
 func TestNewProgressiveStateFieldsSchema(t *testing.T) {
 	t.Run("MaximumFields", func(t *testing.T) {
-		allFields := make([]types.FieldIndex, maxProgressiveStateFields)
+		allFields := make([]types.FieldIndex, ssz.MaxProgressiveActiveFields)
 		for i := range allFields {
 			allFields[i] = types.FieldIndex(i)
 		}
 
 		schema, err := newProgressiveStateFieldsSchema(allFields, nil, len(allFields))
 		require.NoError(t, err)
-		require.Equal(t, maxProgressiveStateFields, len(schema.activeFields))
-		require.Equal(t, maxProgressiveStateFields, len(schema.fields))
-		require.Equal(t, maxProgressiveStateFields, len(schema.fieldIndex))
+		require.Equal(t, ssz.MaxProgressiveActiveFields, len(schema.activeFields))
+		require.Equal(t, ssz.MaxProgressiveActiveFields, len(schema.fields))
+		require.Equal(t, ssz.MaxProgressiveActiveFields, len(schema.fieldIndex))
 		for i, active := range schema.activeFields {
 			require.Equal(t, true, active, "field position %d should be active", i)
 		}
@@ -105,7 +106,7 @@ func TestNewProgressiveStateFieldsSchema(t *testing.T) {
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
-		tooManyFields := make([]types.FieldIndex, maxProgressiveStateFields+1)
+		tooManyFields := make([]types.FieldIndex, ssz.MaxProgressiveActiveFields+1)
 
 		tests := []struct {
 			name           string

--- a/beacon-chain/state/state-native/fields_test.go
+++ b/beacon-chain/state/state-native/fields_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGloasProgressiveStateSchema(t *testing.T) {
-	schema, ok := progressiveStateSchemaForVersion(version.Gloas)
+	schema, ok := ProgressiveStateSchemaForVersion(version.Gloas)
 	require.Equal(t, true, ok)
 	require.Equal(t, params.BeaconConfig().BeaconStateGloasFieldCount, len(schema.fields))
 	require.Equal(t, len(schema.fields), len(schema.activeFields))
@@ -22,7 +22,7 @@ func TestGloasProgressiveStateSchema(t *testing.T) {
 		require.Equal(t, true, schema.activeFields[i], "field %s should be active", field.String())
 		require.Equal(t, i, field.RealPosition(), "unexpected Gloas position for field %s", field.String())
 
-		index, found := schema.getFieldIndex(field)
+		index, found := schema.GetFieldIndex(field)
 		require.Equal(t, true, found, "field %s should have an index", field.String())
 		require.Equal(t, i, index, "unexpected index for field %s", field.String())
 	}
@@ -81,7 +81,7 @@ func TestNewProgressiveStateFieldsSchema(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.field.String(), func(t *testing.T) {
-				index, found := schema.getFieldIndex(tt.field)
+				index, found := schema.GetFieldIndex(tt.field)
 				require.Equal(t, tt.found, found)
 				require.Equal(t, tt.index, index)
 			})
@@ -100,7 +100,7 @@ func TestNewProgressiveStateFieldsSchema(t *testing.T) {
 
 		require.DeepEqual(t, []bool{true, false, true}, schema.activeFields)
 		require.DeepEqual(t, []types.FieldIndex{types.GenesisTime, types.Balances}, schema.fields)
-		index, found := schema.getFieldIndex(types.GenesisTime)
+		index, found := schema.GetFieldIndex(types.GenesisTime)
 		require.Equal(t, true, found)
 		require.Equal(t, 0, index)
 	})
@@ -170,7 +170,7 @@ func TestNewProgressiveStateFieldsSchema(t *testing.T) {
 }
 
 func TestProgressiveStateSchemaForVersion_Unsupported(t *testing.T) {
-	schema, ok := progressiveStateSchemaForVersion(version.Gloas + 1)
+	schema, ok := ProgressiveStateSchemaForVersion(version.Gloas + 1)
 	require.Equal(t, false, ok)
 	require.IsNil(t, schema)
 }

--- a/beacon-chain/state/state-native/progressive_ssz_test.go
+++ b/beacon-chain/state/state-native/progressive_ssz_test.go
@@ -110,7 +110,7 @@ func TestHashTreeRoot(t *testing.T) {
 		require.ErrorContains(t, "unsupported version: fulu", err)
 
 		_, err = st.progressiveHashTreeRoot(t.Context())
-		require.ErrorContains(t, "progressive SSZ is not supported for version: fulu", err)
+		require.ErrorContains(t, "unsupported version: fulu", err)
 	})
 
 	t.Run("ProgressiveSSZGate", func(t *testing.T) {

--- a/beacon-chain/state/state-native/progressive_ssz_test.go
+++ b/beacon-chain/state/state-native/progressive_ssz_test.go
@@ -110,7 +110,7 @@ func TestHashTreeRoot(t *testing.T) {
 		require.ErrorContains(t, "unsupported version: fulu", err)
 
 		_, err = st.progressiveHashTreeRoot(t.Context())
-		require.ErrorContains(t, "unsupported version: fulu", err)
+		require.ErrorContains(t, "unsupported version for progressive HTR: fulu", err)
 	})
 
 	t.Run("ProgressiveSSZGate", func(t *testing.T) {

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"math/bits"
 	"runtime"
-	"slices"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/fieldtrie"
@@ -26,121 +25,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
-)
-
-var (
-	phase0Fields = []types.FieldIndex{
-		types.GenesisTime,
-		types.GenesisValidatorsRoot,
-		types.Slot,
-		types.Fork,
-		types.LatestBlockHeader,
-		types.BlockRoots,
-		types.StateRoots,
-		types.HistoricalRoots,
-		types.Eth1Data,
-		types.Eth1DataVotes,
-		types.Eth1DepositIndex,
-		types.Validators,
-		types.Balances,
-		types.RandaoMixes,
-		types.Slashings,
-		types.PreviousEpochAttestations,
-		types.CurrentEpochAttestations,
-		types.JustificationBits,
-		types.PreviousJustifiedCheckpoint,
-		types.CurrentJustifiedCheckpoint,
-		types.FinalizedCheckpoint,
-	}
-
-	altairFields = []types.FieldIndex{
-		types.GenesisTime,
-		types.GenesisValidatorsRoot,
-		types.Slot,
-		types.Fork,
-		types.LatestBlockHeader,
-		types.BlockRoots,
-		types.StateRoots,
-		types.HistoricalRoots,
-		types.Eth1Data,
-		types.Eth1DataVotes,
-		types.Eth1DepositIndex,
-		types.Validators,
-		types.Balances,
-		types.RandaoMixes,
-		types.Slashings,
-		types.PreviousEpochParticipationBits,
-		types.CurrentEpochParticipationBits,
-		types.JustificationBits,
-		types.PreviousJustifiedCheckpoint,
-		types.CurrentJustifiedCheckpoint,
-		types.FinalizedCheckpoint,
-		types.InactivityScores,
-		types.CurrentSyncCommittee,
-		types.NextSyncCommittee,
-	}
-
-	bellatrixFields = append(altairFields, types.LatestExecutionPayloadHeader)
-
-	withdrawalAndHistoricalSummaryFields = []types.FieldIndex{
-		types.NextWithdrawalIndex,
-		types.NextWithdrawalValidatorIndex,
-		types.HistoricalSummaries,
-	}
-
-	capellaFields = slices.Concat(
-		altairFields,
-		[]types.FieldIndex{types.LatestExecutionPayloadHeaderCapella},
-		withdrawalAndHistoricalSummaryFields,
-	)
-
-	denebFields = slices.Concat(
-		altairFields,
-		[]types.FieldIndex{types.LatestExecutionPayloadHeaderDeneb},
-		withdrawalAndHistoricalSummaryFields,
-	)
-
-	electraAdditionalFields = []types.FieldIndex{
-		types.DepositRequestsStartIndex,
-		types.DepositBalanceToConsume,
-		types.ExitBalanceToConsume,
-		types.EarliestExitEpoch,
-		types.ConsolidationBalanceToConsume,
-		types.EarliestConsolidationEpoch,
-		types.PendingDeposits,
-		types.PendingPartialWithdrawals,
-		types.PendingConsolidations,
-	}
-
-	electraFields = slices.Concat(
-		denebFields,
-		electraAdditionalFields,
-	)
-
-	fuluFields = append(
-		electraFields,
-		types.ProposerLookahead,
-	)
-
-	gloasAdditionalFields = []types.FieldIndex{
-		types.Builders,
-		types.NextWithdrawalBuilderIndex,
-		types.ExecutionPayloadAvailability,
-		types.BuilderPendingPayments,
-		types.BuilderPendingWithdrawals,
-		types.LatestExecutionPayloadBid,
-		types.PayloadExpectedWithdrawals,
-		types.PTCWindow,
-	}
-
-	gloasFields = slices.Concat(
-		altairFields,
-		[]types.FieldIndex{types.LatestBlockHash},
-		withdrawalAndHistoricalSummaryFields,
-		electraAdditionalFields,
-		[]types.FieldIndex{types.ProposerLookahead},
-		gloasAdditionalFields,
-	)
 )
 
 // promotionThresholdByField defines absolute overlay promotion thresholds
@@ -1115,8 +999,9 @@ func (b *BeaconState) HashTreeRoot(ctx context.Context) ([32]byte, error) {
 }
 
 func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, error) {
-	if b.version < version.Gloas {
-		return [32]byte{}, fmt.Errorf("progressive SSZ is not supported for version: %s", version.String(b.version))
+	schema, ok := progressiveStateSchemaForVersion(b.version)
+	if !ok {
+		return [32]byte{}, fmt.Errorf("progressiveHashTreeRoot: unsupported version: %s", version.String(b.version))
 	}
 
 	if err := b.initializeProgressiveMerkleTree(ctx); err != nil {
@@ -1126,18 +1011,7 @@ func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, er
 		return [32]byte{}, err
 	}
 
-	var activeFields []bool
-	switch b.version {
-	case version.Gloas:
-		activeFields = make([]bool, params.BeaconConfig().BeaconStateGloasFieldCount)
-		for i := range activeFields {
-			activeFields[i] = true
-		}
-	default:
-		return [32]byte{}, fmt.Errorf("unsupported version: %s", version.String(b.version))
-	}
-
-	root, err := ssz.MixInActiveFields(b.progressiveMerkleTree.Root(), activeFields)
+	root, err := ssz.MixInActiveFields(b.progressiveMerkleTree.Root(), schema.activeFields)
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("could not mix in progressive container active fields: %w", err)
 	}
@@ -1150,23 +1024,22 @@ func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, er
 //
 // WARNING: Caller must acquire the mutex before using.
 func (b *BeaconState) initializeProgressiveMerkleTree(ctx context.Context) error {
+	schema, ok := progressiveStateSchemaForVersion(b.version)
+	if !ok {
+		return fmt.Errorf("initializeProgressiveMerkleTree: unsupported version: %s", version.String(b.version))
+	}
+
 	if b.progressiveMerkleTree != nil {
 		return nil
 	}
 
-	var fieldRoots [][]byte
-	switch b.version {
-	case version.Gloas:
-		fieldRoots = make([][]byte, params.BeaconConfig().BeaconStateGloasFieldCount)
-		for _, field := range gloasFields {
-			root, err := b.rootSelector(ctx, field)
-			if err != nil {
-				return fmt.Errorf("could not compute progressive field %s: %w", field.String(), err)
-			}
-			fieldRoots[field.RealPosition()] = bytesutil.SafeCopyBytes(root[:])
+	fieldRoots := make([][]byte, len(schema.fields))
+	for fieldIndex, field := range schema.fields {
+		root, err := b.rootSelector(ctx, field)
+		if err != nil {
+			return fmt.Errorf("could not compute progressive field %s: %w", field.String(), err)
 		}
-	default:
-		return fmt.Errorf("unsupported version: %s", version.String(b.version))
+		fieldRoots[fieldIndex] = bytesutil.SafeCopyBytes(root[:])
 	}
 
 	b.progressiveMerkleTree = stateutil.MerkleizeProgressive(fieldRoots)
@@ -1179,12 +1052,21 @@ func (b *BeaconState) initializeProgressiveMerkleTree(ctx context.Context) error
 //
 // WARNING: Caller must acquire the mutex before using.
 func (b *BeaconState) recomputeProgressiveDirtyFields(ctx context.Context) error {
+	schema, ok := progressiveStateSchemaForVersion(b.version)
+	if !ok {
+		return fmt.Errorf("recomputeProgressiveDirtyFields: unsupported version: %s", version.String(b.version))
+	}
+
 	for field := range b.dirtyFields {
 		root, err := b.rootSelector(ctx, field)
 		if err != nil {
 			return err
 		}
-		if err := b.progressiveMerkleTree.RecomputeRoot(field.RealPosition(), root); err != nil {
+		fieldIndex, ok := schema.getFieldIndex(field)
+		if !ok {
+			return fmt.Errorf("could not find field index for progressive field %s in %s", field.String(), version.String(b.version))
+		}
+		if err := b.progressiveMerkleTree.RecomputeRoot(fieldIndex, root); err != nil {
 			return fmt.Errorf("could not recompute progressive field %s: %w", field.String(), err)
 		}
 		delete(b.dirtyFields, field)

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -1001,14 +1001,14 @@ func (b *BeaconState) HashTreeRoot(ctx context.Context) ([32]byte, error) {
 func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, error) {
 	schema, ok := ProgressiveStateSchemaForVersion(b.version)
 	if !ok {
-		return [32]byte{}, fmt.Errorf("progressiveHashTreeRoot: unsupported version: %s", version.String(b.version))
+		return [32]byte{}, fmt.Errorf("unsupported version for progressive HTR: %s", version.String(b.version))
 	}
 
 	if err := b.initializeProgressiveMerkleTree(ctx); err != nil {
-		return [32]byte{}, err
+		return [32]byte{}, fmt.Errorf("initializeProgressiveMerkleTree: %w", err)
 	}
 	if err := b.recomputeProgressiveDirtyFields(ctx); err != nil {
-		return [32]byte{}, err
+		return [32]byte{}, fmt.Errorf("recomputeProgressiveDirtyFields: %w", err)
 	}
 
 	root, err := ssz.MixInActiveFields(b.progressiveMerkleTree.Root(), schema.ActiveFields())
@@ -1026,7 +1026,7 @@ func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, er
 func (b *BeaconState) initializeProgressiveMerkleTree(ctx context.Context) error {
 	schema, ok := ProgressiveStateSchemaForVersion(b.version)
 	if !ok {
-		return fmt.Errorf("initializeProgressiveMerkleTree: unsupported version: %s", version.String(b.version))
+		return fmt.Errorf("unsupported version: %s", version.String(b.version))
 	}
 
 	if b.progressiveMerkleTree != nil {
@@ -1054,7 +1054,7 @@ func (b *BeaconState) initializeProgressiveMerkleTree(ctx context.Context) error
 func (b *BeaconState) recomputeProgressiveDirtyFields(ctx context.Context) error {
 	schema, ok := ProgressiveStateSchemaForVersion(b.version)
 	if !ok {
-		return fmt.Errorf("recomputeProgressiveDirtyFields: unsupported version: %s", version.String(b.version))
+		return fmt.Errorf("unsupported version: %s", version.String(b.version))
 	}
 
 	for field := range b.dirtyFields {

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -999,7 +999,7 @@ func (b *BeaconState) HashTreeRoot(ctx context.Context) ([32]byte, error) {
 }
 
 func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, error) {
-	schema, ok := progressiveStateSchemaForVersion(b.version)
+	schema, ok := ProgressiveStateSchemaForVersion(b.version)
 	if !ok {
 		return [32]byte{}, fmt.Errorf("progressiveHashTreeRoot: unsupported version: %s", version.String(b.version))
 	}
@@ -1011,7 +1011,7 @@ func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, er
 		return [32]byte{}, err
 	}
 
-	root, err := ssz.MixInActiveFields(b.progressiveMerkleTree.Root(), schema.activeFields)
+	root, err := ssz.MixInActiveFields(b.progressiveMerkleTree.Root(), schema.ActiveFields())
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("could not mix in progressive container active fields: %w", err)
 	}
@@ -1024,7 +1024,7 @@ func (b *BeaconState) progressiveHashTreeRoot(ctx context.Context) ([32]byte, er
 //
 // WARNING: Caller must acquire the mutex before using.
 func (b *BeaconState) initializeProgressiveMerkleTree(ctx context.Context) error {
-	schema, ok := progressiveStateSchemaForVersion(b.version)
+	schema, ok := ProgressiveStateSchemaForVersion(b.version)
 	if !ok {
 		return fmt.Errorf("initializeProgressiveMerkleTree: unsupported version: %s", version.String(b.version))
 	}
@@ -1033,8 +1033,8 @@ func (b *BeaconState) initializeProgressiveMerkleTree(ctx context.Context) error
 		return nil
 	}
 
-	fieldRoots := make([][]byte, len(schema.fields))
-	for fieldIndex, field := range schema.fields {
+	fieldRoots := make([][]byte, len(schema.Fields()))
+	for fieldIndex, field := range schema.Fields() {
 		root, err := b.rootSelector(ctx, field)
 		if err != nil {
 			return fmt.Errorf("could not compute progressive field %s: %w", field.String(), err)
@@ -1052,7 +1052,7 @@ func (b *BeaconState) initializeProgressiveMerkleTree(ctx context.Context) error
 //
 // WARNING: Caller must acquire the mutex before using.
 func (b *BeaconState) recomputeProgressiveDirtyFields(ctx context.Context) error {
-	schema, ok := progressiveStateSchemaForVersion(b.version)
+	schema, ok := ProgressiveStateSchemaForVersion(b.version)
 	if !ok {
 		return fmt.Errorf("recomputeProgressiveDirtyFields: unsupported version: %s", version.String(b.version))
 	}
@@ -1062,7 +1062,7 @@ func (b *BeaconState) recomputeProgressiveDirtyFields(ctx context.Context) error
 		if err != nil {
 			return err
 		}
-		fieldIndex, ok := schema.getFieldIndex(field)
+		fieldIndex, ok := schema.GetFieldIndex(field)
 		if !ok {
 			return fmt.Errorf("could not find field index for progressive field %s in %s", field.String(), version.String(b.version))
 		}

--- a/changelog/bastin_progressive-state-schema.md
+++ b/changelog/bastin_progressive-state-schema.md
@@ -1,0 +1,3 @@
+### Added
+
+- Introduce progressiveStateSchema for gloas and later forks.

--- a/encoding/ssz/progressive_merkleize.go
+++ b/encoding/ssz/progressive_merkleize.go
@@ -9,7 +9,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/crypto/hash"
 )
 
-const maxProgressiveActiveFields = 256
+const MaxProgressiveActiveFields = 256
 
 // MerkleizeProgressiveChunks computes the progressive Merkle root of 32-byte chunks.
 //
@@ -108,8 +108,8 @@ func ContainerRootProgressive(fieldRoots [][32]byte, activeFields []bool) ([32]b
 		return [32]byte{}, errors.New("active fields cannot be empty")
 	}
 
-	if len(activeFields) > maxProgressiveActiveFields {
-		return [32]byte{}, fmt.Errorf("active fields length %d exceeds maximum %d", len(activeFields), maxProgressiveActiveFields)
+	if len(activeFields) > MaxProgressiveActiveFields {
+		return [32]byte{}, fmt.Errorf("active fields length %d exceeds maximum %d", len(activeFields), MaxProgressiveActiveFields)
 	}
 
 	activeCount := 0
@@ -128,10 +128,10 @@ func ContainerRootProgressive(fieldRoots [][32]byte, activeFields []bool) ([32]b
 }
 
 // MixInActiveFields computes hash(root, pack_bits(activeFields)) where
-// activeFields is restricted to at most 256 bits.
+// activeFields is restricted to at most MaxProgressiveActiveFields bits.
 func MixInActiveFields(root [32]byte, activeFields []bool) ([32]byte, error) {
-	if len(activeFields) > maxProgressiveActiveFields {
-		return [32]byte{}, fmt.Errorf("active fields length %d exceeds maximum %d", len(activeFields), maxProgressiveActiveFields)
+	if len(activeFields) > MaxProgressiveActiveFields {
+		return [32]byte{}, fmt.Errorf("active fields length %d exceeds maximum %d", len(activeFields), MaxProgressiveActiveFields)
 	}
 
 	var packed [32]byte

--- a/encoding/ssz/progressive_merkleize_test.go
+++ b/encoding/ssz/progressive_merkleize_test.go
@@ -188,7 +188,7 @@ func TestContainerRootProgressive_EmptyActiveFields(t *testing.T) {
 }
 
 func TestContainerRootProgressive_ActiveFieldsExceedsLimit(t *testing.T) {
-	af := make([]bool, 257)
+	af := make([]bool, ssz.MaxProgressiveActiveFields+1)
 	_, err := ssz.ContainerRootProgressive([][32]byte{}, af)
 	require.ErrorContains(t, "exceeds maximum", err)
 }
@@ -217,7 +217,7 @@ func TestMixInActiveFields(t *testing.T) {
 }
 
 func TestMixInActiveFields_TooMany(t *testing.T) {
-	activeFields := make([]bool, 257)
+	activeFields := make([]bool, ssz.MaxProgressiveActiveFields+1)
 	_, err := ssz.MixInActiveFields(chunkFromIndex(0), activeFields)
 	require.ErrorContains(t, "exceeds maximum 256", err)
 }


### PR DESCRIPTION
This PR changes how we access the fields of each fork in the state_native package going forward (starting with gloas).

we can no longer use `FieldIndex.RealPosition()` since a field can have a different index for each fork. 
and now we have another thing to keep track of: each fork's `ActiveField []bool`.

it will create a `ProgressiveStateSchema` for gloas+ forks which will keep track of fields, fieldIndexes, and activeFields.
I've showcased how this should be used. look at the changes in `state_trie.go`. for later forks, the only thing we need to do, is to update the `fields.go` file to include the new fork fields and `ProgressiveStateSchema`.

Fixes #17301  