### PR TITLE
Memoize EIP-4881/EIP-3076 spectest fixture

### DIFF
--- a/beacon-chain/cache/depositsnapshot/spec_test.go
+++ b/beacon-chain/cache/depositsnapshot/spec_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/build/bazel"
@@ -162,7 +163,8 @@ func (sd *snapshot) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func readTestCases() ([]testCase, error) {
+// readTestCases loads the EIP-4881 spec fixture with memoization.
+var readTestCases = sync.OnceValues(func() ([]testCase, error) {
 	if !bazel.BuiltWithBazel() {
 		if err := externaldata.Fetch(externaldata.EIP4881SpecTests); err != nil {
 			return nil, fmt.Errorf("fetch: %w", err)
@@ -192,7 +194,7 @@ func readTestCases() ([]testCase, error) {
 		}
 	}
 	return nil, errors.New("spec test file not found")
-}
+})
 
 func TestRead(t *testing.T) {
 	_, err := readTestCases()

--- a/changelog/syj99_test-memoize-spec-fixture.md
+++ b/changelog/syj99_test-memoize-spec-fixture.md
@@ -1,3 +1,3 @@
 ### Ignored
 
-- Memoize the EIP-4881 spec fixture loads in tests.
+- Memoize the EIP-4881/EIP-3076 spec fixture loads in tests.

--- a/changelog/syj99_test-memoize-spec-fixture.md
+++ b/changelog/syj99_test-memoize-spec-fixture.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Memoize the EIP-4881 spec fixture loads in tests.

--- a/validator/client/slashing_protection_interchange_test.go
+++ b/validator/client/slashing_protection_interchange_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/build/bazel"
@@ -61,25 +62,42 @@ type eip3076TestCase struct {
 	} `json:"steps"`
 }
 
-func setupEIP3076SpecTests(t *testing.T) []*eip3076TestCase {
+// loadEIP3076SpecTests reads the EIP-3076 spec fixture with memoization.
+var loadEIP3076SpecTests = sync.OnceValues(func() ([]*eip3076TestCase, error) {
 	if !bazel.BuiltWithBazel() {
-		require.NoError(t, externaldata.Fetch(externaldata.EIP3076SpecTests))
+		if err := externaldata.Fetch(externaldata.EIP3076SpecTests); err != nil {
+			return nil, fmt.Errorf("fetch: %w", err)
+		}
 	}
 
 	testFolders, err := bazel.ListRunfiles()
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("list runfiles: %w", err)
+	}
 
 	testCases := make([]*eip3076TestCase, 0)
 	for _, ff := range testFolders {
 		if strings.Contains(ff.ShortPath, externaldata.EIP3076SpecTests) &&
 			strings.Contains(ff.ShortPath, "generated/") {
 			enc, err := file.ReadFileAsBytes(ff.Path)
-			require.NoError(t, err)
+			if err != nil {
+				return nil, fmt.Errorf("read file %q: %w", ff.Path, err)
+			}
 			testCase := &eip3076TestCase{}
-			require.NoError(t, json.Unmarshal(enc, testCase))
+			if err := json.Unmarshal(enc, testCase); err != nil {
+				return nil, fmt.Errorf("unmarshal file %q: %w", ff.Path, err)
+			}
 			testCases = append(testCases, testCase)
 		}
 	}
+	return testCases, nil
+})
+
+// setupEIP3076SpecTests returns the memoized spec cases.
+func setupEIP3076SpecTests(t *testing.T) []*eip3076TestCase {
+	testCases, err := loadEIP3076SpecTests()
+	require.NoError(t, err)
+	require.NotEmpty(t, testCases, "no EIP-3076 spec test cases found")
 	return testCases
 }
 


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

- #16982 

We're currently removing Bazel which means we will soon rely on `go test` for our testing harness. One of the bottleneck that we have for running `go test` is running spectest fixtures like EIP-4881 and EIP-3076. `ListRunfiles` walks all the files for spectest (which is over 429k files) so it takes a lot of time as well as memory. 

This PR reduces over 2 minutes of test duration only by adopting memoization for each spectest fixture. (See each commit description)

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

EIP-4881 code and tests will be merged when

- https://github.com/OffchainLabs/prysm/issues/15329

is resolved. And I believe this can be deleted after Kurtosis+E2E migration lands, see the note that I wrote in #15320:

> Bonus, this will make https://github.com/OffchainLabs/prysm/issues/15329 as a low-hanging fruit. See the last [commit](https://github.com/OffchainLabs/prysm/commit/aa574a933ae8667e63c23c1a11ca1f3e9e531aea) of branch [remove-preelectra-deposit-processing](https://github.com/OffchainLabs/prysm/tree/remove-preelectra-deposit-processing). Also this means we should deliberately omit a new deposit for pre-Electra in E2E tests.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
