### PR TITLE
Don't wait on gossip sidecars for a slot that has already passed

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -648,6 +648,11 @@ func (s *Service) inRegularSync() bool {
 	return s.cfg.SyncChecker.Synced()
 }
 
+// canWaitForGossipSidecars reports whether the sidecars for slot may still arrive over gossip.
+func (s *Service) canWaitForGossipSidecars(slot primitives.Slot) bool {
+	return s.inRegularSync() && slot+1 >= s.CurrentSlot()
+}
+
 // validating returns true if at least one validator is attached to this BN
 // via beacon_committee_subscriptions.
 func (s *Service) validating() bool {

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -872,3 +872,37 @@ func Test_hashForGenesisRoot_Gloas(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedHash, [32]byte(genHash))
 }
+
+type mockSyncChecker struct {
+	synced bool
+}
+
+func (m mockSyncChecker) Synced() bool {
+	return m.synced
+}
+
+func TestCanWaitForGossipSidecars(t *testing.T) {
+	const currentSlot = primitives.Slot(100)
+
+	tests := []struct {
+		name   string
+		slot   primitives.Slot
+		synced bool
+		want   bool
+	}{
+		{name: "current slot", synced: true, slot: currentSlot, want: true},
+		{name: "previous slot", synced: true, slot: currentSlot - 1, want: true},
+		{name: "future slot", synced: true, slot: currentSlot + 1, want: true},
+		{name: "two slots behind", synced: true, slot: currentSlot - 2, want: false},
+		{name: "far behind", synced: true, slot: currentSlot - 30, want: false},
+		{name: "initial sync, current slot", synced: false, slot: currentSlot, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{cfg: &config{SyncChecker: mockSyncChecker{synced: tt.synced}}}
+			s.SetGenesisTime(time.Now().Add(time.Duration(-1*int64(currentSlot)*int64(params.BeaconConfig().SecondsPerSlot)) * time.Second))
+			require.Equal(t, tt.want, s.canWaitForGossipSidecars(tt.slot))
+		})
+	}
+}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -918,8 +918,8 @@ func (s *Service) isDataAvailable(
 		if len(kzgCommitments) == 0 {
 			return nil
 		}
-		// Initial sync fetches columns via range requests, so check availability synchronously rather than blocking on gossip; fail if missing.
-		if !s.inRegularSync() {
+		// Outside the gossip window, check availability synchronously rather than blocking; fail if missing.
+		if !s.canWaitForGossipSidecars(block.Slot()) {
 			available, err := s.dataColumnsAvailableNow(ctx, root, block.Slot())
 			if err != nil {
 				return errors.Wrap(err, "data columns available now")

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2783,6 +2783,9 @@ func testIsAvailableSetup(t *testing.T, p testIsAvailableParams) (context.Contex
 	signedBeaconBlock, err := util.GenerateFullBlockFulu(genesisState, secretKeys, conf, fs+1)
 	require.NoError(t, err)
 
+	// The block is the one being imported, so put its slot at the head of the clock.
+	service.SetGenesisTime(time.Now().Add(time.Duration(-1*int64(fs+1)*int64(params.BeaconConfig().SecondsPerSlot)) * time.Second))
+
 	block := signedBeaconBlock.Block
 	bodyRoot, err := block.Body.HashTreeRoot()
 	require.NoError(t, err)
@@ -3853,4 +3856,39 @@ func TestRefreshCaches_CachedStateMatchesHeadRoot(t *testing.T) {
 	cached := transition.NextSlotState(headRoot[:], 1)
 	require.NotNil(t, cached)
 	require.Equal(t, primitives.Slot(1), cached.Slot())
+}
+
+// A node in regular sync whose head has fallen behind is past the gossip window of the
+// slot it is importing, so a block with missing columns must fail fast rather than block.
+func TestIsDataAvailable_BehindHead(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.AltairForkEpoch, cfg.BellatrixForkEpoch, cfg.CapellaForkEpoch, cfg.DenebForkEpoch, cfg.ElectraForkEpoch, cfg.FuluForkEpoch = 0, 0, 0, 0, 0, 0
+	params.OverrideBeaconConfig(cfg)
+
+	testParams := testIsAvailableParams{blobKzgCommitmentsCount: 3}
+
+	ctx, cancel, service, root, signed := testIsAvailableSetup(t, testParams)
+	defer cancel()
+
+	// Move the clock 30 slots past the block being imported.
+	behind := signed.Block().Slot() + 30
+	service.SetGenesisTime(time.Now().Add(time.Duration(-1*int64(behind)*int64(params.BeaconConfig().SecondsPerSlot)) * time.Second))
+	require.Equal(t, true, service.inRegularSync())
+
+	roBlock, err := consensusblocks.NewROBlockWithRoot(signed, root)
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- service.isDataAvailable(ctx, roBlock)
+	}()
+
+	bound := time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + 2*time.Second
+	select {
+	case err := <-done:
+		require.ErrorContains(t, "data columns unavailable for block", err)
+	case <-time.After(bound):
+		t.Fatal("isDataAvailable blocked on gossip for a slot whose gossip window has closed")
+	}
 }

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -99,8 +99,8 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 		if bid == nil || len(bid.BlobKzgCommitments()) == 0 {
 			return nil
 		}
-		// Initial sync fetches columns via range requests, so check availability synchronously rather than blocking on gossip; fail if missing.
-		if !s.inRegularSync() {
+		// Outside the gossip window, check availability synchronously rather than blocking; fail if missing.
+		if !s.canWaitForGossipSidecars(envelope.Slot()) {
 			available, err := s.dataColumnsAvailableNow(availCtx, root, envelope.Slot())
 			if err != nil {
 				return errors.Wrap(err, "data availability check failed for payload envelope")

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -160,8 +160,9 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			cancelFunction()
 
 			// Process synchronously because it's likely that the next pending block depends on it.
-			s.processPendingPayloadEnvelope(ctx, blkRoot)
+			// Columns first: the envelope's availability check reads them from storage.
 			s.processPendingGloasColumns(s.ctx, blkRoot, b)
+			s.processPendingPayloadEnvelope(ctx, blkRoot)
 			s.processPendingPayloadAttestation(ctx, blkRoot)
 			blkRoots = append(blkRoots, blkRoot)
 

--- a/changelog/potuz_fix-stale-envelope-da-wait.md
+++ b/changelog/potuz_fix-stale-envelope-da-wait.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Skip the blocking data availability wait when importing a slot whose gossip window has closed, so a node whose head has fallen behind can catch up instead of stalling a full slot duration per block.
+- Drain pending Gloas data columns before the pending payload envelope in the pending blocks queue, so the envelope's availability check sees the columns already gossiped for that root.


### PR DESCRIPTION
## What

`isDataAvailable` and `ReceiveExecutionPayloadEnvelope` choose between a blocking wait on the sidecar notifier and a synchronous storage read based on `inRegularSync()`. That predicate says nothing about whether the sidecars for the slot being imported could still be in flight, so a node that is *in* regular sync but whose head has fallen behind takes the blocking branch for a slot whose gossip window closed long ago, and only gives up when the caller's context expires.

For the pending payload envelope that context is `SlotDuration` (`pending_payload_envelope.go`), so every queued slot costs a full 12s before the by-root fetcher backfills the columns in well under a second. The backlog then drains slower than the chain advances and the node never recovers.

Gate on slot recency instead. `slot+1` stays eligible because an envelope for slot N routinely lands early in slot N+1 with its columns still in flight.

Second change: the pending blocks queue called `processPendingPayloadEnvelope` before `processPendingGloasColumns`, so the envelope's availability check ran while the columns gossiped for that root were still sitting unsaved in `pendingGloasColumns`. Swapped — the dependency runs the other way.

## Observed on glamsterdam-devnet-8

`prysm-nethermind-1` and `prysm-nethermind-2` after their EL was redeployed (~3 min outage) at 21:21 UTC on 2026-08-29. Both resumed with a ~17 slot backlog and never caught up; lag grew monotonically 16 → 24 → 36 slots.

Per-slot, on repeat:

```
21:38:46.79  Synced new block slot=118067
21:38:58.79  Could not process pending payload envelope error=data availability check failed …   (T+12.00s)
21:38:58.79  Processed pending block and cleared it in cache duration=12.369s slot=118067 slotIndex=1/27
21:38:59.65  Requested direct data column sidecars from peers duration=861ms initialMissingCount=128
21:39:00.13  Synced execution payload envelope slot=118067
```

40 consecutive samples landed in 12.05–12.43s. Over 20 minutes, against healthy peers:

| node | direct col fetches | envelope DA failures | blocks applied |
|---|---|---|---|
| prysm-geth-1 | 0 | 0 | 99 |
| prysm-besu-1 | 0 | 0 | 99 |
| prysm-nethermind-1 | 71 | 71 | 79 |
| prysm-nethermind-2 | 78 | 78 | 86 |

Downstream effect: at proposal time the head was 18–32 slots stale, so both proposals went out on a very old parent, self-built, and were orphaned — slot 118041 with `headSlot=118023`, slot 118106 with `headSlot=118074`.

## Tests

- `TestIsDataAvailable_BehindHead` — regression test; blocks for the full bound without the fix.
- `TestCanWaitForGossipSidecars` — table test for the predicate.
- `testIsAvailableSetup` now puts the generated block at the head of the clock. The fixture had it 127 slots in the past while the subtests meant to exercise the blocking wait, which only happens at the current slot.

## Not addressed here

Two related weaknesses turned up while tracing this, left out because they are judgment calls rather than clear wins:

- `pruneStaleGloasColumns` drops entries older than `currentSlot-1` and `maxPendingGloasRoots` is 8, so a node even two slots behind discards every column it receives and pays a full 128-column refetch per slot (`initialMissingCount=128` above). Widening retention costs roughly 2.3MB/slot; it should probably be bounded by bytes rather than root count.
- `shouldReSync` requires `syncedEpoch < currentEpoch-1`, so a node stuck 20–35 slots behind straddles the threshold and flip-flops in and out of initial sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)