### PR TITLE
Use read-only `BeaconState` for direct head state readers

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -490,7 +490,7 @@ func (s *Service) areSidecarsAvailable(ctx context.Context, avs das.Availability
 }
 
 // the caller of this function must not hold a lock in forkchoice store.
-func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.BeaconState) error {
+func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.ReadOnlyBeaconState) error {
 	e := coreTime.CurrentEpoch(st)
 	if err := helpers.UpdateCommitteeCache(ctx, st, e); err != nil {
 		return errors.Wrap(err, "could not update committee cache")
@@ -556,7 +556,7 @@ func (s *Service) updateCachesAndEpochBoundary(ctx context.Context, currentSlot 
 	}
 }
 
-// Epoch boundary tasks: it copies the headState and updates the epoch boundary
+// Epoch boundary tasks: it advances the head state and updates the epoch boundary
 // caches. The caller of this function must not hold a lock in forkchoice store.
 func (s *Service) handleEpochBoundary(ctx context.Context, slot primitives.Slot, headState state.ReadOnlyBeaconState, blockRoot []byte) error {
 	ctx, span := trace.StartSpan(ctx, "blockChain.handleEpochBoundary")
@@ -568,12 +568,11 @@ func (s *Service) handleEpochBoundary(ctx context.Context, slot primitives.Slot,
 	if !slots.IsEpochEnd(slot) {
 		return nil
 	}
-	copied := headState.Copy()
-	copied, err := transition.ProcessSlotsUsingNextSlotCache(ctx, copied, blockRoot, slot+1)
+	st, err := transition.ProcessSlotsIfNeeded(ctx, headState, blockRoot, slot+1)
 	if err != nil {
 		return err
 	}
-	return s.updateEpochBoundaryCaches(ctx, copied)
+	return s.updateEpochBoundaryCaches(ctx, st)
 }
 
 // This feeds in the attestations included in the block to fork choice store. It's allows fork choice store

--- a/beacon-chain/blockchain/receive_payload_attestation_message.go
+++ b/beacon-chain/blockchain/receive_payload_attestation_message.go
@@ -74,12 +74,12 @@ func (s *Service) PtcLookupState(ctx context.Context, blockRoot [32]byte, blockS
 		}
 	}
 	if bytes.Equal(blockDependent[:], headRoot) {
-		headState, err := s.HeadState(ctx)
+		headState, err := s.HeadStateReadOnly(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		return transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, blockSlot)
+		return transition.ProcessSlotsIfNeeded(ctx, headState, headRoot, blockSlot)
 	}
 	if st := s.cfg.StateGen.StateByRootIfCachedNoCopy(blockRoot); st != nil && slots.ToEpoch(st.Slot()) == blockEpoch {
 		return st, nil

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -539,12 +539,12 @@ func (s *Service) GetAttestationData(
 		return nil, &RpcError{Reason: Internal, Err: errors.Wrap(err, "could not get target root")}
 	}
 
-	headState, err := s.HeadFetcher.HeadState(ctx)
+	headState, err := s.HeadFetcher.HeadStateReadOnly(ctx)
 	if err != nil {
 		return nil, &RpcError{Reason: Internal, Err: errors.Wrap(err, "could not get head state")}
 	}
 	if coreTime.CurrentEpoch(headState) < slots.ToEpoch(req.Slot) { // Ensure justified checkpoint safety by processing head state across the boundary.
-		headState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, req.Slot)
+		headState, err = transition.ProcessSlotsIfNeeded(ctx, headState, headRoot, req.Slot)
 		if err != nil {
 			return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not process slots up to %d: %v", req.Slot, err)}
 		}

--- a/changelog/syjn99_fix-use-ro-state.md
+++ b/changelog/syjn99_fix-use-ro-state.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use `ReadOnlyBeaconState` when it's enough (`handleEpochBoundary` / `PtcLookupState` / `GetAttestationData`)


### PR DESCRIPTION
**What type of PR is this?**

> Other: Optimization

**What does this PR do? Why is it needed?**

Using `HeadState` & `ProcessSlotsUsingNextSlotCache` requires Prysm to copy `BeaconState` **at least** once, regardless of NSC hits. We should avoid copying `BeaconState` unless it needs to be modifed (e.g., `ProcessSlots`) as it'll hold the reference count until GC works.

We have several patterns of copying the state across the codebase, but I'd like to scope it as narrow as possible for thorough reviews. This PR contains the most obvious changes that is enough to use `ProcessSlotsIfNeeded` as well as the first PR for #16692.

**Which issue(s) does this PR fix?**

Part of

- #16692

**Other notes for review**

Each commit message describes why each change is justifed.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
