### PR TITLE
Fix activation and exit queue ordering in GetValidatorQueue

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators.go
@@ -471,10 +471,10 @@ func (bs *Server) GetValidatorQueue(
 		}
 	}
 	sort.Slice(activationQ, func(i, j int) bool {
-		return vals[i].ActivationEligibilityEpoch < vals[j].ActivationEligibilityEpoch
+		return vals[activationQ[i]].ActivationEligibilityEpoch < vals[activationQ[j]].ActivationEligibilityEpoch
 	})
 	sort.Slice(awaitingExit, func(i, j int) bool {
-		return vals[i].WithdrawableEpoch < vals[j].WithdrawableEpoch
+		return vals[awaitingExit[i]].WithdrawableEpoch < vals[awaitingExit[j]].WithdrawableEpoch
 	})
 
 	// Only activate just enough validators according to the activation churn limit.

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
@@ -1335,6 +1335,14 @@ func TestServer_GetValidatorQueue_PendingActivation(t *testing.T) {
 	headState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 		Validators: []*ethpb.Validator{
 			{
+				// Already activated, so not part of the activation queue. This makes
+				// queue positions differ from validator indices.
+				ActivationEpoch:            0,
+				ActivationEligibilityEpoch: 0,
+				PublicKey:                  pubKey(0),
+				WithdrawalCredentials:      make([]byte, 32),
+			},
+			{
 				ActivationEpoch:            helpers.ActivationExitEpoch(0),
 				ActivationEligibilityEpoch: 3,
 				PublicKey:                  pubKey(3),
@@ -1376,7 +1384,7 @@ func TestServer_GetValidatorQueue_PendingActivation(t *testing.T) {
 	wantChurn := helpers.ValidatorActivationChurnLimit(activeValidatorCount)
 	assert.Equal(t, wantChurn, res.ChurnLimit)
 	assert.DeepEqual(t, wanted, res.ActivationPublicKeys)
-	wantedActiveIndices := []primitives.ValidatorIndex{2, 1, 0}
+	wantedActiveIndices := []primitives.ValidatorIndex{3, 2, 1}
 	assert.DeepEqual(t, wantedActiveIndices, res.ActivationValidatorIndices)
 }
 
@@ -1432,10 +1440,12 @@ func TestServer_GetValidatorQueue_PendingExit(t *testing.T) {
 	headState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 		Validators: []*ethpb.Validator{
 			{
+				// Not exiting, so not part of the exit queue. This makes queue
+				// positions differ from validator indices.
 				ActivationEpoch:       0,
-				ExitEpoch:             4,
-				WithdrawableEpoch:     3,
-				PublicKey:             pubKey(3),
+				ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
+				WithdrawableEpoch:     params.BeaconConfig().FarFutureEpoch,
+				PublicKey:             pubKey(0),
 				WithdrawalCredentials: make([]byte, 32),
 			},
 			{
@@ -1443,6 +1453,13 @@ func TestServer_GetValidatorQueue_PendingExit(t *testing.T) {
 				ExitEpoch:             4,
 				WithdrawableEpoch:     2,
 				PublicKey:             pubKey(2),
+				WithdrawalCredentials: make([]byte, 32),
+			},
+			{
+				ActivationEpoch:       0,
+				ExitEpoch:             4,
+				WithdrawableEpoch:     3,
+				PublicKey:             pubKey(3),
 				WithdrawalCredentials: make([]byte, 32),
 			},
 			{

--- a/changelog/satushh_fix-validator-queue-sort.md
+++ b/changelog/satushh_fix-validator-queue-sort.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix `GetValidatorQueue` sorting the activation and exit queues by queue position instead of validator index, which returned misordered `ActivationPublicKeys`, `ActivationValidatorIndices`, `ExitPublicKeys` and `ExitValidatorIndices`.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

- The activation and exit queue sort comparators in the deprecated GetValidatorQueue gRPC handler indexed the full validator registry by queue position (`vals[i]`) instead of by the queued validator's index (`vals[activationQ[i]]`), so `ActivationPublicKeys`, `ActivationValidatorIndices`, `ExitPublicKeys` and `ExitValidatorIndices` were returned misordered whenever queue positions did not coincide with validator indices. 
- This fixes the comparators to sort through the queue slices and strengthens the existing tests with a validator outside the queue, which makes the ordering assertions fail against the old code.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
