### PR TITLE
adding payload value query parameter

### DIFF
--- a/api/server/structs/endpoints_validator.go
+++ b/api/server/structs/endpoints_validator.go
@@ -103,6 +103,7 @@ type ProduceBlockV3Response struct {
 // ProduceBlockV4Response is a wrapper json object for the returned block from the ProduceBlockV4 endpoint
 type ProduceBlockV4Response struct {
 	Version                  string          `json:"version"`
+	ExecutionPayloadValue    string          `json:"execution_payload_value"`
 	ConsensusBlockValue      string          `json:"consensus_block_value"`
 	ExecutionPayloadIncluded bool            `json:"execution_payload_included"`
 	Data                     json.RawMessage `json:"data"`

--- a/beacon-chain/rpc/eth/validator/handlers_block_gloas.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_gloas.go
@@ -123,7 +123,13 @@ func (s *Server) ProduceBlockV4(w http.ResponseWriter, r *http.Request) {
 		consensusBlockValue = "0"
 	}
 
+	executionPayloadValue := v1alpha1resp.PayloadValue
+	if executionPayloadValue == "" {
+		executionPayloadValue = "0"
+	}
+
 	w.Header().Set(api.VersionHeader, version.String(version.Gloas))
+	w.Header().Set(api.ExecutionPayloadValueHeader, executionPayloadValue)
 	w.Header().Set(api.ConsensusBlockValueHeader, consensusBlockValue)
 	w.Header().Set(api.ExecutionPayloadIncludedHeader, fmt.Sprintf("%v", includePayload))
 
@@ -152,6 +158,7 @@ func (s *Server) ProduceBlockV4(w http.ResponseWriter, r *http.Request) {
 		}
 		httputil.WriteJson(w, &structs.ProduceBlockV4Response{
 			Version:                  version.String(version.Gloas),
+			ExecutionPayloadValue:    executionPayloadValue,
 			ConsensusBlockValue:      consensusBlockValue,
 			ExecutionPayloadIncluded: true,
 			Data:                     jsonBytes,
@@ -182,6 +189,7 @@ func (s *Server) ProduceBlockV4(w http.ResponseWriter, r *http.Request) {
 	}
 	httputil.WriteJson(w, &structs.ProduceBlockV4Response{
 		Version:                  version.String(version.Gloas),
+		ExecutionPayloadValue:    executionPayloadValue,
 		ConsensusBlockValue:      consensusBlockValue,
 		ExecutionPayloadIncluded: false,
 		Data:                     jsonBytes,

--- a/beacon-chain/rpc/eth/validator/handlers_block_gloas_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_gloas_test.go
@@ -84,7 +84,9 @@ func TestProduceBlockV4_IncludePayloadTrue(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-	v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(gloasGenericBlockContents(), nil)
+	contents := gloasGenericBlockContents()
+	contents.PayloadValue = "12345"
+	v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(contents, nil)
 
 	server := &Server{
 		V1Alpha1Server:        v1alpha1Server,
@@ -103,6 +105,7 @@ func TestProduceBlockV4_IncludePayloadTrue(t *testing.T) {
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
 	assert.Equal(t, "gloas", resp.Version)
 	assert.Equal(t, true, resp.ExecutionPayloadIncluded)
+	assert.Equal(t, "12345", resp.ExecutionPayloadValue)
 	assert.Equal(t, "10000000000", resp.ConsensusBlockValue)
 
 	var blockContents structs.BlockContentsGloas
@@ -111,6 +114,7 @@ func TestProduceBlockV4_IncludePayloadTrue(t *testing.T) {
 	assert.NotNil(t, blockContents.ExecutionPayloadEnvelope)
 
 	require.Equal(t, "gloas", writer.Header().Get(api.VersionHeader))
+	require.Equal(t, "12345", writer.Header().Get(api.ExecutionPayloadValueHeader))
 	require.Equal(t, "10000000000", writer.Header().Get(api.ConsensusBlockValueHeader))
 	require.Equal(t, "true", writer.Header().Get(api.ExecutionPayloadIncludedHeader))
 }
@@ -197,6 +201,9 @@ func TestProduceBlockV4_IncludePayloadFalse(t *testing.T) {
 	assert.NotNil(t, block.Body)
 
 	require.Equal(t, "gloas", writer.Header().Get(api.VersionHeader))
+	// Producer set no payload value: the response must still carry a numeric value.
+	require.Equal(t, "0", resp.ExecutionPayloadValue)
+	require.Equal(t, "0", writer.Header().Get(api.ExecutionPayloadValueHeader))
 	require.Equal(t, "false", writer.Header().Get(api.ExecutionPayloadIncludedHeader))
 }
 
@@ -210,7 +217,9 @@ func TestProduceBlockV4_BuilderBidExcludesPayload(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 	// External builder bid: the producer returns the block alone (no inline contents), so the payload is excluded.
-	v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(gloasGenericBlockWithBuilder(3), nil)
+	builderBlock := gloasGenericBlockWithBuilder(3)
+	builderBlock.PayloadValue = "2000000000000"
+	v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(builderBlock, nil)
 
 	server := &Server{
 		V1Alpha1Server:        v1alpha1Server,
@@ -228,6 +237,8 @@ func TestProduceBlockV4_BuilderBidExcludesPayload(t *testing.T) {
 	var resp structs.ProduceBlockV4Response
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
 	assert.Equal(t, false, resp.ExecutionPayloadIncluded)
+	assert.Equal(t, "2000000000000", resp.ExecutionPayloadValue)
+	require.Equal(t, "2000000000000", writer.Header().Get(api.ExecutionPayloadValueHeader))
 	require.Equal(t, "false", writer.Header().Get(api.ExecutionPayloadIncludedHeader))
 
 	var block structs.BeaconBlockGloas

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
@@ -58,10 +58,10 @@ func (vs *Server) constructGenericBeaconBlock(
 		}
 		return vs.constructFuluBlock(blockProto, isBlinded, bidStr, bundle), nil
 	case version.Gloas:
-		// Gloas blocks do not carry a separate payload value — the bid is part of the block body.
-		// Stateless self-build bundling into GloasContents happens in BuildBlockParallel.
+		// Stateless self-build bundling into GloasContents happens in buildBlockGloas.
 		return &ethpb.GenericBeaconBlock{
-			Block: &ethpb.GenericBeaconBlock_Gloas{Gloas: blockProto.(*ethpb.BeaconBlockGloas)},
+			Block:        &ethpb.GenericBeaconBlock_Gloas{Gloas: blockProto.(*ethpb.BeaconBlockGloas)},
+			PayloadValue: bidStr,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unknown block version: %d", sBlk.Version())

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
@@ -2,9 +2,11 @@ package validator
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -98,7 +100,7 @@ func (vs *Server) buildBlockGloas(ctx context.Context, sBlk interfaces.SignedBea
 		}
 	}
 
-	blk, err := vs.constructGenericBeaconBlock(sBlk, nil, primitives.ZeroWei())
+	blk, err := vs.constructGenericBeaconBlock(sBlk, nil, vs.gloasPayloadValue(sBlk, local, selfBuilt))
 	if err != nil {
 		return nil, err
 	}
@@ -118,4 +120,21 @@ func (vs *Server) buildBlockGloas(ctx context.Context, sBlk interfaces.SignedBea
 		}}
 	}
 	return blk, nil
+}
+
+// gloasPayloadValue is the local payload value when self-building, or the total
+// bid value (value + execution payment) when committing to an external bid.
+func (vs *Server) gloasPayloadValue(sBlk interfaces.SignedBeaconBlock, local *consensusblocks.GetPayloadResponse, selfBuilt bool) primitives.Wei {
+	if selfBuilt {
+		if local == nil || local.Bid == nil {
+			return primitives.ZeroWei()
+		}
+		return local.Bid
+	}
+	bid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	if err != nil || bid == nil || bid.Message == nil {
+		return primitives.ZeroWei()
+	}
+	sum := new(big.Int).Add(new(big.Int).SetUint64(uint64(bid.Message.Value)), new(big.Int).SetUint64(uint64(bid.Message.ExecutionPayment)))
+	return sum.Mul(sum, big.NewInt(1e9))
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
@@ -122,8 +122,8 @@ func (vs *Server) buildBlockGloas(ctx context.Context, sBlk interfaces.SignedBea
 	return blk, nil
 }
 
-// gloasPayloadValue is the local payload value when self-building, or the total
-// bid value (value + execution payment) when committing to an external bid.
+// gloasPayloadValue is the local payload value when self-building, or the bid
+// value when committing to an external bid.
 func (vs *Server) gloasPayloadValue(sBlk interfaces.SignedBeaconBlock, local *consensusblocks.GetPayloadResponse, selfBuilt bool) primitives.Wei {
 	if selfBuilt {
 		if local == nil || local.Bid == nil {
@@ -135,6 +135,6 @@ func (vs *Server) gloasPayloadValue(sBlk interfaces.SignedBeaconBlock, local *co
 	if err != nil || bid == nil || bid.Message == nil {
 		return primitives.ZeroWei()
 	}
-	sum := new(big.Int).Add(new(big.Int).SetUint64(uint64(bid.Message.Value)), new(big.Int).SetUint64(uint64(bid.Message.ExecutionPayment)))
-	return sum.Mul(sum, big.NewInt(1e9))
+	value := new(big.Int).SetUint64(uint64(bid.Message.Value))
+	return value.Mul(value, big.NewInt(1e9))
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
@@ -126,12 +126,12 @@ func TestGloasPayloadValue(t *testing.T) {
 		got := vs.gloasPayloadValue(newBlockWithBid(0, 0), nil, true)
 		require.Equal(t, "0", primitives.WeiToBigInt(got).String())
 	})
-	t.Run("external bid sums value and payment in wei", func(t *testing.T) {
+	t.Run("external bid uses bid value in wei", func(t *testing.T) {
 		got := vs.gloasPayloadValue(newBlockWithBid(3, 2), &consensusblocks.GetPayloadResponse{}, false)
-		require.Equal(t, "5000000000", primitives.WeiToBigInt(got).String())
+		require.Equal(t, "3000000000", primitives.WeiToBigInt(got).String())
 	})
-	t.Run("external bid sum does not overflow", func(t *testing.T) {
-		got := vs.gloasPayloadValue(newBlockWithBid(primitives.Gwei(math.MaxUint64), primitives.Gwei(math.MaxUint64)), nil, false)
-		require.Equal(t, "36893488147419103230000000000", primitives.WeiToBigInt(got).String())
+	t.Run("external bid value does not overflow", func(t *testing.T) {
+		got := vs.gloasPayloadValue(newBlockWithBid(primitives.Gwei(math.MaxUint64), 0), nil, false)
+		require.Equal(t, "18446744073709551615000000000", primitives.WeiToBigInt(got).String())
 	})
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas_test.go
@@ -4,12 +4,14 @@ package validator
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	chainMock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -102,4 +104,34 @@ func TestSetP2PBidFallback_NoCachedBidErrors(t *testing.T) {
 
 	err = vs.setP2PBidFallback(context.Background(), sBlk, st, false)
 	require.ErrorContains(t, "no cached P2P bid", err)
+}
+
+func TestGloasPayloadValue(t *testing.T) {
+	vs := &Server{}
+	newBlockWithBid := func(value, payment primitives.Gwei) interfaces.SignedBeaconBlock {
+		blk := util.NewBeaconBlockGloas()
+		blk.Block.Body.SignedExecutionPayloadBid.Message.Value = value
+		blk.Block.Body.SignedExecutionPayloadBid.Message.ExecutionPayment = payment
+		sBlk, err := consensusblocks.NewSignedBeaconBlock(blk)
+		require.NoError(t, err)
+		return sBlk
+	}
+
+	t.Run("self-built uses local bid", func(t *testing.T) {
+		local := &consensusblocks.GetPayloadResponse{Bid: primitives.Uint64ToWei(123456789)}
+		got := vs.gloasPayloadValue(newBlockWithBid(0, 0), local, true)
+		require.Equal(t, "123456789", primitives.WeiToBigInt(got).String())
+	})
+	t.Run("self-built without local bid is zero", func(t *testing.T) {
+		got := vs.gloasPayloadValue(newBlockWithBid(0, 0), nil, true)
+		require.Equal(t, "0", primitives.WeiToBigInt(got).String())
+	})
+	t.Run("external bid sums value and payment in wei", func(t *testing.T) {
+		got := vs.gloasPayloadValue(newBlockWithBid(3, 2), &consensusblocks.GetPayloadResponse{}, false)
+		require.Equal(t, "5000000000", primitives.WeiToBigInt(got).String())
+	})
+	t.Run("external bid sum does not overflow", func(t *testing.T) {
+		got := vs.gloasPayloadValue(newBlockWithBid(primitives.Gwei(math.MaxUint64), primitives.Gwei(math.MaxUint64)), nil, false)
+		require.Equal(t, "36893488147419103230000000000", primitives.WeiToBigInt(got).String())
+	})
 }

--- a/changelog/james-prysm_produce-block-v4-payload-value.md
+++ b/changelog/james-prysm_produce-block-v4-payload-value.md
@@ -1,0 +1,3 @@
+### Added
+
+- `execution_payload_value` field and `Eth-Execution-Payload-Value` header in the `produceBlockV4` response, per [ethereum/beacon-APIs#631](https://github.com/ethereum/beacon-APIs/pull/631).


### PR DESCRIPTION
**What type of PR is this?**

 Feature

**What does this PR do? Why is it needed?**

adds the execution_payload_value query parameter to the produce block endpoint

**Which issue(s) does this PR fix?**

addresses https://github.com/ethereum/beacon-APIs/pull/631

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
