### PR TITLE
Beacon API: Return `404` instead of `500` if state not found.

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_state.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_state.go
@@ -2,7 +2,6 @@ package beacon
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,7 +10,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/altair"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/eth/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/eth/shared"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/lookup"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -40,13 +38,7 @@ func (s *Server) GetStateRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stateRoot, err := s.Stater.StateRoot(ctx, []byte(stateId))
-	if err != nil {
-		var rootNotFoundErr *lookup.StateRootNotFoundError
-		if errors.As(err, &rootNotFoundErr) {
-			httputil.HandleError(w, "State root not found: "+rootNotFoundErr.Error(), http.StatusNotFound)
-			return
-		}
-		httputil.HandleError(w, "Could not get state root: "+err.Error(), http.StatusInternalServerError)
+	if !shared.WriteStateRootFetchError(w, err) {
 		return
 	}
 	st, err := s.Stater.State(ctx, []byte(stateId))

--- a/beacon-chain/rpc/eth/beacon/handlers_state_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_state_test.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	chainMock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	dbTest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/lookup"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/testutil"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -25,6 +27,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
 )
 
 func TestGetStateRoot(t *testing.T) {
@@ -119,6 +122,71 @@ func TestGetStateRoot(t *testing.T) {
 		resp := &structs.GetStateRootResponse{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
 		assert.DeepEqual(t, true, resp.Finalized)
+	})
+
+	// A state ID that resolves to no state must be a 404, not a 500.
+	t.Run("state not found", func(t *testing.T) {
+		chainService := &chainMock.ChainService{}
+		stateNotFoundErr := lookup.NewStateNotFoundError(8192, []byte("test"))
+		s := &Server{
+			Stater:                &testutil.MockStater{CustomError: &stateNotFoundErr},
+			HeadFetcher:           chainService,
+			OptimisticModeFetcher: chainService,
+			FinalizationFetcher:   chainService,
+			BeaconDB:              db,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, "http://example.com//eth/v1/beacon/states/{state_id}/root", nil)
+		request.SetPathValue("state_id", "1506150")
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.GetStateRoot(writer, request)
+		require.Equal(t, http.StatusNotFound, writer.Code)
+		e := &httputil.DefaultJsonError{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusNotFound, e.Code)
+		assert.StringContains(t, stateNotFoundErr.Error(), e.Message)
+	})
+
+	t.Run("state root not found", func(t *testing.T) {
+		chainService := &chainMock.ChainService{}
+		rootNotFoundErr := lookup.NewStateRootNotFoundError(8192)
+		s := &Server{
+			Stater:                &testutil.MockStater{CustomError: &rootNotFoundErr},
+			HeadFetcher:           chainService,
+			OptimisticModeFetcher: chainService,
+			FinalizationFetcher:   chainService,
+			BeaconDB:              db,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, "http://example.com//eth/v1/beacon/states/{state_id}/root", nil)
+		request.SetPathValue("state_id", "0x"+strings.Repeat("f", 64))
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.GetStateRoot(writer, request)
+		require.Equal(t, http.StatusNotFound, writer.Code)
+	})
+
+	t.Run("invalid state ID", func(t *testing.T) {
+		chainService := &chainMock.ChainService{}
+		parseErr := lookup.NewStateIdParseError(errors.New("foo"))
+		s := &Server{
+			Stater:                &testutil.MockStater{CustomError: &parseErr},
+			HeadFetcher:           chainService,
+			OptimisticModeFetcher: chainService,
+			FinalizationFetcher:   chainService,
+			BeaconDB:              db,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, "http://example.com//eth/v1/beacon/states/{state_id}/root", nil)
+		request.SetPathValue("state_id", "foo")
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.GetStateRoot(writer, request)
+		require.Equal(t, http.StatusBadRequest, writer.Code)
 	})
 }
 

--- a/beacon-chain/rpc/eth/shared/errors.go
+++ b/beacon-chain/rpc/eth/shared/errors.go
@@ -11,20 +11,53 @@ import (
 	"github.com/pkg/errors"
 )
 
-// WriteStateFetchError writes an appropriate error based on the supplied argument.
-// The argument error should be a result of fetching state.
-func WriteStateFetchError(w http.ResponseWriter, err error) {
-	var stateNotFoundError *lookup.StateNotFoundError
-	if errors.As(err, &stateNotFoundError) || errors.Is(err, stategen.ErrNoDataForSlot) {
-		httputil.HandleError(w, "State not found", http.StatusNotFound)
-		return
+// writeStateIdError handles common state ID lookup errors.
+// Returns true if an error was handled and written to the response, false if no error.
+func writeStateIdError(w http.ResponseWriter, err error, fallbackMsg string) bool {
+	if err == nil {
+		return false
 	}
+
+	// The state root of a given state ID may be missing even though the state itself is known,
+	// so both "not found" flavors must map to 404.
+	var stateRootNotFoundErr *lookup.StateRootNotFoundError
+	if errors.As(err, &stateRootNotFoundErr) {
+		httputil.HandleError(w, "State root not found: "+stateRootNotFoundErr.Error(), http.StatusNotFound)
+		return true
+	}
+
+	var stateNotFoundError *lookup.StateNotFoundError
+	if errors.As(err, &stateNotFoundError) {
+		httputil.HandleError(w, "State not found: "+stateNotFoundError.Error(), http.StatusNotFound)
+		return true
+	}
+
+	if errors.Is(err, stategen.ErrNoDataForSlot) {
+		httputil.HandleError(w, "State not found: "+err.Error(), http.StatusNotFound)
+		return true
+	}
+
 	var parseErr *lookup.StateIdParseError
 	if errors.As(err, &parseErr) {
 		httputil.HandleError(w, "Invalid state ID: "+parseErr.Error(), http.StatusBadRequest)
-		return
+		return true
 	}
-	httputil.HandleError(w, "Could not get state: "+err.Error(), http.StatusInternalServerError)
+
+	httputil.HandleError(w, fallbackMsg+": "+err.Error(), http.StatusInternalServerError)
+	return true
+}
+
+// WriteStateFetchError writes an appropriate error based on the supplied argument.
+// The argument error should be a result of fetching state.
+func WriteStateFetchError(w http.ResponseWriter, err error) {
+	writeStateIdError(w, err, "Could not get state")
+}
+
+// WriteStateRootFetchError writes an appropriate error based on the supplied argument.
+// The argument error should be a result of fetching a state root.
+// Returns true if no error occurred, false otherwise.
+func WriteStateRootFetchError(w http.ResponseWriter, err error) bool {
+	return !writeStateIdError(w, err, "Could not get state root")
 }
 
 // writeBlockIdError handles common block ID lookup errors.

--- a/beacon-chain/rpc/eth/shared/errors_test.go
+++ b/beacon-chain/rpc/eth/shared/errors_test.go
@@ -56,6 +56,76 @@ func TestWriteStateFetchError(t *testing.T) {
 	}
 }
 
+// TestWriteStateRootFetchError tests the WriteStateRootFetchError function
+// to ensure that the correct error message and code are written to the response
+// and that the function returns the correct boolean value.
+func TestWriteStateRootFetchError(t *testing.T) {
+	cases := []struct {
+		name            string
+		err             error
+		expectedMessage string
+		expectedCode    int
+		expectedReturn  bool
+	}{
+		{
+			name:           "Nil error should return true",
+			err:            nil,
+			expectedReturn: true,
+		},
+		{
+			name:            "StateRootNotFoundError should return 404",
+			err:             &lookup.StateRootNotFoundError{},
+			expectedMessage: "State root not found",
+			expectedCode:    http.StatusNotFound,
+			expectedReturn:  false,
+		},
+		{
+			name:            "StateNotFoundError should return 404",
+			err:             &lookup.StateNotFoundError{},
+			expectedMessage: "State not found",
+			expectedCode:    http.StatusNotFound,
+			expectedReturn:  false,
+		},
+		{
+			name:            "ErrNoDataForSlot should return 404",
+			err:             errors.Wrap(stategen.ErrNoDataForSlot, "no data for slot"),
+			expectedMessage: "State not found",
+			expectedCode:    http.StatusNotFound,
+			expectedReturn:  false,
+		},
+		{
+			name:            "StateIdParseError should return 400",
+			err:             &lookup.StateIdParseError{},
+			expectedMessage: "Invalid state ID",
+			expectedCode:    http.StatusBadRequest,
+			expectedReturn:  false,
+		},
+		{
+			name:            "Generic error should return 500",
+			err:             errors.New("database connection failed"),
+			expectedMessage: "Could not get state root",
+			expectedCode:    http.StatusInternalServerError,
+			expectedReturn:  false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			writer := httptest.NewRecorder()
+			result := WriteStateRootFetchError(writer, c.err)
+
+			assert.Equal(t, c.expectedReturn, result, "incorrect return value")
+			if !c.expectedReturn {
+				assert.Equal(t, c.expectedCode, writer.Code, "incorrect status code")
+				assert.StringContains(t, c.expectedMessage, writer.Body.String(), "incorrect error message")
+
+				e := &httputil.DefaultJsonError{}
+				assert.NoError(t, json.Unmarshal(writer.Body.Bytes(), e), "failed to unmarshal response")
+			}
+		})
+	}
+}
+
 // TestWriteBlockFetchError tests the WriteBlockFetchError function
 // to ensure that the correct error message and code are written to the response
 // and that the function returns the correct boolean value.

--- a/beacon-chain/rpc/lookup/stater.go
+++ b/beacon-chain/rpc/lookup/stater.go
@@ -73,6 +73,11 @@ func NewStateNotFoundError(stateRootsSize int, stateRoot []byte) StateNotFoundEr
 	}
 }
 
+// newStateNotFoundErrorf creates a new error instance with a formatted message.
+func newStateNotFoundErrorf(format string, args ...any) *StateNotFoundError {
+	return &StateNotFoundError{message: fmt.Sprintf(format, args...)}
+}
+
 // Error returns the underlying error message.
 func (e *StateNotFoundError) Error() string {
 	return e.message
@@ -287,8 +292,8 @@ func (p *BeaconDbStater) StateBySlot(ctx context.Context, target primitives.Slot
 	ctx, span := trace.StartSpan(ctx, "statefetcher.StateBySlot")
 	defer span.End()
 
-	if target > p.GenesisTimeFetcher.CurrentSlot() {
-		return nil, errors.New("requested slot is in the future")
+	if currentSlot := p.GenesisTimeFetcher.CurrentSlot(); target > currentSlot {
+		return nil, newStateNotFoundErrorf("requested slot is in the future (requested %d, current %d)", target, currentSlot)
 	}
 
 	if p.BeaconDB != nil {
@@ -297,9 +302,7 @@ func (p *BeaconDbStater) StateBySlot(ctx context.Context, target primitives.Slot
 			return nil, errors.Wrap(err, "could not determine state availability")
 		}
 		if err == nil && target > 0 && target < earliestSlot {
-			return nil, &StateNotFoundError{
-				message: fmt.Sprintf("requested slot %d is unavailable; earliest available slot is %d", target, earliestSlot),
-			}
+			return nil, newStateNotFoundErrorf("requested slot %d is unavailable; earliest available slot is %d", target, earliestSlot)
 		}
 
 		backfillStatus, err := p.BeaconDB.BackfillStatus(ctx)
@@ -308,9 +311,7 @@ func (p *BeaconDbStater) StateBySlot(ctx context.Context, target primitives.Slot
 		}
 		if err == nil && backfillStatus != nil {
 			if target > 0 && target < primitives.Slot(backfillStatus.LowSlot) {
-				return nil, &StateNotFoundError{
-					message: fmt.Sprintf("requested slot %d is unavailable; backfill starts at slot %d", target, backfillStatus.LowSlot),
-				}
+				return nil, newStateNotFoundErrorf("requested slot %d is unavailable; backfill starts at slot %d", target, backfillStatus.LowSlot)
 			}
 		}
 	}
@@ -318,9 +319,7 @@ func (p *BeaconDbStater) StateBySlot(ctx context.Context, target primitives.Slot
 	st, err := p.ReplayerBuilder.ReplayerForSlot(target).ReplayBlocks(ctx)
 	if err != nil {
 		if errors.Is(err, stategen.ErrNoDataForSlot) {
-			return nil, &StateNotFoundError{
-				message: fmt.Sprintf("requested slot %d is unavailable; historical data not available", target),
-			}
+			return nil, newStateNotFoundErrorf("requested slot %d is unavailable; historical data not available", target)
 		}
 		msg := fmt.Sprintf("error while replaying history to slot=%d", target)
 		return nil, errors.Wrap(err, msg)
@@ -374,7 +373,7 @@ func (p *BeaconDbStater) headStateRoot(ctx context.Context) ([]byte, error) {
 		return nil, errors.Wrap(err, "could not get head block")
 	}
 	if err = blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+		return nil, newStateNotFoundErrorf("head block is unavailable: %s", err.Error())
 	}
 	stateRoot := b.Block().StateRoot()
 	return stateRoot[:], nil
@@ -386,7 +385,7 @@ func (p *BeaconDbStater) genesisStateRoot(ctx context.Context) ([]byte, error) {
 		return nil, errors.Wrap(err, "could not get genesis block")
 	}
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+		return nil, newStateNotFoundErrorf("genesis block is unavailable: %s", err.Error())
 	}
 	stateRoot := b.Block().StateRoot()
 	return stateRoot[:], nil
@@ -402,7 +401,7 @@ func (p *BeaconDbStater) finalizedStateRoot(ctx context.Context) ([]byte, error)
 		return nil, errors.Wrap(err, "could not get finalized block")
 	}
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+		return nil, newStateNotFoundErrorf("finalized block %#x is unavailable: %s", cp.Root, err.Error())
 	}
 	stateRoot := b.Block().StateRoot()
 	return stateRoot[:], nil
@@ -418,7 +417,7 @@ func (p *BeaconDbStater) justifiedStateRoot(ctx context.Context) ([]byte, error)
 		return nil, errors.Wrap(err, "could not get justified block")
 	}
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+		return nil, newStateNotFoundErrorf("justified block %#x is unavailable: %s", cp.Root, err.Error())
 	}
 	stateRoot := b.Block().StateRoot()
 	return stateRoot[:], nil
@@ -444,20 +443,20 @@ func (p *BeaconDbStater) stateRootByRoot(ctx context.Context, stateRoot []byte) 
 func (p *BeaconDbStater) stateRootBySlot(ctx context.Context, slot primitives.Slot) ([]byte, error) {
 	currentSlot := p.GenesisTimeFetcher.CurrentSlot()
 	if slot > currentSlot {
-		return nil, errors.New("slot cannot be in the future")
+		return nil, newStateNotFoundErrorf("slot cannot be in the future (requested %d, current %d)", slot, currentSlot)
 	}
 	blks, err := p.BeaconDB.BlocksBySlot(ctx, slot)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get blocks")
 	}
 	if len(blks) == 0 {
-		return nil, errors.New("no block exists")
+		return nil, newStateNotFoundErrorf("no block exists at slot %d", slot)
 	}
 	if len(blks) != 1 {
 		return nil, errors.New("multiple blocks exist in same slot")
 	}
 	if blks[0] == nil || blks[0].Block() == nil {
-		return nil, errors.New("nil block")
+		return nil, newStateNotFoundErrorf("nil block at slot %d", slot)
 	}
 	stateRoot := blks[0].Block().StateRoot()
 	return stateRoot[:], nil

--- a/beacon-chain/rpc/lookup/stater_test.go
+++ b/beacon-chain/rpc/lookup/stater_test.go
@@ -411,6 +411,23 @@ func TestGetStateRoot(t *testing.T) {
 		}
 		_, err := p.StateRoot(ctx, []byte(strconv.FormatUint(1, 10)))
 		assert.ErrorContains(t, "slot cannot be in the future", err)
+		// The state does not exist, so callers must be able to map this to a 404.
+		var notFoundErr *StateNotFoundError
+		assert.Equal(t, true, errors.As(err, &notFoundErr))
+	})
+	t.Run("no block at slot", func(t *testing.T) {
+		db := testDB.SetupDB(t)
+		slot := primitives.Slot(40)
+		p := BeaconDbStater{
+			GenesisTimeFetcher: &chainMock.ChainService{Slot: &slot},
+			BeaconDB:           db,
+		}
+
+		_, err := p.StateRoot(ctx, []byte(strconv.FormatUint(uint64(slot), 10)))
+		assert.ErrorContains(t, "no block exists at slot 40", err)
+		// The state does not exist, so callers must be able to map this to a 404.
+		var notFoundErr *StateNotFoundError
+		assert.Equal(t, true, errors.As(err, &notFoundErr))
 	})
 
 	t.Run("invalid state", func(t *testing.T) {
@@ -431,6 +448,9 @@ func TestStateBySlot_FutureSlot(t *testing.T) {
 	p := BeaconDbStater{GenesisTimeFetcher: &chainMock.ChainService{Slot: &slot}}
 	_, err := p.StateBySlot(t.Context(), 101)
 	assert.ErrorContains(t, "requested slot is in the future", err)
+	// The state does not exist, so callers must be able to map this to a 404.
+	var notFoundErr *StateNotFoundError
+	assert.Equal(t, true, errors.As(err, &notFoundErr))
 }
 
 func TestStateBySlot_AfterHeadSlot(t *testing.T) {

--- a/beacon-chain/rpc/prysm/beacon/ssz_query.go
+++ b/beacon-chain/rpc/prysm/beacon/ssz_query.go
@@ -11,7 +11,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/eth/shared"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/lookup"
 	"github.com/OffchainLabs/prysm/v7/encoding/ssz/query"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
@@ -56,13 +55,7 @@ func (s *Server) QueryBeaconState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stateRoot, err := s.Stater.StateRoot(ctx, []byte(stateID))
-	if err != nil {
-		var rootNotFoundErr *lookup.StateRootNotFoundError
-		if errors.As(err, &rootNotFoundErr) {
-			httputil.HandleError(w, "State root not found: "+rootNotFoundErr.Error(), http.StatusNotFound)
-			return
-		}
-		httputil.HandleError(w, "Could not get state root: "+err.Error(), http.StatusInternalServerError)
+	if !shared.WriteStateRootFetchError(w, err) {
 		return
 	}
 

--- a/beacon-chain/rpc/testutil/mock_stater.go
+++ b/beacon-chain/rpc/testutil/mock_stater.go
@@ -38,6 +38,9 @@ func (m *MockStater) State(ctx context.Context, id []byte) (state.BeaconState, e
 
 // StateRoot --
 func (m *MockStater) StateRoot(context.Context, []byte) ([]byte, error) {
+	if m.CustomError != nil {
+		return nil, m.CustomError
+	}
 	return m.BeaconStateRoot, nil
 }
 

--- a/changelog/manu_state-root-404.md
+++ b/changelog/manu_state-root-404.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Return `404` instead of `500` when a state ID cannot be resolved to a state root on `GET /eth/v1/beacon/states/{state_id}/root` and `POST /prysm/v1/beacon/states/{state_id}/query` (e.g. no block at the requested slot, slot in the future, missing genesis/finalized/justified block). An unparseable state ID on those endpoints now returns `400` instead of `500`.
+- Return `404` instead of `500` on every state-fetching endpoint when the requested slot is in the future.
+- Include the underlying reason in the `State not found` error message so callers can tell a skipped slot from a pruned one.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Without this fix, querying a not found block with `GET /eth/v1/beacon/states/{state_id}/root` and `POST /prysm/v1/beacon/states/{state_id}/query`, it returns `500` while it should return `404`.

Example:
```
curl http://localhost:3500/eth/v1/beacon/states/1506150/root | jq
{
  "message": "Could not get state root: no block exists",
  "code": 500
}
```


After this fix, it returns `404`, as specified.
```
curl http://localhost:3500/eth/v1/beacon/states/1506150/root | jq
{
  "message": "State not found: no block exists at slot 1506150",
  "code": 404
}
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
