### PR TITLE
stream hdiff validator comparison

### DIFF
--- a/changelog/bastin_hdiff-diff-to-val-iterator.md
+++ b/changelog/bastin_hdiff-diff-to-val-iterator.md
@@ -1,0 +1,3 @@
+### Changed
+
+- stream hdiff validator comparisons.

--- a/consensus-types/hdiff/state_diff.go
+++ b/consensus-types/hdiff/state_diff.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"iter"
 	"slices"
 
 	"github.com/OffchainLabs/go-bitfield"
@@ -1236,36 +1237,65 @@ func (h *hdiff) serialize() HdiffBytes {
 
 // diffToVals computes the difference between two BeaconStates and returns a slice of validatorDiffs.
 func diffToVals(source, target state.ReadOnlyBeaconState) ([]validatorDiff, error) {
-	sVals := source.ValidatorsReadOnly()
-	tVals := target.ValidatorsReadOnly()
-	if len(tVals) < len(sVals) {
-		return nil, errors.Errorf("target validators length %d is less than source %d", len(tVals), len(sVals))
+	sourceCount := source.NumValidators()
+	targetCount := target.NumValidators()
+	if targetCount < sourceCount {
+		return nil, errors.Errorf("target validators length %d is less than source %d", targetCount, sourceCount)
 	}
+
+	nextTarget, stopTarget := iter.Pull2(target.ValidatorsReadOnlySeq())
+	defer stopTarget()
+
 	diffs := make([]validatorDiff, 0)
-	for i, s := range sVals {
-		ti := tVals[i]
+	processed := 0
+	expectedIndex := primitives.ValidatorIndex(0)
+	for sourceIndex, s := range source.ValidatorsReadOnlySeq() {
+		if sourceIndex != expectedIndex {
+			return nil, errors.Errorf("source validators iterator returned index %d, expected %d", sourceIndex, expectedIndex)
+		}
+		targetIndex, ti, ok := nextTarget()
+		if !ok {
+			return nil, errors.Errorf("target validators iterator ended at index %d, expected length %d", processed, targetCount)
+		}
+		if targetIndex != expectedIndex {
+			return nil, errors.Errorf("target validators iterator returned index %d, expected %d", targetIndex, expectedIndex)
+		}
 		if validatorsEqual(s, ti) {
+			processed++
+			expectedIndex++
 			continue
 		}
 		d := validatorDiff{
 			Slashed:                    ti.Slashed(),
-			index:                      uint32(i),
+			index:                      uint32(processed),
 			EffectiveBalance:           ti.EffectiveBalance(),
 			ActivationEligibilityEpoch: ti.ActivationEligibilityEpoch(),
 			ActivationEpoch:            ti.ActivationEpoch(),
 			ExitEpoch:                  ti.ExitEpoch(),
 			WithdrawableEpoch:          ti.WithdrawableEpoch(),
 		}
-		if !bytes.Equal(s.GetWithdrawalCredentials(), tVals[i].GetWithdrawalCredentials()) {
-			d.WithdrawalCredentials = slices.Clone(tVals[i].GetWithdrawalCredentials())
+		if !bytes.Equal(s.GetWithdrawalCredentials(), ti.GetWithdrawalCredentials()) {
+			d.WithdrawalCredentials = slices.Clone(ti.GetWithdrawalCredentials())
 		}
 		diffs = append(diffs, d)
+		processed++
+		expectedIndex++
 	}
-	for i, ti := range tVals[len(sVals):] {
+	if processed != sourceCount {
+		return nil, errors.Errorf("source validators iterator ended at index %d, expected length %d", processed, sourceCount)
+	}
+	for i := sourceCount; i < targetCount; i++ {
+		targetIndex, ti, ok := nextTarget()
+		if !ok {
+			return nil, errors.Errorf("target validators iterator ended at index %d, expected length %d", i, targetCount)
+		}
+		if targetIndex != expectedIndex {
+			return nil, errors.Errorf("target validators iterator returned index %d, expected %d", targetIndex, expectedIndex)
+		}
 		pubkey := ti.PublicKey()
 		diffs = append(diffs, validatorDiff{
 			Slashed:                    ti.Slashed(),
-			index:                      uint32(i + len(sVals)),
+			index:                      uint32(i),
 			PublicKey:                  pubkey[:],
 			WithdrawalCredentials:      slices.Clone(ti.GetWithdrawalCredentials()),
 			EffectiveBalance:           ti.EffectiveBalance(),
@@ -1274,6 +1304,7 @@ func diffToVals(source, target state.ReadOnlyBeaconState) ([]validatorDiff, erro
 			ExitEpoch:                  ti.ExitEpoch(),
 			WithdrawableEpoch:          ti.WithdrawableEpoch(),
 		})
+		expectedIndex++
 	}
 	return diffs, nil
 }

--- a/consensus-types/hdiff/state_diff_test.go
+++ b/consensus-types/hdiff/state_diff_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
+	"iter"
 	"math"
 	"os"
 	"testing"
@@ -422,6 +423,43 @@ func Test_diffToVals(t *testing.T) {
 		}
 		require.Equal(t, true, found)
 	})
+}
+
+type validatorIterationState struct {
+	state.ReadOnlyBeaconState
+	materializedCalls int
+	streamedCalls     int
+}
+
+func (s *validatorIterationState) ValidatorsReadOnly() []state.ReadOnlyValidator {
+	s.materializedCalls++
+	return s.ReadOnlyBeaconState.ValidatorsReadOnly()
+}
+
+func (s *validatorIterationState) ValidatorsReadOnlySeq() iter.Seq2[primitives.ValidatorIndex, state.ReadOnlyValidator] {
+	s.streamedCalls++
+	return s.ReadOnlyBeaconState.ValidatorsReadOnlySeq()
+}
+
+func TestDiffToValsStreamsValidators(t *testing.T) {
+	source, _ := util.DeterministicGenesisStateElectra(t, 32)
+	target := source.Copy()
+	appended, err := source.ValidatorAtIndexReadOnly(0)
+	require.NoError(t, err)
+	validator := appended.Copy()
+	validator.PublicKey[0]++
+	require.NoError(t, target.AppendValidator(validator))
+
+	streamingSource := &validatorIterationState{ReadOnlyBeaconState: source}
+	streamingTarget := &validatorIterationState{ReadOnlyBeaconState: target}
+	diffs, err := diffToVals(streamingSource, streamingTarget)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(diffs))
+	require.Equal(t, uint32(32), diffs[0].index)
+	require.Equal(t, 0, streamingSource.materializedCalls)
+	require.Equal(t, 0, streamingTarget.materializedCalls)
+	require.Equal(t, 1, streamingSource.streamedCalls)
+	require.Equal(t, 1, streamingTarget.streamedCalls)
 }
 
 // Test_newValidatorDiffs tests validator diff deserialization


### PR DESCRIPTION
Stream validator comparisons directly from the source and target states instead of materializing both validator slices in
memory. This reduces peak allocation pressure and helps smooth memory spikes.