### PR TITLE
Use Gloas attestation deadline for determining block timeliness

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -818,10 +818,7 @@ func (s *Service) runLateBlockTasks() {
 	}
 
 	cfg := params.BeaconConfig()
-	attDueBPS := cfg.AttestationDueBPS
-	if slots.ToEpoch(s.CurrentSlot()) >= cfg.GloasForkEpoch {
-		attDueBPS = cfg.AttestationDueBPSGloas
-	}
+	attDueBPS := cfg.AttestationDueBPSAtSlot(s.CurrentSlot())
 	attThreshold := cfg.SlotComponentDuration(attDueBPS)
 	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, attThreshold, cfg.SlotDuration())
 	for {

--- a/beacon-chain/forkchoice/doubly-linked-tree/node.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/node.go
@@ -39,7 +39,7 @@ func (n *Node) leadsToViableHead(justifiedEpoch, currentEpoch primitives.Epoch) 
 // slot will have secs = 3 below.
 func (n *PayloadNode) arrivedEarly(genesis time.Time) (bool, error) {
 	sss, err := slots.SinceSlotStart(n.node.slot, genesis, n.timestamp.Truncate(time.Second)) // Truncate such that 3.9999 seconds will have a value of 3.
-	votingWindow := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().AttestationDueBPS)
+	votingWindow := params.BeaconConfig().SlotComponentDuration(params.BeaconConfig().AttestationDueBPSAtSlot(n.node.slot))
 	return sss < votingWindow, err
 }
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/node_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/node_test.go
@@ -330,3 +330,29 @@ func TestNode_TimeStampsChecks(t *testing.T) {
 	require.ErrorContains(t, "invalid timestamp", err)
 	require.Equal(t, false, late)
 }
+
+func TestNode_ArrivedEarlyGloas(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 1
+	params.OverrideBeaconConfig(cfg)
+
+	genesis := time.Now().Truncate(time.Second)
+	offset := 3500 * time.Millisecond
+	for _, tc := range []struct {
+		name  string
+		slot  primitives.Slot
+		early bool
+	}{
+		{"pre-gloas slot is early", 1, true},
+		{"gloas slot is late", primitives.Slot(cfg.SlotsPerEpoch), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			slotStart := genesis.Add(time.Duration(uint64(tc.slot)*cfg.SlotDurationMillis()) * time.Millisecond)
+			n := &PayloadNode{node: &Node{slot: tc.slot}, timestamp: slotStart.Add(offset)}
+			early, err := n.arrivedEarly(genesis)
+			require.NoError(t, err)
+			require.Equal(t, tc.early, early)
+		})
+	}
+}

--- a/changelog/syjn99_fix-arrived-early-gloas.md
+++ b/changelog/syjn99_fix-arrived-early-gloas.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use the Gloas attestation deadline (`ATTESTATION_DUE_BPS_GLOAS`) for fork choice block timeliness after the Gloas fork.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -854,3 +854,11 @@ func (b *BeaconChainConfig) SlotComponentDuration(bp primitives.BP) time.Duratio
 	ms := uint64(bp) * b.SlotDurationMillis() / uint64(BasisPoints)
 	return time.Duration(ms) * time.Millisecond
 }
+
+// AttestationDueBPSAtSlot returns the attestation due time in basis points of the slot.
+func (b *BeaconChainConfig) AttestationDueBPSAtSlot(slot primitives.Slot) primitives.BP {
+	if primitives.Epoch(slot.DivSlot(b.SlotsPerEpoch)) >= b.GloasForkEpoch {
+		return b.AttestationDueBPSGloas
+	}
+	return b.AttestationDueBPS
+}

--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -256,12 +256,7 @@ func (v *validator) setHighestSlot(slot primitives.Slot) {
 // attestationDueComponent returns the slot-component basis points for the
 // attestation due time.
 func attestationDueComponent(slot primitives.Slot) primitives.BP {
-	cfg := params.BeaconConfig()
-	if slots.ToEpoch(slot) >= cfg.GloasForkEpoch {
-		return cfg.AttestationDueBPSGloas
-	}
-
-	return cfg.AttestationDueBPS
+	return params.BeaconConfig().AttestationDueBPSAtSlot(slot)
 }
 
 // waitUntilAttestationDueOrValidBlock waits until (a) or (b) whichever comes first:


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Currently, we have been using `ATTESTATION_DUE_BPS` (= `3333`, 4 seconds after the slot start) in `arrivedEarly` even in Gloas. This PR adds `AttestationDueBPSAtSlot` so that the consumer correctly gets the attestation deadline, which will be 3 seconds post-Gloas.

The main problem today is that Prysm contradicts itself - when inserting the node, it uses the attestation deadline correctly:

https://github.com/OffchainLabs/prysm/blob/4ce2825f9c6d86dc7bb8af2268dc44182f919d29/beacon-chain/forkchoice/doubly-linked-tree/store.go#L190-L193

So if a block arrives at `[3s, 4s)` window, and if Prysm proposes a block at slot N + 1, Prysm can build on the late block as `arrivedEarly` says it was timely.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
