### PR TITLE
Verify bid gas limit against the payload at bid.parent_block_hash

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -50,7 +50,7 @@ type ForkchoiceFetcher interface {
 	Ancestor(context.Context, []byte, primitives.Slot) ([]byte, error)
 	BlockHash(root [32]byte) ([32]byte, error)
 	HasPayloadBlockHash(root, blockHash [32]byte) bool
-	GasLimit(root [32]byte) (uint64, error)
+	GasLimit(root, blockHash [32]byte) (uint64, error)
 	CachedHeadRoot() [32]byte
 	GetProposerHead() [32]byte
 	SetForkChoiceGenesisTime(time.Time)

--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@ -63,11 +63,12 @@ func (s *Service) HasPayloadBlockHash(root, blockHash [32]byte) bool {
 	return s.cfg.ForkChoiceStore.HasPayloadBlockHash(root, blockHash)
 }
 
-// GasLimit returns the gas limit of the latest full payload at or before the given beacon block root from forkchoice.
-func (s *Service) GasLimit(root [32]byte) (uint64, error) {
+// GasLimit returns the gas limit of the payload with the given block hash as seen from the given beacon block root:
+// the block's own payload or the parent payload it builds on.
+func (s *Service) GasLimit(root, blockHash [32]byte) (uint64, error) {
 	s.cfg.ForkChoiceStore.RLock()
 	defer s.cfg.ForkChoiceStore.RUnlock()
-	return s.cfg.ForkChoiceStore.GasLimit(root)
+	return s.cfg.ForkChoiceStore.GasLimit(root, blockHash)
 }
 
 // HasNode returns the corresponding value from forkchoice

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -988,8 +988,8 @@ func (s *ChainService) ParentPayloadReady(_ interfaces.ReadOnlyBeaconBlock) bool
 	return true
 }
 
-// GasLimit mocks the execution payload gas limit lookup for a beacon block root.
-func (s *ChainService) GasLimit(root [32]byte) (uint64, error) {
+// GasLimit mocks the execution payload gas limit lookup for a beacon block root. The block hash is ignored.
+func (s *ChainService) GasLimit(root, _ [32]byte) (uint64, error) {
 	if s.ForkchoiceGasLimits != nil {
 		if gasLimit, ok := s.ForkchoiceGasLimits[root]; ok {
 			return gasLimit, nil

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -1041,7 +1041,7 @@ func TestGasLimit_BellatrixInsertStoresGasLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 
-	got, err := f.GasLimit(root)
+	got, err := f.GasLimit(root, indexToHash(100))
 	require.NoError(t, err)
 	assert.Equal(t, gl, got)
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -660,19 +660,30 @@ func (f *ForkChoice) BlockHash(root [32]byte) ([32]byte, error) {
 	return en.node.blockHash, nil
 }
 
-// GasLimit returns the gas limit of the latest full payload at or before root.
-func (f *ForkChoice) GasLimit(root [32]byte) (uint64, error) {
+// GasLimit returns the gas limit of the payload with the given block hash as seen from the
+// block with the given root: either the block's own payload (full node) or the latest full
+// payload the block builds on. A bid whose parent_block_hash is the parent payload of its
+// parent_block_root builds on the root as an empty node and must be checked against the
+// parent payload's gas limit, not the root's own payload.
+func (f *ForkChoice) GasLimit(root, blockHash [32]byte) (uint64, error) {
 	s := f.store
-	if fn := s.fullNodeByRoot[root]; fn != nil {
-		return fn.gasLimit, nil
-	}
 	en := s.emptyNodeByRoot[root]
-	if en == nil {
+	if en == nil || en.node == nil {
 		return 0, errors.Wrap(ErrNilNode, "could not get gas limit for root")
+	}
+	if blockHash == en.node.blockHash {
+		fn := s.fullNodeByRoot[root]
+		if fn == nil {
+			return 0, errors.New("payload for root has not been imported")
+		}
+		return fn.gasLimit, nil
 	}
 	fp := s.fullParent(en)
 	if fp == nil {
 		return 0, errors.New("no full ancestor with gas limit")
+	}
+	if blockHash != fp.node.blockHash {
+		return 0, errors.New("block hash is neither the root's payload nor its parent payload")
 	}
 	return fp.gasLimit, nil
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -220,7 +220,7 @@ func TestMarkFullNode_SetsGasLimit(t *testing.T) {
 	require.NotNil(t, fn)
 	assert.Equal(t, uint64(30_000_000), fn.gasLimit)
 
-	gl, err := f.GasLimit(root)
+	gl, err := f.GasLimit(root, blockHash)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(30_000_000), gl)
 }
@@ -261,7 +261,7 @@ func TestInsertChain_SetsFullNodeGasLimit(t *testing.T) {
 	require.NotNil(t, fn)
 	assert.Equal(t, uint64(36_000_000), fn.gasLimit)
 
-	gl, err := f.GasLimit(root)
+	gl, err := f.GasLimit(root, blockHash)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(36_000_000), gl)
 }
@@ -2220,7 +2220,7 @@ func TestStore_Prune_IncompatibleFullFinalizedChildren(t *testing.T) {
 
 func TestGasLimit_UnknownRootErrors(t *testing.T) {
 	f := setupGloas(t, 0, 0)
-	_, err := f.GasLimit(indexToHash(999))
+	_, err := f.GasLimit(indexToHash(999), [32]byte{})
 	require.ErrorContains(t, ErrNilNode.Error(), err)
 }
 
@@ -2255,14 +2255,73 @@ func TestGasLimit_GloasEmptyNodeWalksToFullAncestor(t *testing.T) {
 	_, hasFullB := f.store.fullNodeByRoot[rootB]
 	require.Equal(t, false, hasFullB)
 
-	got, err := f.GasLimit(rootB)
+	got, err := f.GasLimit(rootB, blockHashA)
 	require.NoError(t, err)
 	assert.Equal(t, gl, got)
 
 	// Direct full lookup on A also returns gl.
-	got, err = f.GasLimit(rootA)
+	got, err = f.GasLimit(rootA, blockHashA)
 	require.NoError(t, err)
 	assert.Equal(t, gl, got)
+}
+
+func TestGasLimit_GloasParentPayloadVsOwnPayload(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+
+	// A is full with gas limit glA.
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	st, roblock, err := prepareGloasForkchoiceState(ctx, 1, rootA, params.BeaconConfig().ZeroHash, blockHashA, params.BeaconConfig().ZeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+	const glA = uint64(42_000_000)
+	pe, err := blocks.WrappedROExecutionPayloadEnvelope(&ethpb.ExecutionPayloadEnvelope{
+		BeaconBlockRoot:       rootA[:],
+		ParentBeaconBlockRoot: make([]byte, 32),
+		Payload:               &enginev1.ExecutionPayloadGloas{GasLimit: glA},
+	})
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	// B builds on A's payload; its own payload is revealed with gas limit glB.
+	rootB := indexToHash(2)
+	blockHashB := indexToHash(200)
+	st, roblock, err = prepareGloasForkchoiceState(ctx, 2, rootB, rootA, blockHashB, blockHashA, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	// Before B's payload is imported, a bid on B's own payload cannot be checked,
+	// while a bid treating B as empty is checked against A's payload.
+	_, err = f.GasLimit(rootB, blockHashB)
+	require.ErrorContains(t, "payload for root has not been imported", err)
+	got, err := f.GasLimit(rootB, blockHashA)
+	require.NoError(t, err)
+	assert.Equal(t, glA, got)
+
+	const glB = uint64(43_000_000)
+	pe, err = blocks.WrappedROExecutionPayloadEnvelope(&ethpb.ExecutionPayloadEnvelope{
+		BeaconBlockRoot:       rootB[:],
+		ParentBeaconBlockRoot: rootA[:],
+		Payload:               &enginev1.ExecutionPayloadGloas{GasLimit: glB},
+	})
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	// A bid with parent_block_root B and parent_block_hash B's payload uses glB.
+	got, err = f.GasLimit(rootB, blockHashB)
+	require.NoError(t, err)
+	assert.Equal(t, glB, got)
+	// A bid with parent_block_root B and parent_block_hash A's payload (B treated as empty) still uses glA.
+	got, err = f.GasLimit(rootB, blockHashA)
+	require.NoError(t, err)
+	assert.Equal(t, glA, got)
+	// Any other hash is neither B's payload nor the payload B builds on.
+	_, err = f.GasLimit(rootB, indexToHash(300))
+	require.ErrorContains(t, "neither the root's payload nor its parent payload", err)
+	// Unknown root.
+	_, err = f.GasLimit(indexToHash(3), blockHashA)
+	require.ErrorContains(t, "could not get gas limit for root", err)
 }
 
 func TestProcessAttestation_SameSlotPayloadVote(t *testing.T) {

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -104,7 +104,7 @@ type FastGetter interface {
 	ParentRoot(root [32]byte) ([32]byte, error)
 	ParentHash(root [32]byte) [32]byte
 	BlockHash(root [32]byte) ([32]byte, error)
-	GasLimit(root [32]byte) (uint64, error)
+	GasLimit(root, blockHash [32]byte) (uint64, error)
 	CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool)
 }
 

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -262,10 +262,10 @@ func (ro *ROForkChoice) BlockHash(root [32]byte) ([32]byte, error) {
 }
 
 // GasLimit delegates to the underlying forkchoice call, under a lock.
-func (ro *ROForkChoice) GasLimit(root [32]byte) (uint64, error) {
+func (ro *ROForkChoice) GasLimit(root, blockHash [32]byte) (uint64, error) {
 	ro.l.RLock()
 	defer ro.l.RUnlock()
-	return ro.getter.GasLimit(root)
+	return ro.getter.GasLimit(root, blockHash)
 }
 
 // CanonicalNodeAtSlot delegates to the underlying forkchoice call, under a lock.

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -208,7 +208,7 @@ func TestROLocking(t *testing.T) {
 		{
 			name: "gasLimitCalled",
 			call: gasLimitCalled,
-			cb:   func(g FastGetter) { _, err := g.GasLimit([32]byte{}); _discard(t, err) },
+			cb:   func(g FastGetter) { _, err := g.GasLimit([32]byte{}, [32]byte{}); _discard(t, err) },
 		},
 		{
 			name: "hasPayloadBlockHashCalled",
@@ -425,7 +425,7 @@ func (ro *mockROForkchoice) BlockHash(_ [32]byte) ([32]byte, error) {
 	return [32]byte{}, nil
 }
 
-func (ro *mockROForkchoice) GasLimit(_ [32]byte) (uint64, error) {
+func (ro *mockROForkchoice) GasLimit(_, _ [32]byte) (uint64, error) {
 	ro.calls = append(ro.calls, gasLimitCalled)
 	return 0, nil
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_gloas.go
@@ -53,7 +53,7 @@ func (vs *Server) buildBlockGloas(ctx context.Context, sBlk interfaces.SignedBea
 		var builderWin *winningBuilderBid
 		if !selfBuildOnly && len(builderConfig.GetBuilders()) > 0 {
 			val, valErr := head.ValidatorAtIndexReadOnly(sBlk.Block().ProposerIndex())
-			parentGasLimit, glErr := vs.ForkchoiceFetcher.GasLimit(sBlk.Block().ParentRoot())
+			parentGasLimit, glErr := vs.ForkchoiceFetcher.GasLimit(sBlk.Block().ParentRoot(), bytesutil.ToBytes32(local.ExecutionData.ParentHash()))
 			switch {
 			case valErr != nil:
 				log.WithError(valErr).Error("Could not get proposer for builder bid request")

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
@@ -121,7 +121,7 @@ func (vs *Server) validateSubmittedBid(ctx context.Context, signed *ethpb.Signed
 	if err := v.VerifyParentBlockHash(vs.ForkchoiceFetcher.HasPayloadBlockHash); err != nil {
 		return status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	parentGasLimit, err := vs.ForkchoiceFetcher.GasLimit(parentRoot)
+	parentGasLimit, err := vs.ForkchoiceFetcher.GasLimit(parentRoot, bid.ParentBlockHash())
 	if err != nil {
 		return status.Errorf(codes.FailedPrecondition, "could not get parent gas limit: %v", err)
 	}

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -131,7 +131,7 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	if err := v.VerifyParentBlockHash(s.cfg.chain.HasPayloadBlockHash); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	parentGasLimit, err := s.cfg.chain.GasLimit(parentBlockRoot)
+	parentGasLimit, err := s.cfg.chain.GasLimit(parentBlockRoot, bid.ParentBlockHash())
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}

--- a/changelog/barnabasbusa_fix-bid-gas-limit-parent-hash.md
+++ b/changelog/barnabasbusa_fix-bid-gas-limit-parent-hash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Verify a bid's gas limit against the payload identified by `bid.parent_block_hash` instead of the parent block's own payload, so bids that build on the parent's parent payload (empty parent) are no longer rejected with "bid gas limit is incompatible with parent and target".


### PR DESCRIPTION
## What

`validateExecutionPayloadBidGossip` and `validateSubmittedBid` derived `parent_gas_limit` via `GasLimit(bid.parent_block_root)`, which returns the parent *block's own* payload gas limit as soon as that payload has been imported. The spec keys the check on the payload the bid actually builds on:

```python
parent_gas_limit = seen.execution_payloads[bid.parent_block_hash].gas_limit
```

A bid with `parent_block_root = head` and `parent_block_hash = head's parent payload` (i.e. building on the head as empty) was therefore compared against the wrong gas limit and rejected with `bid gas limit is incompatible with parent and target` even though its gas limit was exactly `parent + parent/1024 - 1` from the payload it builds on.

`ForkChoice.GasLimit` now takes the block hash and returns the gas limit of either the root's own payload or the full parent payload it builds on (same disambiguation as `HasPayloadBlockHash`); anything else is an error. The proposer's builder-API path passes the hash of the payload it is building on.

## Why

Seen on glamsterdam-devnet-8 with buildoor submitting bids via `POST /eth/v1/beacon/execution_payload_bids`. Slot 85165: payload at 85163 had gas limit 199411976, payload at 85164 had 199606713, target 200000000. The `parent_empty` bid (parent root 85164, parent hash = 85163's payload) carried 199606713, which is correct for its parent payload, but prysm answered:

```
bid gas limit is incompatible with parent and target: bid=199606713 parent=199606713 target=200000000
```

`parent=199606713` is 85164's own payload gas limit. Every parent-empty bid from that builder was rejected while the gas limit schedule was moving.

## Testing

Added `TestGasLimit_GloasParentPayloadVsOwnPayload` covering: parent payload lookup before and after the root's own payload is imported, own-payload lookup, mismatching hash, unknown root. Existing forkchoice / blockchain / sync bid tests pass.