### PR TITLE
Cancel gossip publishing promptly while waiting for topic peers

### DIFF
--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -98,8 +98,7 @@ func (s *Service) PublishToTopic(ctx context.Context, topic string, data []byte,
 		select {
 		case <-ctx.Done():
 			return errors.Wrapf(ctx.Err(), "unable to find requisite number of peers for topic %s, 0 peers found to publish to", topic)
-		default:
-			time.Sleep(100 * time.Millisecond)
+		case <-time.After(100 * time.Millisecond):
 		}
 	}
 }

--- a/beacon-chain/p2p/pubsub_test.go
+++ b/beacon-chain/p2p/pubsub_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/encoder"
 	testp2p "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/pkg/errors"
 )
 
-func TestService_PublishToTopicConcurrentMapWrite(t *testing.T) {
+func TestService_PublishToTopic_Concurrent(t *testing.T) {
 	cs := startup.NewClockSynchronizer()
 	s, err := NewService(t.Context(), &Config{
 		StateNotifier: &mock.MockStateNotifier{},
@@ -57,6 +59,32 @@ func TestService_PublishToTopicConcurrentMapWrite(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestService_PublishToTopic_CancelWhileWaitingForPeers(t *testing.T) {
+	defer flags.Init(flags.Get())
+	flags.Init(&flags.GlobalFlags{MinimumSyncPeers: 1})
+
+	p := testp2p.NewTestP2P(t)
+	t.Cleanup(func() { require.NoError(t, p.BHost.Close()) })
+	s := &Service{pubsub: p.PubSub(), joinedTopics: make(map[string]*pubsub.Topic)}
+	topic := fmt.Sprintf(BlockSubnetTopicFormat, [4]byte{}) + "/" + encoder.ProtocolSuffixSSZSnappy
+	handle, err := s.JoinTopic(topic)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.LeaveTopic(topic)) })
+	require.Equal(t, 0, len(handle.ListPeers()))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	// Cancel during the 100ms peer wait, with room for scheduler delays.
+	timer := time.AfterFunc(10*time.Millisecond, cancel)
+	defer timer.Stop()
+	start := time.Now()
+	err = s.PublishToTopic(ctx, topic, []byte{})
+	elapsed := time.Since(start)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, fmt.Sprintf("unable to find requisite number of peers for topic %s, 0 peers found to publish to", topic), err)
+	assert.Equal(t, true, elapsed < 75*time.Millisecond, "cancellation took %s", elapsed)
 }
 
 func TestExtractGossipDigest(t *testing.T) {

--- a/changelog/syjn99_ctx-pubsub-peer-wait.md
+++ b/changelog/syjn99_ctx-pubsub-peer-wait.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cancel gossip publishing promptly while waiting for topic peers.


### PR DESCRIPTION
**What type of PR is this?**

> Other: Optimization

**What does this PR do? Why is it needed?**

In `PublishToTopic`, we wait for 100ms every iteration when there's no peer to publish. With this change, the loop is context-aware which means it can be cancellable without waiting 100ms. New regression test is added (`TestService_PublishToTopic_CancelWhileWaitingForPeers`).

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
