### PR TITLE
Remove unused `SetProposerSettings` in favor of `UpdateProposerSettings`

### DIFF
--- a/changelog/syjn99_remove-set-proposer-settings.md
+++ b/changelog/syjn99_remove-set-proposer-settings.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed the unused `SetProposerSettings` from the validator RPC `ValidatorService` interface, `ValidatorService`, and `validator`; all writers go through `UpdateProposerSettings`.

--- a/testing/validator-mock/validator_service_mock.go
+++ b/testing/validator-mock/validator_service_mock.go
@@ -129,20 +129,6 @@ func (mr *MockValidatorServiceMockRecorder) SetGraffiti(ctx, pubKey, graffiti an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGraffiti", reflect.TypeOf((*MockValidatorService)(nil).SetGraffiti), ctx, pubKey, graffiti)
 }
 
-// SetProposerSettings mocks base method.
-func (m *MockValidatorService) SetProposerSettings(ctx context.Context, settings *proposer.Settings) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetProposerSettings", ctx, settings)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetProposerSettings indicates an expected call of SetProposerSettings.
-func (mr *MockValidatorServiceMockRecorder) SetProposerSettings(ctx, settings any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProposerSettings", reflect.TypeOf((*MockValidatorService)(nil).SetProposerSettings), ctx, settings)
-}
-
 // UpdateProposerSettings mocks base method.
 func (m *MockValidatorService) UpdateProposerSettings(ctx context.Context, mutate func(*proposer.Settings) (*proposer.Settings, error)) error {
 	m.ctrl.T.Helper()

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -313,17 +313,6 @@ func (v *ValidatorService) UpdateProposerSettings(ctx context.Context, mutate fu
 	return v.validator.UpdateProposerSettings(ctx, mutate)
 }
 
-// SetProposerSettings sets the proposer settings on the validator service as well as the underlying validator
-func (v *ValidatorService) SetProposerSettings(ctx context.Context, settings *proposer.Settings) error {
-	// validator service proposer settings is only used for pass through from node -> validator service -> validator.
-	// in memory use of proposer settings happens on validator.
-	v.proposerSettings = settings
-
-	// passes settings down to be updated in database and saved in memory.
-	// updates to validator proposer settings will be in the validator object and not validator service.
-	return v.validator.SetProposerSettings(ctx, settings)
-}
-
 // ConstructDialOptions constructs a list of grpc dial options
 func ConstructDialOptions(
 	maxCallRecvMsgSize int,

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -721,40 +721,32 @@ func (v *validator) ProposerSettings() *proposer.Settings {
 	return v.proposerSettings
 }
 
-// SetProposerSettings sets and saves the passed in proposer settings overriding the in memory one
-func (v *validator) SetProposerSettings(ctx context.Context, settings *proposer.Settings) error {
-	v.proposerSettingsMu.Lock()
-	defer v.proposerSettingsMu.Unlock()
-	return v.setProposerSettingsLocked(ctx, settings)
-}
-
-func (v *validator) setProposerSettingsLocked(ctx context.Context, settings *proposer.Settings) error {
-	ctx, span := trace.StartSpan(ctx, "validator.SetProposerSettings")
+// UpdateProposerSettings atomically mutates the proposer settings.
+func (v *validator) UpdateProposerSettings(ctx context.Context, mutate func(*proposer.Settings) (*proposer.Settings, error)) error {
+	ctx, span := trace.StartSpan(ctx, "validator.UpdateProposerSettings")
 	defer span.End()
 
 	if v.db == nil {
 		return errors.New("db is not set")
 	}
-	if err := v.db.SaveProposerSettings(ctx, settings); err != nil {
-		return err
-	}
-	v.proposerSettings = settings
-	return nil
-}
 
-// UpdateProposerSettings atomically mutates the proposer settings: mutate gets a
-// deep copy (nil when unset) and returns what to persist, or nil for a no-op.
-func (v *validator) UpdateProposerSettings(ctx context.Context, mutate func(*proposer.Settings) (*proposer.Settings, error)) error {
 	v.proposerSettingsMu.Lock()
 	defer v.proposerSettingsMu.Unlock()
+
 	next, err := mutate(v.proposerSettings.Clone())
 	if err != nil {
-		return err
+		return fmt.Errorf("mutate proposer settings: %w", err)
 	}
 	if next == nil {
 		return nil
 	}
-	return v.setProposerSettingsLocked(ctx, next)
+
+	if err := v.db.SaveProposerSettings(ctx, next); err != nil {
+		return fmt.Errorf("save proposer settings: %w", err)
+	}
+
+	v.proposerSettings = next
+	return nil
 }
 
 // PushProposerSettings pushes proposer and builder preferences plus, pre-Gloas,

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1236,17 +1236,19 @@ func TestValidator_PushSettings(t *testing.T) {
 							GasLimit: 40000000,
 						},
 					}
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: config,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: config,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
+								BuilderConfig: &proposer.BuilderConfig{
+									Enabled:  true,
+									GasLimit: 35000000,
+								},
 							},
-							BuilderConfig: &proposer.BuilderConfig{
-								Enabled:  true,
-								GasLimit: 35000000,
-							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					client.EXPECT().SubmitValidatorRegistrations(
@@ -1322,17 +1324,19 @@ func TestValidator_PushSettings(t *testing.T) {
 							GasLimit: 40000000,
 						},
 					}
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: config,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: config,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
+								BuilderConfig: &proposer.BuilderConfig{
+									Enabled:  false,
+									GasLimit: 35000000,
+								},
 							},
-							BuilderConfig: &proposer.BuilderConfig{
-								Enabled:  false,
-								GasLimit: 35000000,
-							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					client.EXPECT().SubmitValidatorRegistrations(
@@ -1399,13 +1403,15 @@ func TestValidator_PushSettings(t *testing.T) {
 							FeeRecipient: common.HexToAddress("0x055Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
 						},
 					}
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: config,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: config,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
 							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					return &v
@@ -1437,17 +1443,19 @@ func TestValidator_PushSettings(t *testing.T) {
 					require.NoError(t, err)
 					keys, err := km.FetchValidatingPublicKeys(ctx)
 					require.NoError(t, err)
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: nil,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: nil,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
+								BuilderConfig: &proposer.BuilderConfig{
+									Enabled:  true,
+									GasLimit: validatorType.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
+								},
 							},
-							BuilderConfig: &proposer.BuilderConfig{
-								Enabled:  true,
-								GasLimit: validatorType.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
-							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					v.pubkeyToStatus[keys[0]] = &validatorStatus{
@@ -1498,17 +1506,19 @@ func TestValidator_PushSettings(t *testing.T) {
 						enableAPI:                    false,
 						km:                           genMockKeymanager(t, 1),
 					}
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: nil,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: nil,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
+								BuilderConfig: &proposer.BuilderConfig{
+									Enabled:  true,
+									GasLimit: 40000000,
+								},
 							},
-							BuilderConfig: &proposer.BuilderConfig{
-								Enabled:  true,
-								GasLimit: 40000000,
-							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					km, err := v.Keymanager()
@@ -1590,13 +1600,15 @@ func TestValidator_PushSettings(t *testing.T) {
 							FeeRecipient: common.Address{},
 						},
 					}
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: config,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: config,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
 							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					return &v
@@ -1632,13 +1644,15 @@ func TestValidator_PushSettings(t *testing.T) {
 							PublicKeys: [][]byte{keys[0][:]},
 							Indices:    []primitives.ValidatorIndex{unknownIndex},
 						}, nil)
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: config,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: config,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
 							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					return &v
@@ -1684,17 +1698,19 @@ func TestValidator_PushSettings(t *testing.T) {
 							GasLimit: 40000000,
 						},
 					}
-					err = v.SetProposerSettings(t.Context(), &proposer.Settings{
-						ProposeConfig: config,
-						DefaultConfig: &proposer.Option{
-							FeeRecipientConfig: &proposer.FeeRecipientConfig{
-								FeeRecipient: common.HexToAddress(defaultFeeHex),
+					err = v.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+						return &proposer.Settings{
+							ProposeConfig: config,
+							DefaultConfig: &proposer.Option{
+								FeeRecipientConfig: &proposer.FeeRecipientConfig{
+									FeeRecipient: common.HexToAddress(defaultFeeHex),
+								},
+								BuilderConfig: &proposer.BuilderConfig{
+									Enabled:  true,
+									GasLimit: 40000000,
+								},
 							},
-							BuilderConfig: &proposer.BuilderConfig{
-								Enabled:  true,
-								GasLimit: 40000000,
-							},
-						},
+						}, nil
 					})
 					require.NoError(t, err)
 					client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
@@ -3320,13 +3336,15 @@ func TestValidator_PushProposerSettings_SkipsBuilderRegistrationsPostGloas(t *te
 		}, nil).AnyTimes()
 
 	// Builder enabled — would normally trigger registrations pre-fork.
-	require.NoError(t, v.SetProposerSettings(ctx, &proposer.Settings{
-		DefaultConfig: &proposer.Option{
-			FeeRecipientConfig: &proposer.FeeRecipientConfig{
-				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
+	require.NoError(t, v.UpdateProposerSettings(ctx, func(*proposer.Settings) (*proposer.Settings, error) {
+		return &proposer.Settings{
+			DefaultConfig: &proposer.Option{
+				FeeRecipientConfig: &proposer.FeeRecipientConfig{
+					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
+				},
+				BuilderConfig: &proposer.BuilderConfig{Enabled: true, GasLimit: 40000000},
 			},
-			BuilderConfig: &proposer.BuilderConfig{Enabled: true, GasLimit: 40000000},
-		},
+		}, nil
 	}))
 
 	// slot 1 is post-Gloas (GloasForkEpoch == 0).

--- a/validator/rpc/handlers_validator_config_test.go
+++ b/validator/rpc/handlers_validator_config_test.go
@@ -49,10 +49,6 @@ func setupConfigServer(t *testing.T, numKeys int) (*Server, [][48]byte) {
 	vs.EXPECT().ProposerSettings().DoAndReturn(func() *proposer.Settings {
 		return stored
 	}).AnyTimes()
-	vs.EXPECT().SetProposerSettings(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, s *proposer.Settings) error {
-		stored = s
-		return nil
-	}).AnyTimes()
 	vs.EXPECT().UpdateProposerSettings(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mutate func(*proposer.Settings) (*proposer.Settings, error)) error {
 		next, err := mutate(stored.Clone())
 		if err != nil {
@@ -149,11 +145,13 @@ func TestServer_SetBuilderConfig(t *testing.T) {
 		srv, keys := setupConfigServer(t, 2)
 		pkA := hexutil.Encode(keys[0][:])
 		pkB := hexutil.Encode(keys[1][:])
-		require.NoError(t, srv.validatorService.SetProposerSettings(t.Context(), &proposer.Settings{
-			Version: proposer.SchemaV2,
-			DefaultConfig: &proposer.Option{
-				BuilderConfig: &proposer.BuilderConfig{Builders: []*proposer.BuilderEntry{{URL: "https://default.example"}}},
-			},
+		require.NoError(t, srv.validatorService.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+			return &proposer.Settings{
+				Version: proposer.SchemaV2,
+				DefaultConfig: &proposer.Option{
+					BuilderConfig: &proposer.BuilderConfig{Builders: []*proposer.BuilderEntry{{URL: "https://default.example"}}},
+				},
+			}, nil
 		}))
 		require.Equal(t, http.StatusAccepted, postBuilderConfig(t, srv, pkA, `{"builders":[]}`).Code)
 		require.Equal(t, http.StatusAccepted, postBuilderConfig(t, srv, pkB, `{"builders":[{"url":"https://b.example"}]}`).Code)
@@ -166,12 +164,14 @@ func TestServer_SetBuilderConfig(t *testing.T) {
 		srv, keys := setupConfigServer(t, 1)
 		pk := hexutil.Encode(keys[0][:])
 		recipient := common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3")
-		require.NoError(t, srv.validatorService.SetProposerSettings(t.Context(), &proposer.Settings{
-			Version: proposer.SchemaV1,
-			DefaultConfig: &proposer.Option{
-				FeeRecipientConfig: &proposer.FeeRecipientConfig{FeeRecipient: recipient},
-				BuilderConfig:      &proposer.BuilderConfig{Enabled: true},
-			},
+		require.NoError(t, srv.validatorService.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+			return &proposer.Settings{
+				Version: proposer.SchemaV1,
+				DefaultConfig: &proposer.Option{
+					FeeRecipientConfig: &proposer.FeeRecipientConfig{FeeRecipient: recipient},
+					BuilderConfig:      &proposer.BuilderConfig{Enabled: true},
+				},
+			}, nil
 		}))
 		require.Equal(t, http.StatusAccepted, postBuilderConfig(t, srv, pk, `{}`).Code)
 
@@ -185,12 +185,14 @@ func TestServer_SetBuilderConfig(t *testing.T) {
 		srv, keys := setupConfigServer(t, 1)
 		pk := hexutil.Encode(keys[0][:])
 		recipient := common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3")
-		require.NoError(t, srv.validatorService.SetProposerSettings(t.Context(), &proposer.Settings{
-			Version: proposer.SchemaV1,
-			DefaultConfig: &proposer.Option{
-				FeeRecipientConfig: &proposer.FeeRecipientConfig{FeeRecipient: recipient},
-				BuilderConfig:      &proposer.BuilderConfig{Enabled: true},
-			},
+		require.NoError(t, srv.validatorService.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+			return &proposer.Settings{
+				Version: proposer.SchemaV1,
+				DefaultConfig: &proposer.Option{
+					FeeRecipientConfig: &proposer.FeeRecipientConfig{FeeRecipient: recipient},
+					BuilderConfig:      &proposer.BuilderConfig{Enabled: true},
+				},
+			}, nil
 		}))
 		require.Equal(t, http.StatusAccepted, postBuilderConfig(t, srv, pk, `{"min_bid":"5"}`).Code)
 
@@ -207,11 +209,13 @@ func TestServer_SetBuilderConfig(t *testing.T) {
 	t.Run("upgrades v1 settings in place", func(t *testing.T) {
 		srv, keys := setupConfigServer(t, 1)
 		pk := hexutil.Encode(keys[0][:])
-		require.NoError(t, srv.validatorService.SetProposerSettings(t.Context(), &proposer.Settings{
-			Version: proposer.SchemaV1,
-			ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
-				keys[0]: {BuilderConfig: &proposer.BuilderConfig{Enabled: true, GasLimit: 999}},
-			},
+		require.NoError(t, srv.validatorService.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+			return &proposer.Settings{
+				Version: proposer.SchemaV1,
+				ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
+					keys[0]: {BuilderConfig: &proposer.BuilderConfig{Enabled: true, GasLimit: 999}},
+				},
+			}, nil
 		}))
 		require.Equal(t, http.StatusAccepted, postBuilderConfig(t, srv, pk, `{"builders":[{"url":"https://a.example"}]}`).Code)
 
@@ -338,11 +342,13 @@ func TestServer_GetBuilderConfig(t *testing.T) {
 	t.Run("resolves default_config for an unconfigured key", func(t *testing.T) {
 		srv, keys := setupConfigServer(t, 1)
 		pk := hexutil.Encode(keys[0][:])
-		require.NoError(t, srv.validatorService.SetProposerSettings(t.Context(), &proposer.Settings{
-			Version: proposer.SchemaV2,
-			DefaultConfig: &proposer.Option{
-				BuilderConfig: &proposer.BuilderConfig{Builders: []*proposer.BuilderEntry{{URL: "https://default.example"}}},
-			},
+		require.NoError(t, srv.validatorService.UpdateProposerSettings(t.Context(), func(*proposer.Settings) (*proposer.Settings, error) {
+			return &proposer.Settings{
+				Version: proposer.SchemaV2,
+				DefaultConfig: &proposer.Option{
+					BuilderConfig: &proposer.BuilderConfig{Builders: []*proposer.BuilderEntry{{URL: "https://default.example"}}},
+				},
+			}, nil
 		}))
 
 		_, cfg := getBuilderConfig(t, srv, pk)

--- a/validator/rpc/server.go
+++ b/validator/rpc/server.go
@@ -32,7 +32,6 @@ type ValidatorService interface {
 	Keymanager() (keymanager.IKeymanager, error)
 	RemoteSignerConfig() *remoteweb3signer.SetupConfig
 	ProposerSettings() *proposer.Settings
-	SetProposerSettings(ctx context.Context, settings *proposer.Settings) error
 	UpdateProposerSettings(ctx context.Context, mutate func(*proposer.Settings) (*proposer.Settings, error)) error
 	Graffiti(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte) ([]byte, error)
 	SetGraffiti(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, graffiti []byte) error


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

We now don't use `SetProposerSettings` in production path, so this PR removes it. We can use `UpdateProposerSettings` even if we wanna set the proposer settings later on.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
