### PR TITLE
fix sync committee duty bug for exited vals - pre gloas

### DIFF
--- a/changelog/bastin_fix-sync-commiitee-duty-for-exited-vals-pre-gloas.md
+++ b/changelog/bastin_fix-sync-commiitee-duty-for-exited-vals-pre-gloas.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix sync committee duties for validators that exit during an active sync committee period.

--- a/validator/client/duties.go
+++ b/validator/client/duties.go
@@ -100,11 +100,12 @@ func (v *validator) UpdateDuties(ctx context.Context) error {
 
 	epoch := slots.ToEpoch(slots.CurrentSlot(v.genesisTime) + 1)
 
-	filteredKeys, filteredIndices := v.filteredKeysAndIndices(keys, epoch)
 	if epoch >= params.BeaconConfig().GloasForkEpoch {
+		_, filteredIndices := v.filteredKeysAndIndices(keys, epoch)
 		err = v.updateDutiesSplit(ctx, epoch, filteredIndices)
 	} else {
-		err = v.updateDutiesCombined(ctx, epoch, filteredKeys)
+		// Combined duties include sync assignments that remain valid after validator exit.
+		err = v.updateDutiesCombined(ctx, epoch, keys)
 	}
 	if err != nil {
 		return errors.Wrap(err, "could not fetch duties")
@@ -178,13 +179,13 @@ func dropIfDivergent[T interface{ GetDependentRoot() []byte }](resp T, attRoot [
 	return zero
 }
 
-// allCurrentDutiesExited reports whether there is at least one duty and all are EXITED.
+// allCurrentDutiesExited reports whether all duties are EXITED with no sync duty remaining.
 func allCurrentDutiesExited(duties []*ethpb.ValidatorDuty) bool {
 	if len(duties) == 0 {
 		return false
 	}
 	for _, d := range duties {
-		if d.Status != ethpb.ValidatorStatus_EXITED {
+		if d.Status != ethpb.ValidatorStatus_EXITED || d.IsSyncCommittee {
 			return false
 		}
 	}

--- a/validator/client/duties_test.go
+++ b/validator/client/duties_test.go
@@ -188,6 +188,63 @@ func TestUpdateDuties_AllValidatorsExited(t *testing.T) {
 
 }
 
+func TestUpdateDuties_PreGloasRetainsExitedSyncCommitteeKey(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = cfg.FarFutureEpoch
+	params.OverrideBeaconConfig(cfg)
+
+	ctrl := gomock.NewController(t)
+	client := validatormock.NewMockValidatorClient(ctrl)
+	kp := randKeypair(t)
+	v := validator{
+		km:              newMockKeymanager(t, kp),
+		validatorClient: client,
+		duties:          &dutyStore{},
+		pubkeyToStatus: map[pubkey]*validatorStatus{
+			kp.pub: {
+				publicKey: kp.pub[:],
+				status:    &ethpb.ValidatorStatusResponse{Status: ethpb.ValidatorStatus_EXITED},
+				index:     42,
+			},
+		},
+		aggSelector: &stubAggregatorSelector{proofs: make(map[pubkey][]byte)},
+	}
+
+	resp := &ethpb.ValidatorDutiesContainer{
+		CurrentEpochDuties: []*ethpb.ValidatorDuty{{
+			PublicKey:       kp.pub[:],
+			ValidatorIndex:  42,
+			Status:          ethpb.ValidatorStatus_EXITED,
+			IsSyncCommittee: true,
+		}},
+	}
+	client.EXPECT().Duties(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *ethpb.DutiesRequest) (*ethpb.ValidatorDutiesContainer, error) {
+			require.DeepEqual(t, [][]byte{kp.pub[:]}, req.PublicKeys)
+			return resp, nil
+		},
+	)
+
+	var subscribed sync.WaitGroup
+	subscribed.Add(1)
+	client.EXPECT().SubscribeCommitteeSubnets(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *ethpb.CommitteeSubnetsSubscribeRequest) (*emptypb.Empty, error) {
+			subscribed.Done()
+			return &emptypb.Empty{}, nil
+		},
+	)
+
+	require.NoError(t, v.UpdateDuties(t.Context()))
+	util.WaitTimeout(&subscribed, 2*time.Second)
+
+	roles, err := v.RolesAt(t.Context(), 1)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(roles[kp.pub]))
+	assert.Equal(t, roleSyncCommittee, roles[kp.pub][0])
+	assert.Equal(t, roleSyncCommitteeAggregator, roles[kp.pub][1])
+}
+
 func TestUpdateDuties_Distributed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Fix sync committee duties for validators that exit during an active sync committee period.

Pre-Gloas duty fetching now includes exited keys so the beacon node can return their remaining
sync assignments. Exited validators with a sync duty are also no longer treated as having no
remaining duties.

this issue was recognized before: https://github.com/OffchainLabs/prysm/issues/16759
then it was fixed here: https://github.com/OffchainLabs/prysm/pull/16726
then it was reintroduced/ignored here: https://github.com/OffchainLabs/prysm/pull/16421

This is a workaround/hack-fix for only pre-gloas. for post gloas we need a bigger change to fix this bug.