### PR TITLE
refactor(ssz): use strings.Cut for len path validation

### DIFF
--- a/changelog/query-use-cut-for-len-path-validation.md
+++ b/changelog/query-use-cut-for-len-path-validation.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Simplify internal SSZ query path validation without changing behavior.

--- a/encoding/ssz/query/path.go
+++ b/encoding/ssz/query/path.go
@@ -139,7 +139,7 @@ func validateRawPath(rawPath string) error {
 	}
 
 	// 4. Reject len() calls not at the start of the path
-	if strings.Index(rawPath, "len(") > 0 {
+	if prefix, _, ok := strings.Cut(rawPath, "len("); ok && prefix != "" {
 		return fmt.Errorf("len() call must be at the start of the path: %s", rawPath)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**


Use strings.Cut when checking whether len( appears after a path prefix. This keeps the existing validation behavior while making the prefix condition explicit.

**Which issue(s) does this PR fix?**

N/A - small internal refactor.

**Other notes for review**

Testing plan: bazel test //encoding/ssz/query:go_default_test

**Acknowledgements**

- [x] I have read CONTRIBUTING.md.
- [x] I have included a uniquely named Ignored changelog fragment.
- [x] I have added sufficient context.
- [ ] I have run the Bazel test locally.