### PR TITLE
fixes found around stateless flows

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope.go
@@ -145,15 +145,16 @@ func (vs *Server) PublishExecutionPayloadEnvelope(
 	})
 	log.Debug("Publishing execution payload envelope")
 
-	// KZG verification stays synchronous, never gossip unverified sidecars.
+	// KZG verification stays synchronous, never gossip unverified sidecars. A cached-root match means
+	// the columns were built locally from the engine's own bundle, so verification is skipped.
 	var sidecars []consensusblocks.RODataColumn
-	if len(blobs) > 0 {
+	if cachedSidecars, ok := vs.cachedDataColumns(signed.Message); ok {
+		sidecars = cachedSidecars
+	} else if len(blobs) > 0 {
 		sidecars, err = vs.sidecarsFromContents(blobs, kzgProofs, envSlot, beaconBlockRoot)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid execution payload envelope contents: %v", err)
 		}
-	} else if cached, ok := vs.ExecutionPayloadEnvelopeCache.Contents(); ok && cached.Envelope.Payload.SlotNumber == envSlot {
-		sidecars = cached.DataColumns
 	}
 
 	roSigned, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(signed)
@@ -199,6 +200,27 @@ func (vs *Server) importPublishedEnvelope(log *logrus.Entry, sidecars []consensu
 	log.WithField("duration", time.Since(start)).Debug("Imported published execution payload envelope")
 }
 
+// cachedDataColumns returns the precomputed data columns when the published envelope is the cached
+// one, matched by envelope root so a same-slot candidate's columns are never reused.
+func (vs *Server) cachedDataColumns(envelope *ethpb.ExecutionPayloadEnvelope) ([]consensusblocks.RODataColumn, bool) {
+	cached, ok := vs.ExecutionPayloadEnvelopeCache.Contents()
+	if !ok || cached.Envelope == nil {
+		return nil, false
+	}
+	cachedRoot, err := cached.Envelope.HashTreeRoot()
+	if err != nil {
+		return nil, false
+	}
+	submittedRoot, err := envelope.HashTreeRoot()
+	if err != nil {
+		return nil, false
+	}
+	if cachedRoot != submittedRoot {
+		return nil, false
+	}
+	return cached.DataColumns, true
+}
+
 // resolveEnvelopeToPublish extracts the signed envelope plus any caller-supplied blobs. The stateful
 // signed_envelope arm must match the cached envelope so its precomputed data columns apply.
 func (vs *Server) resolveEnvelopeToPublish(req *ethpb.GenericSignedExecutionPayloadEnvelope) (*ethpb.SignedExecutionPayloadEnvelope, [][]byte, [][]byte, error) {
@@ -237,8 +259,7 @@ func (vs *Server) resolveEnvelopeToPublish(req *ethpb.GenericSignedExecutionPayl
 }
 
 // sidecarsFromContents verifies caller-supplied blobs+KZG proofs (stateless publish) and builds the
-// data column sidecars for the slot. Verification matters because broadcastAndReceiveDataColumns
-// upgrades the sidecars to "verified" without re-checking.
+// data column sidecars for the slot. The publish path upgrades them to "verified" without re-checking.
 func (vs *Server) sidecarsFromContents(blobs, kzgProofs [][]byte, slot primitives.Slot, blockRoot [32]byte) ([]consensusblocks.RODataColumn, error) {
 	if err := verifyCellProofs(blobs, kzgProofs); err != nil {
 		return nil, errors.Wrap(err, "kzg verification failed")

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_payload_envelope_test.go
@@ -11,13 +11,16 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
+	mockChain "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
 	mockp2p "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -250,24 +253,7 @@ func TestPublishExecutionPayloadEnvelope_SignedEnvelopeArm(t *testing.T) {
 	cfg.GloasForkEpoch = 0
 	params.OverrideBeaconConfig(cfg)
 
-	envelope := &ethpb.ExecutionPayloadEnvelope{
-		Payload: &enginev1.ExecutionPayloadGloas{
-			ParentHash:    make([]byte, 32),
-			FeeRecipient:  make([]byte, 20),
-			StateRoot:     make([]byte, 32),
-			ReceiptsRoot:  make([]byte, 32),
-			LogsBloom:     make([]byte, 256),
-			PrevRandao:    make([]byte, 32),
-			BaseFeePerGas: make([]byte, 32),
-			BlockHash:     make([]byte, 32),
-			ExtraData:     make([]byte, 0),
-			SlotNumber:    1,
-		},
-		ExecutionRequests:     &enginev1.ExecutionRequestsGloas{},
-		BuilderIndex:          0,
-		BeaconBlockRoot:       make([]byte, 32),
-		ParentBeaconBlockRoot: make([]byte, 32),
-	}
+	envelope := testEnvelope(1)
 	signed := &ethpb.SignedExecutionPayloadEnvelope{Message: envelope, Signature: make([]byte, 96)}
 	statefulReq := &ethpb.GenericSignedExecutionPayloadEnvelope{
 		Envelope: &ethpb.GenericSignedExecutionPayloadEnvelope_SignedEnvelope{SignedEnvelope: signed},
@@ -403,6 +389,101 @@ func TestPublishExecutionPayloadEnvelope_ImportFailureDoesNotFailPublish(t *test
 	require.NotNil(t, resp)
 	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
 	waitForEnvelopeImport(t, receiver)
+}
+
+// Contents-arm sidecar selection: precomputed columns are reused only for the cached envelope,
+// and a cache hit skips verification of the submitted blob data.
+func TestPublishExecutionPayloadEnvelope_ContentsArmCachedColumns(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	envelope := testEnvelope(1)
+	signed := &ethpb.SignedExecutionPayloadEnvelope{Message: envelope, Signature: make([]byte, 96)}
+
+	// Zero-valued cells and proofs suffice: no subtest path performs KZG operations on them.
+	columns, err := peerdas.DataColumnSidecarsGloas(
+		[][]kzg.Cell{make([]kzg.Cell, fieldparams.NumberOfColumns)},
+		[][]kzg.Proof{make([]kzg.Proof, fieldparams.NumberOfColumns)},
+		1, bytesutil.ToBytes32(envelope.BeaconBlockRoot),
+	)
+	require.NoError(t, err)
+
+	newServer := func(t *testing.T, cached *ethpb.ExecutionPayloadEnvelope) (*Server, *mockExecutionPayloadEnvelopeReceiver, *mockChain.ChainService) {
+		envReceiver := &mockExecutionPayloadEnvelopeReceiver{done: make(chan struct{})}
+		chain := &mockChain.ChainService{}
+		vs := &Server{
+			Ctx:                              t.Context(),
+			P2P:                              &mockp2p.MockBroadcaster{},
+			ExecutionPayloadEnvelopeReceiver: envReceiver,
+			DataColumnReceiver:               chain,
+			ExecutionPayloadEnvelopeCache:    cache.NewExecutionPayloadEnvelopeCache(),
+		}
+		vs.ExecutionPayloadEnvelopeCache.Set(&cache.ExecutionPayloadContents{Envelope: cached, DataColumns: columns})
+		return vs, envReceiver, chain
+	}
+
+	contentsReq := func(blobs, kzgProofs [][]byte) *ethpb.GenericSignedExecutionPayloadEnvelope {
+		return &ethpb.GenericSignedExecutionPayloadEnvelope{
+			Envelope: &ethpb.GenericSignedExecutionPayloadEnvelope_Contents{
+				Contents: &ethpb.SignedExecutionPayloadEnvelopeContents{
+					SignedExecutionPayloadEnvelope: signed,
+					Blobs:                          blobs,
+					KzgProofs:                      kzgProofs,
+				},
+			},
+		}
+	}
+
+	t.Run("same-slot cached candidate with a different root is not used", func(t *testing.T) {
+		other := proto.Clone(envelope).(*ethpb.ExecutionPayloadEnvelope)
+		other.BuilderIndex = envelope.BuilderIndex + 1
+		vs, envReceiver, chain := newServer(t, other)
+
+		_, err := vs.PublishExecutionPayloadEnvelope(t.Context(), contentsReq(nil, nil))
+		require.NoError(t, err)
+		// Sidecars are received before the envelope import, so the count is final here.
+		waitForEnvelopeImport(t, envReceiver)
+		require.Equal(t, 0, len(chain.DataColumns))
+	})
+
+	t.Run("matching cached envelope reuses cached columns without verifying blob data", func(t *testing.T) {
+		vs, envReceiver, chain := newServer(t, envelope)
+
+		// Unverifiable proofs pass only because the cached columns are reused and never rebuilt.
+		blob := kzg.Blob{1}
+		badProofs := make([][]byte, fieldparams.NumberOfColumns)
+		for i := range badProofs {
+			badProofs[i] = bytes.Repeat([]byte{0xff}, 48)
+		}
+		_, err := vs.PublishExecutionPayloadEnvelope(t.Context(), contentsReq([][]byte{blob[:]}, badProofs))
+		require.NoError(t, err)
+		waitForEnvelopeImport(t, envReceiver)
+		require.Equal(t, fieldparams.NumberOfColumns, len(chain.DataColumns))
+	})
+}
+
+// testEnvelope returns a minimally populated execution payload envelope for the slot.
+func testEnvelope(slot primitives.Slot) *ethpb.ExecutionPayloadEnvelope {
+	return &ethpb.ExecutionPayloadEnvelope{
+		Payload: &enginev1.ExecutionPayloadGloas{
+			ParentHash:    make([]byte, 32),
+			FeeRecipient:  make([]byte, 20),
+			StateRoot:     make([]byte, 32),
+			ReceiptsRoot:  make([]byte, 32),
+			LogsBloom:     make([]byte, 256),
+			PrevRandao:    make([]byte, 32),
+			BaseFeePerGas: make([]byte, 32),
+			BlockHash:     make([]byte, 32),
+			ExtraData:     make([]byte, 0),
+			SlotNumber:    slot,
+		},
+		ExecutionRequests:     &enginev1.ExecutionRequestsGloas{},
+		BuilderIndex:          0,
+		BeaconBlockRoot:       make([]byte, 32),
+		ParentBeaconBlockRoot: make([]byte, 32),
+	}
 }
 
 type mockExecutionPayloadEnvelopeReceiver struct {

--- a/changelog/james-prysm_stateless-flow-fixes.md
+++ b/changelog/james-prysm_stateless-flow-fixes.md
@@ -1,0 +1,8 @@
+### Added
+
+- Per-validator `validator_failed_envelope_submissions` metric counting failed self-build envelope submissions (omitted under `--disable-account-metrics`).
+
+### Fixed
+
+- Execution payload envelope publishing now selects the beacon node's precomputed data column sidecars by envelope root, and reuses them when the locally built envelope is published with blob data, skipping redundant verification and recomputation.
+- Validator client now records the proposal log and metrics for an accepted Gloas block even when the follow-up envelope publish fails.

--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -69,6 +69,16 @@ var (
 			"pubkey",
 		},
 	)
+	// ValidatorProposeEnvelopeFailVec used to count failed self-build envelope submissions.
+	ValidatorProposeEnvelopeFailVec = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "validator",
+			Name:      "failed_envelope_submissions",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
 	// ValidatorBalancesGaugeVec used to keep track of validator balances by public key.
 	ValidatorBalancesGaugeVec = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -189,9 +189,12 @@ func (v *validator) ProposeBlock(ctx context.Context, slot primitives.Slot, pubK
 		return
 	}
 
+	// The block was already accepted: a failed reveal must not skip the proposal logging and metrics.
 	if err := v.proposeSelfBuildEnvelope(ctx, slot, pubKey, blk); err != nil {
-		log.WithError(err).Error("Failed to propose self-build envelope")
-		return
+		log.WithField("slot", slot).WithError(err).Error("Failed to propose self-build envelope")
+		if v.emitAccountMetrics {
+			ValidatorProposeEnvelopeFailVec.WithLabelValues(fmtKey).Inc()
+		}
 	}
 
 	span.SetAttributes(

--- a/validator/client/propose_gloas_test.go
+++ b/validator/client/propose_gloas_test.go
@@ -238,74 +238,90 @@ func TestSignExecutionPayloadEnvelope_UsesDomainBeaconBuilder(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestProposeBlock_Gloas_EnvelopeAfterBlock verifies that the Gloas propose flow
-// submits the block first, then retrieves, signs, and publishes the envelope.
-// The envelope's state root is lazily computed by the beacon node from the
-// post-block state, so this ordering is critical.
-func TestProposeBlock_Gloas_EnvelopeAfterBlock(t *testing.T) {
-	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t, false)
-	defer finish()
-
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-
-	blk := util.NewBeaconBlockGloas()
+// TestProposeBlock_Gloas verifies the self-build propose flow: the block is submitted before the
+// envelope is retrieved, signed, and published, and a failed reveal does not suppress proposal logging.
+func TestProposeBlock_Gloas(t *testing.T) {
 	builderIndex := params.BeaconConfig().BuilderIndexSelfBuild
-	if blk.Block.Body == nil {
-		blk.Block.Body = &ethpb.BeaconBlockBodyGloas{}
-	}
-	if blk.Block.Body.SignedExecutionPayloadBid == nil {
-		blk.Block.Body.SignedExecutionPayloadBid = &ethpb.SignedExecutionPayloadBid{}
-	}
-	if blk.Block.Body.SignedExecutionPayloadBid.Message == nil {
-		blk.Block.Body.SignedExecutionPayloadBid.Message = &ethpb.ExecutionPayloadBid{}
-	}
-	blk.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex = builderIndex
 
-	gloasBlock := &ethpb.GenericBeaconBlock{
-		Block: &ethpb.GenericBeaconBlock_Gloas{
-			Gloas: blk.Block,
-		},
+	selfBuildBlock := func() *ethpb.GenericBeaconBlock {
+		blk := util.NewBeaconBlockGloas()
+		blk.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex = builderIndex
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Gloas{Gloas: blk.Block}}
 	}
 
-	envelope := testExecutionPayloadEnvelope(1, builderIndex)
+	t.Run("envelope after block", func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		validator, m, validatorKey, finish := setup(t, false)
+		defer finish()
 
-	// DomainData for randao signing.
-	m.validatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
+		var pubKey [fieldparams.BLSPubkeyLength]byte
+		copy(pubKey[:], validatorKey.PublicKey().Marshal())
 
-	// BeaconBlock returns a Gloas block.
-	m.validatorClient.EXPECT().
-		BeaconBlock(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.BlockRequest{})).
-		Return(gloasBlock, nil)
+		// DomainData for randao signing.
+		m.validatorClient.EXPECT().
+			DomainData(gomock.Any(), gomock.Any()).
+			Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
 
-	// DomainData for block signing.
-	m.validatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
+		m.validatorClient.EXPECT().
+			BeaconBlock(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.BlockRequest{})).
+			Return(selfBuildBlock(), nil)
 
-	// Critical ordering: ProposeBeaconBlock must be called BEFORE ExecutionPayloadEnvelope.
-	proposeCall := m.validatorClient.EXPECT().
-		ProposeBeaconBlock(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.GenericSignedBeaconBlock{})).
-		Return(&ethpb.ProposeResponse{BlockRoot: make([]byte, 32)}, nil)
+		// DomainData for block signing.
+		m.validatorClient.EXPECT().
+			DomainData(gomock.Any(), gomock.Any()).
+			Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
 
-	getEnvelopeCall := m.validatorClient.EXPECT().
-		GetExecutionPayloadEnvelope(gomock.Any(), primitives.Slot(1), gomock.Any()).
-		Return(envelope, nil).
-		After(proposeCall)
+		// Critical ordering: ProposeBeaconBlock must be called BEFORE ExecutionPayloadEnvelope.
+		proposeCall := m.validatorClient.EXPECT().
+			ProposeBeaconBlock(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.GenericSignedBeaconBlock{})).
+			Return(&ethpb.ProposeResponse{BlockRoot: make([]byte, 32)}, nil)
 
-	// DomainData for envelope signing.
-	m.validatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil).
-		After(getEnvelopeCall)
+		getEnvelopeCall := m.validatorClient.EXPECT().
+			GetExecutionPayloadEnvelope(gomock.Any(), primitives.Slot(1), gomock.Any()).
+			Return(testExecutionPayloadEnvelope(1, builderIndex), nil).
+			After(proposeCall)
 
-	m.validatorClient.EXPECT().
-		PublishExecutionPayloadEnvelope(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.SignedExecutionPayloadEnvelope{})).
-		Return(&emptypb.Empty{}, nil)
+		// DomainData for envelope signing.
+		m.validatorClient.EXPECT().
+			DomainData(gomock.Any(), gomock.Any()).
+			Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil).
+			After(getEnvelopeCall)
 
-	validator.ProposeBlock(t.Context(), 1, pubKey)
-	require.LogsContain(t, hook, "Submitted new block")
+		m.validatorClient.EXPECT().
+			PublishExecutionPayloadEnvelope(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.SignedExecutionPayloadEnvelope{})).
+			Return(&emptypb.Empty{}, nil)
+
+		validator.ProposeBlock(t.Context(), 1, pubKey)
+		require.LogsContain(t, hook, "Submitted new block")
+	})
+
+	t.Run("envelope failure still logs proposal", func(t *testing.T) {
+		hook := logTest.NewGlobal()
+		validator, m, validatorKey, finish := setup(t, false)
+		defer finish()
+
+		var pubKey [fieldparams.BLSPubkeyLength]byte
+		copy(pubKey[:], validatorKey.PublicKey().Marshal())
+
+		// DomainData for randao and block signing.
+		m.validatorClient.EXPECT().
+			DomainData(gomock.Any(), gomock.Any()).
+			Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil).
+			Times(2)
+
+		m.validatorClient.EXPECT().
+			BeaconBlock(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.BlockRequest{})).
+			Return(selfBuildBlock(), nil)
+
+		m.validatorClient.EXPECT().
+			ProposeBeaconBlock(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.GenericSignedBeaconBlock{})).
+			Return(&ethpb.ProposeResponse{BlockRoot: make([]byte, 32)}, nil)
+
+		m.validatorClient.EXPECT().
+			GetExecutionPayloadEnvelope(gomock.Any(), primitives.Slot(1), gomock.Any()).
+			Return(nil, errors.New("connection refused"))
+
+		validator.ProposeBlock(t.Context(), 1, pubKey)
+		require.LogsContain(t, hook, "Submitted new block")
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

found some small bugs around stateless flow

1. properly printing proposal logs to pass block proposal even if payload fails, adding failed payload metric
2. checking cached payload first skipping validation knowing it's locally built.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
