### PR TITLE
Remove `skipBlockSignaturesForTesting` bypass

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -571,13 +571,7 @@ func (s *Service) validateStateTransition(ctx context.Context, preState state.Be
 		return nil, ErrNotDescendantOfFinalized
 	}
 	stateTransitionStartTime := time.Now()
-	var postState state.BeaconState
-	var err error
-	if s.skipBlockSignaturesForTesting {
-		_, postState, err = transition.ExecuteStateTransitionNoVerifyAnySig(ctx, preState, signed)
-	} else {
-		postState, err = transition.ExecuteStateTransition(ctx, preState, signed)
-	}
+	postState, err := transition.ExecuteStateTransition(ctx, preState, signed)
 	if err != nil {
 		if ctx.Err() != nil || electra.IsExecutionRequestError(err) {
 			return nil, err
@@ -586,11 +580,6 @@ func (s *Service) validateStateTransition(ctx context.Context, preState state.Be
 	}
 	stateTransitionProcessingTime.Observe(float64(time.Since(stateTransitionStartTime).Milliseconds()))
 	return postState, nil
-}
-
-// DisableBlockSignatureVerificationForTesting supports spectest vectors generated with bls_setting 2, their blocks are unsigned.
-func (s *Service) DisableBlockSignatureVerificationForTesting() {
-	s.skipBlockSignaturesForTesting = true
 }
 
 // updateJustificationOnBlock updates the justified checkpoint on DB if the

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -68,7 +68,6 @@ type Service struct {
 	blobStorage                    *filesystem.BlobStorage
 	dataColumnStorage              *filesystem.DataColumnStorage
 	slasherEnabled                 bool
-	skipBlockSignaturesForTesting  bool
 	lcStore                        *lightClient.Store
 	startWaitingDataColumnSidecars chan bool // for testing purposes only
 	syncCommitteeHeadState         *cache.SyncCommitteeHeadStateCache

--- a/changelog/syjn99_remove-skip-block-sigs.md
+++ b/changelog/syjn99_remove-skip-block-sigs.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Removed the `skipBlockSignaturesForTesting` bypass from the blockchain service; the `fake_crypto` backend already accepts the stub signatures in `bls_setting: 2` fork choice vectors.

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -108,13 +108,10 @@ func runTest(t *testing.T, config string, fork int, basePath string, fcr bool) {
 					builder = NewBuilder(t, beaconState, beaconBlock)
 				}
 
-				// Vectors generated with bls_setting 2 carry unsigned blocks.
+				// Vectors generated with bls_setting 2 predate consensus-specs#5489 and carry the stub aggregate pubkey.
 				if metaFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml"); err == nil {
 					meta := &Meta{}
 					require.NoError(t, utils.UnmarshalYaml(metaFile, meta))
-					if meta.BlsSetting == 2 {
-						builder.service.DisableBlockSignatureVerificationForTesting()
-					}
 				}
 
 				for _, step := range steps {

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -108,12 +108,6 @@ func runTest(t *testing.T, config string, fork int, basePath string, fcr bool) {
 					builder = NewBuilder(t, beaconState, beaconBlock)
 				}
 
-				// Vectors generated with bls_setting 2 predate consensus-specs#5489 and carry the stub aggregate pubkey.
-				if metaFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml"); err == nil {
-					meta := &Meta{}
-					require.NoError(t, utils.UnmarshalYaml(metaFile, meta))
-				}
-
 				for _, step := range steps {
 					if step.Tick != nil {
 						tick := int64(*step.Tick)


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Follow-ups for #17122 and #17281 - now `skipBlockSignaturesForTesting` is not needed thanks to fake BLS backend. Verified with spectest.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
