### PR TITLE
better manage mutexes

### DIFF
--- a/beacon-chain/db/kv/state_diff_cache.go
+++ b/beacon-chain/db/kv/state_diff_cache.go
@@ -17,9 +17,10 @@ import (
 
 type stateDiffCache struct {
 	sync.RWMutex
-	anchors        [][]byte
-	levelsWithData []bool
-	offset         uint64
+	anchors          [][]byte
+	levelsWithData   []bool
+	offset           uint64
+	anchorGeneration uint64
 }
 
 func populateStateDiffCacheFromDB(s *Store, offset uint64) (*stateDiffCache, error) {
@@ -184,6 +185,10 @@ func newStateDiffCache(s *Store) (*stateDiffCache, error) {
 
 func (c *stateDiffCache) getAnchor(level int) state.ReadOnlyBeaconState {
 	c.RLock()
+	if level < 0 || level >= len(c.anchors) {
+		c.RUnlock()
+		return nil
+	}
 	compressed := c.anchors[level]
 	c.RUnlock()
 
@@ -205,6 +210,14 @@ func (c *stateDiffCache) getAnchor(level int) state.ReadOnlyBeaconState {
 }
 
 func (c *stateDiffCache) setAnchor(level int, anchor state.ReadOnlyBeaconState) error {
+	c.RLock()
+	if level < 0 || level >= len(c.anchors) {
+		c.RUnlock()
+		return errors.New("state diff cache: anchor level out of range")
+	}
+	generation := c.anchorGeneration
+	c.RUnlock()
+
 	if anchor == nil {
 		return errors.New("state diff cache: anchor cannot be nil")
 	}
@@ -224,8 +237,8 @@ func (c *stateDiffCache) setAnchor(level int, anchor state.ReadOnlyBeaconState) 
 	c.Lock()
 	defer c.Unlock()
 
-	if level >= len(c.anchors) || level < 0 {
-		return errors.New("state diff cache: anchor level out of range")
+	if generation != c.anchorGeneration {
+		return nil
 	}
 	c.anchors[level] = compressed
 	stateDiffAnchorCacheBytes.WithLabelValues(strconv.Itoa(level)).Set(float64(len(compressed)))
@@ -282,6 +295,7 @@ func (c *stateDiffCache) clearAnchors() {
 
 // clearAnchorsLocked is clearAnchors, for the callers that already hold the lock.
 func (c *stateDiffCache) clearAnchorsLocked() {
+	c.anchorGeneration++
 	c.anchors = make([][]byte, len(flags.Get().StateDiffExponents)-1) // -1 because last level doesn't need to be cached
 	for level := range len(c.anchors) {
 		stateDiffAnchorCacheBytes.WithLabelValues(strconv.Itoa(level)).Set(0)

--- a/beacon-chain/db/kv/state_diff_cache.go
+++ b/beacon-chain/db/kv/state_diff_cache.go
@@ -184,9 +184,8 @@ func newStateDiffCache(s *Store) (*stateDiffCache, error) {
 
 func (c *stateDiffCache) getAnchor(level int) state.ReadOnlyBeaconState {
 	c.RLock()
-	defer c.RUnlock()
-
 	compressed := c.anchors[level]
+	c.RUnlock()
 
 	if len(compressed) == 0 {
 		return nil
@@ -206,11 +205,6 @@ func (c *stateDiffCache) getAnchor(level int) state.ReadOnlyBeaconState {
 }
 
 func (c *stateDiffCache) setAnchor(level int, anchor state.ReadOnlyBeaconState) error {
-	c.Lock()
-	defer c.Unlock()
-	if level >= len(c.anchors) || level < 0 {
-		return errors.New("state diff cache: anchor level out of range")
-	}
 	if anchor == nil {
 		return errors.New("state diff cache: anchor cannot be nil")
 	}
@@ -227,6 +221,12 @@ func (c *stateDiffCache) setAnchor(level int, anchor state.ReadOnlyBeaconState) 
 	compressed := make([]byte, len(encoded))
 	copy(compressed, encoded)
 
+	c.Lock()
+	defer c.Unlock()
+
+	if level >= len(c.anchors) || level < 0 {
+		return errors.New("state diff cache: anchor level out of range")
+	}
 	c.anchors[level] = compressed
 	stateDiffAnchorCacheBytes.WithLabelValues(strconv.Itoa(level)).Set(float64(len(compressed)))
 	return nil

--- a/beacon-chain/db/kv/state_diff_test.go
+++ b/beacon-chain/db/kv/state_diff_test.go
@@ -820,6 +820,50 @@ func TestStateDiff_OffsetCache(t *testing.T) {
 	}
 }
 
+type blockingMarshalBeaconState struct {
+	state.ReadOnlyBeaconState
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingMarshalBeaconState) MarshalSSZ() ([]byte, error) {
+	close(s.started)
+	<-s.release
+	return s.ReadOnlyBeaconState.MarshalSSZ()
+}
+
+func TestStateDiffCache_AnchorAccess(t *testing.T) {
+	setDefaultStateDiffExponents()
+
+	t.Run("out of range read", func(t *testing.T) {
+		cache := &stateDiffCache{anchors: make([][]byte, 1)}
+		require.IsNil(t, cache.getAnchor(-1))
+		require.IsNil(t, cache.getAnchor(1))
+	})
+
+	t.Run("reanchor during encoding", func(t *testing.T) {
+		cache := &stateDiffCache{anchors: make([][]byte, len(flags.Get().StateDiffExponents)-1)}
+		anchor, _ := createState(t, 0, version.Phase0)
+		blockingAnchor := &blockingMarshalBeaconState{
+			ReadOnlyBeaconState: anchor,
+			started:             make(chan struct{}),
+			release:             make(chan struct{}),
+		}
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- cache.setAnchor(0, blockingAnchor)
+		}()
+
+		<-blockingAnchor.started
+		cache.reanchor(32, make([]bool, len(flags.Get().StateDiffExponents)))
+		close(blockingAnchor.release)
+
+		require.NoError(t, <-errCh)
+		require.IsNil(t, cache.getAnchor(0))
+		require.Equal(t, uint64(32), cache.getOffset())
+	})
+}
+
 func TestStateDiff_AnchorCache(t *testing.T) {
 	setDefaultStateDiffExponents()
 

--- a/changelog/bastin_state-diff-cache-optimization-2.md
+++ b/changelog/bastin_state-diff-cache-optimization-2.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move out compression mechanism from locked section of state diff cache getter/setter.


### PR DESCRIPTION
Moving compression/decompression code out of the locked section of the getters setters of state diff cache. 