### PR TITLE
Accept empty `skip_randao_verification` for `/eth/v{3,4}/validator/blocks/{slot}` as per Beacon API

### DIFF
--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -51,7 +51,6 @@ func (s *Server) ProduceBlockV3(w http.ResponseWriter, r *http.Request) {
 	rawSlot := r.PathValue("slot")
 	rawRandaoReveal := r.URL.Query().Get("randao_reveal")
 	rawGraffiti := r.URL.Query().Get("graffiti")
-	rawSkipRandaoVerification := r.URL.Query().Get("skip_randao_verification")
 
 	var bbFactor *wrapperspb.UInt64Value // default the factor via fall back
 	rawBbFactor, bbValue, ok := shared.UintFromQuery(w, r, "builder_boost_factor", false)
@@ -68,7 +67,7 @@ func (s *Server) ProduceBlockV3(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var randaoReveal []byte
-	if rawSkipRandaoVerification == "true" {
+	if skipRandaoVerification(r) {
 		randaoReveal = common.InfiniteSignature[:]
 	} else {
 		rr, err := bytesutil.DecodeHexWithLength(rawRandaoReveal, fieldparams.BLSSignatureLength)
@@ -648,4 +647,10 @@ func handleProduceFuluV3(
 		ConsensusBlockValue:     consensusBlockValue,
 		Data:                    jsonBytes,
 	})
+}
+
+// skipRandaoVerification reports whether the flag is present; the spec sends it with an empty value, "true" is kept for compatibility.
+func skipRandaoVerification(r *http.Request) bool {
+	v, ok := r.URL.Query()["skip_randao_verification"]
+	return ok && (v[0] == "" || v[0] == "true")
 }

--- a/beacon-chain/rpc/eth/validator/handlers_block_gloas.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_gloas.go
@@ -51,7 +51,6 @@ func (s *Server) ProduceBlockV4(w http.ResponseWriter, r *http.Request) {
 
 	rawRandaoReveal := r.URL.Query().Get("randao_reveal")
 	rawGraffiti := r.URL.Query().Get("graffiti")
-	rawSkipRandaoVerification := r.URL.Query().Get("skip_randao_verification")
 
 	var bbFactor *wrapperspb.UInt64Value
 	rawBbFactor, bbValue, ok := shared.UintFromQuery(w, r, "builder_boost_factor", false)
@@ -68,7 +67,7 @@ func (s *Server) ProduceBlockV4(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var randaoReveal []byte
-	if rawSkipRandaoVerification == "true" {
+	if skipRandaoVerification(r) {
 		randaoReveal = common.InfiniteSignature[:]
 	} else {
 		rr, err := bytesutil.DecodeHexWithLength(rawRandaoReveal, fieldparams.BLSSignatureLength)

--- a/beacon-chain/rpc/eth/validator/handlers_block_gloas_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_gloas_test.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/crypto/bls/common"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
@@ -405,4 +407,35 @@ func TestProduceBlockV4_SSZ_IncludePayloadFalse(t *testing.T) {
 	server.ProduceBlockV4(writer, request)
 	assert.Equal(t, http.StatusOK, writer.Code)
 	assert.Equal(t, "application/octet-stream", writer.Header().Get("Content-Type"))
+}
+
+func TestProduceBlockV4_SkipRandaoVerification(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	for _, raw := range []string{"skip_randao_verification", "skip_randao_verification=", "skip_randao_verification=true"} {
+		t.Run(raw, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+			v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, req *eth.BlockRequest) (*eth.GenericBeaconBlock, error) {
+					require.DeepEqual(t, common.InfiniteSignature[:], req.RandaoReveal)
+					return gloasGenericBlockContents(), nil
+				})
+			server := &Server{
+				V1Alpha1Server:        v1alpha1Server,
+				SyncChecker:           &mockSync.Sync{IsSyncing: false},
+				OptimisticModeFetcher: &blockchainTesting.ChainService{},
+				BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: &structs.BlockRewards{Total: "10"}},
+			}
+			request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v4/validator/blocks/1?graffiti=%s&%s", testGraffiti, raw), nil)
+			request.SetPathValue("slot", "1")
+			writer := httptest.NewRecorder()
+			writer.Body = &bytes.Buffer{}
+			server.ProduceBlockV4(writer, request)
+			assert.Equal(t, http.StatusOK, writer.Code)
+		})
+	}
 }

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -15,6 +15,7 @@ import (
 	rewardtesting "github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/eth/rewards/testing"
 	rpctesting "github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/eth/shared/testing"
 	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
+	"github.com/OffchainLabs/prysm/v7/crypto/bls/common"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -536,6 +537,47 @@ func TestProduceBlockV3(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV3(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
+	})
+	t.Run("skip_randao_verification", func(t *testing.T) {
+		for _, raw := range []string{"skip_randao_verification", "skip_randao_verification=", "skip_randao_verification=true"} {
+			t.Run(raw, func(t *testing.T) {
+				var block *structs.SignedBeaconBlock
+				err := json.Unmarshal([]byte(rpctesting.Phase0Block), &block)
+				require.NoError(t, err)
+				v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+				v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+					Slot:         1,
+					RandaoReveal: common.InfiniteSignature[:],
+					Graffiti:     bGraffiti,
+					SkipMevBoost: false,
+				}).Return(
+					func() (*eth.GenericBeaconBlock, error) {
+						return block.Message.ToGeneric()
+					}())
+				server := &Server{
+					V1Alpha1Server: v1alpha1Server,
+					SyncChecker:    syncChecker,
+				}
+				request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?graffiti=%s&%s", graffiti, raw), nil)
+				request.SetPathValue("slot", "1")
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+				server.ProduceBlockV3(writer, request)
+				assert.Equal(t, http.StatusOK, writer.Code)
+			})
+		}
+		t.Run("skip_randao_verification=false still requires randao_reveal", func(t *testing.T) {
+			server := &Server{
+				V1Alpha1Server: mock2.NewMockBeaconNodeValidatorServer(ctrl),
+				SyncChecker:    syncChecker,
+			}
+			request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v3/validator/blocks/1?skip_randao_verification=false", nil)
+			request.SetPathValue("slot", "1")
+			writer := httptest.NewRecorder()
+			writer.Body = &bytes.Buffer{}
+			server.ProduceBlockV3(writer, request)
+			assert.Equal(t, http.StatusBadRequest, writer.Code)
+		})
 	})
 	t.Run("syncing", func(t *testing.T) {
 		server := &Server{

--- a/changelog/syjn99_fix-skip-randao-empty-value.md
+++ b/changelog/syjn99_fix-skip-randao-empty-value.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Accept `skip_randao_verification` with an empty value (`?skip_randao_verification`) in `/eth/v3/validator/blocks/{slot}` and `/eth/v4/validator/blocks/{slot}`, as specified by the Beacon API; `=true` is still accepted.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

We should accept empty query parameter value for `skip_randao_verification`. Before this PR, only `true` is accepted. Lighthouse client sends the flag with an empty value: 
https://github.com/sigp/lighthouse/blob/e423a66763bb1bd780492d635123f208d80c3538/common/eth2/src/lib.rs#L2386-L2389

Beacon API specification: https://github.com/ethereum/beacon-APIs/blob/159622d983a703eb03a8a37bb1edeab7ffc3b6bc/params/index.yaml#L30-L41

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
