### PR TITLE
Move slashing protection failure metric out of `ValidatorDB`

### DIFF
--- a/changelog/syjn99_chore-vc-metrics-increment.md
+++ b/changelog/syjn99_chore-vc-metrics-increment.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move slashing protection failure metric out of `ValidatorDB`

--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -117,7 +117,11 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot primitives.Slot,
 	}
 
 	// Send the attestation to the beacon node.
-	if err := v.db.SlashableAttestationCheck(ctx, indexedAtt, pubKey, signingRoot, v.emitAccountMetrics, ValidatorAttestFailVec); err != nil {
+	if err := v.db.SlashableAttestationCheck(ctx, indexedAtt, pubKey, signingRoot); err != nil {
+		if v.emitAccountMetrics {
+			ValidatorAttestFailVec.WithLabelValues(fmtKey).Inc()
+		}
+
 		log.WithError(err).Error("Failed attestation slashing protection check")
 		log.WithFields(
 			attestationLogFields(pubKey, indexedAtt),

--- a/validator/client/attest_test.go
+++ b/validator/client/attest_test.go
@@ -796,7 +796,7 @@ func Test_slashableAttestationCheck(t *testing.T) {
 				},
 			}
 
-			err := validator.db.SlashableAttestationCheck(t.Context(), att, pubKey, [32]byte{1}, false, nil)
+			err := validator.db.SlashableAttestationCheck(t.Context(), att, pubKey, [32]byte{1})
 			require.NoError(t, err, "Expected allowed attestation not to throw error")
 		})
 	}
@@ -834,11 +834,11 @@ func Test_slashableAttestationCheck_UpdatesLowestSignedEpochs(t *testing.T) {
 			_, sr, err := validator.domainAndSigningRoot(ctx, att.Data)
 			require.NoError(t, err)
 
-			err = validator.db.SlashableAttestationCheck(t.Context(), att, pubKey, sr, false, nil)
+			err = validator.db.SlashableAttestationCheck(t.Context(), att, pubKey, sr)
 			require.NoError(t, err)
 			differentSigningRoot := [32]byte{2}
 
-			err = validator.db.SlashableAttestationCheck(t.Context(), att, pubKey, differentSigningRoot, false, nil)
+			err = validator.db.SlashableAttestationCheck(t.Context(), att, pubKey, differentSigningRoot)
 			require.ErrorContains(t, "could not sign attestation", err)
 
 			e, exists, err := validator.db.LowestSignedSourceEpoch(t.Context(), pubKey)
@@ -878,7 +878,7 @@ func Test_slashableAttestationCheck_OK(t *testing.T) {
 			sr := [32]byte{1}
 			fakePubkey := bytesutil.ToBytes48([]byte("test"))
 
-			err := validator.db.SlashableAttestationCheck(ctx, att, fakePubkey, sr, false, nil)
+			err := validator.db.SlashableAttestationCheck(ctx, att, fakePubkey, sr)
 			require.NoError(t, err, "Expected allowed attestation not to throw error")
 		})
 	}
@@ -908,7 +908,7 @@ func Test_slashableAttestationCheck_GenesisEpoch(t *testing.T) {
 			}
 
 			fakePubkey := bytesutil.ToBytes48([]byte("test"))
-			err := validator.db.SlashableAttestationCheck(ctx, att, fakePubkey, [32]byte{}, false, nil)
+			err := validator.db.SlashableAttestationCheck(ctx, att, fakePubkey, [32]byte{})
 			require.NoError(t, err, "Expected allowed attestation not to throw error")
 			e, exists, err := validator.db.LowestSignedSourceEpoch(t.Context(), fakePubkey)
 			require.NoError(t, err)

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -130,7 +130,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot primitives.Slot, pubK
 		return
 	}
 
-	if err := v.db.SlashableProposalCheck(ctx, pubKey, blk, signingRoot, v.emitAccountMetrics, ValidatorProposeFailVec); err != nil {
+	if err := v.db.SlashableProposalCheck(ctx, pubKey, blk, signingRoot); err != nil {
 		log.WithFields(
 			blockLogFields(pubKey, wb, nil),
 		).WithError(err).Error("Failed block slashing protection check")

--- a/validator/client/slashing_protection_interchange_test.go
+++ b/validator/client/slashing_protection_interchange_test.go
@@ -182,7 +182,7 @@ func TestEIP3076SpecTests(t *testing.T) {
 							copy(signingRoot[:], signingRootBytes)
 						}
 
-						err = validator.db.SlashableAttestationCheck(t.Context(), ia, pk, signingRoot, false, nil)
+						err = validator.db.SlashableAttestationCheck(t.Context(), ia, pk, signingRoot)
 						if shouldSucceed {
 							require.NoError(t, err)
 						} else {

--- a/validator/client/slashing_protection_interchange_test.go
+++ b/validator/client/slashing_protection_interchange_test.go
@@ -145,7 +145,7 @@ func TestEIP3076SpecTests(t *testing.T) {
 
 						wsb, err := blocks.NewSignedBeaconBlock(b)
 						require.NoError(t, err)
-						err = validator.db.SlashableProposalCheck(t.Context(), pk, wsb, signingRoot, validator.emitAccountMetrics, ValidatorProposeFailVec)
+						err = validator.db.SlashableProposalCheck(t.Context(), pk, wsb, signingRoot)
 						if shouldSucceed {
 							require.NoError(t, err)
 						} else {

--- a/validator/db/filesystem/BUILD.bazel
+++ b/validator/db/filesystem/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//validator/slashing-protection-history/format:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",
     ],

--- a/validator/db/filesystem/attester_protection.go
+++ b/validator/db/filesystem/attester_protection.go
@@ -10,7 +10,6 @@ import (
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/validator/db/common"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const failedAttLocalProtectionErr = "attempted to make slashable attestation, rejected by local slashing protection"
@@ -102,8 +101,6 @@ func (s *Store) SlashableAttestationCheck(
 	indexedAtt ethpb.IndexedAtt,
 	pubKey [fieldparams.BLSPubkeyLength]byte,
 	signingRoot32 [32]byte,
-	_ bool,
-	_ *prometheus.CounterVec,
 ) error {
 	ctx, span := trace.StartSpan(ctx, "validator.postAttSignUpdate")
 	defer span.End()

--- a/validator/db/filesystem/proposer_protection.go
+++ b/validator/db/filesystem/proposer_protection.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/validator/db/common"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // HighestSignedProposal is implemented only to satisfy the interface.
@@ -128,8 +127,6 @@ func (s *Store) SlashableProposalCheck(
 	pubKey [fieldparams.BLSPubkeyLength]byte,
 	signedBlock interfaces.ReadOnlySignedBeaconBlock,
 	signingRoot [fieldparams.RootLength]byte,
-	emitAccountMetrics bool,
-	validatorProposeFailVec *prometheus.CounterVec,
 ) error {
 	// Check if the proposal is potentially slashable regarding EIP-3076 minimal conditions.
 	// If not, save the new proposal into the database.

--- a/validator/db/filesystem/proposer_protection_test.go
+++ b/validator/db/filesystem/proposer_protection_test.go
@@ -213,7 +213,7 @@ func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 	}
 	wsb, err := blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{4}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{4})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// We expect the same block with a slot equal to the lowest
@@ -228,14 +228,14 @@ func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 	}
 	wsb, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{1}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{1})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// We expect the same block with a slot equal to the lowest
 	// signed slot to fail validation if signing roots are different.
 	wsb, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{4}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{4})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// We expect the same block with a slot > than the lowest
@@ -251,7 +251,7 @@ func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 
 	wsb, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{3}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{3})
 	require.NoError(t, err)
 }
 
@@ -290,11 +290,11 @@ func Test_slashableProposalCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	// We expect the same block sent out should be slasahble.
-	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, dummySigningRoot, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, dummySigningRoot)
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// We expect the same block sent out with a different signing root should be slashable.
-	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// We save a proposal at slot 11 with a nil signing root.
@@ -306,7 +306,7 @@ func Test_slashableProposalCheck(t *testing.T) {
 
 	// We expect the same block sent out should return slashable error even
 	// if we had a nil signing root stored in the database.
-	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// A block with a different slot for which we do not have a proposing history
@@ -314,7 +314,7 @@ func Test_slashableProposalCheck(t *testing.T) {
 	blk.Block.Slot = 9
 	sBlock, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{3}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{3})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 }
 
@@ -335,6 +335,6 @@ func Test_slashableProposalCheck_RemoteProtection(t *testing.T) {
 	sBlock, err := blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
 
-	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2}, false, nil)
+	err = s.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2})
 	require.NoError(t, err, "Expected allowed block not to throw error")
 }

--- a/validator/db/iface/BUILD.bazel
+++ b/validator/db/iface/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
         "//monitoring/backup:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//validator/db/common:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
 )

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -12,7 +12,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/monitoring/backup"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/validator/db/common"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ValidatorDB defines the necessary methods for a Prysm validator DB.
@@ -41,8 +40,6 @@ type ValidatorDB interface {
 		pubKey [fieldparams.BLSPubkeyLength]byte,
 		signedBlock interfaces.ReadOnlySignedBeaconBlock,
 		signingRoot [fieldparams.RootLength]byte,
-		emitAccountMetrics bool,
-		validatorProposeFailVec *prometheus.CounterVec,
 	) error
 
 	// Attester protection related methods.

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -55,10 +55,7 @@ type ValidatorDB interface {
 	LowestSignedSourceEpoch(ctx context.Context, publicKey [fieldparams.BLSPubkeyLength]byte) (primitives.Epoch, bool, error)
 	AttestedPublicKeys(ctx context.Context) ([][fieldparams.BLSPubkeyLength]byte, error)
 	SlashableAttestationCheck(
-		ctx context.Context, indexedAtt ethpb.IndexedAtt, pubKey [fieldparams.BLSPubkeyLength]byte,
-		signingRoot32 [32]byte,
-		emitAccountMetrics bool,
-		validatorAttestFailVec *prometheus.CounterVec,
+		ctx context.Context, indexedAtt ethpb.IndexedAtt, pubKey [fieldparams.BLSPubkeyLength]byte, signingRoot32 [32]byte,
 	) error
 	SaveAttestationForPubKey(
 		ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, signingRoot [fieldparams.RootLength]byte, att ethpb.IndexedAtt,

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -2,7 +2,6 @@ package kv
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"sync"
 	"time"
@@ -16,7 +15,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1/slashings"
 	"github.com/OffchainLabs/prysm/v7/validator/db/common"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -142,8 +140,6 @@ func (s *Store) SlashableAttestationCheck(
 	indexedAtt ethpb.IndexedAtt,
 	pubKey [fieldparams.BLSPubkeyLength]byte,
 	signingRoot32 [32]byte,
-	emitAccountMetrics bool,
-	validatorAttestFailVec *prometheus.CounterVec,
 ) error {
 	ctx, span := trace.StartSpan(ctx, "validator.postAttSignUpdate")
 	defer span.End()
@@ -183,12 +179,8 @@ func (s *Store) SlashableAttestationCheck(
 			lowestTargetEpoch,
 		)
 	}
-	fmtKey := "0x" + hex.EncodeToString(pubKey[:])
 	slashingKind, err := s.CheckSlashableAttestation(ctx, pubKey, signingRoot, indexedAtt)
 	if err != nil {
-		if emitAccountMetrics {
-			validatorAttestFailVec.WithLabelValues(fmtKey).Inc()
-		}
 		switch slashingKind {
 		case DoubleVote:
 			log.Warn("Attestation is slashable as it is a double vote")

--- a/validator/db/kv/proposer_protection.go
+++ b/validator/db/kv/proposer_protection.go
@@ -13,7 +13,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/OffchainLabs/prysm/v7/validator/db/common"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -203,17 +202,10 @@ func (s *Store) SlashableProposalCheck(
 	pubKey [fieldparams.BLSPubkeyLength]byte,
 	signedBlock interfaces.ReadOnlySignedBeaconBlock,
 	signingRoot [fieldparams.RootLength]byte,
-	emitAccountMetrics bool,
-	validatorProposeFailVec *prometheus.CounterVec,
 ) error {
-	fmtKey := fmt.Sprintf("%#x", pubKey[:])
-
 	blk := signedBlock.Block()
 	prevSigningRoot, proposalAtSlotExists, prevSigningRootExists, err := s.ProposalHistoryForSlot(ctx, pubKey, blk.Slot())
 	if err != nil {
-		if emitAccountMetrics {
-			validatorProposeFailVec.WithLabelValues(fmtKey).Inc()
-		}
 		return errors.Wrap(err, "failed to get proposal history")
 	}
 
@@ -258,17 +250,11 @@ func (s *Store) SlashableProposalCheck(
 	// - the signing root differs,
 	// ==> we consider it slashable.
 	if proposalAtSlotExists && (!prevSigningRootExists || prevSigningRoot != signingRoot) {
-		if emitAccountMetrics {
-			validatorProposeFailVec.WithLabelValues(fmtKey).Inc()
-		}
 		return errors.New(common.FailedBlockSignLocalErr)
 	}
 
 	// Save the proposal for this slot.
 	if err := s.SaveProposalHistoryForSlot(ctx, pubKey, blk.Slot(), signingRoot[:]); err != nil {
-		if emitAccountMetrics {
-			validatorProposeFailVec.WithLabelValues(fmtKey).Inc()
-		}
 		return errors.Wrap(err, "failed to save updated proposal history")
 	}
 

--- a/validator/db/kv/proposer_protection_test.go
+++ b/validator/db/kv/proposer_protection_test.go
@@ -333,7 +333,7 @@ func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 	}
 	wsb, err := blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = db.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{4}, false, nil)
+	err = db.SlashableProposalCheck(t.Context(), pubkey, wsb, [32]byte{4})
 	require.ErrorContains(t, "could not sign block with slot < lowest signed", err)
 
 	// We expect the same block with a slot equal to the lowest
@@ -348,14 +348,14 @@ func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 	}
 	wsb, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = db.SlashableProposalCheck(ctx, pubkey, wsb, [32]byte{1}, false, nil)
+	err = db.SlashableProposalCheck(ctx, pubkey, wsb, [32]byte{1})
 	require.NoError(t, err)
 
 	// We expect the same block with a slot equal to the lowest
 	// signed slot to fail validation if signing roots are different.
 	wsb, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = db.SlashableProposalCheck(ctx, pubkey, wsb, [32]byte{4}, false, nil)
+	err = db.SlashableProposalCheck(ctx, pubkey, wsb, [32]byte{4})
 	require.ErrorContains(t, "could not sign block with slot == lowest signed", err)
 
 	// We expect the same block with a slot > than the lowest
@@ -371,7 +371,7 @@ func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 
 	wsb, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = db.SlashableProposalCheck(ctx, pubkey, wsb, [32]byte{3}, false, nil)
+	err = db.SlashableProposalCheck(ctx, pubkey, wsb, [32]byte{3})
 	require.NoError(t, err)
 }
 
@@ -406,12 +406,12 @@ func Test_slashableProposalCheck(t *testing.T) {
 	sBlock, err := blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
 
-	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, dummySigningRoot, false, nil)
+	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, dummySigningRoot)
 	// We expect the same block sent out with the same root should not be slasahble.
 	require.NoError(t, err)
 
 	// We expect the same block sent out with a different signing root should be slashable.
-	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, [32]byte{2}, false, nil)
+	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, [32]byte{2})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// We save a proposal at slot 11 with a nil signing root.
@@ -423,7 +423,7 @@ func Test_slashableProposalCheck(t *testing.T) {
 
 	// We expect the same block sent out should return slashable error even
 	// if we had a nil signing root stored in the database.
-	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, [32]byte{2}, false, nil)
+	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, [32]byte{2})
 	require.ErrorContains(t, common.FailedBlockSignLocalErr, err)
 
 	// A block with a different slot for which we do not have a proposing history
@@ -431,7 +431,7 @@ func Test_slashableProposalCheck(t *testing.T) {
 	blk.Block.Slot = 9
 	sBlock, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
-	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, [32]byte{3}, false, nil)
+	err = db.SlashableProposalCheck(ctx, pubkey, sBlock, [32]byte{3})
 	require.NoError(t, err, "Expected allowed block not to throw error")
 }
 
@@ -449,6 +449,6 @@ func Test_slashableProposalCheck_RemoteProtection(t *testing.T) {
 	sBlock, err := blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
 
-	err = db.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2}, false, nil)
+	err = db.SlashableProposalCheck(t.Context(), pubkey, sBlock, [32]byte{2})
 	require.NoError(t, err, "Expected allowed block not to throw error")
 }

--- a/validator/helpers/BUILD.bazel
+++ b/validator/helpers/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
         "//validator/db/common:go_default_library",
         "//validator/db/iface:go_default_library",
         "//validator/slashing-protection-history/format:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/validator/helpers/metadata_test.go
+++ b/validator/helpers/metadata_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/validator/db/common"
 	"github.com/OffchainLabs/prysm/v7/validator/db/iface"
 	"github.com/OffchainLabs/prysm/v7/validator/slashing-protection-history/format"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type ValidatorDBMock struct {
@@ -76,8 +75,6 @@ func (db *ValidatorDBMock) SlashableProposalCheck(
 	pubKey [fieldparams.BLSPubkeyLength]byte,
 	signedBlock interfaces.ReadOnlySignedBeaconBlock,
 	signingRoot [fieldparams.RootLength]byte,
-	emitAccountMetrics bool,
-	validatorProposeFailVec *prometheus.CounterVec,
 ) error {
 	panic("not implemented")
 }

--- a/validator/helpers/metadata_test.go
+++ b/validator/helpers/metadata_test.go
@@ -105,10 +105,7 @@ func (db *ValidatorDBMock) AttestedPublicKeys(ctx context.Context) ([][fieldpara
 }
 
 func (db *ValidatorDBMock) SlashableAttestationCheck(
-	ctx context.Context, indexedAtt ethpb.IndexedAtt, pubKey [fieldparams.BLSPubkeyLength]byte,
-	signingRoot32 [32]byte,
-	emitAccountMetrics bool,
-	validatorAttestFailVec *prometheus.CounterVec,
+	ctx context.Context, indexedAtt ethpb.IndexedAtt, pubKey [fieldparams.BLSPubkeyLength]byte, signingRoot32 [32]byte,
 ) error {
 	panic("not implemented")
 }


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Introduced in:

- #13360

`SlashableAttestationCheck` and `SlashableProposalCheck` both have two arguments: a metric (`ValidatorAttestFailVec`, `ValidatorProposeFailVec`) and a flag (`v.emitAccountMetrics`).  `Validator*FailVec` is incremented *conditionally* (and bit inconsistently) inside those methods. 

This PR completely moves failure metrics out of `ValidatorDB`, and handles them consistently, after each call. This PR also removes double counting problem for `ValidatorProposeFailVec`: It can be first incremented in `SlashableProposalCheck` and then incremented again at the caller side.

- https://github.com/OffchainLabs/prysm/pull/13360#discussion_r1442003600

I guess it was a mechnical change in order to preserve the same semantics regarding metrics, but as 1) we already have the double counting issue in proposal metrics 2) for sake of consistency and 3) it should be considered as "failure" when slashing protection check fails, I'd suggest to handle like this PR.


**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
