### PR TITLE
Use read-only states in caches (`CheckpointStateCache` & `SyncCommitteeHeadStateCache`)

### DIFF
--- a/beacon-chain/blockchain/head_sync_committee_info.go
+++ b/beacon-chain/blockchain/head_sync_committee_info.go
@@ -132,9 +132,7 @@ func (s *Service) domainWithHeadState(ctx context.Context, slot primitives.Slot,
 
 // returns the head state that is advanced up to `slot`. It utilizes the cache `syncCommitteeHeadState` by retrieving using `slot` as key.
 // For the cache miss, it processes head state up to slot and fill the cache with `slot` as key.
-func (s *Service) getSyncCommitteeHeadState(ctx context.Context, slot primitives.Slot) (state.BeaconState, error) {
-	var headState state.BeaconState
-	var err error
+func (s *Service) getSyncCommitteeHeadState(ctx context.Context, slot primitives.Slot) (state.ReadOnlyBeaconState, error) {
 	mLock := async.NewMultilock(fmt.Sprintf("%s-%d", "syncHeadState", slot))
 	mLock.Lock()
 	defer mLock.Unlock()
@@ -144,21 +142,23 @@ func (s *Service) getSyncCommitteeHeadState(ctx context.Context, slot primitives
 	switch {
 	case err == nil:
 		syncHeadStateHit.Inc()
-		headState = cachedState
-		return headState, nil
+		return cachedState, nil
 	case errors.Is(err, cache.ErrNotFound):
-		headState, err = s.HeadState(ctx)
+		headState, err := s.HeadStateReadOnly(ctx)
 		if err != nil {
 			return nil, err
 		}
 		if headState == nil || headState.IsNil() {
 			return nil, errors.New("nil state")
 		}
+		if headState.Slot() > slot {
+			return nil, fmt.Errorf("expected head state slot %d <= slot %d", headState.Slot(), slot)
+		}
 		headRoot, err := s.HeadRoot(ctx)
 		if err != nil {
 			return nil, err
 		}
-		headState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, slot)
+		headState, err = transition.ProcessSlotsIfNeeded(ctx, headState, headRoot, slot)
 		if err != nil {
 			return nil, err
 		}

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -75,11 +75,11 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		return cachedState
 	}
 	// If we haven't advanced yet then process the slots from head state.
-	st, err := s.HeadState(ctx)
+	st, err := s.HeadStateReadOnly(ctx)
 	if err != nil {
 		return nil
 	}
-	st, err = transition.ProcessSlotsUsingNextSlotCache(ctx, st, c.Root, slot)
+	st, err = transition.ProcessSlotsIfNeeded(ctx, st, c.Root, slot)
 	if err != nil {
 		return nil
 	}
@@ -115,8 +115,7 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (stat
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compute epoch start")
 	}
-	cachedState = transition.NextSlotState(c.Root, slot)
-	if cachedState != nil && !cachedState.IsNil() {
+	if cachedState := transition.NextSlotState(c.Root, slot); cachedState != nil && !cachedState.IsNil() {
 		if cachedState.Slot() != slot {
 			cachedState, err = transition.ProcessSlots(ctx, cachedState, slot)
 			if err != nil {

--- a/beacon-chain/cache/checkpoint_state.go
+++ b/beacon-chain/cache/checkpoint_state.go
@@ -51,7 +51,7 @@ func NewCheckpointStateCache() *CheckpointStateCache {
 
 // StateByCheckpoint fetches state by checkpoint. Returns true with a
 // reference to the CheckpointState info, if exists. Otherwise returns false, nil.
-func (c *CheckpointStateCache) StateByCheckpoint(cp *ethpb.Checkpoint) (state.BeaconState, error) {
+func (c *CheckpointStateCache) StateByCheckpoint(cp *ethpb.Checkpoint) (state.ReadOnlyBeaconState, error) {
 	h, err := hash.Proto(cp)
 	if err != nil {
 		return nil, err
@@ -65,8 +65,7 @@ func (c *CheckpointStateCache) StateByCheckpoint(cp *ethpb.Checkpoint) (state.Be
 	}
 
 	checkpointStateHit.Inc()
-	// Copy here is unnecessary since the return will only be used to verify attestation signature.
-	return item.(state.BeaconState), nil
+	return item.(state.ReadOnlyBeaconState), nil
 }
 
 // AddCheckpointState adds CheckpointState object to the cache. This method also trims the least

--- a/beacon-chain/cache/sync_committee_head_state.go
+++ b/beacon-chain/cache/sync_committee_head_state.go
@@ -23,7 +23,7 @@ func NewSyncCommitteeHeadState() *SyncCommitteeHeadStateCache {
 }
 
 // Put `slot` as key and `state` as value onto the cache.
-func (c *SyncCommitteeHeadStateCache) Put(slot primitives.Slot, st state.BeaconState) error {
+func (c *SyncCommitteeHeadStateCache) Put(slot primitives.Slot, st state.ReadOnlyBeaconState) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	// Make sure that the provided state is non nil
@@ -41,14 +41,14 @@ func (c *SyncCommitteeHeadStateCache) Put(slot primitives.Slot, st state.BeaconS
 }
 
 // Get `state` using `slot` as key. Return nil if nothing is found.
-func (c *SyncCommitteeHeadStateCache) Get(slot primitives.Slot) (state.BeaconState, error) {
+func (c *SyncCommitteeHeadStateCache) Get(slot primitives.Slot) (state.ReadOnlyBeaconState, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	val, exists := c.cache.Get(slot)
 	if !exists {
 		return nil, ErrNotFound
 	}
-	st, ok := val.(state.BeaconState)
+	st, ok := val.(state.ReadOnlyBeaconState)
 	if !ok {
 		return nil, ErrIncorrectType
 	}

--- a/beacon-chain/cache/sync_committee_head_state_test.go
+++ b/beacon-chain/cache/sync_committee_head_state_test.go
@@ -43,13 +43,13 @@ func TestSyncCommitteeHeadState(t *testing.T) {
 	require.NoError(t, err)
 	type put struct {
 		slot  primitives.Slot
-		state state.BeaconState
+		state state.ReadOnlyBeaconState
 	}
 	tests := []struct {
 		name       string
 		key        primitives.Slot
 		put        *put
-		want       state.BeaconState
+		want       state.ReadOnlyBeaconState
 		wantErr    bool
 		wantPutErr bool
 	}{

--- a/beacon-chain/core/helpers/sync_committee.go
+++ b/beacon-chain/core/helpers/sync_committee.go
@@ -156,7 +156,7 @@ func CurrentPeriodSyncSubcommitteeIndices(
 
 // NextPeriodSyncSubcommitteeIndices returns the subcommittee indices of the next period sync committee for input validator.
 func NextPeriodSyncSubcommitteeIndices(
-	st state.BeaconState, valIdx primitives.ValidatorIndex,
+	st state.ReadOnlyBeaconState, valIdx primitives.ValidatorIndex,
 ) ([]primitives.CommitteeIndex, error) {
 	root, err := SyncPeriodBoundaryRoot(st)
 	if err != nil {

--- a/changelog/syjn99_fix-ro-state-caches.md
+++ b/changelog/syjn99_fix-ro-state-caches.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use read-only states in caches (`CheckpointStateCache` & `SyncCommitteeHeadStateCache`)


### PR DESCRIPTION
**What type of PR is this?**

> Other: Optimization

**What does this PR do? Why is it needed?**

See previous PR (#17424) for the needs. This PR aims to change method signatures of our caches, as those are enough to store/return the read-only states.

**Which issue(s) does this PR fix?**

Part of 

- #16692

**Other notes for review**

Each commit message describes why each change is justifed.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
