### PR TITLE
prefer subtests in agents.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -33,4 +33,5 @@ Prysm implements the [Ethereum consensus specs](https://github.com/ethereum/cons
 - Branch from and target `develop`.
 - Every PR needs a changelog fragment: `changelog/<github_user>_<branch_name>.md` (managed by `unclog`).
 - Keep comments short — one line, no multi-line explanations.
+- When appropriate, prefer subtests and nested subtests over multiple test functions that exercise the same production function.
 - Verify tests you add or modify with `/test`.

--- a/changelog/bastin_agents-subtests.md
+++ b/changelog/bastin_agents-subtests.md
@@ -1,3 +1,3 @@
-### Changed
+### Ignored
 
 - prefer subtests over multiple test functions in AGENTS.md

--- a/changelog/bastin_agents-subtests.md
+++ b/changelog/bastin_agents-subtests.md
@@ -1,0 +1,3 @@
+### Changed
+
+- prefer subtests over multiple test functions in AGENTS.md


### PR DESCRIPTION
codex keeps creating multiple test function for the same production function. this will make it use subtests.