### PR TITLE
Cancel sidecar parent-block fetches on sync service shutdown

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -429,7 +429,6 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 
 		// Optimistically request parent payload envelopes in parallel with the parent blocks.
 		var wg sync.WaitGroup
-		wg.Add(1)
 		wg.Go(func() {
 			s.fetchAndQueuePayloadEnvelopesForRoots(ctx, pid, req)
 		})

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -398,6 +398,9 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 	pid := bestPeers[randomIndex]
 
 	for range numOfTries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		req := p2ptypes.BeaconBlockByRootsReq(roots)
 
 		// Get the current epoch.
@@ -427,10 +430,9 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 		// Optimistically request parent payload envelopes in parallel with the parent blocks.
 		var wg sync.WaitGroup
 		wg.Add(1)
-		go func(pid core.PeerID, roots p2ptypes.BeaconBlockByRootsReq) {
-			defer wg.Done()
-			s.fetchAndQueuePayloadEnvelopesForRoots(ctx, pid, roots)
-		}(pid, req)
+		wg.Go(func() {
+			s.fetchAndQueuePayloadEnvelopesForRoots(ctx, pid, req)
+		})
 
 		// Send the request to the peer.
 		if err := s.sendBeaconBlocksRequest(ctx, &req, pid); err != nil {
@@ -438,6 +440,9 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 			log.WithError(err).Debug("Could not send recent block request")
 		}
 		wg.Wait()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 
 		// Filter out roots that are already seen in pending blocks.
 		newRoots := make([][32]byte, 0, rootCount)
@@ -504,6 +509,8 @@ func (s *Service) fetchAndQueuePayloadEnvelopesForRoots(
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, respTimeout)
+	defer cancel()
 	envelopes, err := SendExecutionPayloadEnvelopesByRootRequest(ctx, s.cfg.clock, s.cfg.p2p, pid, s.ctxMap, &envelopeRoots)
 	if err != nil {
 		log.WithError(err).Debug("Could not request execution payload envelopes by root")

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"reflect"
 	"sync"
@@ -1103,6 +1104,95 @@ func TestValidateSidecar_ParentRequestServiceLifetime(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("service stop did not interrupt the parent response read")
 			}
+		})
+	}
+}
+
+func TestService_BatchRootRequestCancellation(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	params.BeaconConfig().GloasForkEpoch = 0
+	params.BeaconConfig().InitializeForkSchedule()
+
+	t.Run("block and envelope reads", func(t *testing.T) {
+		streams := make(chan *stalledParentStream, 2*numOfTries)
+		s := parentRequestService(t, func(ctx context.Context, _ any) (network.Stream, error) {
+			_, bounded := ctx.Deadline()
+			assert.Equal(t, true, bounded)
+			stream := &stalledParentStream{reading: make(chan struct{}), reset: make(chan struct{})}
+			t.Cleanup(func() { _ = stream.Reset() })
+			streams <- stream
+			return stream, nil
+		})
+		done := make(chan error, 1)
+		go func() { done <- s.sendBatchRootRequest(s.ctx, [][32]byte{{1}}, rand.NewGenerator()) }()
+		for range 2 {
+			select {
+			case stream := <-streams:
+				select {
+				case <-stream.reading:
+				case <-time.After(time.Second):
+					t.Fatal("request did not reach response read")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("block and envelope requests did not both start")
+			}
+		}
+		require.NoError(t, s.Stop())
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(time.Second):
+			t.Fatal("canceled batch did not return promptly")
+		}
+		require.Equal(t, 0, len(streams), "canceled requests must not be retried")
+	})
+
+	t.Run("envelope timeouts preserve retries", func(t *testing.T) {
+		previousTimeout := respTimeout
+		respTimeout = 20 * time.Millisecond
+		t.Cleanup(func() { respTimeout = previousTimeout })
+
+		blockAttempts, envelopeAttempts := 0, 0
+		s := parentRequestService(t, func(ctx context.Context, msg any) (network.Stream, error) {
+			if _, ok := msg.(*p2ptypes.ExecutionPayloadEnvelopesByRootReq); ok {
+				envelopeAttempts++
+				<-ctx.Done()
+				assert.Equal(t, context.DeadlineExceeded, ctx.Err())
+				return nil, ctx.Err()
+			}
+			blockAttempts++
+			return nil, errors.New("request failed")
+		})
+
+		require.NoError(t, s.sendBatchRootRequest(s.ctx, [][32]byte{{1}}, rand.NewGenerator()))
+		require.NoError(t, s.ctx.Err())
+		require.Equal(t, numOfTries, blockAttempts)
+		require.Equal(t, numOfTries, envelopeAttempts)
+	})
+
+	params.BeaconConfig().GloasForkEpoch = 1
+	for _, cancelAt := range []int{0, 1, numOfTries, numOfTries + 1} {
+		t.Run(fmt.Sprintf("cancel at attempt %d", cancelAt), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			attempts := 0
+			s := parentRequestService(t, func(context.Context, any) (network.Stream, error) {
+				attempts++
+				if attempts == cancelAt {
+					cancel()
+				}
+				return nil, errors.New("request failed")
+			})
+			if cancelAt == 0 {
+				cancel()
+			}
+			err := s.sendBatchRootRequest(ctx, [][32]byte{{1}}, rand.NewGenerator())
+			if cancelAt <= numOfTries {
+				require.ErrorIs(t, err, context.Canceled)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, min(cancelAt, numOfTries), attempts)
 		})
 	}
 }

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -1,7 +1,11 @@
 package sync
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"math"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -12,11 +16,14 @@ import (
 	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/execution"
 	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/peers"
 	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	p2ptypes "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stategen"
+	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -26,7 +33,10 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/ethereum/go-ethereum/p2p/enr"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	gcache "github.com/patrickmn/go-cache"
 	logTest "github.com/sirupsen/logrus/hooks/test"
@@ -972,4 +982,127 @@ func TestExpirationCache_PruneOldBlocksCorrectly(t *testing.T) {
 	assert.Equal(t, false, r.seenPendingBlocks[b1Root])
 	assert.Equal(t, false, r.seenPendingBlocks[b2Root])
 	assert.Equal(t, 0, len(r.pendingBlocksInCache(1)))
+}
+
+// Override only the transport so requests still exercise the shared fetch and RPC paths.
+type parentRequestP2P struct {
+	p2p.P2P
+	send func(context.Context, any) (network.Stream, error)
+}
+
+func (p *parentRequestP2P) Send(ctx context.Context, msg any, _ string, _ peer.ID) (network.Stream, error) {
+	return p.send(ctx, msg)
+}
+
+type stalledParentStream struct {
+	network.Stream
+	reading chan struct{}
+	reset   chan struct{}
+	started sync.Once
+	once    sync.Once
+}
+
+func (s *stalledParentStream) Read([]byte) (int, error) {
+	s.started.Do(func() { close(s.reading) })
+	<-s.reset
+	return 0, network.ErrReset
+}
+
+func (s *stalledParentStream) Reset() error {
+	s.once.Do(func() { close(s.reset) })
+	return nil
+}
+
+func (*stalledParentStream) Close() error                    { return nil }
+func (*stalledParentStream) SetReadDeadline(time.Time) error { return nil }
+
+func parentRequestService(t *testing.T, send func(context.Context, any) (network.Stream, error)) *Service {
+	t.Helper()
+	p := &parentRequestP2P{P2P: p2ptest.NewTestP2P(t), send: send}
+	pid := peer.ID("parent-peer")
+	p.Peers().Add(new(enr.Record), pid, nil, network.DirOutbound)
+	p.Peers().SetConnectionState(pid, peers.Connected)
+	p.Peers().SetChainState(pid, &ethpb.StatusV2{FinalizedEpoch: 1})
+	s := NewService(t.Context(), WithP2P(p), WithDatabase(dbtest.SetupDB(t)),
+		WithChainService(&mock.ChainService{FinalizedCheckPoint: &ethpb.Checkpoint{}}))
+	t.Cleanup(s.cancel)
+	s.cfg.clock = startup.NewClock(time.Now(), [32]byte{})
+	s.cfg.initialSync = &mockSync.Sync{}
+	return s
+}
+
+func TestValidateSidecar_ParentRequestServiceLifetime(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	params.BeaconConfig().FuluForkEpoch = 0
+	params.BeaconConfig().GloasForkEpoch = 1
+	params.BeaconConfig().InitializeForkSchedule()
+
+	for _, kind := range []string{"blob", "data column"} {
+		t.Run(kind, func(t *testing.T) {
+			requests := make(chan context.Context, numOfTries)
+			stream := &stalledParentStream{reading: make(chan struct{}), reset: make(chan struct{})}
+			t.Cleanup(func() { _ = stream.Reset() })
+			s := parentRequestService(t, func(ctx context.Context, _ any) (network.Stream, error) {
+				requests <- ctx
+				return stream, nil
+			})
+			missingParent := errors.New("missing parent")
+			s.newBlobVerifier = func(blocks.ROBlob, []verification.Requirement) verification.BlobVerifier {
+				return &verification.MockBlobVerifier{ErrSidecarParentSeen: missingParent}
+			}
+			s.newColumnsVerifier = testNewDataColumnSidecarsVerifier(verification.MockDataColumnsVerifier{ErrSidecarParentSeen: missingParent})
+			_, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{1}, 1, 1)
+			blob := blobs[0].BlobSidecar
+			buf := new(bytes.Buffer)
+			var topic string
+			validate := s.validateBlob
+			if kind == "blob" {
+				_, err := s.cfg.p2p.Encoding().EncodeGossip(buf, blob)
+				require.NoError(t, err)
+				topic = p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.BlobSidecar]()]
+			} else {
+				column := &ethpb.DataColumnSidecar{
+					SignedBlockHeader:            blob.SignedBlockHeader,
+					KzgCommitmentsInclusionProof: make([][]byte, 4),
+				}
+				for i := range column.KzgCommitmentsInclusionProof {
+					column.KzgCommitmentsInclusionProof[i] = make([]byte, 32)
+				}
+				_, err := s.cfg.p2p.Encoding().EncodeGossip(buf, column)
+				require.NoError(t, err)
+				topic = p2p.GossipTypeMapping[reflect.TypeFor[*ethpb.DataColumnSidecar]()]
+				validate = s.validateDataColumn
+			}
+			topic = s.addDigestAndIndexToTopic(topic, s.currentForkDigest(), 0) + s.cfg.p2p.Encoding().ProtocolSuffix()
+
+			// Regression of #13061.
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			result, err := validate(ctx, "", &pubsub.Message{Message: &pb.Message{Data: buf.Bytes(), Topic: &topic}})
+			cancel()
+			require.Equal(t, pubsub.ValidationIgnore, result)
+			require.ErrorIs(t, err, missingParent)
+
+			select {
+			case <-stream.reading:
+			case <-time.After(time.Second):
+				t.Fatal("parent request did not reach response read after validation returned")
+			}
+			requestCtx := <-requests
+			require.NoError(t, requestCtx.Err(), "validation cancellation must not cancel parent fetch")
+
+			// Ensure the request context has a bounded deadline.
+			_, bounded := requestCtx.Deadline()
+			require.Equal(t, true, bounded)
+
+			// Stop the service and ensure the parent request is canceled.
+			require.NoError(t, s.Stop())
+			require.ErrorIs(t, requestCtx.Err(), context.Canceled)
+			select {
+			case <-stream.reset:
+			case <-time.After(time.Second):
+				t.Fatal("service stop did not interrupt the parent response read")
+			}
+		})
+	}
 }

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -198,6 +198,8 @@ func SendBeaconBlocksByRootRequest(
 		return nil, err
 	}
 	defer closeStream(stream, log)
+	stop := context.AfterFunc(ctx, func() { _ = stream.Reset() })
+	defer stop()
 
 	// Augment block processing function, if non-nil block processor is provided.
 	blocks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(*req))
@@ -873,6 +875,8 @@ func SendExecutionPayloadEnvelopesByRootRequest(
 		return nil, err
 	}
 	defer closeStream(stream, log)
+	stop := context.AfterFunc(ctx, func() { _ = stream.Reset() })
+	defer stop()
 
 	max := min(uint64(len(*req)), params.BeaconConfig().MaxRequestPayloads)
 

--- a/beacon-chain/sync/validate_blob.go
+++ b/beacon-chain/sync/validate_blob.go
@@ -85,7 +85,7 @@ func (s *Service) validateBlob(ctx context.Context, pid peer.ID, msg *pubsub.Mes
 
 	if err := vf.SidecarParentSeen(s.hasBadBlock); err != nil {
 		go func() {
-			if err := s.sendBatchRootRequest(context.Background(), [][32]byte{blob.ParentRoot()}, rand.NewGenerator()); err != nil {
+			if err := s.sendBatchRootRequest(s.ctx, [][32]byte{blob.ParentRoot()}, rand.NewGenerator()); err != nil {
 				log.WithError(err).WithFields(blobFields(blob)).Debug("Failed to send batch root request")
 			}
 		}()

--- a/beacon-chain/sync/validate_blob_test.go
+++ b/beacon-chain/sync/validate_blob_test.go
@@ -257,6 +257,7 @@ func TestValidateBlob_ErrorPathsWithMock(t *testing.T) {
 			p := p2ptest.NewTestP2P(t)
 			chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0)}
 			s := &Service{
+				ctx:               ctx,
 				seenBlobCache:     lruwrpr.New(10),
 				seenPendingBlocks: make(map[[32]byte]bool),
 				cfg:               &config{chain: chainService, p2p: p, initialSync: &mockSync.Sync{}, clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)}}

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -184,7 +184,6 @@ func (s *Service) validateDataColumnFulu(
 	// (a client MAY queue sidecars for processing once the parent block is retrieved).
 	if err := verifier.SidecarParentSeen(s.hasBadBlock); err != nil {
 		go func() {
-			customCtx := context.Background()
 			parentRoot, err := roDataColumn.ParentRoot()
 			if err != nil {
 				log.WithError(err).WithFields(logging.DataColumnFields(roDataColumn)).Debug("Failed to get parent root for batch root request")
@@ -192,7 +191,7 @@ func (s *Service) validateDataColumnFulu(
 			}
 			roots := [][fieldparams.RootLength]byte{parentRoot}
 			randGenerator := rand.NewGenerator()
-			if reqErr := s.sendBatchRootRequest(customCtx, roots, randGenerator); reqErr != nil {
+			if reqErr := s.sendBatchRootRequest(s.ctx, roots, randGenerator); reqErr != nil {
 				log.WithError(reqErr).WithFields(logging.DataColumnFields(roDataColumn)).Debug("Failed to send batch root request")
 			}
 		}()

--- a/changelog/syjn99_ctx-parent-block-fetches.md
+++ b/changelog/syjn99_ctx-parent-block-fetches.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Cancel background sidecar parent-block and payload-envelope requests when the sync service stops, and stop retrying canceled requests.
+- Apply the response timeout to the complete parent-block and payload-envelope response reads for each attempt, preserving retries when an individual request times out.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

When a blob or data column sidecar arrives over gossip before its parent block, the (blob/data column) validator spawns a goroutine that requests the parent by root (`sendBatchRootRequest`). 
Since #13061 that goroutine ran on `context.Background()`, so it never observed beacon node shutdown, and a cancelled context was not honored mid-request either.

This PR:

- Runs the sidecar parent fetch on the sync service context (`s.ctx`) instead of `context.Background()`.
- Registers `context.AfterFunc(ctx, stream.Reset)` in `SendBeaconBlocksByRootRequest` and `SendExecutionPayloadEnvelopesByRootRequest`, so cancellation interrupts a blocked response read instead of waiting for the next chunk deadline.
- Checks `ctx.Err()` at the top of each retry and after each attempt in `sendBatchRootRequest`, so a cancelled request returns immediately instead of burning the remaining `numOfTries` attempts.
- Bounds the optimistic payload envelope fetch with `respTimeout` per attempt, the same bound `sendBeaconBlocksRequest` already applies to the block request. Previously the envelope request inherited the caller's context with no timeout of its own.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
