### PR TITLE
`POST graffiti`: Respond with `202` instead of `200` as per spec

### DIFF
--- a/changelog/syjn99_fix-202-set-graffiti.md
+++ b/changelog/syjn99_fix-202-set-graffiti.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `POST /eth/v1/validator/{pubkey}/graffiti` now responds with `202 Accepted` instead of `200 OK`.

--- a/validator/rpc/handlers_keymanager.go
+++ b/validator/rpc/handlers_keymanager.go
@@ -851,6 +851,8 @@ func (s *Server) SetGraffiti(w http.ResponseWriter, r *http.Request) {
 		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	w.WriteHeader(http.StatusAccepted)
 }
 
 func (s *Server) DeleteGraffiti(w http.ResponseWriter, r *http.Request) {

--- a/validator/rpc/handlers_keymanager_test.go
+++ b/validator/rpc/handlers_keymanager_test.go
@@ -2049,7 +2049,7 @@ func TestServer_Graffiti(t *testing.T) {
 	w := httptest.NewRecorder()
 	w.Body = &bytes.Buffer{}
 	s.SetGraffiti(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code)
 
 	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/eth/v1/validator/{pubkey}/graffiti"), nil)
 	req.SetPathValue("pubkey", pubkey)


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

https://ethereum.github.io/keymanager-APIs/#/Graffiti/setGraffiti

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
