### PR TITLE
Explicitly set bid fields when upgrading to Gloas

### DIFF
--- a/beacon-chain/core/gloas/upgrade.go
+++ b/beacon-chain/core/gloas/upgrade.go
@@ -264,6 +264,8 @@ func upgradeToGloas(beaconState state.BeaconState) (state.BeaconState, error) {
 		return nil, errors.Wrap(err, "could not compute empty execution requests root")
 	}
 
+	latestBlockHeader := beaconState.LatestBlockHeader()
+
 	s := &ethpb.BeaconStateGloas{
 		GenesisTime:           uint64(beaconState.GenesisTime().Unix()),
 		GenesisValidatorsRoot: beaconState.GenesisValidatorsRoot(),
@@ -273,7 +275,7 @@ func upgradeToGloas(beaconState state.BeaconState) (state.BeaconState, error) {
 			CurrentVersion:  params.BeaconConfig().GloasForkVersion,
 			Epoch:           time.CurrentEpoch(beaconState),
 		},
-		LatestBlockHeader:           beaconState.LatestBlockHeader(),
+		LatestBlockHeader:           latestBlockHeader,
 		BlockRoots:                  beaconState.BlockRoots(),
 		StateRoots:                  beaconState.StateRoots(),
 		HistoricalRoots:             beaconState.HistoricalRoots(),
@@ -294,12 +296,14 @@ func upgradeToGloas(beaconState state.BeaconState) (state.BeaconState, error) {
 		CurrentSyncCommittee:        currentSyncCommittee,
 		NextSyncCommittee:           nextSyncCommittee,
 		LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
+			ParentBlockHash:       payloadHeader.ParentHash(),
+			ParentBlockRoot:       latestBlockHeader.ParentRoot,
 			BlockHash:             payloadHeader.BlockHash(),
-			GasLimit:              payloadHeader.GasLimit(),
+			PrevRandao:            payloadHeader.PrevRandao(),
 			FeeRecipient:          make([]byte, fieldparams.FeeRecipientLength),
-			ParentBlockHash:       make([]byte, fieldparams.RootLength),
-			ParentBlockRoot:       make([]byte, fieldparams.RootLength),
-			PrevRandao:            make([]byte, fieldparams.RootLength),
+			GasLimit:              payloadHeader.GasLimit(),
+			BuilderIndex:          params.BeaconConfig().BuilderIndexSelfBuild,
+			Slot:                  latestBlockHeader.Slot,
 			ExecutionRequestsRoot: emptyExecutionRequestsRoot[:],
 		},
 		NextWithdrawalIndex:           wi,

--- a/beacon-chain/core/gloas/upgrade_test.go
+++ b/beacon-chain/core/gloas/upgrade_test.go
@@ -12,6 +12,7 @@ import (
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -35,7 +36,9 @@ func TestUpgradeToGloas_Basic(t *testing.T) {
 	require.NoError(t, st.SetPendingConsolidations([]*ethpb.PendingConsolidation{{SourceIndex: 3, TargetIndex: 4}}))
 
 	blockHash := bytes.Repeat([]byte{0xAB}, 32)
-	header := &enginev1.ExecutionPayloadHeaderDeneb{BlockHash: blockHash}
+	parentHash := bytes.Repeat([]byte{0xCD}, 32)
+	prevRandao := bytes.Repeat([]byte{0xEF}, 32)
+	header := &enginev1.ExecutionPayloadHeaderDeneb{BlockHash: blockHash, ParentHash: parentHash, PrevRandao: prevRandao}
 	wrappedHeader, err := consensusblocks.WrappedExecutionPayloadHeaderDeneb(header)
 	require.NoError(t, err)
 	require.NoError(t, st.SetLatestExecutionPayloadHeader(wrappedHeader))
@@ -60,9 +63,11 @@ func TestUpgradeToGloas_Basic(t *testing.T) {
 	copy(wantBlockHash[:], blockHash)
 	require.DeepSSZEqual(t, wantBlockHash, bid.BlockHash())
 	require.DeepSSZEqual(t, [20]byte{}, bid.FeeRecipient())
-	require.DeepSSZEqual(t, [32]byte{}, bid.ParentBlockHash())
-	require.DeepSSZEqual(t, [32]byte{}, bid.ParentBlockRoot())
-	require.DeepSSZEqual(t, [32]byte{}, bid.PrevRandao())
+	require.DeepSSZEqual(t, bytesutil.ToBytes32(parentHash), bid.ParentBlockHash())
+	require.DeepSSZEqual(t, bytesutil.ToBytes32(preForkState.LatestBlockHeader().ParentRoot), bid.ParentBlockRoot())
+	require.DeepSSZEqual(t, bytesutil.ToBytes32(prevRandao), bid.PrevRandao())
+	require.Equal(t, params.BeaconConfig().BuilderIndexSelfBuild, bid.BuilderIndex())
+	require.Equal(t, preForkState.LatestBlockHeader().Slot, bid.Slot())
 
 	latestBlockHash, err := mSt.LatestBlockHash()
 	require.NoError(t, err)

--- a/changelog/terence_gloas-fork-bid-fields.md
+++ b/changelog/terence_gloas-fork-bid-fields.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Explicitly set execution payload bid fields when upgrading to Gloas per consensus-specs#5553.


### PR DESCRIPTION
- Implements https://github.com/ethereum/consensus-specs/pull/5553: set `parent_block_hash`, `parent_block_root`, `prev_randao`, `builder_index` (self build), and `slot` on `latest_execution_payload_bid` in the Gloas fork upgrade
- Gloas fork/transition spectests will stay red until the spec version bump