### PR TITLE
Gate `getFFG()` precompute for epoch start & "already-head" case

### DIFF
--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -177,8 +177,10 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 		}
 		return ffg
 	})
+	// honest() is only reachable at an epoch start once the slot's own block is already head.
+	honestReachable := !slots.IsEpochStart(currentSlot) || headSlot >= currentSlot
 	// The pulled up head state can copy and advance a state, precompute it off the forkchoice lock.
-	if confirmedSlotErr != nil || confirmedIsAncErr != nil || !confirmedIsAnc || slots.ToEpoch(confirmedSlot) < slots.ToEpoch(currentSlot) {
+	if honestReachable && (confirmedSlotErr != nil || confirmedIsAncErr != nil || !confirmedIsAnc || slots.ToEpoch(confirmedSlot) < slots.ToEpoch(currentSlot)) {
 		getFFG()
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

> Other: FCR optimization

**What does this PR do? Why is it needed?**

<img width="2000" height="443" alt="image" src="https://github.com/user-attachments/assets/d34cfb4e-8a7b-4b81-a072-de17f8aa3dee" />

FCR duration is much longer in every epoch boundary (= first slot of the epoch). Flamegraph above shows the anatomy there, and this PR resolves the **second part** (= `confirmation.OnFastConfirmation.OnceValue...`).

`getFFG()` is called for sake of precomputing, when certain conditions met. One of the condition is `slots.ToEpoch(confirmedSlot) < slots.ToEpoch(currentSlot)`. It is always true in epoch boundary, as `confirmedSlot` would always be the previous epoch. So, we can say `getFFG()` is always called (which takes ~110ms for the Hoodi testnet in my machine).

The only consumer of `getFFG()` is `honest()` call which is wrapped with `sync.OnceValues` for memoization purpose. If `honest()` isn't called, then `getFFG()` doesn't have to be eagerly called.

There are three places where `honest()` is consumed, and new variable `honestReachable` gates `getFFG()` when it isn't needed:

```go
	// honest() is only reachable at an epoch start once the slot's own block is already head.
	honestReachable := !slots.IsEpochStart(currentSlot) || headSlot >= currentSlot
```

https://github.com/OffchainLabs/prysm/blob/1e307c23a3f8ac693123864addeeadca9d40cca2/beacon-chain/confirmation/confirmation.go#L588-L598

1. `pass1GateOpen`: If the current slot is epoch start, it returns true.

https://github.com/OffchainLabs/prysm/blob/1e307c23a3f8ac693123864addeeadca9d40cca2/beacon-chain/confirmation/confirmation.go#L692-L694

2. `applyPass2SafetyGate`: Same as `pass1GateOpen`.

https://github.com/OffchainLabs/prysm/blob/1e307c23a3f8ac693123864addeeadca9d40cca2/beacon-chain/confirmation/confirmation.go#L650-L654

3. `confirmCurrentEpochBlocks`: When `headSlot < currentSlot`, `slots.ToEpoch(blockSlot) > slots.ToEpoch(tentativeSlot)` is always false.
  - `blockSlot <= `headSlot` & `headSlot < currentSlot` => `slots.ToEpoch(blockSlot) <= previous epoch`
  - `tentativeSlot` comes from `confirmedRoot`, thus `slots.ToEpoch(tentativeSlot) >= previous epoch`
  - Therefore, `slots.ToEpoch(blockSlot) <= slots.ToEpoch(tentativeSlot)`.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
