### PR TITLE
Fix quadratic BLS signature verification during Gloas builder onboarding

### DIFF
--- a/beacon-chain/core/gloas/payload_attestation_test.go
+++ b/beacon-chain/core/gloas/payload_attestation_test.go
@@ -329,7 +329,7 @@ func signAttestation(t *testing.T, st state.ReadOnlyBeaconState, data *eth.Paylo
 
 func TestProcessPTCWindow(t *testing.T) {
 	fuluSt, _ := testutil.DeterministicGenesisStateFulu(t, 256)
-	st, err := gloas.UpgradeToGloas(fuluSt)
+	st, err := gloas.UpgradeToGloas(t.Context(), fuluSt)
 	require.NoError(t, err)
 
 	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
@@ -376,7 +376,7 @@ func TestProcessPTCWindow(t *testing.T) {
 // state, guarding against unintended behavioral drift.
 func TestProcessPTCWindow_GoldenVector(t *testing.T) {
 	fuluSt, _ := testutil.DeterministicGenesisStateFulu(t, 256)
-	st, err := gloas.UpgradeToGloas(fuluSt)
+	st, err := gloas.UpgradeToGloas(t.Context(), fuluSt)
 	require.NoError(t, err)
 	require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch))
 	require.NoError(t, gloas.ProcessPTCWindow(t.Context(), st))
@@ -426,7 +426,7 @@ func (s *validatorLookupErrState) ValidatorAtIndexReadOnly(idx primitives.Valida
 // what's expected: we skipped SHA256 work, not memory traffic.
 func BenchmarkProcessPTCWindow(b *testing.B) {
 	fuluSt, _ := testutil.DeterministicGenesisStateFulu(b, 2048)
-	st, err := gloas.UpgradeToGloas(fuluSt)
+	st, err := gloas.UpgradeToGloas(b.Context(), fuluSt)
 	require.NoError(b, err)
 	require.NoError(b, st.SetSlot(params.BeaconConfig().SlotsPerEpoch))
 

--- a/beacon-chain/core/gloas/upgrade.go
+++ b/beacon-chain/core/gloas/upgrade.go
@@ -116,19 +116,19 @@ import (
 //
 //	    return post
 //	</spec>
-func UpgradeToGloas(beaconState state.BeaconState) (state.BeaconState, error) {
+func UpgradeToGloas(ctx context.Context, beaconState state.BeaconState) (state.BeaconState, error) {
 	s, err := upgradeToGloas(beaconState)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not convert to gloas")
 	}
-	ptcWindow, err := initializePTCWindow(context.Background(), s)
+	ptcWindow, err := initializePTCWindow(ctx, s)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize ptc window")
 	}
 	if err := s.SetPTCWindow(ptcWindow); err != nil {
 		return nil, errors.Wrap(err, "failed to set ptc window")
 	}
-	if err := s.OnboardBuildersFromPendingDeposits(); err != nil {
+	if err := s.OnboardBuildersFromPendingDeposits(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to onboard builders from pending deposits")
 	}
 	return s, nil

--- a/beacon-chain/core/gloas/upgrade_test.go
+++ b/beacon-chain/core/gloas/upgrade_test.go
@@ -2,6 +2,7 @@ package gloas_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
@@ -19,6 +20,15 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
+
+func TestUpgradeToGloas_ContextCancellation(t *testing.T) {
+	st, _ := util.DeterministicGenesisStateFulu(t, params.BeaconConfig().MaxValidatorsPerCommittee)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := gloas.UpgradeToGloas(ctx, st)
+	require.ErrorIs(t, err, context.Canceled)
+}
 
 func TestUpgradeToGloas_Basic(t *testing.T) {
 	st, _ := util.DeterministicGenesisStateFulu(t, params.BeaconConfig().MaxValidatorsPerCommittee)
@@ -44,7 +54,7 @@ func TestUpgradeToGloas_Basic(t *testing.T) {
 	require.NoError(t, st.SetLatestExecutionPayloadHeader(wrappedHeader))
 
 	preForkState := st.Copy()
-	mSt, err := gloas.UpgradeToGloas(st)
+	mSt, err := gloas.UpgradeToGloas(t.Context(), st)
 	require.NoError(t, err)
 
 	require.Equal(t, preForkState.GenesisTime(), mSt.GenesisTime())
@@ -119,7 +129,7 @@ func TestUpgradeToGloas_OnboardsBuilderDeposit(t *testing.T) {
 
 	require.NoError(t, st.SetPendingDeposits([]*ethpb.PendingDeposit{deposit}))
 
-	mSt, err := gloas.UpgradeToGloas(st)
+	mSt, err := gloas.UpgradeToGloas(t.Context(), st)
 	require.NoError(t, err)
 
 	pbState, ok := mSt.ToProtoUnsafe().(*ethpb.BeaconStateGloas)

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -425,7 +425,7 @@ func UpgradeState(ctx context.Context, state state.BeaconState) (state.BeaconSta
 	}
 
 	if time.CanUpgradeToGloas(slot) {
-		state, err = gloas.UpgradeToGloas(state)
+		state, err = gloas.UpgradeToGloas(ctx, state)
 		if err != nil {
 			tracing.AnnotateError(span, err)
 			return nil, err

--- a/beacon-chain/db/kv/state_diff_test.go
+++ b/beacon-chain/db/kv/state_diff_test.go
@@ -746,7 +746,7 @@ func TestStateDiff_SaveAndReadDiffForkTransitionGloas(t *testing.T) {
 	require.NoError(t, err)
 
 	slot := primitives.Slot(math.PowerOf2(5))
-	gloasSt, err := gloas.UpgradeToGloas(st.Copy())
+	gloasSt, err := gloas.UpgradeToGloas(t.Context(), st.Copy())
 	require.NoError(t, err)
 	require.NoError(t, gloasSt.SetSlot(slot))
 

--- a/beacon-chain/state/interfaces_gloas.go
+++ b/beacon-chain/state/interfaces_gloas.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"context"
+
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -45,7 +47,7 @@ type writeOnlyGloasFields interface {
 	DecreaseWithdrawalBalances(withdrawals []*enginev1.Withdrawal) error
 	DequeueBuilderPendingWithdrawals(num uint64) error
 	SetNextWithdrawalBuilderIndex(idx primitives.BuilderIndex) error
-	OnboardBuildersFromPendingDeposits() error
+	OnboardBuildersFromPendingDeposits(context.Context) error
 }
 
 type readOnlyGloasFields interface {

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -1,6 +1,7 @@
 package state_native
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -681,6 +682,17 @@ func decreaseBalanceWithVal(currBalance, delta primitives.Gwei) primitives.Gwei 
 	return currBalance - delta
 }
 
+type depositSignatureVerifier func(*ethpb.Deposit_Data) (bool, error)
+
+// pendingValidatorStatus caches signature checks for the already-processed prefix of pending
+// deposits for one pubkey. A literal implementation of is_pending_validator rescans and
+// reverifies that prefix for every builder deposit, which can require quadratic work.
+type pendingValidatorStatus struct {
+	deposits []*ethpb.PendingDeposit
+	checked  int
+	found    bool
+}
+
 // OnboardBuildersFromPendingDeposits applies any pending builder deposits at the fork.
 // It mutates the state and prunes pending deposits accordingly.
 //
@@ -736,9 +748,16 @@ func decreaseBalanceWithVal(currBalance, delta primitives.Gwei) primitives.Gwei 
 //
 //	    state.pending_deposits = pending_deposits
 //	</spec>
-func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
+func (b *BeaconState) OnboardBuildersFromPendingDeposits(ctx context.Context) error {
+	return b.onboardBuildersFromPendingDeposits(ctx, helpers.IsValidDepositSignature)
+}
+
+func (b *BeaconState) onboardBuildersFromPendingDeposits(ctx context.Context, verify depositSignatureVerifier) error {
 	if b.version < version.Gloas {
 		return errNotSupported("OnboardBuildersFromPendingDeposits", b.version)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	b.lock.Lock()
@@ -746,8 +765,14 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 
 	pendingDeposits := b.pendingDeposits
 	newPendingDeposits := make([]*ethpb.PendingDeposit, 0, len(pendingDeposits))
+	// For every pubkey in this map, found is true exactly when the already-built
+	// newPendingDeposits prefix contains a valid deposit for that pubkey.
+	pendingValidators := make(map[[fieldparams.BLSPubkeyLength]byte]*pendingValidatorStatus)
 
 	for _, deposit := range pendingDeposits {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		pubkey := bytesutil.ToBytes48(deposit.PublicKey)
 		if _, ok := b.validatorIndexByPubkey(pubkey); ok {
 			newPendingDeposits = append(newPendingDeposits, deposit)
@@ -764,20 +789,53 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 
 		if !helpers.IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials) {
 			newPendingDeposits = append(newPendingDeposits, deposit)
+			status := pendingValidators[pubkey]
+			if status == nil {
+				status = &pendingValidatorStatus{}
+				pendingValidators[pubkey] = status
+			}
+			if !status.found {
+				status.deposits = append(status.deposits, deposit)
+			}
 			continue
 		}
-		isPending, err := helpers.IsPendingValidator(newPendingDeposits, deposit.PublicKey)
-		if err != nil {
-			return err
+
+		status := pendingValidators[pubkey]
+		if status != nil {
+			// Verify only deposits appended since the previous builder candidate. Invalid
+			// deposits remain in the pending queue but never need to be verified again here.
+			for !status.found && status.checked < len(status.deposits) {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				pendingDeposit := status.deposits[status.checked]
+				status.checked++
+				valid, err := verify(&ethpb.Deposit_Data{
+					PublicKey:             pendingDeposit.PublicKey,
+					WithdrawalCredentials: pendingDeposit.WithdrawalCredentials,
+					Amount:                pendingDeposit.Amount,
+					Signature:             pendingDeposit.Signature,
+				})
+				if err != nil {
+					log.WithField("pubkey", fmt.Sprintf("%x", pendingDeposit.PublicKey)).WithError(err).Warn("Could not verify pending deposit signature")
+					continue
+				}
+				if valid {
+					status.found = true
+				}
+			}
 		}
-		if isPending {
+		if status != nil && status.found {
 			newPendingDeposits = append(newPendingDeposits, deposit)
 			continue
 		}
 
-		if err := b.applyDepositForNewBuilder(deposit); err != nil {
+		if err := b.applyDepositForNewBuilder(ctx, deposit, verify); err != nil {
 			return err
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	b.sharedFieldReferences[types.PendingDeposits].MinusRef()
@@ -789,8 +847,11 @@ func (b *BeaconState) OnboardBuildersFromPendingDeposits() error {
 }
 
 // applyDepositForNewBuilder onboards a single pending deposit as a new builder, used by onboard_builders_from_pending_deposits.
-func (b *BeaconState) applyDepositForNewBuilder(deposit *ethpb.PendingDeposit) error {
-	valid, err := helpers.IsValidDepositSignature(&ethpb.Deposit_Data{
+func (b *BeaconState) applyDepositForNewBuilder(ctx context.Context, deposit *ethpb.PendingDeposit, verify depositSignatureVerifier) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	valid, err := verify(&ethpb.Deposit_Data{
 		PublicKey:             deposit.PublicKey,
 		WithdrawalCredentials: deposit.WithdrawalCredentials,
 		Amount:                deposit.Amount,
@@ -803,6 +864,9 @@ func (b *BeaconState) applyDepositForNewBuilder(deposit *ethpb.PendingDeposit) e
 	if !valid {
 		log.WithField("pubkey", fmt.Sprintf("%x", deposit.PublicKey)).Debug("Skipping builder deposit with invalid signature")
 		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	pubkey := bytesutil.ToBytes48(deposit.PublicKey)
 	depositEpoch := slots.ToEpoch(deposit.Slot)

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -2,6 +2,7 @@ package state_native
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
@@ -1004,7 +1005,7 @@ func TestAddBuilderFromDeposit_CopyOnWrite(t *testing.T) {
 func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 	t.Run("returns error before gloas", func(t *testing.T) {
 		st := &BeaconState{version: version.Fulu}
-		err := st.OnboardBuildersFromPendingDeposits()
+		err := st.OnboardBuildersFromPendingDeposits(t.Context())
 		require.ErrorContains(t, "OnboardBuildersFromPendingDeposits", err)
 	})
 
@@ -1023,7 +1024,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		}
 
 		st := newGloasState(t, []*ethpb.Validator{validator}, nil, []*ethpb.PendingDeposit{deposit}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 1, len(st.pendingDeposits))
 		require.Equal(t, 0, len(st.builders))
 	})
@@ -1037,7 +1038,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		deposit := newPendingDeposit(t, sk, builderCreds, amount, depSlot, true)
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{deposit}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 0, len(st.pendingDeposits))
 		require.Equal(t, 1, len(st.builders))
 
@@ -1061,7 +1062,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		deposit := newPendingDeposit(t, sk, nonBuilderCreds, 5, 0, false)
 
 		st := newGloasState(t, nil, []*ethpb.Builder{builder}, []*ethpb.PendingDeposit{deposit}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 0, len(st.pendingDeposits))
 		require.Equal(t, 1, len(st.builders))
 		require.Equal(t, primitives.Gwei(15), st.builders[0].Balance)
@@ -1074,7 +1075,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		deposit := newPendingDeposit(t, sk, builderCreds, 10, 0, false)
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{deposit}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 0, len(st.pendingDeposits))
 		require.Equal(t, 0, len(st.builders))
 	})
@@ -1089,9 +1090,25 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		depositBuilder := newPendingDeposit(t, sk, builderCreds, 7, 0, true)
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositValidator, depositBuilder}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 2, len(st.pendingDeposits))
 		require.Equal(t, 0, len(st.builders))
+	})
+
+	t.Run("builder deposit before validator deposit creates builder", func(t *testing.T) {
+		sk, err := bls.RandKey()
+		require.NoError(t, err)
+		builderCreds := builderWithdrawalCredentials(0xEF)
+		validatorCreds := nonBuilderWithdrawalCredentials()
+
+		depositBuilder := newPendingDeposit(t, sk, builderCreds, 7, 0, true)
+		depositValidator := newPendingDeposit(t, sk, validatorCreds, 5, 0, true)
+
+		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositBuilder, depositValidator}, 0)
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
+		require.Equal(t, 0, len(st.pendingDeposits))
+		require.Equal(t, 1, len(st.builders))
+		require.Equal(t, primitives.Gwei(12), st.builders[0].Balance)
 	})
 
 	t.Run("keeps invalid non-builder deposit in pending queue", func(t *testing.T) {
@@ -1101,7 +1118,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		deposit := newPendingDeposit(t, sk, validatorCreds, 5, 0, false)
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{deposit}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 1, len(st.pendingDeposits))
 		require.Equal(t, 0, len(st.builders))
 	})
@@ -1115,7 +1132,7 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		depositTopUp := newPendingDeposit(t, sk, builderCreds, 5, depSlot, true)
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositCreate, depositTopUp}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 0, len(st.pendingDeposits))
 		require.Equal(t, 1, len(st.builders))
 		require.Equal(t, primitives.Gwei(15), st.builders[0].Balance)
@@ -1131,12 +1148,160 @@ func TestOnboardBuildersFromPendingDeposits(t *testing.T) {
 		depositBuilder := newPendingDeposit(t, sk, builderCreds, 7, 0, true)
 
 		st := newGloasState(t, nil, nil, []*ethpb.PendingDeposit{depositInvalidValidator, depositBuilder}, 0)
-		require.NoError(t, st.OnboardBuildersFromPendingDeposits())
+		require.NoError(t, st.OnboardBuildersFromPendingDeposits(t.Context()))
 		require.Equal(t, 1, len(st.pendingDeposits))
 		require.DeepEqual(t, depositInvalidValidator, st.pendingDeposits[0])
 		require.Equal(t, 1, len(st.builders))
 		require.Equal(t, primitives.Gwei(7), st.builders[0].Balance)
 	})
+}
+
+func TestOnboardBuildersFromPendingDeposits_VerificationWorkIsLinear(t *testing.T) {
+	t.Run("invalid pending deposits are checked once", func(t *testing.T) {
+		const (
+			pendingCount = 100
+			builderCount = 50
+		)
+		pubkey := bytes.Repeat([]byte{0x42}, fieldparams.BLSPubkeyLength)
+		pendingDeposits := make([]*ethpb.PendingDeposit, 0, pendingCount+builderCount)
+		for i := range pendingCount {
+			pendingDeposits = append(pendingDeposits, &ethpb.PendingDeposit{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: nonBuilderWithdrawalCredentials(),
+				Amount:                uint64(i + 1),
+				Signature:             make([]byte, fieldparams.BLSSignatureLength),
+			})
+		}
+		for i := range builderCount {
+			pendingDeposits = append(pendingDeposits, &ethpb.PendingDeposit{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: builderWithdrawalCredentials(byte(i)),
+				Amount:                uint64(pendingCount + i + 1),
+				Signature:             make([]byte, fieldparams.BLSSignatureLength),
+			})
+		}
+
+		st := newGloasState(t, nil, nil, pendingDeposits, 0)
+		verificationCount := 0
+		err := st.onboardBuildersFromPendingDeposits(t.Context(), func(*ethpb.Deposit_Data) (bool, error) {
+			verificationCount++
+			return false, nil
+		})
+		require.NoError(t, err)
+
+		// Each retained pending deposit and each builder candidate is verified at most once.
+		// The previous implementation performed pendingCount*builderCount+builderCount checks.
+		require.Equal(t, pendingCount+builderCount, verificationCount)
+		require.Equal(t, pendingCount, len(st.pendingDeposits))
+		require.Equal(t, 0, len(st.builders))
+	})
+
+	t.Run("valid pending validator result is reused", func(t *testing.T) {
+		const builderCount = 50
+		pubkey := bytes.Repeat([]byte{0x43}, fieldparams.BLSPubkeyLength)
+		pendingDeposits := []*ethpb.PendingDeposit{
+			{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: nonBuilderWithdrawalCredentials(),
+				Amount:                1,
+			},
+			{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: nonBuilderWithdrawalCredentials(),
+				Amount:                2,
+			},
+		}
+		for i := range builderCount {
+			pendingDeposits = append(pendingDeposits, &ethpb.PendingDeposit{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: builderWithdrawalCredentials(byte(i)),
+				Amount:                uint64(i + 3),
+			})
+		}
+
+		st := newGloasState(t, nil, nil, pendingDeposits, 0)
+		verificationCount := 0
+		err := st.onboardBuildersFromPendingDeposits(t.Context(), func(data *ethpb.Deposit_Data) (bool, error) {
+			verificationCount++
+			return data.Amount == 2, nil
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, 2, verificationCount)
+		require.Equal(t, len(pendingDeposits), len(st.pendingDeposits))
+		require.Equal(t, 0, len(st.builders))
+	})
+
+	t.Run("only newly appended pending deposits are checked", func(t *testing.T) {
+		pubkey := bytes.Repeat([]byte{0x45}, fieldparams.BLSPubkeyLength)
+		pendingDeposits := []*ethpb.PendingDeposit{
+			{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: nonBuilderWithdrawalCredentials(),
+				Amount:                1,
+			},
+			{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: builderWithdrawalCredentials(0xA1),
+				Amount:                2,
+			},
+			{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: nonBuilderWithdrawalCredentials(),
+				Amount:                3,
+			},
+			{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: builderWithdrawalCredentials(0xA2),
+				Amount:                4,
+			},
+			{
+				PublicKey:             pubkey,
+				WithdrawalCredentials: builderWithdrawalCredentials(0xA3),
+				Amount:                5,
+			},
+		}
+
+		st := newGloasState(t, nil, nil, pendingDeposits, 0)
+		verifiedAmounts := make([]uint64, 0, len(pendingDeposits))
+		err := st.onboardBuildersFromPendingDeposits(t.Context(), func(data *ethpb.Deposit_Data) (bool, error) {
+			verifiedAmounts = append(verifiedAmounts, data.Amount)
+			return false, nil
+		})
+		require.NoError(t, err)
+
+		require.DeepEqual(t, []uint64{1, 2, 3, 4, 5}, verifiedAmounts)
+		require.Equal(t, 2, len(st.pendingDeposits))
+		require.Equal(t, 0, len(st.builders))
+	})
+}
+
+func TestOnboardBuildersFromPendingDeposits_ContextCancellation(t *testing.T) {
+	pubkey := bytes.Repeat([]byte{0x44}, fieldparams.BLSPubkeyLength)
+	pendingDeposits := []*ethpb.PendingDeposit{
+		{
+			PublicKey:             pubkey,
+			WithdrawalCredentials: nonBuilderWithdrawalCredentials(),
+			Amount:                1,
+		},
+		{
+			PublicKey:             pubkey,
+			WithdrawalCredentials: builderWithdrawalCredentials(0xAA),
+			Amount:                2,
+		},
+	}
+	st := newGloasState(t, nil, nil, pendingDeposits, 0)
+	ctx, cancel := context.WithCancel(t.Context())
+	verificationCount := 0
+	err := st.onboardBuildersFromPendingDeposits(ctx, func(*ethpb.Deposit_Data) (bool, error) {
+		verificationCount++
+		cancel()
+		return false, nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, verificationCount)
+	require.Equal(t, len(pendingDeposits), len(st.pendingDeposits))
+	require.Equal(t, 0, len(st.builders))
 }
 
 func newGloasState(

--- a/consensus-types/hdiff/state_diff.go
+++ b/consensus-types/hdiff/state_diff.go
@@ -2180,7 +2180,7 @@ func updateToVersion(ctx context.Context, source state.BeaconState, target int) 
 	case version.Electra:
 		ret, err = fulu.ConvertToFulu(source)
 	case version.Fulu:
-		ret, err = gloas.UpgradeToGloas(source)
+		ret, err = gloas.UpgradeToGloas(ctx, source)
 	default:
 		return nil, errors.Errorf("unsupported version %s", version.String(source.Version()))
 	}

--- a/consensus-types/hdiff/state_diff_gloas_test.go
+++ b/consensus-types/hdiff/state_diff_gloas_test.go
@@ -19,7 +19,7 @@ import (
 
 func gloasState(t testing.TB, numValidators uint64) (state.BeaconState, error) {
 	fuluState, _ := util.DeterministicGenesisStateFulu(t, numValidators)
-	return gloas.UpgradeToGloas(fuluState)
+	return gloas.UpgradeToGloas(t.Context(), fuluState)
 }
 
 func requireEqualState(t testing.TB, expected, actual state.BeaconState) {
@@ -244,7 +244,7 @@ func TestGloasCrossForkDiff(t *testing.T) {
 	// Test Fulu → Gloas cross-fork diff via updateToVersion.
 	fuluSource, _ := util.DeterministicGenesisStateFulu(t, 64)
 
-	gloasTarget, err := gloas.UpgradeToGloas(fuluSource.Copy())
+	gloasTarget, err := gloas.UpgradeToGloas(t.Context(), fuluSource.Copy())
 	require.NoError(t, err)
 	require.NoError(t, gloasTarget.SetSlot(fuluSource.Slot()+1))
 
@@ -280,7 +280,7 @@ func TestGloasCrossForkDiffOnboardsBuilderDeposit(t *testing.T) {
 		Slot:                  0,
 	}}))
 
-	gloasTarget, err := gloas.UpgradeToGloas(fuluSource.Copy())
+	gloasTarget, err := gloas.UpgradeToGloas(t.Context(), fuluSource.Copy())
 	require.NoError(t, err)
 	require.NoError(t, gloasTarget.SetSlot(fuluSource.Slot()+1))
 

--- a/testing/spectest/shared/gloas/fork/upgrade_to_gloas.go
+++ b/testing/spectest/shared/gloas/fork/upgrade_to_gloas.go
@@ -38,7 +38,7 @@ func RunUpgradeToGloas(t *testing.T, config string) {
 			}
 			preState, err := state_native.InitializeFromProtoFulu(preStateBase)
 			require.NoError(t, err)
-			postState, err := gloas.UpgradeToGloas(preState)
+			postState, err := gloas.UpgradeToGloas(t.Context(), preState)
 			require.NoError(t, err)
 			postStateFromFunction, err := state_native.ProtobufBeaconStateGloas(postState.ToProtoUnsafe())
 			require.NoError(t, err)

--- a/testing/util/gloas_state.go
+++ b/testing/util/gloas_state.go
@@ -15,7 +15,7 @@ func DeterministicGenesisStateGloas(t testing.TB, numValidators uint64) (state.B
 	t.Helper()
 
 	fuluState, privKeys := DeterministicGenesisStateFulu(t, numValidators)
-	beaconState, err := gloas.UpgradeToGloas(fuluState)
+	beaconState, err := gloas.UpgradeToGloas(t.Context(), fuluState)
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "failed to upgrade genesis beacon state of %d validators to gloas", numValidators))
 	}


### PR DESCRIPTION
OnboardBuildersFromPendingDeposits previously rescanned and reverified earlier same-pubkey
  deposits for every builder candidate. Devnet-8 triggered millions of redundant checks, causing
  Prysm nodes to stall at the Gloas fork.

  This change:

  - Caches pending-validator status per pubkey while preserving deposit-order semantics.
  - Verifies each pending deposit at most once.
  - Propagates context through the Gloas upgrade and checks cancellation during onboarding.
  - Adds regression tests for linear verification, ordering, incremental deposits, and cancellation.

