### PR TITLE
Bound the payload envelope data column wait in envelope recovery paths

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -37,38 +37,39 @@ var ErrNilState = errors.New("nil state")
 
 // ChainService defines the mock interface for testing
 type ChainService struct {
-	NotFinalized                bool
-	BuiltOnFullParentVal        bool
-	Full                        bool
-	ValidAttestation            bool
-	Optimistic                  bool
-	BidCompatibleWithHead       bool
-	ValidatorsRoot              [32]byte
-	OptimisticCheckRootReceived [32]byte
-	SyncingRoot                 [32]byte
-	TargetRoot                  [32]byte
-	HeadDependentRoot           [32]byte
-	PublicKey                   [fieldparams.BLSPubkeyLength]byte
-	MockHeadSlot                *primitives.Slot
-	DependentRootCB             func([32]byte, primitives.Epoch) ([32]byte, error)
-	MockCanonicalRoots          map[primitives.Slot][32]byte
-	InitSyncBlockRoots          map[[32]byte]bool
-	MockPayloadEarly            map[[32]byte]bool
-	MockDataAvailable           map[[32]byte]bool
-	MockDataAvailableErr        error
-	ParentPayloadReadyVal       *bool
-	BlockSlot                   primitives.Slot
-	OptimisticRoots             map[[32]byte]bool
-	FinalizedRoots              map[[32]byte]bool
-	ForkchoiceRoots             map[[32]byte]bool
-	ForkchoiceBlockHashes       map[[32]byte][32]byte
-	ForkchoiceGasLimits         map[[32]byte]uint64
-	FinalizedCheckPoint         *ethpb.Checkpoint
-	CurrentJustifiedCheckPoint  *ethpb.Checkpoint
-	PreviousJustifiedCheckPoint *ethpb.Checkpoint
-	Slot                        *primitives.Slot // Pointer because 0 is a useful value, so checking against it can be incorrect.
-	Balance                     *precompute.Balance
-	CanonicalRoots              map[[32]byte]bool
+	NotFinalized                         bool
+	BuiltOnFullParentVal                 bool
+	ReceivePayloadEnvelopeCtxHadDeadline bool
+	Full                                 bool
+	ValidAttestation                     bool
+	Optimistic                           bool
+	BidCompatibleWithHead                bool
+	ValidatorsRoot                       [32]byte
+	OptimisticCheckRootReceived          [32]byte
+	SyncingRoot                          [32]byte
+	TargetRoot                           [32]byte
+	HeadDependentRoot                    [32]byte
+	PublicKey                            [fieldparams.BLSPubkeyLength]byte
+	MockHeadSlot                         *primitives.Slot
+	DependentRootCB                      func([32]byte, primitives.Epoch) ([32]byte, error)
+	MockCanonicalRoots                   map[primitives.Slot][32]byte
+	InitSyncBlockRoots                   map[[32]byte]bool
+	MockPayloadEarly                     map[[32]byte]bool
+	MockDataAvailable                    map[[32]byte]bool
+	MockDataAvailableErr                 error
+	ParentPayloadReadyVal                *bool
+	BlockSlot                            primitives.Slot
+	OptimisticRoots                      map[[32]byte]bool
+	FinalizedRoots                       map[[32]byte]bool
+	ForkchoiceRoots                      map[[32]byte]bool
+	ForkchoiceBlockHashes                map[[32]byte][32]byte
+	ForkchoiceGasLimits                  map[[32]byte]uint64
+	FinalizedCheckPoint                  *ethpb.Checkpoint
+	CurrentJustifiedCheckPoint           *ethpb.Checkpoint
+	PreviousJustifiedCheckPoint          *ethpb.Checkpoint
+	Slot                                 *primitives.Slot // Pointer because 0 is a useful value, so checking against it can be incorrect.
+	Balance                              *precompute.Balance
+	CanonicalRoots                       map[[32]byte]bool
 	// Ancestors lets a test stub the result of Ancestor(root, slot) without
 	// wiring a full forkchoice store. Keyed by the input root.
 	Ancestors                   map[[32]byte][32]byte
@@ -969,7 +970,8 @@ func (c *ChainService) PtcLookupState(_ context.Context, _ [32]byte, _ primitive
 }
 
 // ReceiveExecutionPayloadEnvelope implements the same method in the chain service.
-func (c *ChainService) ReceiveExecutionPayloadEnvelope(_ context.Context, _ interfaces.ROSignedExecutionPayloadEnvelope) error {
+func (c *ChainService) ReceiveExecutionPayloadEnvelope(ctx context.Context, _ interfaces.ROSignedExecutionPayloadEnvelope) error {
+	_, c.ReceivePayloadEnvelopeCtxHadDeadline = ctx.Deadline()
 	return c.ReceivePayloadEnvelopeErr
 }
 

--- a/beacon-chain/sync/pending_payload_envelope.go
+++ b/beacon-chain/sync/pending_payload_envelope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/OffchainLabs/prysm/v7/async"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
@@ -58,7 +59,10 @@ func (s *Service) processPendingPayloadEnvelope(ctx context.Context, root [32]by
 			continue
 		}
 
-		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(ctx, e); err != nil {
+		receiveCtx, cancel := context.WithTimeout(ctx, params.BeaconConfig().SlotDuration())
+		err = s.cfg.chain.ReceiveExecutionPayloadEnvelope(receiveCtx, e)
+		cancel()
+		if err != nil {
 			log.WithError(err).Debug("Could not process pending payload envelope")
 			continue
 		}

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -117,6 +117,7 @@ func TestProcessPendingPayloadEnvelope_HappyPath(t *testing.T) {
 	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
 	require.Equal(t, true, s.hasSeenPayloadEnvelope(root, builderIdx))
 	require.Equal(t, true, broadcaster.BroadcastCalled.Load())
+	require.Equal(t, true, chainService.ReceivePayloadEnvelopeCtxHadDeadline)
 }
 
 func TestProcessPendingPayloadEnvelope_DoesNotBroadcastOnReceiveError(t *testing.T) {

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -113,8 +113,8 @@ func (s *Service) requestDataColumnsForEnvelope(root [32]byte) {
 const maxPayloadEnvelopeFetchAttempts = 3
 
 func (s *Service) fetchPayloadEnvelope(root [32]byte) {
-	// Validating the envelope requires the block's data column sidecars; fetch any we are missing.
-	go s.requestDataColumnsForEnvelope(root)
+	// Fetch missing columns before the envelope so envelope processing does not wait on columns that were never requested.
+	s.requestDataColumnsForEnvelope(root)
 
 	bestPeers := s.getBestPeers()
 	if len(bestPeers) == 0 {
@@ -143,7 +143,10 @@ func (s *Service) fetchPayloadEnvelope(root [32]byte) {
 			log.WithError(err).Debug("Could not wrap requested payload envelope")
 			continue
 		}
-		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(s.ctx, wrapped); err != nil {
+		ctx, cancel := context.WithTimeout(s.ctx, params.BeaconConfig().SlotDuration())
+		err = s.cfg.chain.ReceiveExecutionPayloadEnvelope(ctx, wrapped)
+		cancel()
+		if err != nil {
 			if blockchain.IsInvalidBlock(err) {
 				s.setBadPayload(s.ctx, root)
 				return

--- a/beacon-chain/sync/validate_beacon_block_gloas_test.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas_test.go
@@ -2,16 +2,26 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/peers"
+	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
+	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/require"
 )
 
@@ -221,4 +231,64 @@ func TestRequestPayloadEnvelope_SkipsWhenAlreadyResolved(t *testing.T) {
 			require.NotPanics(t, func() { s.requestPayloadEnvelope(root) })
 		})
 	}
+}
+
+func TestFetchPayloadEnvelope_ReceiveHasDeadline(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	params.BeaconConfig().InitializeForkSchedule()
+
+	ctxMap, err := ContextByteVersionsForValRoot(params.BeaconConfig().GenesisValidatorsRoot)
+	require.NoError(t, err)
+
+	p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
+	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
+
+	root := [32]byte{0x42}
+	envelope := &ethpb.SignedExecutionPayloadEnvelope{
+		Message: &ethpb.ExecutionPayloadEnvelope{
+			Payload: &enginev1.ExecutionPayloadGloas{
+				ParentHash:    make([]byte, fieldparams.RootLength),
+				FeeRecipient:  make([]byte, 20),
+				StateRoot:     make([]byte, fieldparams.RootLength),
+				ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+				LogsBloom:     make([]byte, 256),
+				PrevRandao:    make([]byte, fieldparams.RootLength),
+				BaseFeePerGas: make([]byte, fieldparams.RootLength),
+				BlockHash:     make([]byte, fieldparams.RootLength),
+				SlotNumber:    1,
+			},
+			BeaconBlockRoot:       root[:],
+			ParentBeaconBlockRoot: make([]byte, fieldparams.RootLength),
+		},
+		Signature: make([]byte, fieldparams.BLSSignatureLength),
+	}
+
+	protocol := fmt.Sprintf("%s/ssz_snappy", p2p.RPCExecutionPayloadEnvelopesByRootTopicV1)
+	p2.SetStreamHandler(protocol, func(stream network.Stream) {
+		req := new(p2ptypes.ExecutionPayloadEnvelopesByRootReq)
+		require.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+		require.NoError(t, WriteExecutionPayloadEnvelopeChunk(stream, p2.Encoding(), envelope))
+		require.NoError(t, stream.CloseWrite())
+	})
+
+	chain := &mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{}}
+	s := &Service{
+		ctx: context.Background(),
+		cfg: &config{
+			chain: chain,
+			p2p:   p1,
+			clock: startup.NewClock(time.Now(), [fieldparams.RootLength]byte{}),
+		},
+		ctxMap:          ctxMap,
+		badPayloadCache: lruwrpr.New(10),
+	}
+
+	s.fetchPayloadEnvelope(root)
+	require.True(t, chain.ReceivePayloadEnvelopeCtxHadDeadline)
 }

--- a/changelog/terence_envelope-da-deadline.md
+++ b/changelog/terence_envelope-da-deadline.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Bounded the payload envelope wait on missing data columns in the by-root recovery and pending envelope paths, and fetch missing columns before requesting the envelope.


### PR DESCRIPTION
- Envelope import waits forever on missing data columns when the caller passes a default context, and the stuck call holds the by-root recovery singleflight so all retries silently no-op
- Gossip and initial-sync callers are unchanged, gossip already has the pubsub timeout and initial sync takes the fail-fast branch.