### PR TITLE
Use head state for next-epoch attestation target states

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -61,11 +61,12 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 	if err != nil {
 		return nil
 	}
-	if c.Epoch == headEpoch+1 && slots.ToForkVersion(slot) == slots.ToForkVersion(s.HeadSlot()) {
-		st, err := s.HeadStateReadOnly(ctx)
-		if err != nil {
-			return nil
-		}
+	st, err := s.HeadStateReadOnly(ctx)
+	if err != nil {
+		return nil
+	}
+	// The next epoch's shuffling is already determined by the dependent root, so the head state can compute its committees without the boundary transition, unless the fork version changes at the boundary.
+	if c.Epoch == slots.ToEpoch(st.Slot())+1 && slots.ToForkVersion(slot) == slots.ToForkVersion(st.Slot()) {
 		return st
 	}
 	// Try if we have already set the checkpoint cache. This will be tried again if we fail here but the check is cheap anyway.
@@ -81,10 +82,6 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		return cachedState
 	}
 	// If we haven't advanced yet then process the slots from head state.
-	st, err := s.HeadStateReadOnly(ctx)
-	if err != nil {
-		return nil
-	}
 	st, err = transition.ProcessSlotsIfNeeded(ctx, st, c.Root, slot)
 	if err != nil {
 		return nil
@@ -95,7 +92,7 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 	return st
 }
 
-// getAttPreState retrieves the att pre state by either from the cache or the DB.
+// getAttPreState returns a state valid for computing c.Epoch's committees and signature domains, its slot may be one epoch behind c.Epoch.
 // The caller of this function must have a lock on forkchoice.
 func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (state.ReadOnlyBeaconState, error) {
 	// If the attestation is recent and canonical we can use the head state to compute the shuffling.

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -52,11 +52,10 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		}
 		return st
 	}
-	// At this point we can only have c.Epoch > headEpoch.
-	if !s.cfg.ForkChoiceStore.IsCanonical([32]byte(c.Root)) {
+	// At this point we can only have c.Epoch > headEpoch, and LMD/FFG consistency was already verified, so the target root must be the head root.
+	if bytesutil.ToBytes32(c.Root) != bytesutil.ToBytes32(headRoot) {
 		return nil
 	}
-	// This point can only be reached if c.Root == headRoot and c.Epoch > headEpoch.
 	slot, err := slots.EpochStart(c.Epoch)
 	if err != nil {
 		return nil
@@ -66,7 +65,7 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		return nil
 	}
 	// The next epoch's shuffling is already determined by the dependent root, so the head state can compute its committees without the boundary transition, unless the fork version changes at the boundary.
-	if c.Epoch == slots.ToEpoch(st.Slot())+1 && bytesutil.ToBytes32(c.Root) == bytesutil.ToBytes32(headRoot) && slots.ToForkVersion(slot) == slots.ToForkVersion(st.Slot()) {
+	if c.Epoch == slots.ToEpoch(st.Slot())+1 && slots.ToForkVersion(slot) == slots.ToForkVersion(st.Slot()) {
 		return st
 	}
 	// Try if we have already set the checkpoint cache. This will be tried again if we fail here but the check is cheap anyway.

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -66,7 +66,7 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		return nil
 	}
 	// The next epoch's shuffling is already determined by the dependent root, so the head state can compute its committees without the boundary transition, unless the fork version changes at the boundary.
-	if c.Epoch == slots.ToEpoch(st.Slot())+1 && slots.ToForkVersion(slot) == slots.ToForkVersion(st.Slot()) {
+	if c.Epoch == slots.ToEpoch(st.Slot())+1 && bytesutil.ToBytes32(c.Root) == bytesutil.ToBytes32(headRoot) && slots.ToForkVersion(slot) == slots.ToForkVersion(st.Slot()) {
 		return st
 	}
 	// Try if we have already set the checkpoint cache. This will be tried again if we fail here but the check is cheap anyway.

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -56,11 +56,17 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 	if !s.cfg.ForkChoiceStore.IsCanonical([32]byte(c.Root)) {
 		return nil
 	}
-	// Advance the head state to the start of the target epoch.
 	// This point can only be reached if c.Root == headRoot and c.Epoch > headEpoch.
 	slot, err := slots.EpochStart(c.Epoch)
 	if err != nil {
 		return nil
+	}
+	if c.Epoch == headEpoch+1 && slots.ToForkVersion(slot) == slots.ToForkVersion(s.HeadSlot()) {
+		st, err := s.HeadStateReadOnly(ctx)
+		if err != nil {
+			return nil
+		}
+		return st
 	}
 	// Try if we have already set the checkpoint cache. This will be tried again if we fail here but the check is cheap anyway.
 	epochKey := strconv.FormatUint(uint64(c.Epoch), 10 /* base 10 */)

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
@@ -242,6 +243,7 @@ func TestService_GetRecentPreState_NextEpochUsesHeadState(t *testing.T) {
 
 	s, err := util.NewBeaconState()
 	require.NoError(t, err)
+	require.NoError(t, s.SetSlot(31))
 	ckRoot := bytesutil.PadTo([]byte{'A'}, fieldparams.RootLength)
 	cp0 := &ethpb.Checkpoint{Epoch: 0, Root: ckRoot}
 	require.NoError(t, s.SetFinalizedCheckpoint(cp0))
@@ -257,7 +259,72 @@ func TestService_GetRecentPreState_NextEpochUsesHeadState(t *testing.T) {
 	}
 	recent := service.getRecentPreState(ctx, &ethpb.Checkpoint{Epoch: 1, Root: ckRoot})
 	require.NotNil(t, recent)
-	require.Equal(t, s.Slot(), recent.Slot())
+	require.Equal(t, primitives.Slot(31), recent.Slot())
+}
+
+func TestService_GetRecentPreState_NextEpochCommitteesMatchAdvancedState(t *testing.T) {
+	helpers.ClearCache()
+	defer helpers.ClearCache()
+	ctx := t.Context()
+
+	st, _ := util.DeterministicGenesisState(t, 8192)
+	require.NoError(t, st.SetSlot(31))
+
+	activeCount, err := helpers.ActiveValidatorCount(ctx, st, 1)
+	require.NoError(t, err)
+	committeeCount := helpers.SlotCommitteeCount(activeCount)
+	require.Equal(t, true, committeeCount > 1)
+
+	headCommittees := make(map[[2]uint64][]primitives.ValidatorIndex)
+	for slot := primitives.Slot(32); slot < 64; slot++ {
+		for idx := primitives.CommitteeIndex(0); idx < primitives.CommitteeIndex(committeeCount); idx++ {
+			committee, err := helpers.BeaconCommitteeFromState(ctx, st, slot, idx)
+			require.NoError(t, err)
+			headCommittees[[2]uint64{uint64(slot), uint64(idx)}] = committee
+		}
+	}
+
+	// Cleared so the advanced state's committees are computed independently, the committee cache is seed keyed.
+	helpers.ClearCache()
+	advanced, err := transition.ProcessSlots(ctx, st.Copy(), 32)
+	require.NoError(t, err)
+	for slot := primitives.Slot(32); slot < 64; slot++ {
+		for idx := primitives.CommitteeIndex(0); idx < primitives.CommitteeIndex(committeeCount); idx++ {
+			committee, err := helpers.BeaconCommitteeFromState(ctx, advanced, slot, idx)
+			require.NoError(t, err)
+			require.DeepEqual(t, headCommittees[[2]uint64{uint64(slot), uint64(idx)}], committee)
+		}
+	}
+}
+
+func TestService_GetRecentPreState_ForkBoundaryFallsBack(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.AltairForkEpoch = 1
+	params.OverrideBeaconConfig(cfg)
+
+	service, _ := minimalTestService(t)
+	ctx := t.Context()
+
+	s, _ := util.DeterministicGenesisState(t, 64)
+	require.NoError(t, s.SetSlot(31))
+	ckRoot := bytesutil.PadTo([]byte{'A'}, fieldparams.RootLength)
+	cp0 := &ethpb.Checkpoint{Epoch: 0, Root: ckRoot}
+	require.NoError(t, s.SetFinalizedCheckpoint(cp0))
+
+	st, blk, err := prepareForkchoiceState(ctx, 31, [32]byte(ckRoot), [32]byte{}, [32]byte{'R'}, cp0, cp0)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, st, blk))
+	service.head = &head{
+		root:  [32]byte(ckRoot),
+		state: s,
+		block: blk,
+		slot:  31,
+	}
+	recent := service.getRecentPreState(ctx, &ethpb.Checkpoint{Epoch: 1, Root: ckRoot})
+	require.NotNil(t, recent)
+	require.Equal(t, primitives.Slot(32), recent.Slot())
+	require.Equal(t, version.Altair, recent.Version())
 }
 
 func TestService_GetRecentPreState_Epoch_0(t *testing.T) {

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -236,6 +236,30 @@ func TestService_GetRecentPreState(t *testing.T) {
 	require.NotNil(t, service.getRecentPreState(ctx, &ethpb.Checkpoint{Epoch: 1, Root: ckRoot}))
 }
 
+func TestService_GetRecentPreState_NextEpochUsesHeadState(t *testing.T) {
+	service, _ := minimalTestService(t)
+	ctx := t.Context()
+
+	s, err := util.NewBeaconState()
+	require.NoError(t, err)
+	ckRoot := bytesutil.PadTo([]byte{'A'}, fieldparams.RootLength)
+	cp0 := &ethpb.Checkpoint{Epoch: 0, Root: ckRoot}
+	require.NoError(t, s.SetFinalizedCheckpoint(cp0))
+
+	st, blk, err := prepareForkchoiceState(ctx, 31, [32]byte(ckRoot), [32]byte{}, [32]byte{'R'}, cp0, cp0)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, st, blk))
+	service.head = &head{
+		root:  [32]byte(ckRoot),
+		state: s,
+		block: blk,
+		slot:  31,
+	}
+	recent := service.getRecentPreState(ctx, &ethpb.Checkpoint{Epoch: 1, Root: ckRoot})
+	require.NotNil(t, recent)
+	require.Equal(t, s.Slot(), recent.Slot())
+}
+
 func TestService_GetRecentPreState_Epoch_0(t *testing.T) {
 	service, _ := minimalTestService(t)
 	ctx := t.Context()

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -37,7 +37,7 @@ type AttestationReceiver interface {
 	InForkchoice([32]byte) bool
 }
 
-// AttestationTargetState returns the pre state of attestation.
+// AttestationTargetState returns a state valid for the target epoch's committees and signature domains, its slot may be one epoch behind the target.
 func (s *Service) AttestationTargetState(ctx context.Context, target *ethpb.Checkpoint) (state.ReadOnlyBeaconState, error) {
 	ss, err := slots.EpochStart(target.Epoch)
 	if err != nil {

--- a/changelog/terence_att-target-head-state.md
+++ b/changelog/terence_att-target-head-state.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Serve next-epoch attestation target states from the head state instead of running an epoch transition under the forkchoice lock.


### PR DESCRIPTION
`getAttPreState` runs a full epoch transition to the target epoch start while holding the forkchoice lock. The next epoch's shuffling is already determined by the dependent root, so serve canonical `headEpoch+1` targets from the head state 