### PR TITLE
Use read-only states in validator RPC calls for duties

### DIFF
--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -278,7 +278,7 @@ type CommitteeAssignment struct {
 // VerifyAssignmentEpoch verifies if the given epoch is valid for assignment based on the provided state.
 // It checks if the epoch is not greater than the next epoch, and if the start slot of the epoch is greater
 // than or equal to the minimum valid start slot calculated based on the state's current slot and historical roots.
-func VerifyAssignmentEpoch(epoch primitives.Epoch, state state.BeaconState) error {
+func VerifyAssignmentEpoch(epoch primitives.Epoch, state state.ReadOnlyBeaconState) error {
 	nextEpoch := time.NextEpoch(state)
 	if epoch > nextEpoch {
 		return fmt.Errorf("epoch %d can't be greater than next epoch %d", epoch, nextEpoch)
@@ -301,7 +301,7 @@ func VerifyAssignmentEpoch(epoch primitives.Epoch, state state.BeaconState) erro
 // ProposerAssignments calculates proposer assignments for each validator during the specified epoch.
 // It verifies the validity of the epoch, then iterates through each slot in the epoch to determine the
 // proposer for that slot and assigns them accordingly.
-func ProposerAssignments(ctx context.Context, state state.BeaconState, epoch primitives.Epoch) (map[primitives.ValidatorIndex][]primitives.Slot, error) {
+func ProposerAssignments(ctx context.Context, state state.ReadOnlyBeaconState, epoch primitives.Epoch) (map[primitives.ValidatorIndex][]primitives.Slot, error) {
 	ctx, span := trace.StartSpan(ctx, "helpers.ProposerAssignments")
 	defer span.End()
 
@@ -338,7 +338,7 @@ func ProposerAssignments(ctx context.Context, state state.BeaconState, epoch pri
 // CommitteeAssignments calculates committee assignments for each validator during the specified epoch.
 // It retrieves active validator indices, determines the number of committees per slot, and computes
 // assignments for each validator based on their presence in the provided validators slice.
-func CommitteeAssignments(ctx context.Context, state state.BeaconState, epoch primitives.Epoch, validators []primitives.ValidatorIndex) (map[primitives.ValidatorIndex]*CommitteeAssignment, error) {
+func CommitteeAssignments(ctx context.Context, state state.ReadOnlyBeaconState, epoch primitives.Epoch, validators []primitives.ValidatorIndex) (map[primitives.ValidatorIndex]*CommitteeAssignment, error) {
 	ctx, span := trace.StartSpan(ctx, "helpers.CommitteeAssignments")
 	defer span.End()
 

--- a/beacon-chain/core/helpers/sync_committee.go
+++ b/beacon-chain/core/helpers/sync_committee.go
@@ -57,7 +57,7 @@ func CurrentPeriodPositions(st state.BeaconState, indices []primitives.Validator
 // along with the sync committee root.
 // 1. Checks if the public key exists in the sync committee cache
 // 2. If 1 fails, checks if the public key exists in the input current sync committee object
-func IsCurrentPeriodSyncCommittee(st state.BeaconState, valIdx primitives.ValidatorIndex) (bool, error) {
+func IsCurrentPeriodSyncCommittee(st state.ReadOnlyBeaconState, valIdx primitives.ValidatorIndex) (bool, error) {
 	root, err := SyncPeriodBoundaryRoot(st)
 	if err != nil {
 		return false, err
@@ -93,7 +93,7 @@ func IsCurrentPeriodSyncCommittee(st state.BeaconState, valIdx primitives.Valida
 // 1. Checks if the public key exists in the sync committee cache
 // 2. If 1 fails, checks if the public key exists in the input next sync committee object
 func IsNextPeriodSyncCommittee(
-	st state.BeaconState, valIdx primitives.ValidatorIndex,
+	st state.ReadOnlyBeaconState, valIdx primitives.ValidatorIndex,
 ) (bool, error) {
 	root, err := SyncPeriodBoundaryRoot(st)
 	if err != nil {

--- a/beacon-chain/core/time/slot_epoch.go
+++ b/beacon-chain/core/time/slot_epoch.go
@@ -49,7 +49,7 @@ func NextEpoch(state state.ReadOnlyBeaconState) primitives.Epoch {
 }
 
 // HigherEqualThanAltairVersionAndEpoch returns if the input state `s` has a higher version number than Altair state and input epoch `e` is higher equal than fork epoch.
-func HigherEqualThanAltairVersionAndEpoch(s state.BeaconState, e primitives.Epoch) bool {
+func HigherEqualThanAltairVersionAndEpoch(s state.ReadOnlyBeaconState, e primitives.Epoch) bool {
 	return s.Version() >= version.Altair && e >= params.BeaconConfig().AltairForkEpoch
 }
 

--- a/beacon-chain/rpc/core/duties.go
+++ b/beacon-chain/rpc/core/duties.go
@@ -54,7 +54,7 @@ type PTCDutyResult struct {
 
 // AttesterDuties computes attester duties for the requested validators at the given epoch.
 // The caller is responsible for providing a state that is adequate for the requested epoch.
-func (s *Service) AttesterDuties(ctx context.Context, st state.BeaconState, epoch primitives.Epoch, indices []primitives.ValidatorIndex) ([]*AttesterDutyResult, *RpcError) {
+func (s *Service) AttesterDuties(ctx context.Context, st state.ReadOnlyBeaconState, epoch primitives.Epoch, indices []primitives.ValidatorIndex) ([]*AttesterDutyResult, *RpcError) {
 	ctx, span := trace.StartSpan(ctx, "coreService.AttesterDuties")
 	defer span.End()
 
@@ -94,7 +94,7 @@ func (s *Service) AttesterDuties(ctx context.Context, st state.BeaconState, epoc
 
 // ProposerDuties computes proposer duties for the given epoch.
 // Results are sorted by slot.
-func (s *Service) ProposerDuties(ctx context.Context, st state.BeaconState, epoch primitives.Epoch) ([]*ProposerDutyResult, *RpcError) {
+func (s *Service) ProposerDuties(ctx context.Context, st state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]*ProposerDutyResult, *RpcError) {
 	ctx, span := trace.StartSpan(ctx, "coreService.ProposerDuties")
 	defer span.End()
 
@@ -125,7 +125,7 @@ func (s *Service) ProposerDuties(ctx context.Context, st state.BeaconState, epoc
 // SyncCommitteeDuties computes sync committee duties for the requested validators.
 // It also registers sync subnets for matched validators.
 // The caller is responsible for providing a state that is adequate for the requested epoch.
-func (s *Service) SyncCommitteeDuties(ctx context.Context, st state.BeaconState, requestedEpoch primitives.Epoch, currentEpoch primitives.Epoch, indices []primitives.ValidatorIndex) ([]*SyncCommitteeDutyResult, *RpcError) {
+func (s *Service) SyncCommitteeDuties(ctx context.Context, st state.ReadOnlyBeaconState, requestedEpoch primitives.Epoch, currentEpoch primitives.Epoch, indices []primitives.ValidatorIndex) ([]*SyncCommitteeDutyResult, *RpcError) {
 	_, span := trace.StartSpan(ctx, "coreService.SyncCommitteeDuties")
 	defer span.End()
 
@@ -190,7 +190,7 @@ func (s *Service) SyncCommitteeDuties(ctx context.Context, st state.BeaconState,
 
 // PTCDuties computes payload timeliness committee duties for the requested validators
 // at the given epoch. Pre-Gloas epochs return an empty result.
-func (s *Service) PTCDuties(ctx context.Context, st state.BeaconState, epoch primitives.Epoch, indices []primitives.ValidatorIndex) ([]*PTCDutyResult, *RpcError) {
+func (s *Service) PTCDuties(ctx context.Context, st state.ReadOnlyBeaconState, epoch primitives.Epoch, indices []primitives.ValidatorIndex) ([]*PTCDutyResult, *RpcError) {
 	_, span := trace.StartSpan(ctx, "coreService.PTCDuties")
 	defer span.End()
 
@@ -255,7 +255,7 @@ func findValidatorIndexInCommittee(committee []primitives.ValidatorIndex, valida
 
 // syncDutyStatus returns a validator.Status suitable for sync subnet registration.
 // It returns Active for any active validator and Pending otherwise.
-func syncDutyStatus(st state.BeaconState, idx primitives.ValidatorIndex) validator.Status {
+func syncDutyStatus(st state.ReadOnlyBeaconState, idx primitives.ValidatorIndex) validator.Status {
 	val, err := st.ValidatorAtIndexReadOnly(idx)
 	if err != nil {
 		return validator.Pending
@@ -270,7 +270,7 @@ func syncDutyStatus(st state.BeaconState, idx primitives.ValidatorIndex) validat
 // AttestationDependentRoot returns the block root at (epoch-1 start - 1),
 // which is the dependent root for attester duties at the given epoch.
 // Callers must handle epoch <= 1 separately (e.g. using the genesis block root from the DB).
-func AttestationDependentRoot(s state.BeaconState, epoch primitives.Epoch) ([]byte, error) {
+func AttestationDependentRoot(s state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]byte, error) {
 	if epoch <= 1 {
 		return nil, errors.New("epoch <= 1 requires genesis block root from DB")
 	}
@@ -289,7 +289,7 @@ func AttestationDependentRoot(s state.BeaconState, epoch primitives.Epoch) ([]by
 // which is the dependent root for proposer duties at the given epoch.
 // This is the pre-Fulu (v1) calculation used by the REST /eth/v1 endpoint.
 // Callers must handle epoch 0 separately (e.g. using the genesis block root from the DB).
-func ProposalDependentRoot(s state.BeaconState, epoch primitives.Epoch) ([]byte, error) {
+func ProposalDependentRoot(s state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]byte, error) {
 	if epoch == 0 {
 		return nil, errors.New("epoch 0 requires genesis block root from DB")
 	}
@@ -305,7 +305,7 @@ func ProposalDependentRoot(s state.BeaconState, epoch primitives.Epoch) ([]byte,
 }
 
 // ProposalDependentRootV2 returns the dependent root for proposer duties.
-func ProposalDependentRootV2(s state.BeaconState, epoch primitives.Epoch) ([]byte, error) {
+func ProposalDependentRootV2(s state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]byte, error) {
 	if s.Version() >= version.Fulu {
 		// Post-Fulu (EIP-7917) the proposer schedule is deterministic from the
 		// previous epoch's state, so the dependent root is (prev_epoch_start - 1),

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -647,7 +647,7 @@ func (s *Service) SubmitSyncMessage(ctx context.Context, msg *ethpb.SyncCommitte
 }
 
 // RegisterSyncSubnetCurrentPeriod registers a persistent subnet for the current sync committee period.
-func RegisterSyncSubnetCurrentPeriod(s beaconState.BeaconState, epoch primitives.Epoch, pubKey []byte, status validator.Status) error {
+func RegisterSyncSubnetCurrentPeriod(s beaconState.ReadOnlyBeaconState, epoch primitives.Epoch, pubKey []byte, status validator.Status) error {
 	committee, err := s.CurrentSyncCommittee()
 	if err != nil {
 		return err
@@ -658,7 +658,7 @@ func RegisterSyncSubnetCurrentPeriod(s beaconState.BeaconState, epoch primitives
 }
 
 // RegisterSyncSubnetCurrentPeriodProto registers a persistent subnet for the current sync committee period.
-func RegisterSyncSubnetCurrentPeriodProto(s beaconState.BeaconState, epoch primitives.Epoch, pubKey []byte, status ethpb.ValidatorStatus) error {
+func RegisterSyncSubnetCurrentPeriodProto(s beaconState.ReadOnlyBeaconState, epoch primitives.Epoch, pubKey []byte, status ethpb.ValidatorStatus) error {
 	committee, err := s.CurrentSyncCommittee()
 	if err != nil {
 		return err
@@ -669,7 +669,7 @@ func RegisterSyncSubnetCurrentPeriodProto(s beaconState.BeaconState, epoch primi
 }
 
 // RegisterSyncSubnetNextPeriod registers a persistent subnet for the next sync committee period.
-func RegisterSyncSubnetNextPeriod(s beaconState.BeaconState, epoch primitives.Epoch, pubKey []byte, status validator.Status) error {
+func RegisterSyncSubnetNextPeriod(s beaconState.ReadOnlyBeaconState, epoch primitives.Epoch, pubKey []byte, status validator.Status) error {
 	committee, err := s.NextSyncCommittee()
 	if err != nil {
 		return err
@@ -680,7 +680,7 @@ func RegisterSyncSubnetNextPeriod(s beaconState.BeaconState, epoch primitives.Ep
 }
 
 // RegisterSyncSubnetNextPeriodProto registers a persistent subnet for the next sync committee period.
-func RegisterSyncSubnetNextPeriodProto(s beaconState.BeaconState, epoch primitives.Epoch, pubKey []byte, status ethpb.ValidatorStatus) error {
+func RegisterSyncSubnetNextPeriodProto(s beaconState.ReadOnlyBeaconState, epoch primitives.Epoch, pubKey []byte, status ethpb.ValidatorStatus) error {
 	committee, err := s.NextSyncCommittee()
 	if err != nil {
 		return err

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	coreTime "github.com/OffchainLabs/prysm/v7/beacon-chain/core/time"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/core"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -36,25 +35,10 @@ func (vs *Server) duties(ctx context.Context, req *ethpb.DutiesRequest) (*ethpb.
 		return nil, status.Errorf(codes.Unavailable, "Request epoch %d can not be greater than next epoch %d", req.Epoch, currentEpoch+1)
 	}
 
-	s, err := vs.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-
-	// Advance state with empty transitions up to the requested epoch start slot.
-	epochStartSlot, err := slots.EpochStart(req.Epoch)
+	// Load a read only head state advanced with empty transitions up to the requested epoch start slot.
+	s, err := vs.stateForEpoch(ctx, req.Epoch)
 	if err != nil {
 		return nil, err
-	}
-	if s.Slot() < epochStartSlot {
-		headRoot, err := vs.HeadFetcher.HeadRoot(ctx)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not retrieve head root: %v", err)
-		}
-		s, err = transition.ProcessSlotsUsingNextSlotCache(ctx, s, headRoot, epochStartSlot)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not process slots up to %d: %v", epochStartSlot, err)
-		}
 	}
 
 	requestIndices := make([]primitives.ValidatorIndex, 0, len(req.PublicKeys))

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
@@ -37,14 +37,8 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 		return nil, status.Errorf(codes.Unavailable, "Request epoch %d can not be greater than next epoch %d", req.Epoch, currentEpoch+1)
 	}
 
-	// Load head state
-	s, err := vs.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-
-	// Advance to start of requested epoch if necessary
-	s, err = vs.stateForEpoch(ctx, s, req.Epoch)
+	// Load a read only head state advanced to the start of the requested epoch if necessary.
+	s, err := vs.stateForEpoch(ctx, req.Epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -228,12 +222,16 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 	}, nil
 }
 
-// stateForEpoch returns a state advanced (with empty slot transitions) to the
-// start slot of the requested epoch.
-func (vs *Server) stateForEpoch(ctx context.Context, s state.BeaconState, reqEpoch primitives.Epoch) (state.BeaconState, error) {
+// stateForEpoch returns a read only head state advanced (with empty slot
+// transitions) to the start slot of the requested epoch.
+func (vs *Server) stateForEpoch(ctx context.Context, reqEpoch primitives.Epoch) (state.ReadOnlyBeaconState, error) {
 	epochStartSlot, err := slots.EpochStart(reqEpoch)
 	if err != nil {
 		return nil, err
+	}
+	s, err := vs.HeadFetcher.HeadStateReadOnly(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
 	}
 	if s.Slot() >= epochStartSlot {
 		return s, nil
@@ -242,7 +240,7 @@ func (vs *Server) stateForEpoch(ctx context.Context, s state.BeaconState, reqEpo
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not retrieve head root: %v", err)
 	}
-	s, err = transition.ProcessSlotsUsingNextSlotCache(ctx, s, headRoot, epochStartSlot)
+	s, err = transition.ProcessSlotsIfNeeded(ctx, s, headRoot, epochStartSlot)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not process slots up to %d: %v", epochStartSlot, err)
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v3.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v3.go
@@ -237,7 +237,7 @@ func (vs *Server) GetPTCDuties(ctx context.Context, req *ethpb.PTCDutiesRequest)
 
 // attestationDependentRoot returns the dependent root for attestation-style duties.
 // For epochs <= 1 it returns the genesis block root; otherwise it computes the root from state.
-func (vs *Server) attestationDependentRoot(ctx context.Context, s state.BeaconState, epoch primitives.Epoch) ([]byte, error) {
+func (vs *Server) attestationDependentRoot(ctx context.Context, s state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]byte, error) {
 	if epoch <= 1 {
 		r, err := vs.BeaconDB.GenesisBlockRoot(ctx)
 		if err != nil {
@@ -255,7 +255,7 @@ func (vs *Server) attestationDependentRoot(ctx context.Context, s state.BeaconSt
 // proposalDependentRoot returns the dependent root for proposer duties.
 // Epoch 0 always needs genesis root. Epoch 1 also needs it post-Fulu because
 // V2 uses AttestationDependentRoot which requires epoch > 1.
-func (vs *Server) proposalDependentRoot(ctx context.Context, s state.BeaconState, epoch primitives.Epoch) ([]byte, error) {
+func (vs *Server) proposalDependentRoot(ctx context.Context, s state.ReadOnlyBeaconState, epoch primitives.Epoch) ([]byte, error) {
 	if epoch == 0 || (epoch == 1 && s.Version() >= version.Fulu) {
 		r, err := vs.BeaconDB.GenesisBlockRoot(ctx)
 		if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v3.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v3.go
@@ -29,11 +29,7 @@ func (vs *Server) GetAttesterDuties(ctx context.Context, req *ethpb.AttesterDuti
 		return nil, status.Errorf(codes.InvalidArgument, "Request epoch %d can not be greater than next epoch %d", req.Epoch, currentEpoch+1)
 	}
 
-	s, err := vs.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-	s, err = vs.stateForEpoch(ctx, s, req.Epoch)
+	s, err := vs.stateForEpoch(ctx, req.Epoch)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get state for epoch: %v", err)
 	}
@@ -87,11 +83,7 @@ func (vs *Server) GetProposerDutiesV2(ctx context.Context, req *ethpb.ProposerDu
 		return nil, status.Errorf(codes.InvalidArgument, "Request epoch %d can not be greater than next epoch %d", req.Epoch, currentEpoch+1)
 	}
 
-	s, err := vs.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-	s, err = vs.stateForEpoch(ctx, s, req.Epoch)
+	s, err := vs.stateForEpoch(ctx, req.Epoch)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get state for epoch: %v", err)
 	}
@@ -142,11 +134,7 @@ func (vs *Server) GetSyncCommitteeDuties(ctx context.Context, req *ethpb.SyncCom
 		return nil, status.Errorf(codes.InvalidArgument, "Request epoch %d can not be greater than last valid epoch %d for sync committee duties", req.Epoch, lastValidEpoch)
 	}
 
-	s, err := vs.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-	s, err = vs.stateForEpoch(ctx, s, req.Epoch)
+	s, err := vs.stateForEpoch(ctx, req.Epoch)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get state for epoch: %v", err)
 	}
@@ -195,11 +183,7 @@ func (vs *Server) GetPTCDuties(ctx context.Context, req *ethpb.PTCDutiesRequest)
 		return nil, status.Errorf(codes.InvalidArgument, "Request epoch %d can not be greater than next epoch %d", req.Epoch, nextEpoch)
 	}
 
-	s, err := vs.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-	s, err = vs.stateForEpoch(ctx, s, req.Epoch)
+	s, err := vs.stateForEpoch(ctx, req.Epoch)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get state for epoch: %v", err)
 	}

--- a/changelog/syjn99_fix-duties-ro-states.md
+++ b/changelog/syjn99_fix-duties-ro-states.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use read-only states in validator duties RPC.


### PR DESCRIPTION
**What type of PR is this?**

> Other: Optimization

**What does this PR do? Why is it needed?**

See previous PR (#17424) for the needs. This PR aims to make our validator RPC calls for duties use read-only `BeaconState`.

**Which issue(s) does this PR fix?**

Part of 

- #16692

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
