### PR TITLE
Add `--submit-blacklisted-builder-bids` feature flag

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
@@ -41,8 +41,6 @@ func (vs *Server) SubmitSignedExecutionPayloadBid(
 			"execution payload bids are not supported before Gloas fork (slot %d)", req.Message.Slot)
 	}
 
-	// Do not broadcast a bid this node would itself ignore on gossip. A builder testing the
-	// circuit breaker can opt out to broadcast anyway and observe that peers do not propagate it.
 	if !features.Get().SubmitBlacklistedBuilderBids &&
 		vs.BuilderCircuitBreaker.Blacklisted(req.Message.BuilderIndex, slots.ToEpoch(req.Message.Slot)) {
 		return nil, status.Errorf(codes.FailedPrecondition, "builder %d is blacklisted by the circuit breaker", req.Message.BuilderIndex)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -40,8 +41,10 @@ func (vs *Server) SubmitSignedExecutionPayloadBid(
 			"execution payload bids are not supported before Gloas fork (slot %d)", req.Message.Slot)
 	}
 
-	// Do not broadcast a bid this node would itself ignore on gossip.
-	if vs.BuilderCircuitBreaker.Blacklisted(req.Message.BuilderIndex, slots.ToEpoch(req.Message.Slot)) {
+	// Do not broadcast a bid this node would itself ignore on gossip. A builder testing the
+	// circuit breaker can opt out to broadcast anyway and observe that peers do not propagate it.
+	if !features.Get().SubmitBlacklistedBuilderBids &&
+		vs.BuilderCircuitBreaker.Blacklisted(req.Message.BuilderIndex, slots.ToEpoch(req.Message.Slot)) {
 		return nil, status.Errorf(codes.FailedPrecondition, "builder %d is blacklisted by the circuit breaker", req.Message.BuilderIndex)
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_submit_bid_test.go
@@ -12,6 +12,7 @@ import (
 	p2pmock "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -85,6 +86,76 @@ func TestSubmitSignedExecutionPayloadBid_OK(t *testing.T) {
 	cached, ok := bidCache.Get(1, [32]byte{}, parentRoot)
 	require.Equal(t, true, ok)
 	require.Equal(t, req, cached)
+}
+
+func TestSubmitSignedExecutionPayloadBid_Blacklisted(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	p2p := &p2pmock.MockBroadcaster{}
+	vs := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		P2P:                   p2p,
+		BuilderCircuitBreaker: blacklistedBreaker(t, 1, 1),
+		NewExecutionPayloadBidVerifier: func(interfaces.ROSignedExecutionPayloadBid, []verification.Requirement) verification.ExecutionPayloadBidVerifier {
+			return &fakeBidVerifier{}
+		},
+	}
+
+	req := testSignedBid(1, [32]byte{'p'})
+	_, err := vs.SubmitSignedExecutionPayloadBid(t.Context(), req)
+	require.ErrorContains(t, "blacklisted by the circuit breaker", err)
+	assert.Equal(t, false, p2p.BroadcastCalled.Load())
+}
+
+// A blacklisted builder can still broadcast its own bid with the feature flag on, so that the
+// gossip-side rejection by its peers can be observed.
+func TestSubmitSignedExecutionPayloadBid_BlacklistedWithFeatureFlag(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	resetFeatures := features.InitWithReset(&features.Flags{SubmitBlacklistedBuilderBids: true})
+	defer resetFeatures()
+
+	ctx := t.Context()
+	st, _ := util.DeterministicGenesisStateGloas(t, 64)
+	parentRoot := [32]byte{'p'}
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, parentRoot[:], st))
+
+	db := dbutil.SetupDB(t)
+	genesisRoot := [32]byte{'g'}
+	require.NoError(t, db.SaveGenesisBlockRoot(ctx, genesisRoot))
+
+	prefs := cache.NewProposerPreferencesCache()
+	prefs.Add(cache.ProposerPreference{DependentRoot: genesisRoot}, 1)
+
+	p2p := &p2pmock.MockBroadcaster{}
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	vs := &Server{
+		SyncChecker:              &mockSync.Sync{IsSyncing: false},
+		P2P:                      p2p,
+		BeaconDB:                 db,
+		ProposerPreferencesCache: prefs,
+		HighestBidCache:          bidCache,
+		OperationNotifier:        &mockChain.MockOperationNotifier{},
+		BuilderCircuitBreaker:    blacklistedBreaker(t, 1, 1),
+		ForkchoiceFetcher: &mockChain.ChainService{
+			ForkchoiceGasLimits: map[[32]byte]uint64{parentRoot: 30_000_000},
+		},
+		NewExecutionPayloadBidVerifier: func(interfaces.ROSignedExecutionPayloadBid, []verification.Requirement) verification.ExecutionPayloadBidVerifier {
+			return &fakeBidVerifier{}
+		},
+	}
+
+	req := testSignedBid(1, parentRoot)
+	resp, err := vs.SubmitSignedExecutionPayloadBid(ctx, req)
+	require.NoError(t, err)
+	require.DeepEqual(t, &emptypb.Empty{}, resp)
+	assert.Equal(t, true, p2p.BroadcastCalled.Load())
+	require.Equal(t, 1, len(p2p.BroadcastMessages))
 }
 
 func TestSubmitSignedExecutionPayloadBid_NoParentState(t *testing.T) {

--- a/changelog/potuz_submit-blacklisted-builder-bids.md
+++ b/changelog/potuz_submit-blacklisted-builder-bids.md
@@ -1,0 +1,3 @@
+### Added
+
+- `--submit-blacklisted-builder-bids` hidden feature flag to skip the builder circuit breaker check in `SubmitSignedExecutionPayloadBid`, so a blacklisted builder can still broadcast its bid for testing that peers do not propagate it.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -52,6 +52,7 @@ type Flags struct {
 	EnableStateDiff                     bool // EnableStateDiff enables the experimental state diff feature for the beacon node.
 	EnableProgressiveSSZ                bool // EnableProgressiveSSZ enables experimental progressive SSZ merkleization for converted consensus types.
 	ReorgLatePayloads                   bool // ReorgLatePayloads enables reorging late payloads in the beacon node.
+	SubmitBlacklistedBuilderBids        bool // SubmitBlacklistedBuilderBids skips the circuit breaker check when submitting a signed execution payload bid.
 
 	// Logging related toggles.
 	DisableGRPCConnectionLogs bool // Disables logging when a new grpc client has connected.
@@ -312,6 +313,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.Bool(reorgLatePayloads.Name) {
 		logEnabled(reorgLatePayloads)
 		cfg.ReorgLatePayloads = true
+	}
+	if ctx.Bool(submitBlacklistedBuilderBids.Name) {
+		logEnabled(submitBlacklistedBuilderBids)
+		cfg.SubmitBlacklistedBuilderBids = true
 	}
 
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -232,6 +232,13 @@ var (
 		Name:  "track-equivocations",
 		Usage: "Records proposer equivocations observed on gossip and marks the slot in forkchoice if the equivocation arrives before the configured early deadline.",
 	}
+	// submitBlacklistedBuilderBids lets a builder broadcast its own bids even while this node's
+	// circuit breaker has it blacklisted. Testing only: peers still ignore the bid on gossip.
+	submitBlacklistedBuilderBids = &cli.BoolFlag{
+		Name:   "submit-blacklisted-builder-bids",
+		Usage:  "Skips the builder circuit breaker check when submitting a signed execution payload bid, so a blacklisted builder still broadcasts its bid. For testing only.",
+		Hidden: true,
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -298,6 +305,7 @@ var BeaconChainFlags = combinedFlags([]cli.Flag{
 	forceHeadFlag,
 	blacklistRoots,
 	enableHashtree,
+	submitBlacklistedBuilderBids,
 }, deprecatedBeaconFlags, deprecatedFlags, upcomingDeprecation)
 
 func combinedFlags(flags ...[]cli.Flag) []cli.Flag {


### PR DESCRIPTION
## What

`SubmitSignedExecutionPayloadBid` rejects a bid whose builder this node's circuit breaker has blacklisted, on the grounds that we should not broadcast something we would ourselves ignore on gossip:

```
{"message":"builder 0 is blacklisted by the circuit breaker","code":400}
```

That check also makes the gossip-side behavior untestable: a blacklisted builder cannot get its bid onto the wire at all, so there is no way to observe that peers refuse to propagate it.

This adds a hidden `--submit-blacklisted-builder-bids` flag that skips the check on the **submit path only**. A builder can then broadcast while blacklisted, and we can verify its peers drop the bid.

## Scope

- Only `SubmitSignedExecutionPayloadBid` is gated. The `[IGNORE]` check in `validateExecutionPayloadBidPubSub` is untouched, so receiving peers still ignore the bid — that is the behavior under test.
- The rest of `validateSubmittedBid` still runs (signature, builder active/version, fee recipient vs. proposer preferences, gas limit, parent hash, …), so the bid must otherwise be valid to be broadcast. This isolates the circuit breaker as the single reason peers drop it.
- Hidden flag, consistent with other testing-only flags such as `--reorg-late-payloads`. Testing only; not intended for mainnet.

## Note

With the flag on, the blacklisted bid is also recorded in the local `HighestBidCache`, so a node that is both the flagged builder and a proposer in that slot could select its own blacklisted builder's bid. That is out of scope here — the flag is meant for a builder-only node — but happy to gate that too if reviewers prefer.

## Tests

- `TestSubmitSignedExecutionPayloadBid_Blacklisted` — rejected, no broadcast, with the flag off.
- `TestSubmitSignedExecutionPayloadBid_BlacklistedWithFeatureFlag` — broadcast succeeds with the flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)