### PR TITLE
Persist execution payload envelope before emitting execution_payload_available

### DIFF
--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -122,6 +122,14 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 		return err
 	}
 
+	// Persist the envelope before announcing its availability so that consumers of the
+	// execution_payload_available event can immediately fetch it through the beacon API.
+	if err := s.savePostPayload(ctx, signed); err != nil {
+		cancelEL()
+		_ = elGroup.Wait()
+		return err
+	}
+
 	// execution_payload_available is emitted when an execution payload
 	// and all data are available for payload attestation
 	// without verifying the execution payload itself
@@ -135,12 +143,12 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 
 	// Join EL validation group after firing availability event.
 	if err := elGroup.Wait(); err != nil {
+		if dErr := s.cfg.BeaconDB.DeleteExecutionPayloadEnvelope(ctx, root); dErr != nil {
+			log.WithError(dErr).WithField("blockRoot", fmt.Sprintf("%#x", root)).Error("Could not delete execution payload envelope after failed execution validation")
+		}
 		return err
 	}
 
-	if err := s.savePostPayload(ctx, signed); err != nil {
-		return err
-	}
 	if err := s.InsertPayload(envelope); err != nil {
 		return errors.Wrap(err, "could not insert payload into forkchoice")
 	}

--- a/beacon-chain/blockchain/receive_execution_payload_envelope_test.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope_test.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
@@ -154,7 +155,45 @@ func TestReceiveExecutionPayloadEnvelope_EmitEvents(t *testing.T) {
 			got := countStateEventsByType(events)
 			require.Equal(t, tt.wantAvailable, got[statefeed.ExecutionPayloadAvailable])
 			require.Equal(t, tt.wantProcessed, got[statefeed.ExecutionPayloadProcessed])
+			require.Equal(t, !tt.wantErr, s.cfg.BeaconDB.HasExecutionPayloadEnvelope(ctx, blockRoot))
 		})
+	}
+}
+
+// TestReceiveExecutionPayloadEnvelope_EnvelopeSavedBeforeAvailableEvent verifies that the
+// envelope is retrievable from the DB by the time `execution_payload_available` is emitted,
+// so API consumers reacting to the event do not race the DB write.
+func TestReceiveExecutionPayloadEnvelope_EnvelopeSavedBeforeAvailableEvent(t *testing.T) {
+	s, _ := setupGloasService(t, &mockExecution.EngineClient{})
+	ctx := t.Context()
+
+	blockRoot := bytesutil.ToBytes32([]byte("envelope-root"))
+	base, blk, signedProto := gloasEnvelopeFixture(t, blockRoot)
+	insertGloasBlock(t, s, base, blk, blockRoot)
+
+	events := make(chan *feed.Event, 10)
+	sub := s.cfg.StateNotifier.StateFeed().Subscribe(events)
+	defer sub.Unsubscribe()
+
+	savedAtEvent := make(chan bool, 1)
+	go func() {
+		for ev := range events {
+			if ev.Type == statefeed.ExecutionPayloadAvailable {
+				savedAtEvent <- s.cfg.BeaconDB.HasExecutionPayloadEnvelope(ctx, blockRoot)
+				return
+			}
+		}
+	}()
+
+	signed, err := blocks.WrappedROSignedExecutionPayloadEnvelope(signedProto)
+	require.NoError(t, err)
+	require.NoError(t, s.ReceiveExecutionPayloadEnvelope(ctx, signed))
+
+	select {
+	case saved := <-savedAtEvent:
+		require.Equal(t, true, saved)
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution_payload_available event was not received")
 	}
 }
 

--- a/changelog/barnabasbusa_fix-payload-available-event-ordering.md
+++ b/changelog/barnabasbusa_fix-payload-available-event-ordering.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Persist the execution payload envelope before emitting the `execution_payload_available` event so that `GET /eth/v1/beacon/execution_payload_envelopes/{block_id}` no longer returns 404 for consumers reacting to the event; the envelope is removed again if execution validation fails.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`ReceiveExecutionPayloadEnvelope` emits `execution_payload_available` before `savePostPayload` writes the envelope to the DB (the save only happened after EL validation). `GET /eth/v1/beacon/execution_payload_envelopes/{block_id}` reads from the DB, so a client that fetches the envelope in reaction to the event gets a 404 for a few milliseconds.

Observed on a gloas devnet with Dora (which fetches on `execution_payload_available` and treats 404 as "no envelope"): ~90% of unfinalized slots showed the payload as unavailable, and Prysm's `http_request_count{endpoint="beacon.GetExecutionPayloadEnvelope",code="404"}` grew by ~2 per slot per node. Trace with a proxy between Dora and the BN (same root, same node):

```
11:51:25.078 SSE execution_payload_available slot=317 root=0xd2c946b6
11:51:25.079 GET /eth/v1/beacon/execution_payload_envelopes/0xd2c946b6… -> 404
```

This PR saves the envelope right after consensus verification and data availability succeed, then emits the event (its timing is unchanged, it still does not wait for EL validation), and deletes the envelope again if EL validation fails so nothing invalid is left behind.

**Which issues(s) does this PR fix?**

N/A (no existing issue)

**Other notes for review**

- Adds a regression test asserting the envelope is present in the DB when `execution_payload_available` is delivered, and that an EL-invalid envelope is not left in the DB.
- Verified the new test fails against the previous ordering.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/OffchainLabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry in the changelog directory.
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.