### PR TITLE
tentative fix to allow export of antislashing database for dynamic keys

### DIFF
--- a/validator/slashing-protection-history/export.go
+++ b/validator/slashing-protection-history/export.go
@@ -98,11 +98,12 @@ func ExportStandardProtectionJSON(
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not retrieve signed attestations for public key %s", pubKeyHex)
 		}
-		if _, ok := dataByPubKey[pubKey]; !ok {
-			// This should never happen
-			return nil, errors.Wrapf(err, "could not retrieve proposer public key from array")
+		data, ok := dataByPubKey[pubKey]
+		if !ok {
+			data = &format.ProtectionData{Pubkey: pubKeyHex}
+			dataByPubKey[pubKey] = data
 		}
-		dataByPubKey[pubKey].SignedAttestations = signedAttestations
+		data.SignedAttestations = signedAttestations
 
 		if err := bar.Add(1); err != nil {
 			return nil, err

--- a/validator/slashing-protection-history/export_test.go
+++ b/validator/slashing-protection-history/export_test.go
@@ -32,6 +32,28 @@ func TestExportStandardProtectionJSON_EmptyGenesisRoot(t *testing.T) {
 	}
 }
 
+func TestExportStandardProtectionJSON_AttestationWithoutProposalIndex(t *testing.T) {
+	ctx := t.Context()
+	pubKey := [fieldparams.BLSPubkeyLength]byte{1}
+	validatorDB := dbtest.SetupDB(t, t.TempDir(), nil, false)
+	genesisValidatorsRoot := [32]byte{1}
+	require.NoError(t, validatorDB.SaveGenesisValidatorsRoot(ctx, genesisValidatorsRoot[:]))
+	require.NoError(t, validatorDB.SaveAttestationForPubKey(
+		ctx,
+		pubKey,
+		[32]byte{4},
+		createAttestation(3, 4),
+	))
+
+	exported, err := ExportStandardProtectionJSON(ctx, validatorDB)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(exported.Data))
+	assert.Equal(t, 0, len(exported.Data[0].SignedBlocks))
+	require.Equal(t, 1, len(exported.Data[0].SignedAttestations))
+	assert.Equal(t, "3", exported.Data[0].SignedAttestations[0].SourceEpoch)
+	assert.Equal(t, "4", exported.Data[0].SignedAttestations[0].TargetEpoch)
+}
+
 func Test_getSignedAttestationsByPubKey(t *testing.T) {
 	for _, isSlashingProtectionMinimal := range [...]bool{false, true} {
 		t.Run(fmt.Sprintf("OK/isSlashingProtectionMinimal:%v", isSlashingProtectionMinimal), func(t *testing.T) {


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

This PR enables validators that were previously loaded via the keymanager API to export their local antislashing database. Currently only when purely using local keys does this work, because the way keys are initialized differs between the keymanager implementation and local keys.

Another approach to this fix would be to actually fix the keymanager addition of keys to properly create the expected entry in the database. However I am not confident with all the potential side effects.

Tested on hoodi.

Fixes #17408
