### PR TITLE
Fix builder payment weight double-count under target equivocation

### DIFF
--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -441,6 +441,7 @@ func (b *BeaconState) builderInsertionIndex(currentEpoch primitives.Epoch) primi
 //
 //	proposer_reward_numerator = 0
 //	for index in get_attesting_indices(state, attestation):
+//	    had_no_participation = epoch_participation[index] == ParticipationFlags(0b0000_0000)
 //	    will_set_new_flag = False
 //	    for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
 //	        if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
@@ -450,6 +451,7 @@ func (b *BeaconState) builderInsertionIndex(currentEpoch primitives.Epoch) primi
 //	            will_set_new_flag = True
 //	    if (
 //	        will_set_new_flag
+//	        and had_no_participation
 //	        and is_attestation_same_slot(state, data)
 //	        and payment.withdrawal.amount > 0
 //	    ):
@@ -510,6 +512,9 @@ func (b *BeaconState) UpdatePendingPaymentWeight(att ethpb.Att, indices []uint64
 				return false, fmt.Errorf("index %d exceeds participation length %d", idx, len(epochParticipation))
 			}
 			participation := epochParticipation[idx]
+			if participation != 0 {
+				continue
+			}
 			for _, f := range flagIndices {
 				if !participatedFlags[f] {
 					continue

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -281,6 +281,34 @@ func TestUpdatePendingPaymentWeight(t *testing.T) {
 			require.Equal(t, tt.wantWeight, payment.Weight)
 		})
 	}
+
+	t.Run("target equivocation credits once", func(t *testing.T) {
+		paymentIdx := int(slotsPerEpoch + (slot % slotsPerEpoch))
+		state := buildGloasStateForPaymentWeightTest(t, stateSlot, paymentIdx, 1, 0, map[primitives.Slot][]byte{
+			slot: rootA,
+		})
+
+		att := &ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Slot:            slot,
+				CommitteeIndex:  0,
+				BeaconBlockRoot: rootA,
+				Source:          &ethpb.Checkpoint{},
+				Target: &ethpb.Checkpoint{
+					Epoch: stateEpoch,
+				},
+			},
+		}
+		indices := []uint64{0}
+
+		require.NoError(t, state.UpdatePendingPaymentWeight(att, indices, map[uint8]bool{cfg.TimelySourceFlagIndex: true}))
+		state.currentEpochParticipation[0] |= 1 << cfg.TimelySourceFlagIndex
+		require.NoError(t, state.UpdatePendingPaymentWeight(att, indices, map[uint8]bool{cfg.TimelyTargetFlagIndex: true}))
+
+		payment, err := state.BuilderPendingPayment(uint64(paymentIdx))
+		require.NoError(t, err)
+		require.Equal(t, primitives.Gwei(cfg.MinActivationBalance), payment.Weight)
+	})
 }
 
 func TestRotateBuilderPendingPayments(t *testing.T) {

--- a/changelog/terence_fix-payment-weight-double-count.md
+++ b/changelog/terence_fix-payment-weight-double-count.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Gate builder payment weight on the attester having no prior participation flags to prevent double-counting under target equivocation.


### PR DESCRIPTION
Implements ethereum/consensus-specs#5543: credit builder payment weight only on an attester's first flag setting inclusion, so a target equivocation is not counted twice
