### PR TITLE
Make initial-sync retry and peer polling waits cancellable

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher_peers.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_peers.go
@@ -67,7 +67,11 @@ func (f *blocksFetcher) waitForMinimumPeers(ctx context.Context) ([]peer.ID, err
 		log.WithFields(logrus.Fields{
 			"suitable": len(peers),
 			"required": required}).Info("Waiting for enough suitable peers before syncing")
-		time.Sleep(handshakePollingInterval)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(handshakePollingInterval):
+		}
 	}
 }
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_peers_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_peers_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/peers/scorers"
@@ -17,6 +18,64 @@ import (
 	prysmTime "github.com/OffchainLabs/prysm/v7/time"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
+
+func TestBlocksFetcher_WaitForMinimumPeersCancellation(t *testing.T) {
+	mc, p2p, _ := initializeTestServices(t, nil, nil)
+	resetFlags := *flags.Get()
+	withPeers := resetFlags
+	withPeers.MinimumSyncPeers = 1
+	flags.Init(&withPeers)
+	t.Cleanup(func() { flags.Init(&resetFlags) })
+
+	for _, tt := range []struct {
+		name     string
+		mode     syncMode
+		deadline bool
+	}{
+		{name: "finalized/canceled", mode: modeStopOnFinalizedEpoch},
+		{name: "finalized/deadline", mode: modeStopOnFinalizedEpoch, deadline: true},
+		{name: "nonconstrained/canceled", mode: modeNonConstrained},
+		{name: "nonconstrained/deadline", mode: modeNonConstrained, deadline: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				fetcher := &blocksFetcher{ctx: t.Context(), chain: mc, p2p: p2p, mode: tt.mode}
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				wantErr := context.Canceled
+				if tt.deadline {
+					var deadlineCancel context.CancelFunc
+					ctx, deadlineCancel = context.WithTimeout(ctx, time.Second)
+					defer deadlineCancel()
+					wantErr = context.DeadlineExceeded
+				}
+				done := make(chan error, 1)
+				go func() {
+					_, err := fetcher.waitForMinimumPeers(ctx)
+					done <- err
+				}()
+				synctest.Wait()
+				select {
+				case err := <-done:
+					t.Fatalf("peer wait returned before cancellation: %v", err)
+				default:
+				}
+				if tt.deadline {
+					time.Sleep(time.Second)
+				} else {
+					cancel()
+				}
+				synctest.Wait()
+				select {
+				case err := <-done:
+					require.ErrorIs(t, err, wantErr)
+				default:
+					t.Fatal("peer wait did not return on cancellation")
+				}
+			})
+		})
+	}
+}
 
 func TestBlocksFetcher_filterPeers(t *testing.T) {
 	type weightedPeer struct {

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -238,7 +238,11 @@ func (q *blocksQueue) loop() {
 						} else {
 							q.exitConditions.noRequiredPeersErrRetries++
 							log.Debug("Waiting for finalized peers")
-							time.Sleep(noRequiredPeersErrRefreshInterval)
+							select {
+							case <-q.ctx.Done():
+								return
+							case <-time.After(noRequiredPeersErrRefreshInterval):
+							}
 						}
 						continue
 					}

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
@@ -133,6 +134,46 @@ func TestBlocksQueue_InitStartStop(t *testing.T) {
 		assert.NoError(t, queue.start())
 		cancel()
 		assert.NoError(t, queue.stop())
+	})
+}
+
+func TestBlocksQueue_StopDuringPeerRetry(t *testing.T) {
+	mc, p2p, _ := initializeTestServices(t, nil, nil)
+	resetFlags := *flags.Get()
+	withPeers := resetFlags
+	withPeers.MinimumSyncPeers = 1
+	flags.Init(&withPeers)
+	t.Cleanup(func() { flags.Init(&resetFlags) })
+
+	synctest.Test(t, func(t *testing.T) {
+		queue := newBlocksQueue(t.Context(), &blocksQueueConfig{
+			chain:               mc,
+			p2p:                 p2p,
+			highestExpectedSlot: 128,
+			mode:                modeNonConstrained,
+		})
+		defer queue.cancel()
+		queue.smm.handlers[stateNew][eventTick] = func(m *stateMachine, _ any) (stateID, error) {
+			return m.state, errNoRequiredPeers
+		}
+		require.NoError(t, queue.start())
+		// Advance to the first tick, then let the queue block in its retry wait.
+		time.Sleep(pollingInterval)
+		synctest.Wait()
+		require.Equal(t, 1, queue.exitConditions.noRequiredPeersErrRetries)
+
+		assert.NoError(t, queue.stop())
+		synctest.Wait()
+		select {
+		case <-queue.quit:
+		default:
+			t.Fatal("queue did not finish shutdown")
+		}
+		_, open := <-queue.fetchedData
+		assert.Equal(t, false, open)
+		_, open = <-queue.blocksFetcher.fetchResponses
+		assert.Equal(t, false, open)
+		require.IsNil(t, queue.blocksFetcher.rateLimiter)
 	})
 }
 

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -343,7 +343,11 @@ func (s *Service) waitForMinimumPeers() ([]peer.ID, error) {
 			"suitable": len(peers),
 			"required": required,
 		}).Info("Waiting for enough suitable peers before syncing")
-		time.Sleep(handshakePollingInterval)
+		select {
+		case <-s.ctx.Done():
+			return nil, s.ctx.Err()
+		case <-time.After(handshakePollingInterval):
+		}
 	}
 }
 

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
@@ -40,6 +41,39 @@ import (
 	"github.com/paulbellamy/ratecounter"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
+
+func TestService_StopDuringPeerWait(t *testing.T) {
+	mc, p2p, _ := initializeTestServices(t, nil, nil)
+	resetFlags := *flags.Get()
+	withPeers := resetFlags
+	withPeers.MinimumSyncPeers = 1
+	flags.Init(&withPeers)
+	t.Cleanup(func() { flags.Init(&resetFlags) })
+
+	synctest.Test(t, func(t *testing.T) {
+		s := NewService(t.Context(), &Config{Chain: mc, P2P: p2p})
+		defer s.cancel()
+		done := make(chan error, 1)
+		go func() {
+			_, err := s.waitForMinimumPeers()
+			done <- err
+		}()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("peer wait returned before shutdown: %v", err)
+		default:
+		}
+		require.NoError(t, s.Stop())
+		synctest.Wait()
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		default:
+			t.Fatal("peer wait did not return on shutdown")
+		}
+	})
+}
 
 func TestService_Constants(t *testing.T) {
 	if params.BeaconConfig().MaxPeersToSync*flags.Get().BlockBatchLimit > 1000 {

--- a/changelog/syjn99_ctx-sync-retry-waits.md
+++ b/changelog/syjn99_ctx-sync-retry-waits.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Make initial-sync retry and peer polling waits cancellable so shutdown does not wait for the polling interval.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

We have `time.Sleep` pattern for few seconds in initial-sync phase, which doesn't honor the parent's context cancellation. This PR makes waiting be cancellable inside the context.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
