### PR TITLE
FCR: Prewarm the next OJC checkpoint balances at the last slot of the epoch

### DIFF
--- a/beacon-chain/blockchain/fcr_accessors_test.go
+++ b/beacon-chain/blockchain/fcr_accessors_test.go
@@ -11,43 +11,90 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 )
 
-func TestBalanceInfoByCheckpoint_SkippedBoundaryUsesCheckpointEpoch(t *testing.T) {
-	helpers.ClearCache()
-	service, tr := minimalTestService(t)
-	ctx := tr.ctx
-	cfg := params.BeaconConfig()
+func TestBalanceInfoByCheckpoint(t *testing.T) {
+	t.Run("skipped boundary uses the checkpoint epoch", func(t *testing.T) {
+		helpers.ClearCache()
+		service, tr := minimalTestService(t)
+		ctx := tr.ctx
+		cfg := params.BeaconConfig()
 
-	st, _ := util.DeterministicGenesisState(t, 64)
-	// Inactive in epoch 0, active in epoch 1, so it is only counted if the epoch transition ran.
-	pk := make([]byte, 48)
-	pk[0] = 0xff
-	require.NoError(t, st.AppendValidator(&ethpb.Validator{
-		PublicKey:                  pk,
-		WithdrawalCredentials:      make([]byte, 32),
-		ActivationEligibilityEpoch: 0,
-		ActivationEpoch:            1,
-		ExitEpoch:                  cfg.FarFutureEpoch,
-		WithdrawableEpoch:          cfg.FarFutureEpoch,
-		EffectiveBalance:           cfg.MaxEffectiveBalance,
-	}))
-	require.NoError(t, st.AppendBalance(cfg.MaxEffectiveBalance))
-	newIdx := st.NumValidators() - 1
+		st, _ := util.DeterministicGenesisState(t, 64)
+		// Inactive in epoch 0, active in epoch 1, so it is only counted if the epoch transition ran.
+		pk := make([]byte, 48)
+		pk[0] = 0xff
+		require.NoError(t, st.AppendValidator(&ethpb.Validator{
+			PublicKey:                  pk,
+			WithdrawalCredentials:      make([]byte, 32),
+			ActivationEligibilityEpoch: 0,
+			ActivationEpoch:            1,
+			ExitEpoch:                  cfg.FarFutureEpoch,
+			WithdrawableEpoch:          cfg.FarFutureEpoch,
+			EffectiveBalance:           cfg.MaxEffectiveBalance,
+		}))
+		require.NoError(t, st.AppendBalance(cfg.MaxEffectiveBalance))
+		newIdx := st.NumValidators() - 1
 
-	// The checkpoint block sits in the last slot of epoch 0 and the epoch 1 boundary slot is skipped.
-	lastSlotOfEpoch0 := cfg.SlotsPerEpoch - 1
-	require.NoError(t, st.SetSlot(lastSlotOfEpoch0))
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = lastSlotOfEpoch0
-	util.SaveBlock(t, ctx, tr.db, blk)
-	root, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, tr.db.SaveState(ctx, st, root))
+		// The checkpoint block sits in the last slot of epoch 0 and the epoch 1 boundary slot is skipped.
+		lastSlotOfEpoch0 := cfg.SlotsPerEpoch - 1
+		require.NoError(t, st.SetSlot(lastSlotOfEpoch0))
+		blk := util.NewBeaconBlock()
+		blk.Block.Slot = lastSlotOfEpoch0
+		util.SaveBlock(t, ctx, tr.db, blk)
+		root, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, tr.db.SaveState(ctx, st, root))
 
-	acc := &fcrBalanceAccessor{s: service}
-	info, err := acc.BalanceInfoByCheckpoint(ctx, forkchoicetypes.Checkpoint{Epoch: 1, Root: root})
-	require.NoError(t, err)
+		acc := &fcrBalanceAccessor{s: service}
+		info, err := acc.BalanceInfoByCheckpoint(ctx, forkchoicetypes.Checkpoint{Epoch: 1, Root: root})
+		require.NoError(t, err)
 
-	require.Equal(t, st.NumValidators(), len(info.Balances))
-	require.Equal(t, cfg.MaxEffectiveBalance, info.Balances[newIdx])
-	require.Equal(t, uint64(st.NumValidators())*cfg.MaxEffectiveBalance, info.TotalActiveBalance)
+		require.Equal(t, st.NumValidators(), len(info.Balances))
+		require.Equal(t, cfg.MaxEffectiveBalance, info.Balances[newIdx])
+		require.Equal(t, uint64(st.NumValidators())*cfg.MaxEffectiveBalance, info.TotalActiveBalance)
+	})
+
+	t.Run("second lookup hits the cache", func(t *testing.T) {
+		helpers.ClearCache()
+		service, tr := minimalTestService(t)
+		st, _ := util.DeterministicGenesisState(t, 64)
+		blk := util.NewBeaconBlock()
+		util.SaveBlock(t, tr.ctx, tr.db, blk)
+		root, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.NoError(t, tr.db.SaveState(tr.ctx, st, root))
+		acc := &fcrBalanceAccessor{s: service}
+		cp := forkchoicetypes.Checkpoint{Epoch: 0, Root: root}
+
+		first, err := acc.BalanceInfoByCheckpoint(tr.ctx, cp)
+		require.NoError(t, err)
+		second, err := acc.BalanceInfoByCheckpoint(tr.ctx, cp)
+		require.NoError(t, err)
+		// Equal compares the pointers, so this proves the second lookup did not recompute.
+		require.Equal(t, first, second)
+	})
+
+	t.Run("failed lookup leaves no entry", func(t *testing.T) {
+		helpers.ClearCache()
+		service, tr := minimalTestService(t)
+
+		st, _ := util.DeterministicGenesisState(t, 64)
+		blk := util.NewBeaconBlock()
+		root, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+
+		acc := &fcrBalanceAccessor{s: service}
+		cp := forkchoicetypes.Checkpoint{Epoch: 0, Root: root}
+
+		// Unknown root: a failed prewarm-time lookup must not poison the cache.
+		_, err = acc.BalanceInfoByCheckpoint(tr.ctx, cp)
+		require.ErrorContains(t, "could not get state for checkpoint root", err)
+		require.Equal(t, 0, len(acc.byCheckpoint))
+
+		// The state becomes available later, the slot-start lookup still computes it.
+		util.SaveBlock(t, tr.ctx, tr.db, blk)
+		require.NoError(t, tr.db.SaveState(tr.ctx, st, root))
+		got, err := acc.BalanceInfoByCheckpoint(tr.ctx, cp)
+		require.NoError(t, err)
+		require.Equal(t, st.NumValidators(), len(got.Balances))
+	})
 }

--- a/beacon-chain/confirmation/confirmation.go
+++ b/beacon-chain/confirmation/confirmation.go
@@ -164,6 +164,14 @@ func (f *FastConfirmationRule) OnFastConfirmation(ctx context.Context, currentSl
 		return
 	}
 
+	// Prewarm the next OJC after this run releases its forkchoice lock.
+	if slots.IsEpochStart(currentSlot + 1) {
+		nextOJC := f.previousEpochGreatestUnrealizedCheckpoint
+		defer func() {
+			go func() { _, _ = f.balances.BalanceInfoByCheckpoint(ctx, nextOJC) }()
+		}()
+	}
+
 	// Checkpoint state loads can replay from disk, keep them off the forkchoice lock.
 	info, err := f.balances.BalanceInfoByCheckpoint(ctx, f.currentEpochObservedJustifiedCheckpoint)
 	if err != nil {

--- a/beacon-chain/confirmation/confirmation_test.go
+++ b/beacon-chain/confirmation/confirmation_test.go
@@ -2,7 +2,9 @@ package confirmation
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"testing/synctest"
 
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
@@ -686,4 +688,88 @@ func TestGetLatestConfirmed_RestartsToJustified(t *testing.T) {
 	// (rootFin slot 0 < rootJust slot 27, and epoch 0+1==1)
 	// Phase 3 may try to advance further, but with no support it stays at rootJust
 	require.Equal(t, rootJust, result)
+}
+
+// blockingLookupRecorder records every checkpoint lookup and holds the lookup for hold until release
+// is closed, so the test can observe that the prewarm runs on its own goroutine.
+type blockingLookupRecorder struct {
+	mockBalanceAccessor
+	hold           forkchoicetypes.Checkpoint
+	release        chan struct{}
+	currentRelease chan struct{}
+	mu             sync.Mutex
+	lookups        []forkchoicetypes.Checkpoint
+}
+
+func (m *blockingLookupRecorder) BalanceInfoByCheckpoint(_ context.Context, cp forkchoicetypes.Checkpoint) (*FFGStateInfo, error) {
+	m.mu.Lock()
+	m.lookups = append(m.lookups, cp)
+	m.mu.Unlock()
+	if cp == m.hold {
+		<-m.release
+	} else if m.currentRelease != nil {
+		<-m.currentRelease
+	}
+	return &FFGStateInfo{}, nil
+}
+
+// counts returns the number of lookups seen so far and how many of them were for cp.
+func (m *blockingLookupRecorder) counts(cp forkchoicetypes.Checkpoint) (total, ofCp int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, l := range m.lookups {
+		if l == cp {
+			ofCp++
+		}
+	}
+	return len(m.lookups), ofCp
+}
+
+func TestOnFastConfirmation_LastSlotPrewarmsNextOJC(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		spe := primitives.Slot(params.BeaconConfig().SlotsPerEpoch)
+		anchor := [32]byte{0x10}
+		head := [32]byte{1}
+		anchorCp := forkchoicetypes.Checkpoint{Epoch: 0, Root: anchor}
+		ujc := forkchoicetypes.Checkpoint{Epoch: 1, Root: head}
+
+		fc := &chainTestFC{
+			mockForkchoiceReader: mockForkchoiceReader{headRoot: head, ujc: &ujc},
+			parents:              map[[32]byte][32]byte{head: anchor},
+			slotsByRoot:          map[[32]byte]primitives.Slot{anchor: 0, head: 2*spe - 2},
+		}
+		balances := &blockingLookupRecorder{hold: ujc, release: make(chan struct{})}
+		defer close(balances.release)
+		fcr := New(fc, &mockCommitteeAccessor{}, balances, anchorCp)
+
+		// Mid-epoch slot: exactly one lookup, the synchronous one for the current OJC.
+		fcr.OnFastConfirmation(t.Context(), 2*spe-2)
+		synctest.Wait()
+		total, ofUJC := balances.counts(ujc)
+		require.Equal(t, 1, total)
+		require.Equal(t, 0, ofUJC)
+
+		// Hold the current lookup to verify prewarm waits for this run to finish using the accessor.
+		balances.currentRelease = make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			fcr.OnFastConfirmation(t.Context(), 2*spe-1)
+			close(done)
+		}()
+		synctest.Wait()
+		total, ofUJC = balances.counts(ujc)
+		require.Equal(t, 2, total)
+		require.Equal(t, 0, ofUJC)
+		close(balances.currentRelease)
+		synctest.Wait()
+		// The prewarm is still blocked, but the current run must have returned.
+		select {
+		case <-done:
+		default:
+			t.Fatal("OnFastConfirmation waited for the prewarm lookup instead of returning")
+		}
+		total, ofUJC = balances.counts(ujc)
+		require.Equal(t, 3, total)
+		require.Equal(t, 1, ofUJC)
+	})
 }

--- a/changelog/syjn99_fcr-ojc-prewarm.md
+++ b/changelog/syjn99_fcr-ojc-prewarm.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Fast confirmation rule: prewarm the next observed justified checkpoint balances on a background goroutine after the last slot's confirmation run, allowing the epoch-start lookup to reuse the cached balances.


### PR DESCRIPTION
**What type of PR is this?**

> Other: FCR Optimization

**What does this PR do? Why is it needed?**

https://github.com/OffchainLabs/prysm/blob/fc4e5dfed7f24b7b62050c86d38bcae696022f0e/beacon-chain/confirmation/confirmation.go#L767-L777

Every epoch start, previous GJC becomes current OJC.

https://github.com/OffchainLabs/prysm/blob/fc4e5dfed7f24b7b62050c86d38bcae696022f0e/beacon-chain/confirmation/confirmation.go#L167-L171

And current OJC is **always** used for loading total active balances. As current OJC is not yet warmed at epoch start, `BalanceInfoByCheckpoint` will not follow the cached path, instead it calculates from the scratch to get the balance info.

<img width="2000" height="443" alt="image" src="https://github.com/user-attachments/assets/9b776af0-a89a-4ef1-9667-95705b8c985b" />

This kind of flamegraph is always shown at the epoch start. This PR removes the first big block of flamegraph (`BalanceInfoByCheckpoint`), by firing a background goroutine for next OJC at epoch end. In order to minimize the change (especially lock retention), it defers spawning goroutine until the end of current `OnFastConfirmation` call.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

<img width="1367" height="810" alt="image" src="https://github.com/user-attachments/assets/19fc83e4-e31e-4c6b-88b8-4f41c2e124f7" />

Testing in my Hoodi node. Note that my node was restarted around 09:00

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
