### PR TITLE
add grace period to REST ptc endpoint

### DIFF
--- a/changelog/james-prysm_ptc-read-deadline-grace.md
+++ b/changelog/james-prysm_ptc-read-deadline-grace.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Extended the REST validator client's payload attestation data read window past the PTC due mark, so the read no longer ends at the instant the beacon node finalizes the data.

--- a/validator/client/beacon-api/freshness.go
+++ b/validator/client/beacon-api/freshness.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	readFreshnessBudget = 500 * time.Millisecond // Floor for a read's deadline.
-	blockPublishMargin  = 250 * time.Millisecond // Time reserved to sign, publish and gossip a block in hand before the committee votes if no accepted block is returned by the deadline.
+	readFreshnessBudget        = 500 * time.Millisecond // Floor for a read's deadline.
+	blockPublishMargin         = 250 * time.Millisecond // Time reserved to sign, publish and gossip a block in hand before the committee votes if no accepted block is returned by the deadline.
+	payloadAttestationDueGrace = 500 * time.Millisecond // Polling time past the PTC due mark, where the node may first serve the data.
 )
 
 var (
@@ -198,8 +199,8 @@ func blockFreshnessOptions(ctx context.Context, decode func([]byte, http.Header)
 //   - WithRace: query every node concurrently.
 //   - WithSSZAccept: among those responses, prefer the one whose beacon_block_root
 //     matches the announced head (decoded via payloadAttestationBeaconBlockRoot).
-//   - WithDeadline: bound the read by the hint deadline (floored by
-//     readFreshnessBudget so a lagging node still gets time to catch up).
+//   - WithDeadline: bound the read by the hint deadline plus a grace (floored by
+//     readFreshnessBudget), since the node may only serve the data at that deadline.
 //   - WithRepoll: keep re-polling until a node reports the head or the deadline
 //     fires.
 func payloadAttestationFreshnessOptions(ctx context.Context) []rest.QueryOption {
@@ -226,7 +227,9 @@ func payloadAttestationFreshnessOptions(ctx context.Context) []rest.QueryOption 
 		return opts
 	}
 
-	deadline := hint.Deadline
+	// The node holds non-final data until the hint deadline (the PTC due mark),
+	// so keep polling past it rather than giving up at that exact instant.
+	deadline := hint.Deadline.Add(payloadAttestationDueGrace)
 	if floor := time.Now().Add(readFreshnessBudget); deadline.Before(floor) {
 		deadline = floor
 	}

--- a/validator/client/beacon-api/freshness_test.go
+++ b/validator/client/beacon-api/freshness_test.go
@@ -241,13 +241,16 @@ func TestPayloadAttestationFreshnessOptions(t *testing.T) {
 		require.Equal(t, time.Duration(0), cfg.PollInterval)
 	})
 
-	t.Run("hint with a deadline sets that deadline and repolls", func(t *testing.T) {
+	t.Run("hint with a deadline polls past that deadline", func(t *testing.T) {
 		deadline := time.Now().Add(time.Hour)
 		ctx := iface.WithHint(context.Background(), headHint([32]byte{0x01}, 10, true, deadline))
 		cfg := rest.ResolveOptions(payloadAttestationFreshnessOptions(ctx)...)
 
 		require.Equal(t, true, cfg.Race)
-		require.Equal(t, deadline, cfg.Deadline)
+		// The node holds non-final data until the hint deadline, so the read must
+		// outlive it or it gives up at the exact instant the data becomes servable.
+		require.Equal(t, deadline.Add(payloadAttestationDueGrace), cfg.Deadline)
+		require.Equal(t, true, cfg.Deadline.After(deadline))
 		// WithRepoll(0) falls back to the default poll interval.
 		require.NotEqual(t, time.Duration(0), cfg.PollInterval)
 	})


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

the PTC due mark (75% of the slot, PayloadAttestationDueBPS=7500), the beacon node returns Unavailable unless the data is already final, meaning PayloadPresent && BlobDataAvailable. PayloadPresent is recorded as "envelope arrived before the 50% mark" (recordPayloadArrival, beacon-chain/blockchain/receive_execution_payload_envelope.go:385). So for a payload arriving in (50%, 75%), the node answers 503 on every request until exactly 75%, then serves the final data (payload_present=false).

we need a grace period instead of setting 

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
