### PR TITLE
Use value slices for epoch-precompute validators and Altair attestation deltas

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -380,7 +380,7 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 	processedDepositsCount.Set(float64(postState.Eth1DepositIndex() + 1))
 
 	var b *precompute.Balance
-	var v []*precompute.Validator
+	var v []precompute.Validator
 	var err error
 
 	if headState.Version() == version.Phase0 {

--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "block_test.go",
         "deposit_fuzz_test.go",
         "deposit_test.go",
+        "epoch_precompute_bench_test.go",
         "epoch_precompute_test.go",
         "epoch_spec_test.go",
         "exports_test.go",

--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -25,10 +25,10 @@ type AttDelta struct {
 }
 
 // InitializePrecomputeValidators precomputes individual validator for its attested balances and the total sum of validators attested balances of the epoch.
-func InitializePrecomputeValidators(ctx context.Context, beaconState state.BeaconState) ([]*precompute.Validator, *precompute.Balance, error) {
+func InitializePrecomputeValidators(ctx context.Context, beaconState state.BeaconState) ([]precompute.Validator, *precompute.Balance, error) {
 	_, span := trace.StartSpan(ctx, "altair.InitializePrecomputeValidators")
 	defer span.End()
-	vals := make([]*precompute.Validator, beaconState.NumValidators())
+	vals := make([]precompute.Validator, beaconState.NumValidators())
 	bal := &precompute.Balance{}
 	prevEpoch := time.PrevEpoch(beaconState)
 	currentEpoch := time.CurrentEpoch(beaconState)
@@ -44,12 +44,11 @@ func InitializePrecomputeValidators(ctx context.Context, beaconState state.Beaco
 	}
 	for idx, val := range beaconState.ValidatorsReadOnlySeq() {
 		// Set validator's balance, inactivity score and slashed/withdrawable status.
-		v := &precompute.Validator{
-			CurrentEpochEffectiveBalance: val.EffectiveBalance(),
-			InactivityScore:              inactivityScores[idx],
-			IsSlashed:                    val.Slashed(),
-			IsWithdrawableCurrentEpoch:   currentEpoch >= val.WithdrawableEpoch(),
-		}
+		v := &vals[idx]
+		v.CurrentEpochEffectiveBalance = val.EffectiveBalance()
+		v.InactivityScore = inactivityScores[idx]
+		v.IsSlashed = val.Slashed()
+		v.IsWithdrawableCurrentEpoch = currentEpoch >= val.WithdrawableEpoch()
 		// Set validator's active status for current epoch.
 		if helpers.IsActiveValidatorUsingTrie(val, currentEpoch) {
 			v.IsActiveCurrentEpoch = true
@@ -66,7 +65,6 @@ func InitializePrecomputeValidators(ctx context.Context, beaconState state.Beaco
 				return nil, nil, fmt.Errorf("add64: %w", err)
 			}
 		}
-		vals[idx] = v
 	}
 	return vals, bal, nil
 }
@@ -83,8 +81,8 @@ func InitializePrecomputeValidators(ctx context.Context, beaconState state.Beaco
 func ProcessInactivityScores(
 	ctx context.Context,
 	beaconState state.BeaconState,
-	vals []*precompute.Validator,
-) (state.BeaconState, []*precompute.Validator, error) {
+	vals []precompute.Validator,
+) (state.BeaconState, []precompute.Validator, error) {
 	_, span := trace.StartSpan(ctx, "altair.ProcessInactivityScores")
 	defer span.End()
 
@@ -102,7 +100,10 @@ func ProcessInactivityScores(
 	recoveryRate := cfg.InactivityScoreRecoveryRate
 	prevEpoch := time.PrevEpoch(beaconState)
 	finalizedEpoch := beaconState.FinalizedCheckpointEpoch()
-	for i, v := range vals {
+	for i := range vals {
+		// Mutations below must go through the slice element, not a copy, so that
+		// updated inactivity scores are visible to later epoch processing stages.
+		v := &vals[i]
 		if !precompute.EligibleForRewards(v) {
 			continue
 		}
@@ -149,8 +150,8 @@ func ProcessEpochParticipation(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	bal *precompute.Balance,
-	vals []*precompute.Validator,
-) ([]*precompute.Validator, *precompute.Balance, error) {
+	vals []precompute.Validator,
+) ([]precompute.Validator, *precompute.Balance, error) {
 	_, span := trace.StartSpan(ctx, "altair.ProcessEpochParticipation")
 	defer span.End()
 
@@ -217,7 +218,7 @@ func ProcessEpochParticipation(
 func ProcessRewardsAndPenaltiesPrecompute(
 	beaconState state.BeaconState,
 	bal *precompute.Balance,
-	vals []*precompute.Validator,
+	vals []precompute.Validator,
 ) (state.BeaconState, error) {
 	// Don't process rewards and penalties in genesis epoch.
 	cfg := params.BeaconConfig()
@@ -261,8 +262,8 @@ func ProcessRewardsAndPenaltiesPrecompute(
 
 // AttestationsDelta computes and returns the rewards and penalties differences for individual validators based on the
 // voting records.
-func AttestationsDelta(beaconState state.BeaconState, bal *precompute.Balance, vals []*precompute.Validator) ([]*AttDelta, error) {
-	attDeltas := make([]*AttDelta, len(vals))
+func AttestationsDelta(beaconState state.BeaconState, bal *precompute.Balance, vals []precompute.Validator) ([]AttDelta, error) {
+	attDeltas := make([]AttDelta, len(vals))
 
 	cfg := params.BeaconConfig()
 	prevEpoch := time.PrevEpoch(beaconState)
@@ -280,8 +281,8 @@ func AttestationsDelta(beaconState state.BeaconState, bal *precompute.Balance, v
 	}
 	inactivityDenominator := bias * inactivityPenaltyQuotient
 
-	for i, v := range vals {
-		attDeltas[i], err = attestationDelta(bal, v, baseRewardMultiplier, inactivityDenominator, leak)
+	for i := range vals {
+		attDeltas[i], err = attestationDelta(bal, &vals[i], baseRewardMultiplier, inactivityDenominator, leak)
 		if err != nil {
 			return nil, err
 		}
@@ -294,11 +295,11 @@ func attestationDelta(
 	bal *precompute.Balance,
 	val *precompute.Validator,
 	baseRewardMultiplier, inactivityDenominator uint64,
-	inactivityLeak bool) (*AttDelta, error) {
+	inactivityLeak bool) (AttDelta, error) {
 	eligible := val.IsActivePrevEpoch || (val.IsSlashed && !val.IsWithdrawableCurrentEpoch)
 	// Per spec `ActiveCurrentEpoch` can't be 0 to process attestation delta.
 	if !eligible || bal.ActiveCurrentEpoch == 0 {
-		return &AttDelta{}, nil
+		return AttDelta{}, nil
 	}
 
 	cfg := params.BeaconConfig()
@@ -311,7 +312,7 @@ func attestationDelta(
 	srcWeight := cfg.TimelySourceWeight
 	tgtWeight := cfg.TimelyTargetWeight
 	headWeight := cfg.TimelyHeadWeight
-	attDelta := &AttDelta{}
+	attDelta := AttDelta{}
 	// Process source reward / penalty
 	if val.IsPrevEpochSourceAttester && !val.IsSlashed {
 		if !inactivityLeak {
@@ -345,7 +346,7 @@ func attestationDelta(
 	if !val.IsPrevEpochTargetAttester || val.IsSlashed {
 		n, err := math.Mul64(effectiveBalance, val.InactivityScore)
 		if err != nil {
-			return &AttDelta{}, err
+			return AttDelta{}, err
 		}
 		attDelta.InactivityPenalty = n / inactivityDenominator
 	}

--- a/beacon-chain/core/altair/epoch_precompute_bench_test.go
+++ b/beacon-chain/core/altair/epoch_precompute_bench_test.go
@@ -1,0 +1,53 @@
+package altair_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/altair"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+)
+
+// Results at 16,384 validators (Apple M4 Pro, darwin/arm64, -benchtime=20x),
+// before and after converting []*precompute.Validator / []*AttDelta to value slices:
+//
+//	                                      ns/op    B/op     allocs/op
+//	InitializePrecomputeValidators
+//	  pointer slices (before)             907479   1573280  16395
+//	  value slices   (after)              850990   1311136  11
+//	AttestationsDelta
+//	  pointer slices (before)             239548   917504   16385
+//	  value slices   (after)              90319    786434   1
+const benchPrecomputeValidatorCount = 16384
+
+func BenchmarkInitializePrecomputeValidators(b *testing.B) {
+	st, _ := util.DeterministicGenesisStateAltair(b, benchPrecomputeValidatorCount)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := altair.InitializePrecomputeValidators(ctx, st); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAttestationsDelta(b *testing.B) {
+	st, _ := util.DeterministicGenesisStateAltair(b, benchPrecomputeValidatorCount)
+	ctx := context.Background()
+	vp, bal, err := altair.InitializePrecomputeValidators(ctx, st)
+	if err != nil {
+		b.Fatal(err)
+	}
+	vp, bal, err = altair.ProcessEpochParticipation(ctx, st, bal, vp)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := altair.AttestationsDelta(st, bal, vp); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/beacon-chain/core/altair/epoch_precompute_bench_test.go
+++ b/beacon-chain/core/altair/epoch_precompute_bench_test.go
@@ -1,7 +1,6 @@
 package altair_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/altair"
@@ -22,10 +21,9 @@ const benchPrecomputeValidatorCount = 16384
 
 func BenchmarkInitializePrecomputeValidators(b *testing.B) {
 	st, _ := util.DeterministicGenesisStateAltair(b, benchPrecomputeValidatorCount)
-	ctx := context.Background()
+	ctx := b.Context()
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, _, err := altair.InitializePrecomputeValidators(ctx, st); err != nil {
 			b.Fatal(err)
 		}
@@ -34,7 +32,7 @@ func BenchmarkInitializePrecomputeValidators(b *testing.B) {
 
 func BenchmarkAttestationsDelta(b *testing.B) {
 	st, _ := util.DeterministicGenesisStateAltair(b, benchPrecomputeValidatorCount)
-	ctx := context.Background()
+	ctx := b.Context()
 	vp, bal, err := altair.InitializePrecomputeValidators(ctx, st)
 	if err != nil {
 		b.Fatal(err)
@@ -44,8 +42,7 @@ func BenchmarkAttestationsDelta(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := altair.AttestationsDelta(st, bal, vp); err != nil {
 			b.Fatal(err)
 		}

--- a/beacon-chain/core/altair/epoch_precompute_test.go
+++ b/beacon-chain/core/altair/epoch_precompute_test.go
@@ -33,23 +33,23 @@ func TestInitializeEpochValidators_Ok(t *testing.T) {
 	require.NoError(t, err)
 	v, b, err := InitializePrecomputeValidators(t.Context(), s)
 	require.NoError(t, err)
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsSlashed:                    true,
 		CurrentEpochEffectiveBalance: 100,
 		InactivityScore:              0,
 	}, v[0], "Incorrect validator 0 status")
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsWithdrawableCurrentEpoch:   true,
 		CurrentEpochEffectiveBalance: 100,
 		InactivityScore:              1,
 	}, v[1], "Incorrect validator 1 status")
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsActivePrevEpoch:            true,
 		IsActiveCurrentEpoch:         true,
 		CurrentEpochEffectiveBalance: 100,
 		InactivityScore:              2,
 	}, v[2], "Incorrect validator 2 status")
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsActivePrevEpoch:            true,
 		CurrentEpochEffectiveBalance: 100,
 		InactivityScore:              3,
@@ -94,13 +94,13 @@ func TestProcessEpochParticipation(t *testing.T) {
 	require.NoError(t, err)
 	validators, balance, err = ProcessEpochParticipation(t.Context(), s, balance, validators)
 	require.NoError(t, err)
-	require.DeepEqual(t, &precompute.Validator{
+	require.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         true,
 		IsActivePrevEpoch:            true,
 		IsWithdrawableCurrentEpoch:   true,
 		CurrentEpochEffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
 	}, validators[0])
-	require.DeepEqual(t, &precompute.Validator{
+	require.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         true,
 		IsActivePrevEpoch:            true,
 		IsWithdrawableCurrentEpoch:   true,
@@ -109,7 +109,7 @@ func TestProcessEpochParticipation(t *testing.T) {
 		IsPrevEpochAttester:          true,
 		IsPrevEpochSourceAttester:    true,
 	}, validators[1])
-	require.DeepEqual(t, &precompute.Validator{
+	require.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         true,
 		IsActivePrevEpoch:            true,
 		IsWithdrawableCurrentEpoch:   true,
@@ -120,7 +120,7 @@ func TestProcessEpochParticipation(t *testing.T) {
 		IsCurrentEpochTargetAttester: true,
 		IsPrevEpochTargetAttester:    true,
 	}, validators[2])
-	require.DeepEqual(t, &precompute.Validator{
+	require.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         true,
 		IsActivePrevEpoch:            true,
 		IsWithdrawableCurrentEpoch:   true,
@@ -172,13 +172,13 @@ func TestProcessEpochParticipation_InactiveValidator(t *testing.T) {
 	require.NoError(t, err)
 	validators, balance, err = ProcessEpochParticipation(t.Context(), st, balance, validators)
 	require.NoError(t, err)
-	require.DeepEqual(t, &precompute.Validator{
+	require.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         false,
 		IsActivePrevEpoch:            false,
 		IsWithdrawableCurrentEpoch:   true,
 		CurrentEpochEffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
 	}, validators[0])
-	require.DeepEqual(t, &precompute.Validator{
+	require.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         false,
 		IsActivePrevEpoch:            true,
 		IsPrevEpochAttester:          true,
@@ -187,7 +187,7 @@ func TestProcessEpochParticipation_InactiveValidator(t *testing.T) {
 		IsWithdrawableCurrentEpoch:   true,
 		CurrentEpochEffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
 	}, validators[1])
-	require.DeepEqual(t, &precompute.Validator{
+	require.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         true,
 		IsActivePrevEpoch:            true,
 		IsWithdrawableCurrentEpoch:   true,
@@ -432,7 +432,7 @@ func TestProcessRewardsAndPenaltiesPrecompute_BadState(t *testing.T) {
 	require.NoError(t, err)
 	_, balance, err = ProcessEpochParticipation(t.Context(), s, balance, validators)
 	require.NoError(t, err)
-	_, err = ProcessRewardsAndPenaltiesPrecompute(s, balance, []*precompute.Validator{})
+	_, err = ProcessRewardsAndPenaltiesPrecompute(s, balance, []precompute.Validator{})
 	require.ErrorContains(t, "validator registries not the same length as state's validator registries", err)
 }
 

--- a/beacon-chain/core/epoch/precompute/attestation.go
+++ b/beacon-chain/core/epoch/precompute/attestation.go
@@ -22,9 +22,9 @@ import (
 func ProcessAttestations(
 	ctx context.Context,
 	state state.ReadOnlyBeaconState,
-	vp []*Validator,
+	vp []Validator,
 	pBal *Balance,
-) ([]*Validator, *Balance, error) {
+) ([]Validator, *Balance, error) {
 	ctx, span := trace.StartSpan(ctx, "precomputeEpoch.ProcessAttestations")
 	defer span.End()
 
@@ -141,7 +141,7 @@ func SameHead(state state.ReadOnlyBeaconState, a *ethpb.PendingAttestation) (boo
 }
 
 // UpdateValidator updates pre computed validator store.
-func UpdateValidator(vp []*Validator, record *Validator, indices []uint64, a *ethpb.PendingAttestation, aSlot primitives.Slot) []*Validator {
+func UpdateValidator(vp []Validator, record *Validator, indices []uint64, a *ethpb.PendingAttestation, aSlot primitives.Slot) []Validator {
 	inclusionSlot := aSlot + a.InclusionDelay
 
 	for _, i := range indices {
@@ -171,8 +171,9 @@ func UpdateValidator(vp []*Validator, record *Validator, indices []uint64, a *et
 }
 
 // UpdateBalance updates pre computed balance store.
-func UpdateBalance(vp []*Validator, bBal *Balance, stateVersion int) *Balance {
-	for _, v := range vp {
+func UpdateBalance(vp []Validator, bBal *Balance, stateVersion int) *Balance {
+	for i := range vp {
+		v := &vp[i]
 		if !v.IsSlashed {
 			if v.IsCurrentEpochAttester {
 				bBal.CurrentEpochAttested += v.CurrentEpochEffectiveBalance

--- a/beacon-chain/core/epoch/precompute/attestation_test.go
+++ b/beacon-chain/core/epoch/precompute/attestation_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestUpdateValidator_Works(t *testing.T) {
 	e := params.BeaconConfig().FarFutureSlot
-	vp := []*precompute.Validator{{}, {InclusionSlot: e}, {}, {InclusionSlot: e}, {}, {InclusionSlot: e}}
+	vp := []precompute.Validator{{}, {InclusionSlot: e}, {}, {InclusionSlot: e}, {}, {InclusionSlot: e}}
 	record := &precompute.Validator{IsCurrentEpochAttester: true, IsCurrentEpochTargetAttester: true,
 		IsPrevEpochAttester: true, IsPrevEpochTargetAttester: true, IsPrevEpochHeadAttester: true}
 	a := &ethpb.PendingAttestation{InclusionDelay: 1, ProposerIndex: 2}
@@ -25,28 +25,28 @@ func TestUpdateValidator_Works(t *testing.T) {
 	// Indices 1 3 and 5 attested
 	vp = precompute.UpdateValidator(vp, record, []uint64{1, 3, 5}, a, 100)
 
-	wanted := &precompute.Validator{IsCurrentEpochAttester: true, IsCurrentEpochTargetAttester: true,
+	wanted := precompute.Validator{IsCurrentEpochAttester: true, IsCurrentEpochTargetAttester: true,
 		IsPrevEpochAttester: true, IsPrevEpochTargetAttester: true, IsPrevEpochHeadAttester: true,
 		ProposerIndex: 2, InclusionDistance: 1, InclusionSlot: 101}
-	wantedVp := []*precompute.Validator{{}, wanted, {}, wanted, {}, wanted}
+	wantedVp := []precompute.Validator{{}, wanted, {}, wanted, {}, wanted}
 	assert.DeepEqual(t, wantedVp, vp, "Incorrect attesting validator calculations")
 }
 
 func TestUpdateValidator_InclusionOnlyCountsPrevEpoch(t *testing.T) {
 	e := params.BeaconConfig().FarFutureSlot
-	vp := []*precompute.Validator{{InclusionSlot: e}}
+	vp := []precompute.Validator{{InclusionSlot: e}}
 	record := &precompute.Validator{IsCurrentEpochAttester: true, IsCurrentEpochTargetAttester: true}
 	a := &ethpb.PendingAttestation{InclusionDelay: 1, ProposerIndex: 2}
 
 	// Verify inclusion info doesn't get updated.
 	vp = precompute.UpdateValidator(vp, record, []uint64{0}, a, 100)
-	wanted := &precompute.Validator{IsCurrentEpochAttester: true, IsCurrentEpochTargetAttester: true, InclusionSlot: e}
-	wantedVp := []*precompute.Validator{wanted}
+	wanted := precompute.Validator{IsCurrentEpochAttester: true, IsCurrentEpochTargetAttester: true, InclusionSlot: e}
+	wantedVp := []precompute.Validator{wanted}
 	assert.DeepEqual(t, wantedVp, vp, "Incorrect attesting validator calculations")
 }
 
 func TestUpdateBalance(t *testing.T) {
-	vp := []*precompute.Validator{
+	vp := []precompute.Validator{
 		{IsCurrentEpochAttester: true, CurrentEpochEffectiveBalance: 100 * params.BeaconConfig().EffectiveBalanceIncrement},
 		{IsCurrentEpochTargetAttester: true, IsCurrentEpochAttester: true, CurrentEpochEffectiveBalance: 100 * params.BeaconConfig().EffectiveBalanceIncrement},
 		{IsCurrentEpochTargetAttester: true, CurrentEpochEffectiveBalance: 100 * params.BeaconConfig().EffectiveBalanceIncrement},
@@ -70,7 +70,7 @@ func TestUpdateBalance(t *testing.T) {
 }
 
 func TestUpdateBalanceDifferentVersions(t *testing.T) {
-	vp := []*precompute.Validator{
+	vp := []precompute.Validator{
 		{IsCurrentEpochAttester: true, CurrentEpochEffectiveBalance: 100 * params.BeaconConfig().EffectiveBalanceIncrement},
 		{IsCurrentEpochTargetAttester: true, IsCurrentEpochAttester: true, CurrentEpochEffectiveBalance: 100 * params.BeaconConfig().EffectiveBalanceIncrement},
 		{IsCurrentEpochTargetAttester: true, CurrentEpochEffectiveBalance: 100 * params.BeaconConfig().EffectiveBalanceIncrement},
@@ -201,9 +201,9 @@ func TestProcessAttestations(t *testing.T) {
 	err = beaconState.AppendCurrentEpochAttestations(&ethpb.PendingAttestation{Data: att2.Data, AggregationBits: bf, InclusionDelay: 1})
 	require.NoError(t, err)
 
-	pVals := make([]*precompute.Validator, validators)
+	pVals := make([]precompute.Validator, validators)
 	for i := 0; i < len(pVals); i++ {
-		pVals[i] = &precompute.Validator{CurrentEpochEffectiveBalance: 100}
+		pVals[i] = precompute.Validator{CurrentEpochEffectiveBalance: 100}
 	}
 	pVals, _, err = precompute.ProcessAttestations(t.Context(), beaconState, pVals, &precompute.Balance{})
 	require.NoError(t, err)

--- a/beacon-chain/core/epoch/precompute/new.go
+++ b/beacon-chain/core/epoch/precompute/new.go
@@ -16,11 +16,11 @@ import (
 // New gets called at the beginning of process epoch cycle to return
 // pre computed instances of validators attesting records and total
 // balances attested in an epoch.
-func New(ctx context.Context, s state.BeaconState) ([]*Validator, *Balance, error) {
+func New(ctx context.Context, s state.BeaconState) ([]Validator, *Balance, error) {
 	_, span := trace.StartSpan(ctx, "precomputeEpoch.New")
 	defer span.End()
 
-	pValidators := make([]*Validator, s.NumValidators())
+	pValidators := make([]Validator, s.NumValidators())
 	pBal := &Balance{}
 
 	currentEpoch := time.CurrentEpoch(s)
@@ -29,11 +29,10 @@ func New(ctx context.Context, s state.BeaconState) ([]*Validator, *Balance, erro
 	for idx, val := range s.ValidatorsReadOnlySeq() {
 		// Was validator withdrawable or slashed
 		withdrawable := prevEpoch+1 >= val.WithdrawableEpoch()
-		pVal := &Validator{
-			IsSlashed:                    val.Slashed(),
-			IsWithdrawableCurrentEpoch:   withdrawable,
-			CurrentEpochEffectiveBalance: val.EffectiveBalance(),
-		}
+		pVal := &pValidators[idx]
+		pVal.IsSlashed = val.Slashed()
+		pVal.IsWithdrawableCurrentEpoch = withdrawable
+		pVal.CurrentEpochEffectiveBalance = val.EffectiveBalance()
 		// Was validator active current epoch
 		if helpers.IsActiveValidatorUsingTrie(val, currentEpoch) {
 			pVal.IsActiveCurrentEpoch = true
@@ -48,8 +47,6 @@ func New(ctx context.Context, s state.BeaconState) ([]*Validator, *Balance, erro
 		// with the lower values
 		pVal.InclusionSlot = params.BeaconConfig().FarFutureSlot
 		pVal.InclusionDistance = params.BeaconConfig().FarFutureSlot
-
-		pValidators[idx] = pVal
 	}
 	return pValidators, pBal, nil
 }

--- a/beacon-chain/core/epoch/precompute/new_test.go
+++ b/beacon-chain/core/epoch/precompute/new_test.go
@@ -30,26 +30,26 @@ func TestNew(t *testing.T) {
 	e := params.BeaconConfig().FarFutureSlot
 	v, b, err := precompute.New(t.Context(), s)
 	require.NoError(t, err)
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsSlashed:                    true,
 		CurrentEpochEffectiveBalance: 100,
 		InclusionDistance:            e,
 		InclusionSlot:                e,
 	}, v[0], "Incorrect validator 0 status")
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsWithdrawableCurrentEpoch:   true,
 		CurrentEpochEffectiveBalance: 100,
 		InclusionDistance:            e,
 		InclusionSlot:                e,
 	}, v[1], "Incorrect validator 1 status")
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsActiveCurrentEpoch:         true,
 		IsActivePrevEpoch:            true,
 		CurrentEpochEffectiveBalance: 100,
 		InclusionDistance:            e,
 		InclusionSlot:                e,
 	}, v[2], "Incorrect validator 2 status")
-	assert.DeepEqual(t, &precompute.Validator{
+	assert.DeepEqual(t, precompute.Validator{
 		IsActivePrevEpoch:            true,
 		CurrentEpochEffectiveBalance: 100,
 		InclusionDistance:            e,

--- a/beacon-chain/core/epoch/precompute/reward_penalty.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty.go
@@ -10,15 +10,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-type attesterRewardsFunc func(state.ReadOnlyBeaconState, *Balance, []*Validator) ([]uint64, []uint64, error)
-type proposerRewardsFunc func(state.ReadOnlyBeaconState, *Balance, []*Validator) ([]uint64, error)
+type attesterRewardsFunc func(state.ReadOnlyBeaconState, *Balance, []Validator) ([]uint64, []uint64, error)
+type proposerRewardsFunc func(state.ReadOnlyBeaconState, *Balance, []Validator) ([]uint64, error)
 
 // ProcessRewardsAndPenaltiesPrecompute processes the rewards and penalties of individual validator.
 // This is an optimized version by passing in precomputed validator attesting records and total epoch balances.
 func ProcessRewardsAndPenaltiesPrecompute(
 	state state.BeaconState,
 	pBal *Balance,
-	vp []*Validator,
+	vp []Validator,
 	attRewardsFunc attesterRewardsFunc,
 	proRewardsFunc proposerRewardsFunc,
 ) (state.BeaconState, error) {
@@ -65,7 +65,7 @@ func ProcessRewardsAndPenaltiesPrecompute(
 
 // AttestationsDelta computes and returns the rewards and penalties differences for individual validators based on the
 // voting records.
-func AttestationsDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []*Validator) ([]uint64, []uint64, error) {
+func AttestationsDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []Validator) ([]uint64, []uint64, error) {
 	numOfVals := state.NumValidators()
 	rewards := make([]uint64, numOfVals)
 	penalties := make([]uint64, numOfVals)
@@ -73,8 +73,8 @@ func AttestationsDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []*Val
 	finalizedEpoch := state.FinalizedCheckpointEpoch()
 
 	sqrtActiveCurrentEpoch := math.CachedSquareRoot(pBal.ActiveCurrentEpoch)
-	for i, v := range vp {
-		rewards[i], penalties[i] = attestationDelta(pBal, sqrtActiveCurrentEpoch, v, prevEpoch, finalizedEpoch)
+	for i := range vp {
+		rewards[i], penalties[i] = attestationDelta(pBal, sqrtActiveCurrentEpoch, &vp[i], prevEpoch, finalizedEpoch)
 	}
 	return rewards, penalties, nil
 }
@@ -155,7 +155,7 @@ func attestationDelta(pBal *Balance, sqrtActiveCurrentEpoch uint64, v *Validator
 
 // ProposersDelta computes and returns the rewards and penalties differences for individual validators based on the
 // proposer inclusion records.
-func ProposersDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []*Validator) ([]uint64, error) {
+func ProposersDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []Validator) ([]uint64, error) {
 	numofVals := state.NumValidators()
 	rewards := make([]uint64, numofVals)
 
@@ -169,7 +169,8 @@ func ProposersDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []*Valida
 	baseRewardFactor := params.BeaconConfig().BaseRewardFactor
 	baseRewardsPerEpoch := params.BeaconConfig().BaseRewardsPerEpoch
 	proposerRewardQuotient := params.BeaconConfig().ProposerRewardQuotient
-	for _, v := range vp {
+	for i := range vp {
+		v := &vp[i]
 		if uint64(v.ProposerIndex) >= uint64(len(rewards)) {
 			// This should never happen with a valid state / validator.
 			return nil, errors.New("proposer index out of range")

--- a/beacon-chain/core/epoch/precompute/reward_penalty_test.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty_test.go
@@ -223,7 +223,7 @@ func TestProposerDeltaPrecompute_HappyCase(t *testing.T) {
 
 	proposerIndex := primitives.ValidatorIndex(1)
 	b := &Balance{ActiveCurrentEpoch: 1000}
-	v := []*Validator{
+	v := []Validator{
 		{IsPrevEpochAttester: true, CurrentEpochEffectiveBalance: 32, ProposerIndex: proposerIndex},
 	}
 	r, err := ProposersDelta(beaconState, b, v)
@@ -245,7 +245,7 @@ func TestProposerDeltaPrecompute_ValidatorIndexOutOfRange(t *testing.T) {
 
 	proposerIndex := primitives.ValidatorIndex(validatorCount)
 	b := &Balance{ActiveCurrentEpoch: 1000}
-	v := []*Validator{
+	v := []Validator{
 		{IsPrevEpochAttester: true, CurrentEpochEffectiveBalance: 32, ProposerIndex: proposerIndex},
 	}
 	_, err = ProposersDelta(beaconState, b, v)
@@ -261,7 +261,7 @@ func TestProposerDeltaPrecompute_SlashedCase(t *testing.T) {
 
 	proposerIndex := primitives.ValidatorIndex(1)
 	b := &Balance{ActiveCurrentEpoch: 1000}
-	v := []*Validator{
+	v := []Validator{
 		{IsPrevEpochAttester: true, CurrentEpochEffectiveBalance: 32, ProposerIndex: proposerIndex, IsSlashed: true},
 	}
 	r, err := ProposersDelta(beaconState, b, v)

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -66,7 +66,7 @@ func (s *Service) ComputeValidatorPerformance(
 			return nil, &RpcError{Err: errors.Wrapf(err, "could not process slots up to %d", currSlot), Reason: Internal}
 		}
 	}
-	var validatorSummary []*precompute.Validator
+	var validatorSummary []precompute.Validator
 	if headState.Version() == version.Phase0 {
 		vp, bp, err := precompute.New(ctx, headState)
 		if err != nil {
@@ -240,7 +240,7 @@ func (s *Service) IndividualVotes(
 	}
 	slices.Sort(filteredIndices)
 
-	var v []*precompute.Validator
+	var v []precompute.Validator
 	var bal *precompute.Balance
 	if st.Version() == version.Phase0 {
 		v, bal, err = precompute.New(ctx, st)
@@ -802,7 +802,7 @@ func (s *Service) ValidatorParticipation(
 	if err != nil {
 		return nil, &RpcError{Reason: Internal, Err: errors.Wrapf(err, "error replaying blocks for state at slot %d", endSlot)}
 	}
-	var v []*precompute.Validator
+	var v []precompute.Validator
 	var b *precompute.Balance
 
 	if beaconSt.Version() == version.Phase0 {

--- a/beacon-chain/rpc/eth/rewards/handlers.go
+++ b/beacon-chain/rpc/eth/rewards/handlers.go
@@ -251,7 +251,7 @@ func attRewardsBalancesAndVals(
 	w http.ResponseWriter,
 	r *http.Request,
 	st state.BeaconState,
-) (*precompute.Balance, []*precompute.Validator, []primitives.ValidatorIndex, bool) {
+) (*precompute.Balance, []precompute.Validator, []primitives.ValidatorIndex, bool) {
 	allVals, bal, err := altair.InitializePrecomputeValidators(r.Context(), st)
 	if err != nil {
 		httputil.HandleError(w, "Could not initialize precompute validators: "+err.Error(), http.StatusBadRequest)
@@ -269,7 +269,7 @@ func attRewardsBalancesAndVals(
 	if len(valIndices) == len(allVals) {
 		return bal, allVals, valIndices, true
 	} else {
-		filteredVals := make([]*precompute.Validator, len(valIndices))
+		filteredVals := make([]precompute.Validator, len(valIndices))
 		for i, valIx := range valIndices {
 			filteredVals[i] = allVals[valIx]
 		}
@@ -283,7 +283,7 @@ func idealAttRewards(
 	w http.ResponseWriter,
 	st state.BeaconState,
 	bal *precompute.Balance,
-	vals []*precompute.Validator,
+	vals []precompute.Validator,
 ) ([]structs.IdealAttestationReward, bool) {
 	increment := params.BeaconConfig().EffectiveBalanceIncrement
 	maxIdealRewards := int((params.BeaconConfig().MaxEffectiveBalanceElectra - params.BeaconConfig().EjectionBalance) / increment)
@@ -304,9 +304,9 @@ func idealAttRewards(
 	slices.Sort(effectiveBalances)
 
 	idealRewards := make([]structs.IdealAttestationReward, 0, len(effectiveBalances))
-	idealVals := make([]*precompute.Validator, 0, len(effectiveBalances))
+	idealVals := make([]precompute.Validator, 0, len(effectiveBalances))
 	for _, effectiveBalance := range effectiveBalances {
-		idealVals = append(idealVals, &precompute.Validator{
+		idealVals = append(idealVals, precompute.Validator{
 			IsActivePrevEpoch:            true,
 			IsSlashed:                    false,
 			CurrentEpochEffectiveBalance: effectiveBalance,
@@ -349,7 +349,7 @@ func totalAttRewards(
 	w http.ResponseWriter,
 	st state.BeaconState,
 	bal *precompute.Balance,
-	vals []*precompute.Validator,
+	vals []precompute.Validator,
 	valIndices []primitives.ValidatorIndex,
 ) ([]structs.TotalAttestationReward, bool) {
 	totalRewards := make([]structs.TotalAttestationReward, len(valIndices))
@@ -386,7 +386,7 @@ func syncRewardsVals(
 	w http.ResponseWriter,
 	r *http.Request,
 	st state.BeaconState,
-) ([]*precompute.Validator, []primitives.ValidatorIndex, bool) {
+) ([]precompute.Validator, []primitives.ValidatorIndex, bool) {
 	allVals, _, err := altair.InitializePrecomputeValidators(r.Context(), st)
 	if err != nil {
 		httputil.HandleError(w, "Could not initialize precompute validators: "+err.Error(), http.StatusBadRequest)
@@ -413,7 +413,7 @@ func syncRewardsVals(
 	}
 
 	scIndices := make([]primitives.ValidatorIndex, 0, len(allScIndices))
-	scVals := make([]*precompute.Validator, 0, len(allScIndices))
+	scVals := make([]precompute.Validator, 0, len(allScIndices))
 	for _, valIdx := range valIndices {
 		if slices.Contains(allScIndices, valIdx) {
 			scVals = append(scVals, allVals[valIdx])
@@ -424,7 +424,7 @@ func syncRewardsVals(
 	return scVals, scIndices, true
 }
 
-func requestedValIndices(w http.ResponseWriter, r *http.Request, st state.BeaconState, allVals []*precompute.Validator) ([]primitives.ValidatorIndex, bool) {
+func requestedValIndices(w http.ResponseWriter, r *http.Request, st state.BeaconState, allVals []precompute.Validator) ([]primitives.ValidatorIndex, bool) {
 	var rawValIds []string
 	if r.Body != http.NoBody {
 		if err := json.NewDecoder(r.Body).Decode(&rawValIds); err != nil {

--- a/changelog/satushh_precompute-value-slices.md
+++ b/changelog/satushh_precompute-value-slices.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Store epoch-precompute validators and Altair attestation deltas as value slices (`[]precompute.Validator`, `[]altair.AttDelta`) instead of slices of per-validator heap-allocated pointers, eliminating roughly two heap objects per validator per epoch transition.


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

- InitializePrecomputeValidators and precompute.New allocated one *precompute.Validator per validator, and AttestationsDelta one *AttDelta per validator, so every epoch transition minted roughly two heap objects per registry entry plus two pointer arrays. 
- Convert []*precompute.Validator to []precompute.Validator and []*AttDelta to []AttDelta, threading the value slices through phase0 and Altair epoch processing, the rewards API handlers, the validator performance RPC, and epoch metrics.
- Mutation sites now go through the slice element (&vals[i]); in particular ProcessInactivityScores writes inactivity scores through the element so the updated scores still reach SetInactivityScores.
- Benchmarks at 16,384 validators (Apple M4 Pro, results recorded in epoch_precompute_bench_test.go):
         InitializePrecomputeValidators: 16,395 -> 11 allocs/op
        AttestationsDelta: 16,385 -> 1 allocs/op, 240us -> 90us/op

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
