### PR TITLE
Remove the remaining Eth1 bridge deposit transition from Fulu as per consensus-specs#4704

### DIFF
--- a/beacon-chain/core/electra/deposits.go
+++ b/beacon-chain/core/electra/deposits.go
@@ -184,7 +184,7 @@ func verifyDepositDataSigningRoot(obj *ethpb.Deposit_Data, domain []byte) error 
 
 // ProcessPendingDeposits implements the spec definition below. This method mutates the state.
 // Iterating over `pending_deposits` queue this function runs the following checks before applying pending deposit:
-// 1. All Eth1 bridge deposits are processed before the first deposit request gets processed.
+// 1. All Eth1 bridge deposits are processed before the first deposit request gets processed (pre-Fulu only).
 // 2. Deposit position in the queue is finalized.
 // 3. Deposit does not exceed the `MAX_PENDING_DEPOSITS_PER_EPOCH` limit.
 // 4. Deposit does not exceed the activation churn limit.
@@ -282,9 +282,16 @@ func ProcessPendingDeposits(ctx context.Context, st state.BeaconState, activeBal
 		return errors.Wrap(err, "could not get finalized slot")
 	}
 
-	startIndex, err := st.DepositRequestsStartIndex()
-	if err != nil {
-		return errors.Wrap(err, "could not get starting pendingDeposit index")
+	// The former deposit mechanism is removed, so the Eth1 bridge gate in the
+	// loop below, and the start index it reads, only exist before Fulu.
+	var startIndex uint64
+	bridgeGateApplies := st.Version() < version.Fulu
+
+	if bridgeGateApplies {
+		startIndex, err = st.DepositRequestsStartIndex()
+		if err != nil {
+			return errors.Wrap(err, "could not get starting pendingDeposit index")
+		}
 	}
 
 	pendingDeposits, err := st.PendingDeposits()
@@ -293,7 +300,7 @@ func ProcessPendingDeposits(ctx context.Context, st state.BeaconState, activeBal
 	}
 	for _, pendingDeposit := range pendingDeposits {
 		// Do not process pendingDeposit requests if Eth1 bridge deposits are not yet applied.
-		if pendingDeposit.Slot > params.BeaconConfig().GenesisSlot && st.Eth1DepositIndex() < startIndex {
+		if bridgeGateApplies && pendingDeposit.Slot > params.BeaconConfig().GenesisSlot && st.Eth1DepositIndex() < startIndex {
 			break
 		}
 

--- a/beacon-chain/core/electra/deposits_test.go
+++ b/beacon-chain/core/electra/deposits_test.go
@@ -313,6 +313,85 @@ func TestProcessPendingDeposits(t *testing.T) {
 	}
 }
 
+func TestProcessPendingDeposits_Eth1BridgeGate(t *testing.T) {
+	// Queue a deposit request while the Eth1 bridge is unfinished, i.e. `eth1_deposit_index` has
+	// not caught up with `deposit_requests_start_index`.
+	withUnfinishedBridge := func(t *testing.T, st state.BeaconState, startIndex uint64) uint64 {
+		require.NoError(t, st.SetSlot(10*params.BeaconConfig().SlotsPerEpoch))
+		require.NoError(t, st.SetFinalizedCheckpoint(&eth.Checkpoint{Epoch: 1, Root: make([]byte, 32)}))
+		require.NoError(t, st.SetEth1DepositIndex(0))
+		require.NoError(t, st.SetDepositRequestsStartIndex(startIndex))
+		val, err := st.ValidatorAtIndex(0)
+		require.NoError(t, err)
+		require.NoError(t, st.SetPendingDeposits([]*eth.PendingDeposit{{
+			PublicKey:             val.PublicKey,
+			WithdrawalCredentials: val.WithdrawalCredentials,
+			Amount:                1_000,
+			Signature:             make([]byte, fieldparams.BLSSignatureLength),
+			Slot:                  1,
+		}}))
+		bal, err := st.BalanceAtIndex(0)
+		require.NoError(t, err)
+		return bal
+	}
+
+	unset := params.BeaconConfig().UnsetDepositRequestsStartIndex
+
+	for _, tt := range []struct {
+		name       string
+		newState   func(testing.TB) state.BeaconState
+		startIndex uint64
+		applied    bool
+	}{
+		{
+			name:       "electra postpones deposit requests until Eth1 bridge deposits are applied",
+			newState:   func(t testing.TB) state.BeaconState { st, _ := util.DeterministicGenesisStateElectra(t, 64); return st },
+			startIndex: unset,
+		},
+		{
+			name:       "electra postpones deposit requests mid-bridge",
+			newState:   func(t testing.TB) state.BeaconState { st, _ := util.DeterministicGenesisStateElectra(t, 64); return st },
+			startIndex: 5,
+		},
+		{
+			name:       "fulu processes deposit requests without the Eth1 bridge gate",
+			newState:   func(t testing.TB) state.BeaconState { st, _ := util.DeterministicGenesisStateFulu(t, 64); return st },
+			startIndex: unset,
+			applied:    true,
+		},
+		{
+			name:       "fulu processes deposit requests mid-bridge",
+			newState:   func(t testing.TB) state.BeaconState { st, _ := util.DeterministicGenesisStateFulu(t, 64); return st },
+			startIndex: 5,
+			applied:    true,
+		},
+		{
+			name:       "gloas processes deposit requests without the Eth1 bridge gate",
+			newState:   func(t testing.TB) state.BeaconState { st, _ := util.DeterministicGenesisStateGloas(t, 64); return st },
+			startIndex: unset,
+			applied:    true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			st := tt.newState(t)
+			balBefore := withUnfinishedBridge(t, st, tt.startIndex)
+
+			require.NoError(t, electra.ProcessPendingDeposits(t.Context(), st, 10_000))
+
+			wantBal, wantRemaining := balBefore, 1
+			if tt.applied {
+				wantBal, wantRemaining = balBefore+1_000, 0
+			}
+			balAfter, err := st.BalanceAtIndex(0)
+			require.NoError(t, err)
+			require.Equal(t, wantBal, balAfter)
+			remaining, err := st.PendingDeposits()
+			require.NoError(t, err)
+			require.Equal(t, wantRemaining, len(remaining))
+		})
+	}
+}
+
 func TestBatchProcessNewPendingDeposits(t *testing.T) {
 	t.Run("one valid deposit one garbage deposit", func(t *testing.T) {
 		st := stateWithActiveBalanceETH(t, 0)

--- a/beacon-chain/core/electra/transition.go
+++ b/beacon-chain/core/electra/transition.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 )
 
@@ -131,7 +132,20 @@ func ProcessEpoch(ctx context.Context, state state.BeaconState) error {
 //	      assert len(body.deposits) == min(MAX_DEPOSITS, eth1_deposit_index_limit - state.eth1_deposit_index)
 //	  else:
 //	      assert len(body.deposits) == 0
+//
+// From Fulu onward the former deposit mechanism is gone entirely, so the Electra limit is
+// replaced by a flat assertion.
+//
+//	# [Modified in Fulu]
+//	assert len(body.deposits) == 0
 func VerifyBlockDepositLength(body interfaces.ReadOnlyBeaconBlockBody, state state.BeaconState) error {
+	if state.Version() >= version.Fulu {
+		if len(body.Deposits()) != 0 {
+			return fmt.Errorf("eth1 bridge deposits are not allowed from Fulu, wanted: 0, got: %d", len(body.Deposits()))
+		}
+		return nil
+	}
+
 	eth1Data := state.Eth1Data()
 	requestsStartIndex, err := state.DepositRequestsStartIndex()
 	if err != nil {

--- a/beacon-chain/core/electra/transition_test.go
+++ b/beacon-chain/core/electra/transition_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/electra"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -14,41 +15,117 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func TestVerifyOperationLengths_Electra(t *testing.T) {
-	t.Run("happy path", func(t *testing.T) {
-		s, _ := util.DeterministicGenesisStateElectra(t, 1)
-		sb, err := consensusblocks.NewSignedBeaconBlock(util.NewBeaconBlockElectra())
-		require.NoError(t, err)
-		require.NoError(t, electra.VerifyBlockDepositLength(sb.Block().Body(), s))
-	})
-	t.Run("eth1depositIndex less than eth1depositIndexLimit & number of deposits incorrect", func(t *testing.T) {
-		s, _ := util.DeterministicGenesisStateElectra(t, 1)
-		sb, err := consensusblocks.NewSignedBeaconBlock(util.NewBeaconBlockElectra())
-		require.NoError(t, err)
-		require.NoError(t, s.SetEth1DepositIndex(0))
-		require.NoError(t, s.SetDepositRequestsStartIndex(1))
-		err = electra.VerifyBlockDepositLength(sb.Block().Body(), s)
-		require.ErrorContains(t, "incorrect outstanding deposits in block body", err)
-	})
-	t.Run("eth1depositIndex more than eth1depositIndexLimit & number of deposits is not 0", func(t *testing.T) {
-		s, _ := util.DeterministicGenesisStateElectra(t, 1)
-		sb, err := consensusblocks.NewSignedBeaconBlock(util.NewBeaconBlockElectra())
-		require.NoError(t, err)
-		sb.SetDeposits([]*ethpb.Deposit{
-			{
-				Data: &ethpb.Deposit_Data{
-					PublicKey:             []byte{1, 2, 3},
-					Amount:                1000,
-					WithdrawalCredentials: make([]byte, common.AddressLength),
-					Signature:             []byte{4, 5, 6},
-				},
+func TestVerifyBlockDepositLength(t *testing.T) {
+	oneDeposit := []*ethpb.Deposit{
+		{
+			Data: &ethpb.Deposit_Data{
+				PublicKey:             []byte{1, 2, 3},
+				Amount:                1000,
+				WithdrawalCredentials: make([]byte, common.AddressLength),
+				Signature:             []byte{4, 5, 6},
 			},
+		},
+	}
+	unsetStartIndex := params.BeaconConfig().UnsetDepositRequestsStartIndex
+
+	// From Fulu onward the start index is never set, so every post-Fulu case below leaves the Eth1
+	// bridge unfinished: the Electra limit would have asked for a deposit there, which is what
+	// makes each case fail if the Fulu branch is removed. Gloas is covered alongside Fulu because
+	// the gate is keyed on `>= version.Fulu`.
+	for _, tt := range []struct {
+		name             string
+		newState         func(testing.TB) state.BeaconState
+		newBlock         func() any
+		eth1DepositIndex uint64
+		startIndex       uint64
+		deposits         []*ethpb.Deposit
+		wantErr          string
+	}{
+		{
+			name:             "electra accepts an empty body once eth1_deposit_index reached the limit",
+			newState:         func(t testing.TB) state.BeaconState { s, _ := util.DeterministicGenesisStateElectra(t, 64); return s },
+			newBlock:         func() any { return util.NewBeaconBlockElectra() },
+			eth1DepositIndex: 64,
+			startIndex:       unsetStartIndex,
+		},
+		{
+			name:             "electra requires the outstanding Eth1 bridge deposits",
+			newState:         func(t testing.TB) state.BeaconState { s, _ := util.DeterministicGenesisStateElectra(t, 64); return s },
+			newBlock:         func() any { return util.NewBeaconBlockElectra() },
+			eth1DepositIndex: 0,
+			startIndex:       1,
+			wantErr:          "incorrect outstanding deposits in block body",
+		},
+		{
+			name:             "electra rejects an Eth1 bridge deposit once the bridge is drained",
+			newState:         func(t testing.TB) state.BeaconState { s, _ := util.DeterministicGenesisStateElectra(t, 64); return s },
+			newBlock:         func() any { return util.NewBeaconBlockElectra() },
+			eth1DepositIndex: 1,
+			startIndex:       1,
+			deposits:         oneDeposit,
+			wantErr:          "incorrect outstanding deposits in block body",
+		},
+		{
+			name: "fulu accepts an empty body while the Eth1 bridge is unfinished",
+			newState: func(t testing.TB) state.BeaconState {
+				s, _ := util.DeterministicGenesisStateFulu(t, 64)
+				return s
+			},
+			newBlock:         func() any { return util.NewBeaconBlockFulu() },
+			eth1DepositIndex: 0,
+			startIndex:       unsetStartIndex,
+		},
+		{
+			name: "fulu rejects an Eth1 bridge deposit",
+			newState: func(t testing.TB) state.BeaconState {
+				s, _ := util.DeterministicGenesisStateFulu(t, 64)
+				return s
+			},
+			newBlock:         func() any { return util.NewBeaconBlockFulu() },
+			eth1DepositIndex: 0,
+			startIndex:       unsetStartIndex,
+			deposits:         oneDeposit,
+			wantErr:          "eth1 bridge deposits are not allowed from Fulu",
+		},
+		{
+			name: "gloas accepts an empty body while the Eth1 bridge is unfinished",
+			newState: func(t testing.TB) state.BeaconState {
+				s, _ := util.DeterministicGenesisStateGloas(t, 64)
+				return s
+			},
+			newBlock:         func() any { return util.NewBeaconBlockGloas() },
+			eth1DepositIndex: 0,
+			startIndex:       unsetStartIndex,
+		},
+		{
+			name: "gloas rejects an Eth1 bridge deposit",
+			newState: func(t testing.TB) state.BeaconState {
+				s, _ := util.DeterministicGenesisStateGloas(t, 64)
+				return s
+			},
+			newBlock:         func() any { return util.NewBeaconBlockGloas() },
+			eth1DepositIndex: 0,
+			startIndex:       unsetStartIndex,
+			deposits:         oneDeposit,
+			wantErr:          "eth1 bridge deposits are not allowed from Fulu",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.newState(t)
+			require.NoError(t, s.SetEth1DepositIndex(tt.eth1DepositIndex))
+			require.NoError(t, s.SetDepositRequestsStartIndex(tt.startIndex))
+			sb, err := consensusblocks.NewSignedBeaconBlock(tt.newBlock())
+			require.NoError(t, err)
+			sb.SetDeposits(tt.deposits)
+
+			err = electra.VerifyBlockDepositLength(sb.Block().Body(), s)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, tt.wantErr, err)
 		})
-		require.NoError(t, s.SetEth1DepositIndex(1))
-		require.NoError(t, s.SetDepositRequestsStartIndex(1))
-		err = electra.VerifyBlockDepositLength(sb.Block().Body(), s)
-		require.ErrorContains(t, "incorrect outstanding deposits in block body", err)
-	})
+	}
 }
 
 func TestProcessEpoch_CanProcessElectra(t *testing.T) {

--- a/beacon-chain/core/helpers/legacy.go
+++ b/beacon-chain/core/helpers/legacy.go
@@ -7,10 +7,16 @@ import (
 
 // DepositRequestsStarted determines if the deposit requests have started.
 func DepositRequestsStarted(beaconState state.BeaconState) bool {
+	// The former deposit mechanism is removed, so deposit requests are always started.
+	if beaconState.Version() >= version.Fulu {
+		return true
+	}
+
 	if beaconState.Version() < version.Electra {
 		return false
 	}
 
+	// Only Electra checks deposit requests start index.
 	requestsStartIndex, err := beaconState.DepositRequestsStartIndex()
 	if err != nil {
 		return false

--- a/beacon-chain/core/helpers/legacy_test.go
+++ b/beacon-chain/core/helpers/legacy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/stretchr/testify/require"
 )
@@ -27,6 +28,22 @@ func TestDepositRequestHaveStarted(t *testing.T) {
 		st, _ := util.DeterministicGenesisStateElectra(t, 1)
 		require.NoError(t, st.SetEth1DepositIndex(33))
 		require.NoError(t, st.SetDepositRequestsStartIndex(33))
+		result := helpers.DepositRequestsStarted(st)
+		require.True(t, result)
+	})
+
+	t.Run("Version is Fulu returns true even with an unset requestsStartIndex", func(t *testing.T) {
+		st, _ := util.DeterministicGenesisStateFulu(t, 1)
+		require.NoError(t, st.SetEth1DepositIndex(1))
+		require.NoError(t, st.SetDepositRequestsStartIndex(params.BeaconConfig().UnsetDepositRequestsStartIndex))
+		result := helpers.DepositRequestsStarted(st)
+		require.True(t, result)
+	})
+
+	t.Run("Version is above Fulu returns true even with an unset requestsStartIndex", func(t *testing.T) {
+		st, _ := util.DeterministicGenesisStateGloas(t, 64)
+		require.NoError(t, st.SetEth1DepositIndex(1))
+		require.NoError(t, st.SetDepositRequestsStartIndex(params.BeaconConfig().UnsetDepositRequestsStartIndex))
 		result := helpers.DepositRequestsStarted(st)
 		require.True(t, result)
 	})

--- a/beacon-chain/core/transition/transition_test.go
+++ b/beacon-chain/core/transition/transition_test.go
@@ -532,6 +532,22 @@ func TestProcessBlock_IncorrectDeposits(t *testing.T) {
 	assert.ErrorContains(t, want, err)
 }
 
+func TestProcessBlock_NoEth1BridgeDepositsFromFulu(t *testing.T) {
+	s, _ := util.DeterministicGenesisStateFulu(t, 1)
+	// The start index is never set from Fulu onward, so the Electra limit would have asked for
+	// one deposit here.
+	require.NoError(t, s.SetEth1DepositIndex(0))
+	require.NoError(t, s.SetDepositRequestsStartIndex(params.BeaconConfig().UnsetDepositRequestsStartIndex))
+
+	b := util.NewBeaconBlockFulu()
+	b.Block.Body.Deposits = []*ethpb.Deposit{{}}
+	wsb, err := consensusblocks.NewSignedBeaconBlock(b)
+	require.NoError(t, err)
+
+	_, err = transition.VerifyOperationLengths(t.Context(), s, wsb.Block())
+	assert.ErrorContains(t, "eth1 bridge deposits are not allowed from Fulu", err)
+}
+
 func TestProcessSlots_SameSlotAsParentState(t *testing.T) {
 	slot := primitives.Slot(2)
 	parentState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: slot})

--- a/changelog/syjn99_fix-fulu-pending-deposits-gate.md
+++ b/changelog/syjn99_fix-fulu-pending-deposits-gate.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Remove the remaining Eth1 bridge deposit transition from Fulu as per consensus-specs#4704.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Implements:

- https://github.com/ethereum/consensus-specs/pull/4704

in Prysm. Eth1 deposit bridge has already been terminated as in Fulu, so we're now safe to skip the checks related to Eth1 deposit bridge.

**Which issue(s) does this PR fix?**

Fixes #17315

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
