### PR TITLE
Initialize the keymanager once per validator runner

### DIFF
--- a/changelog/syjn99_fix-web3signer-km-leak-17426.md
+++ b/changelog/syjn99_fix-web3signer-km-leak-17426.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Initialize the keymanager once per validator runner instead of on every beacon-node connection retry, which leaked a key watcher goroutine (web3signer URL poller or wallet/file watcher) and a duplicate accounts-changed subscription per retry. (fixes #17426)

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -198,6 +198,7 @@ func initialize(ctx context.Context, v *validator) error {
 	defer ticker.Stop()
 
 	firstTime := true
+	kmInitialized := false
 
 	for {
 		if !firstTime {
@@ -219,8 +220,12 @@ func initialize(ctx context.Context, v *validator) error {
 			return errors.Wrap(err, "could not determine if beacon chain started")
 		}
 
-		if err := v.WaitForKeymanagerInitialization(ctx); err != nil {
-			return errors.Wrap(err, "Wallet is not ready")
+		// Initialize the keymanager once per runner.
+		if !kmInitialized {
+			if err := v.WaitForKeymanagerInitialization(ctx); err != nil {
+				return errors.Wrap(err, "Wallet is not ready")
+			}
+			kmInitialized = true
 		}
 
 		if err := v.WaitForSync(ctx); err != nil {

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -219,6 +219,9 @@ func (v *validator) WaitForKeymanagerInitialization(ctx context.Context) error {
 	if err := v.snapshotBootKeysForDoppelGanger(ctx); err != nil {
 		return err
 	}
+	if v.accountChangedSub != nil {
+		v.accountChangedSub.Unsubscribe()
+	}
 	v.accountChangedSub = v.km.SubscribeAccountChanges(v.accountsChangedChannel)
 	return nil
 }

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -958,6 +961,130 @@ func TestValidator_WaitForKeymanagerInitialization_web3Signer(t *testing.T) {
 			require.NotNil(t, km)
 		})
 	}
+}
+
+func settledPollerCount() int {
+	// countURLPollerInStack counts the number of pollRemoteKeysFromURL goroutines in the stack trace.
+	countURLPollerInStack := func() int {
+		buf := make([]byte, 1<<20)
+		for {
+			n := runtime.Stack(buf, true)
+			if n < len(buf) {
+				return strings.Count(string(buf[:n]), "pollRemoteKeysFromURL")
+			}
+			buf = make([]byte, 2*len(buf))
+		}
+	}
+
+	count := 0
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		count = countURLPollerInStack()
+		if count == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return count
+}
+
+func TestInitialize_Keymanager(t *testing.T) {
+	gvr := func() []byte {
+		root := make([]byte, 32)
+		copy(root[2:], "a")
+		return root
+	}()
+
+	newWeb3SignerTestValidator := func(t *testing.T, keysURL string, pollInterval time.Duration) *validator {
+		ctx := t.Context()
+		db := dbTest.SetupDB(t, t.TempDir(), [][fieldparams.BLSPubkeyLength]byte{}, false)
+		require.NoError(t, db.SaveGenesisValidatorsRoot(ctx, gvr))
+		return &validator{
+			db: db,
+			web3SignerConfig: &remoteweb3signer.SetupConfig{
+				BaseEndpoint:  "http://localhost:8545",
+				PublicKeysURL: keysURL,
+				PollInterval:  pollInterval,
+			},
+			accountsChangedChannel: make(chan [][fieldparams.BLSPubkeyLength]byte, 2),
+		}
+	}
+
+	setupInitTest := func(t *testing.T) (*validator, *validatormock.MockValidatorClient, *validatormock.MockNodeClient, *atomic.Value) {
+		var resp atomic.Value
+		resp.Store(`["0xa2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"]`)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(resp.Load().(string)))
+		}))
+		t.Cleanup(srv.Close)
+
+		v := newWeb3SignerTestValidator(t, srv.URL, 20*time.Millisecond)
+		ctrl := gomock.NewController(t)
+		validatorClient := validatormock.NewMockValidatorClient(ctrl)
+		nodeClient := validatormock.NewMockNodeClient(ctrl)
+		v.validatorClient = validatorClient
+		v.nodeClient = nodeClient
+		return v, validatorClient, nodeClient, &resp
+	}
+	chainStarted := func() *ethpb.ChainStartResponse {
+		return &ethpb.ChainStartResponse{
+			Started:               true,
+			GenesisTime:           uint64(time.Now().Unix()),
+			GenesisValidatorsRoot: gvr,
+		}
+	}
+
+	oldBackOff := backOffPeriod
+	backOffPeriod = 5 * time.Millisecond
+	defer func() { backOffPeriod = oldBackOff }()
+
+	t.Run("initialized once per runner", func(t *testing.T) {
+		v, validatorClient, nodeClient, resp := setupInitTest(t)
+		validatorClient.EXPECT().WaitForChainStart(gomock.Any(), gomock.Any()).Return(chainStarted(), nil).Times(3)
+
+		// Two connection errors followed by a successful sync status check.
+		gomock.InOrder(
+			nodeClient.EXPECT().SyncStatus(gomock.Any(), gomock.Any()).Return(nil, errors.New("connection refused")),
+			nodeClient.EXPECT().SyncStatus(gomock.Any(), gomock.Any()).Return(nil, errors.New("connection refused")),
+			nodeClient.EXPECT().SyncStatus(gomock.Any(), gomock.Any()).Return(&ethpb.SyncStatus{Syncing: false}, nil),
+		)
+		validatorClient.EXPECT().MultipleValidatorStatus(gomock.Any(), gomock.Any()).DoAndReturn(allActiveStatuses)
+
+		require.NoError(t, initialize(t.Context(), v))
+		require.Equal(t, 1, settledPollerCount(), "expected exactly one key poller goroutine")
+
+		// Test that subscription delivers exactly one event.
+		resp.Store(`["0xb2b5aaad9c6efefe7bb9b1243a043404f3362937cfb6b31833929833173f476630ea2cfeb0d9ddf15f97ca8685948820"]`)
+		select {
+		case <-v.accountsChangedChannel:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for accounts changed event")
+		}
+		select {
+		case <-v.accountsChangedChannel:
+			t.Fatal("duplicate accounts changed delivery from a leaked keymanager")
+		case <-time.After(500 * time.Millisecond):
+		}
+	})
+
+	t.Run("rebuilt by a runner restart", func(t *testing.T) {
+		v, validatorClient, nodeClient, _ := setupInitTest(t)
+		validatorClient.EXPECT().WaitForChainStart(gomock.Any(), gomock.Any()).Return(chainStarted(), nil).Times(2)
+		nodeClient.EXPECT().SyncStatus(gomock.Any(), gomock.Any()).Return(&ethpb.SyncStatus{Syncing: false}, nil).Times(2)
+		validatorClient.EXPECT().MultipleValidatorStatus(gomock.Any(), gomock.Any()).DoAndReturn(allActiveStatuses).Times(2)
+
+		runnerCtx, cancel := context.WithCancel(t.Context())
+		require.NoError(t, initialize(runnerCtx, v))
+		km := v.km
+
+		// Simulate a health-monitor runner restart.
+		cancel()
+		v.Done()
+		require.NoError(t, initialize(t.Context(), v))
+		require.Equal(t, false, km == v.km, "restart must rebuild the keymanager")
+		require.Equal(t, 1, settledPollerCount(), "expected exactly one key poller goroutine after restart")
+	})
 }
 
 func TestValidator_WaitForKeymanagerInitialization_Web(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

`initialize` retry loop re-enters `WaitForKeymanagerInitialization`, and in each call new km is created. This makes several goroutines leak per retry (including URL poller / file watcher...). Also accounts changed subscription can be subscribed duplicatavely.

This PR guards the `WaitForKeymanagerInitialization` with a local flag (`kmInitialized`) so it guarantees a single keymanager in a runtime. See `TestInitialize_Keymanager` for the regression test.

**Which issue(s) does this PR fix?**

Fixes #17426 

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
