### PR TITLE
Keep `--suggested-fee-recipient` as default when settings file has no `default_config`

### DIFF
--- a/changelog/syjn99_proposer-settings-flag-default.md
+++ b/changelog/syjn99_proposer-settings-flag-default.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `--suggested-fee-recipient` is now applied as the default fee recipient when `--proposer-settings-file`/`--proposer-settings-url` is also set but the settings source has no `default_config`; previously the flag was silently dropped and validators not listed in the file were registered with the burn address.

--- a/config/proposer/loader/loader.go
+++ b/config/proposer/loader/loader.go
@@ -139,33 +139,36 @@ func (psl *SettingsLoader) Load(cliCtx *cli.Context) (*proposer.Settings, error)
 			Debug("Loaded proposer settings from DB")
 	}
 
-	// start to process based on load method
+	// start to process based on load method,
+	// each method merges onto the previous method's result.
+	base := dbSettings
 	for _, method := range psl.loadMethods {
 		var err error
 		switch method {
 		case defaultFlag:
-			loadedSettings, err = psl.loadFromDefault(cliCtx, dbSettings)
+			loadedSettings, err = psl.loadFromDefault(cliCtx, base)
 			if err != nil {
 				return nil, err
 			}
 		case fileFlag:
-			loadedSettings, err = psl.loadFromFile(cliCtx, dbSettings)
+			loadedSettings, err = psl.loadFromFile(cliCtx, base)
 			if err != nil {
 				return nil, err
 			}
 		case urlFlag:
-			loadedSettings, err = psl.loadFromURL(cliCtx, dbSettings)
+			loadedSettings, err = psl.loadFromURL(cliCtx, base)
 			if err != nil {
 				return nil, err
 			}
 		case onlyDB, none:
-			loadedSettings = psl.processProposerSettings(&validatorpb.ProposerSettingsPayload{}, dbSettings)
+			loadedSettings = psl.processProposerSettings(&validatorpb.ProposerSettingsPayload{}, base)
 			if psl.existsInDB {
 				log.Info("Proposer settings loaded from the DB")
 			}
 		default:
 			return nil, errors.New("load method for proposer settings does not exist")
 		}
+		base = loadedSettings
 	}
 
 	// exit early if nothing is provided
@@ -419,12 +422,13 @@ func mergeProposerSettingsV2(merged, loaded, db *validatorpb.ProposerSettingsPay
 
 func processBuilderConfig(current *validatorpb.BuilderConfig, override *validatorpb.BuilderConfig, gasLimitOnly *validator.Uint64) *validatorpb.BuilderConfig {
 	if current != nil {
-		current.GasLimit = reviewGasLimit(current.GasLimit)
-		if override != nil {
-			current.Enabled = override.Enabled
-		}
 		if gasLimitOnly != nil {
 			current.GasLimit = *gasLimitOnly
+		} else {
+			current.GasLimit = reviewGasLimit(current.GasLimit)
+		}
+		if override != nil {
+			current.Enabled = override.Enabled
 		}
 		return current
 	}

--- a/config/proposer/loader/loader_test.go
+++ b/config/proposer/loader/loader_test.go
@@ -659,6 +659,179 @@ func TestProposerSettingsLoader(t *testing.T) {
 			validatorRegistrationEnabled: true,
 		},
 		{
+			name: "Suggested Fee is the default when v1 file has no default_config",
+			args: args{
+				proposerSettingsFlagValues: &proposerSettingsFlag{
+					dir:        "./testdata/proposer-config-only.json",
+					url:        "",
+					defaultfee: "0x6e35733c5af9B61374A128e6F85f553aF09ff89B",
+				},
+			},
+			want: func() *proposer.Settings {
+				key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+				require.NoError(t, err)
+				return &proposer.Settings{
+					ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
+						bytesutil.ToBytes48(key1): {
+							FeeRecipientConfig: &proposer.FeeRecipientConfig{
+								FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
+							},
+						},
+					},
+					DefaultConfig: &proposer.Option{
+						FeeRecipientConfig: &proposer.FeeRecipientConfig{
+							FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89B"),
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "Suggested Fee is the default when v2 file has no default_config",
+			args: args{
+				proposerSettingsFlagValues: &proposerSettingsFlag{
+					dir:        "./testdata/v2-proposer-config-only.json",
+					url:        "",
+					defaultfee: "0x6e35733c5af9B61374A128e6F85f553aF09ff89B",
+				},
+			},
+			want: func() *proposer.Settings {
+				key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+				require.NoError(t, err)
+				u64 := func(v uint64) *validator.Uint64 { u := validator.Uint64(v); return &u }
+				return &proposer.Settings{
+					Version: proposer.SchemaV2,
+					ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
+						bytesutil.ToBytes48(key1): {
+							FeeRecipientConfig: &proposer.FeeRecipientConfig{
+								FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
+							},
+							GasLimit: 40000000,
+							BuilderConfig: &proposer.BuilderConfig{
+								MinBid: u64(500000000),
+								Builders: []*proposer.BuilderEntry{
+									{URL: "https://builder-a.example"},
+								},
+							},
+						},
+					},
+					DefaultConfig: &proposer.Option{
+						FeeRecipientConfig: &proposer.FeeRecipientConfig{
+							FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89B"),
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "Suggested Fee replaces db default when file has no default_config",
+			args: args{
+				proposerSettingsFlagValues: &proposerSettingsFlag{
+					dir:        "./testdata/proposer-config-only.json",
+					url:        "",
+					defaultfee: "0x6e35733c5af9B61374A128e6F85f553aF09ff89B",
+				},
+			},
+			want: func() *proposer.Settings {
+				key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+				require.NoError(t, err)
+				return &proposer.Settings{
+					ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
+						bytesutil.ToBytes48(key1): {
+							FeeRecipientConfig: &proposer.FeeRecipientConfig{
+								FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
+							},
+						},
+					},
+					DefaultConfig: &proposer.Option{
+						FeeRecipientConfig: &proposer.FeeRecipientConfig{
+							FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89B"),
+						},
+					},
+				}
+			},
+			withdb: func(db iface.ValidatorDB) error {
+				settings := &proposer.Settings{
+					DefaultConfig: &proposer.Option{
+						FeeRecipientConfig: &proposer.FeeRecipientConfig{
+							FeeRecipient: common.HexToAddress("0xae967917c465db8578ca9024c205720b1a3651A9"),
+						},
+					},
+				}
+				return db.SaveProposerSettings(t.Context(), settings)
+			},
+		},
+		{
+			name: "Suggested Fee is the default when url has no default_config",
+			args: args{
+				proposerSettingsFlagValues: &proposerSettingsFlag{
+					dir:        "",
+					url:        "./testdata/proposer-config-only.json",
+					defaultfee: "0x6e35733c5af9B61374A128e6F85f553aF09ff89B",
+				},
+			},
+			want: func() *proposer.Settings {
+				key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+				require.NoError(t, err)
+				return &proposer.Settings{
+					ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
+						bytesutil.ToBytes48(key1): {
+							FeeRecipientConfig: &proposer.FeeRecipientConfig{
+								FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
+							},
+						},
+					},
+					DefaultConfig: &proposer.Option{
+						FeeRecipientConfig: &proposer.FeeRecipientConfig{
+							FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89B"),
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "file proposer_config replaces db proposer_config while Suggested Fee stays the default",
+			args: args{
+				proposerSettingsFlagValues: &proposerSettingsFlag{
+					dir:        "./testdata/proposer-config-only.json",
+					url:        "",
+					defaultfee: "0x6e35733c5af9B61374A128e6F85f553aF09ff89B",
+				},
+			},
+			want: func() *proposer.Settings {
+				key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+				require.NoError(t, err)
+				return &proposer.Settings{
+					ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
+						bytesutil.ToBytes48(key1): {
+							FeeRecipientConfig: &proposer.FeeRecipientConfig{
+								FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
+							},
+						},
+					},
+					DefaultConfig: &proposer.Option{
+						FeeRecipientConfig: &proposer.FeeRecipientConfig{
+							FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89B"),
+						},
+					},
+				}
+			},
+			withdb: func(db iface.ValidatorDB) error {
+				key2, err := hexutil.Decode("0xb057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7b")
+				require.NoError(t, err)
+				settings := &proposer.Settings{
+					ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*proposer.Option{
+						bytesutil.ToBytes48(key2): {
+							FeeRecipientConfig: &proposer.FeeRecipientConfig{
+								FeeRecipient: common.HexToAddress("0x60155530FCE8a85ec7055A5F8b2bE214B3DaeFd4"),
+							},
+						},
+					},
+				}
+				return db.SaveProposerSettings(t.Context(), settings)
+			},
+		},
+		{
 			name: "Enable Builder flag overrides empty config",
 			args: args{
 				proposerSettingsFlagValues: &proposerSettingsFlag{

--- a/config/proposer/loader/testdata/v2-proposer-config-only.json
+++ b/config/proposer/loader/testdata/v2-proposer-config-only.json
@@ -1,0 +1,15 @@
+{
+  "proposer_config": {
+    "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
+      "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3",
+      "gas_limit": "40000000",
+      "builder": {
+        "min_bid": "500000000",
+        "builders": [
+          { "url": "https://builder-a.example" }
+        ]
+      }
+    }
+  },
+  "version": 2
+}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

This PR fixes an issue when 

- an user specifies both `--suggested-fee-recipient 0x...` and `--proposer-settings-file settings.json` 
- but there is no `default_config` in `settings.json`
- as a result, every validator not listed in `proposer_config` was registered with the burn address.

by accumulating proposer settings when loading them via different methods.

According to [docs](https://prysm.offchainlabs.com/docs/configure-prysm/fee-recipient/), it is described file as a layer on top of the flag:

> In this case, the `default_config` fee recipient address would apply to all validator public keys not specified in `proposer_config`, and will override any wallet address specified by the `--suggested-fee-recipient` flag.

So this PR makes it consistent with our docs which I presume the original intention of the loader.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

`Suggested Fee is the default when v1 file has no default_config` is the key regression test.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
