### PR TITLE
Use `go-version-file` instead of pinned go version in Github Actions

### DIFF
--- a/.github/workflows/check-logs.yml
+++ b/.github/workflows/check-logs.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go 1.25.1
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.1'
+          go-version-file: 'go.mod'
 
       - name: Check log.go files
         run: ./hack/check-logs.sh

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.25.1'
+          go-version-file: 'go.mod'
       - id: list
         uses: shogo82148/actions-go-fuzz/list@v0
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.25.1'
+          go-version-file: 'go.mod'
       - uses: shogo82148/actions-go-fuzz/run@v0
         with:
           packages: ${{ matrix.package }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.25.1
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.1'
+          go-version-file: 'go.mod'
 
       - name: Go mod tidy checker
         run: go mod tidy -diff
@@ -35,10 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go 1.26.5
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.5'
+          go-version-file: 'go.mod'
       - name: Run Gosec Security Scanner
         run: | # https://github.com/securego/gosec/issues/469
           export PATH=$PATH:$(go env GOPATH)/bin
@@ -54,10 +54,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go 1.26.5
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version-file: 'go.mod'
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -68,18 +68,14 @@ jobs:
     name: Build
     runs-on: ubuntu-4
     steps:
-      - name: Set up Go 1.26.5
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.26.5'
-        id: go
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+        id: go
 
       - name: Build
         # Use blst tag to allow go and bazel builds for blst.
@@ -100,12 +96,12 @@ jobs:
     # TODO: Remove `continue-on-error: true` when removing Bazel
     continue-on-error: true
     steps:
-      - name: Set up Go 1.26.5
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.5'
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - name: Run mainnet tests
         run: make test mainnet
         env:
@@ -117,12 +113,12 @@ jobs:
     # TODO: Remove `continue-on-error: true` when removing Bazel
     continue-on-error: true
     steps:
-      - name: Set up Go 1.26.5
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.5'
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - name: Run mainnet spectests
         run: make test mainnet-spectest
         env:
@@ -134,12 +130,12 @@ jobs:
     # TODO: Remove `continue-on-error: true` when removing Bazel
     continue-on-error: true
     steps:
-      - name: Set up Go 1.26.5
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.5'
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - name: Run minimal tests
         run: make test minimal minimal-spectest
         env:
@@ -151,12 +147,12 @@ jobs:
     # TODO: Remove `continue-on-error: true` when removing Bazel
     continue-on-error: true
     steps:
-      - name: Set up Go 1.26.5
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.5'
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - name: Run mainnet spectests with the fake BLS backend
         run: make test mainnet-spectest bls=fake
         env:
@@ -168,12 +164,12 @@ jobs:
     # TODO: Remove `continue-on-error: true` when removing Bazel
     continue-on-error: true
     steps:
-      - name: Set up Go 1.26.5
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.5'
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - name: Run minimal spectests with the fake BLS backend
         run: make test minimal-spectest bls=fake
         env:

--- a/changelog/syjn99_ci-use-go-version-file.md
+++ b/changelog/syjn99_ci-use-go-version-file.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use `go-version-file` instead of pinned go version as `go.mod` contains canonical go version.


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

`go.mod` annotates our canonical go version, so let all CI in Github watch `go.mod`.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
