### PR TITLE
fixing ux bug on default hosts log

### DIFF
--- a/api/redact.go
+++ b/api/redact.go
@@ -16,7 +16,8 @@ func RedactEndpoint(endpoint string) string {
 	// Scheme-less forms like 127.0.0.1:4000 fail to parse (or parse as opaque);
 	// reparse as an authority so the host survives and credentials are still masked.
 	u, err = url.Parse("//" + endpoint)
-	if err != nil {
+	if err != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		// Anything beyond a pure authority could smuggle credentials past Redacted.
 		return "[invalid endpoint]"
 	}
 	return strings.TrimPrefix(u.Redacted(), "//")

--- a/api/redact.go
+++ b/api/redact.go
@@ -10,10 +10,16 @@ import (
 // placeholder rather than the raw string, so a token is never leaked to logs.
 func RedactEndpoint(endpoint string) string {
 	u, err := url.Parse(endpoint)
+	if err == nil && u.Opaque == "" {
+		return u.Redacted()
+	}
+	// Scheme-less forms like 127.0.0.1:4000 fail to parse (or parse as opaque);
+	// reparse as an authority so the host survives and credentials are still masked.
+	u, err = url.Parse("//" + endpoint)
 	if err != nil {
 		return "[invalid endpoint]"
 	}
-	return u.Redacted()
+	return strings.TrimPrefix(u.Redacted(), "//")
 }
 
 // RedactEndpointList applies RedactEndpoint to a comma-separated list of

--- a/api/redact_test.go
+++ b/api/redact_test.go
@@ -28,6 +28,21 @@ func TestRedactEndpoint(t *testing.T) {
 			want:     "localhost:4000",
 		},
 		{
+			name:     "grpc ip:port unchanged",
+			endpoint: "127.0.0.1:4000",
+			want:     "127.0.0.1:4000",
+		},
+		{
+			name:     "scheme-less credentials masked",
+			endpoint: "eth:fake-token-not-real@127.0.0.1:4000",
+			want:     "eth:xxxxx@127.0.0.1:4000",
+		},
+		{
+			name:     "unparseable becomes placeholder",
+			endpoint: "http://127.0.0.1:4000\x00",
+			want:     "[invalid endpoint]",
+		},
+		{
 			name:     "username only still masked",
 			endpoint: "https://eth@bn-lodestar.example.io",
 			want:     "https://eth@bn-lodestar.example.io",

--- a/api/redact_test.go
+++ b/api/redact_test.go
@@ -43,6 +43,11 @@ func TestRedactEndpoint(t *testing.T) {
 			want:     "[invalid endpoint]",
 		},
 		{
+			name:     "unparseable with credentials becomes placeholder",
+			endpoint: "http://user:fake-pass@local host:8080",
+			want:     "[invalid endpoint]",
+		},
+		{
 			name:     "username only still masked",
 			endpoint: "https://eth@bn-lodestar.example.io",
 			want:     "https://eth@bn-lodestar.example.io",

--- a/changelog/james-prysm_fix-endpoint-redaction-hostport.md
+++ b/changelog/james-prysm_fix-endpoint-redaction-hostport.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed beacon node endpoints such as the default `127.0.0.1:4000` being logged as `[invalid endpoint]` in validator client failover logs.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

fixes a bug that displays WARN fallback: No responsive beacon node found tried=[[invalid endpoint]] when connecting to an unsynced node. the invalid endpoint was actually just the default.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
