### PR TITLE
Pluralize `POST /eth/v1/builder/beacon_blocks` for builder client

### DIFF
--- a/api/client/builder/client_gloas.go
+++ b/api/client/builder/client_gloas.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const postBeaconBlockPath = "/eth/v1/builder/beacon_block"
+const postBeaconBlockPath = "/eth/v1/builder/beacon_blocks"
 
 func executionPayloadBidPath(slot primitives.Slot, parentHash, parentRoot [32]byte, proposerPubkey [48]byte) string {
 	return fmt.Sprintf("/eth/v1/builder/execution_payload_bid/%d/%#x/%#x/%#x", slot, parentHash, parentRoot, proposerPubkey)

--- a/changelog/syjn99_pluralize-beacon-block-path.md
+++ b/changelog/syjn99_pluralize-beacon-block-path.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Pluralize `POST /eth/v1/builder/beacon_blocks` for builder client.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Found when testing with buildoor. 

https://github.com/ethereum/builder-specs/blob/main/apis/builder/beacon_blocks.yaml

The endpoint for submitting a beacon block to builder has to be pluralized.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
