### PR TITLE
FCR spectest for `v1.7.0-beta.0`

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -163,6 +163,7 @@ go_test(
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/cache/depositsnapshot:go_default_library",
+        "//beacon-chain/confirmation:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/confirmation"
 	testDB "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
@@ -151,6 +152,36 @@ func TestUnrealizedJustifiedBlockHash(t *testing.T) {
 	h := service.UnrealizedJustifiedPayloadBlockHash()
 	require.Equal(t, params.BeaconConfig().ZeroHash, h)
 	require.Equal(t, [32]byte{'j'}, service.cfg.ForkChoiceStore.JustifiedCheckpoint().Root)
+}
+
+func TestSafeBlockHash(t *testing.T) {
+	ctx := t.Context()
+	service := testServiceWithDB(t)
+	ojc := &ethpb.Checkpoint{Root: []byte{'j'}}
+	ofc := &ethpb.Checkpoint{Root: []byte{'f'}}
+	// Genesis carries a zero payload hash, the justified block a real one.
+	st, roblock, err := prepareForkchoiceState(ctx, 0, [32]byte{'g'}, [32]byte{}, params.BeaconConfig().ZeroHash, ojc, ofc)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, st, roblock))
+	st, roblock, err = prepareForkchoiceState(ctx, 1, [32]byte{'j'}, [32]byte{'g'}, [32]byte{'p'}, ojc, ofc)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, st, roblock))
+	service.cfg.ForkChoiceStore.SetBalancesByRooter(func(_ context.Context, _ [32]byte) ([]uint64, error) { return []uint64{}, nil })
+	require.NoError(t, service.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(ctx, &forkchoicetypes.Checkpoint{Epoch: 6, Root: [32]byte{'j'}}))
+	require.Equal(t, [32]byte{'p'}, service.UnrealizedJustifiedPayloadBlockHash())
+
+	t.Run("fcr disabled uses unrealized justified", func(t *testing.T) {
+		service.fcr = nil
+		require.Equal(t, [32]byte{'p'}, service.SafeBlockHash())
+	})
+	t.Run("confirmed genesis returns its zero payload hash", func(t *testing.T) {
+		service.fcr = confirmation.New(service.cfg.ForkChoiceStore, nil, nil, forkchoicetypes.Checkpoint{Root: [32]byte{'g'}})
+		require.Equal(t, params.BeaconConfig().ZeroHash, service.SafeBlockHash())
+	})
+	t.Run("pruned confirmed root falls back to unrealized justified", func(t *testing.T) {
+		service.fcr = confirmation.New(service.cfg.ForkChoiceStore, nil, nil, forkchoicetypes.Checkpoint{Root: [32]byte{'x'}})
+		require.Equal(t, [32]byte{'p'}, service.SafeBlockHash())
+	})
 }
 
 func TestHeadSlot_CanRetrieve(t *testing.T) {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -467,11 +467,9 @@ func (s *Service) SafeBlockHash() [32]byte {
 func (s *Service) safeBlockHash() [32]byte {
 	if s.fcr != nil {
 		root := s.fcr.ConfirmedRoot()
-		if root != ([32]byte{}) {
-			// The lookup can miss, for example on a pruned node, fall back to unrealized justified.
-			if hash := s.cfg.ForkChoiceStore.ConfirmedPayloadBlockHash(root); hash != ([32]byte{}) {
-				return hash
-			}
+		// A pruned confirmed root falls back to unrealized justified.
+		if root != ([32]byte{}) && s.cfg.ForkChoiceStore.HasNode(root) {
+			return s.cfg.ForkChoiceStore.ConfirmedPayloadBlockHash(root)
 		}
 	}
 	return s.cfg.ForkChoiceStore.UnrealizedJustifiedPayloadBlockHash()

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -58,7 +58,10 @@ func (s *Store) resolveParentPayloadStatus(block interfaces.ReadOnlyBeaconBlock)
 	builderIndex := bid.BuilderIndex()
 	parent := s.emptyNodeByRoot[block.ParentRoot()]
 	if parent == nil {
-		// This is the tree root node.
+		// This is the tree root node: remember the payload it builds on.
+		if s.treeRootNode == nil {
+			s.treeRootParentHash = bid.ParentBlockHash()
+		}
 		return nil, blockHash, builderIndex, nil
 	}
 	if bid.ParentBlockHash() == parent.node.blockHash {
@@ -160,11 +163,11 @@ func (s *Store) fullParent(pn *PayloadNode) *PayloadNode {
 	return parent
 }
 
-// parentHash return the payload hash of the latest full node that this block builds on.
+// parentHash returns the payload hash of the latest full node that this block builds on.
 func (s *Store) parentHash(pn *PayloadNode) [32]byte {
 	fullParent := s.fullParent(pn)
 	if fullParent == nil {
-		return [32]byte{}
+		return s.treeRootParentHash
 	}
 	return fullParent.node.blockHash
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -466,6 +466,73 @@ func TestParentHash_UnknownRoot(t *testing.T) {
 	assert.Equal(t, [32]byte{}, f.ParentHash(indexToHash(999)))
 }
 
+func TestParentHash_TreeRootBuildsOnPayload(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	f := New()
+	f.SetBalancesByRooter(func(_ context.Context, _ [32]byte) ([]uint64, error) { return f.justifiedBalances, nil })
+	ctx := t.Context()
+
+	// Genesis-shaped anchor: the bid carries no payload of its own (zero block hash) but records the payload it builds on.
+	rootA := indexToHash(1)
+	preAnchorHash := indexToHash(50)
+	st, roblock, err := prepareGloasForkchoiceState(ctx, 0, rootA, [32]byte{}, params.BeaconConfig().ZeroHash, preAnchorHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	// B builds on A's empty variant, so no full parent exists in the tree.
+	rootB := indexToHash(2)
+	st, roblock, err = prepareGloasForkchoiceState(ctx, 1, rootB, rootA, indexToHash(200), preAnchorHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	assert.Equal(t, preAnchorHash, f.ConfirmedPayloadBlockHash(rootA))
+	assert.Equal(t, preAnchorHash, f.ConfirmedPayloadBlockHash(rootB))
+	assert.Equal(t, preAnchorHash, f.ParentHash(rootB))
+}
+
+func TestParentHash_PrunePreservesLastFullAncestor(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	f := New()
+	f.SetBalancesByRooter(func(_ context.Context, _ [32]byte) ([]uint64, error) { return f.justifiedBalances, nil })
+	ctx := t.Context()
+
+	h0, h1, h2 := indexToHash(50), indexToHash(100), indexToHash(200)
+	rootA, rootB, rootC, rootD := indexToHash(1), indexToHash(2), indexToHash(3), indexToHash(4)
+
+	// A: genesis-shaped root building on h0. B: builds on A's empty variant and its payload h1 arrives.
+	st, blk, err := prepareGloasForkchoiceState(ctx, 0, rootA, [32]byte{}, params.BeaconConfig().ZeroHash, h0, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+	st, blk, err = prepareGloasForkchoiceState(ctx, 1, rootB, rootA, h1, h0, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+	pe, err := prepareGloasForkchoicePayload(rootB)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+	// C builds on full B but its own payload never arrives; D builds on C's empty variant.
+	st, blk, err = prepareGloasForkchoiceState(ctx, 2, rootC, rootB, h2, h1, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+	st, blk, err = prepareGloasForkchoiceState(ctx, 3, rootD, rootC, indexToHash(300), h1, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+	require.Equal(t, h1, f.ParentHash(rootD))
+
+	// Finalizing C prunes B, the only full ancestor. The walk from D now falls off the root and must still resolve to h1, not h0.
+	f.store.finalizedCheckpoint = &forkchoicetypes.Checkpoint{Epoch: 0, Root: rootC}
+	require.NoError(t, f.store.prune(ctx))
+	require.Equal(t, rootC, f.store.treeRootNode.root)
+	assert.Equal(t, h1, f.ParentHash(rootD))
+	assert.Equal(t, h1, f.ConfirmedPayloadBlockHash(rootC))
+	assert.Equal(t, h1, f.FinalizedPayloadBlockHash())
+}
+
 func TestHasPayloadBlockHash(t *testing.T) {
 	f := setupGloas(t, 0, 0)
 	ctx := t.Context()

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -288,6 +288,7 @@ func (s *Store) prune(ctx context.Context) error {
 		return nil
 	}
 	s.finalizedPayloadBlockHash = s.checkpointPayloadHashForRoot(finalizedRoot)
+	treeRootParentHash := s.parentHash(fen)
 
 	// Save the new finalized dependent root because it will be pruned
 	s.finalizedDependentRoot = fn.parent.node.root
@@ -299,6 +300,7 @@ func (s *Store) prune(ctx context.Context) error {
 
 	fn.parent = nil
 	s.treeRootNode = fn
+	s.treeRootParentHash = treeRootParentHash
 
 	prunedCount.Inc()
 	// Prune all children of the finalized checkpoint block that are incompatible with it

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -37,6 +37,7 @@ type Store struct {
 	finalizedPayloadBlockHash     [fieldparams.RootLength]byte                  // cached payload hash at the finalized checkpoint. Refreshed before pruning at finalization since the node it resolves from is removed by prune.
 	committeeWeight               uint64                                        // tracks the total active validator balance divided by the number of slots per Epoch.
 	treeRootNode                  *Node                                         // the root node of the store tree.
+	treeRootParentHash            [fieldparams.RootLength]byte                  // payload hash the tree root's bid builds on (Gloas). Answers the full-parent walk when it falls off the tree.
 	headNode                      *Node                                         // last head Node
 	emptyNodeByRoot               map[[fieldparams.RootLength]byte]*PayloadNode // nodes indexed by roots.
 	fullNodeByRoot                map[[fieldparams.RootLength]byte]*PayloadNode // full nodes (the payload was present) indexed by beacon block root.

--- a/changelog/syjn99_fcr-spectest.md
+++ b/changelog/syjn99_fcr-spectest.md
@@ -1,6 +1,7 @@
 ### Fixed
 
 - Return the confirmed block's payload hash as the safe execution block hash even when it is zero (pre-merge, genesis in spec tests) instead of falling back to the unrealized justified hash.
+- Gloas: when no full ancestor is left in forkchoice, resolve the payload a block builds on to the tree root's bid `parent_block_hash` instead of zero.
 
 ### Ignored
 

--- a/changelog/syjn99_fcr-spectest.md
+++ b/changelog/syjn99_fcr-spectest.md
@@ -1,3 +1,7 @@
+### Fixed
+
+- Return the confirmed block's payload hash as the safe execution block hash even when it is zero (pre-merge, genesis in spec tests) instead of falling back to the unrealized justified hash.
+
 ### Ignored
 
 - Revert the spectest-only stub pubkey aggregation (`SetStubPubkeyAggregation`): consensus-spec-tests `>= v1.7.0-alpha.13` compute real aggregate pubkeys with BLS disabled (consensus-specs#5489), so the stub breaks `next_sync_committee.aggregate_pubkey` on newer vectors.

--- a/changelog/syjn99_revert-stub-pubkey-aggregation.md
+++ b/changelog/syjn99_revert-stub-pubkey-aggregation.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Revert the spectest-only stub pubkey aggregation (`SetStubPubkeyAggregation`): consensus-spec-tests `>= v1.7.0-alpha.13` compute real aggregate pubkeys with BLS disabled (consensus-specs#5489), so the stub breaks `next_sync_committee.aggregate_pubkey` on newer vectors.

--- a/crypto/bls/fake.go
+++ b/crypto/bls/fake.go
@@ -5,10 +5,8 @@
 //
 // The split mirrors eth2spec/utils/bls.py with `bls_active = False`, where only
 // the signature functions are stubbed: Verify/AggregateVerify/FastAggregateVerify
-// return True and Sign/Aggregate return STUB_SIGNATURE. AggregatePKs is computed
-// for real by default, matching consensus-specs#5489, but vectors generated before
-// that fix write STUB_PUBKEY into the beacon state, so SetStubPubkeyAggregation
-// lets the spectest runner opt a bls_setting 2 case into the stub.
+// return True and Sign/Aggregate return STUB_SIGNATURE, while AggregatePKs is
+// computed for real because their results are data written into the beacon state.
 //
 // Never production: the cmd/beacon-chain, cmd/validator and cmd/prysmctl builds fail with the tag.
 package bls
@@ -31,14 +29,8 @@ var (
 	// Note: It is not a curve point, so the real backend cannot even deserialize it.
 	stubSignature = bytes.Repeat([]byte{0x11}, fieldparams.BLSSignatureLength)
 
-	// stubPubkey is what pre-#5489 spec versions return from AggregatePKs with BLS disabled.
-	stubPubkey = bytes.Repeat([]byte{0x22}, fieldparams.BLSPubkeyLength)
-
-	stubPubkeyAggregation bool
-
 	_ common.SecretKey = (*fakeSecretKey)(nil)
 	_ common.Signature = (*fakeSignature)(nil)
-	_ common.PublicKey = (*fakePublicKey)(nil)
 )
 
 type (
@@ -47,9 +39,6 @@ type (
 
 	// fakeSignature holds raw bytes rather than a curve point.
 	fakeSignature struct{ b []byte }
-
-	// fakePublicKey holds raw bytes rather than a curve point.
-	fakePublicKey struct{ b []byte }
 )
 
 // SecretKeyFromBytes --
@@ -95,24 +84,13 @@ func MultipleSignaturesFromBytes(sigs [][]byte) ([]Signature, error) {
 	return out, nil
 }
 
-// SetStubPubkeyAggregation makes AggregatePublicKeys and AggregateMultiplePubkeys return the spec's stub pubkey.
-func SetStubPubkeyAggregation(v bool) {
-	stubPubkeyAggregation = v
-}
-
 // AggregatePublicKeys --
 func AggregatePublicKeys(pubs [][]byte) (PublicKey, error) {
-	if stubPubkeyAggregation {
-		return newPublicKey(), nil
-	}
 	return blst.AggregatePublicKeys(pubs)
 }
 
 // AggregateMultiplePubkeys --
 func AggregateMultiplePubkeys(pubs []PublicKey) PublicKey {
-	if stubPubkeyAggregation {
-		return newPublicKey()
-	}
 	return blst.AggregateMultiplePubkeys(pubs)
 }
 
@@ -203,27 +181,8 @@ func (s *fakeSignature) Marshal() []byte { return copyBytes(s.b) }
 // Copy returns a full deep copy of a signature.
 func (s *fakeSignature) Copy() common.Signature { return &fakeSignature{b: copyBytes(s.b)} }
 
-// Marshal a public key into a byte slice.
-func (p *fakePublicKey) Marshal() []byte { return copyBytes(p.b) }
-
-// Copy returns a full deep copy of a public key.
-func (p *fakePublicKey) Copy() common.PublicKey { return &fakePublicKey{b: copyBytes(p.b)} }
-
-// Aggregate returns the spec's stub pubkey, as AggregatePKs does with BLS disabled.
-func (p *fakePublicKey) Aggregate(_ common.PublicKey) common.PublicKey { return newPublicKey() }
-
-// IsInfinite --
-func (p *fakePublicKey) IsInfinite() bool { return false }
-
-// Equals --
-func (p *fakePublicKey) Equals(p2 common.PublicKey) bool { return bytes.Equal(p.b, p2.Marshal()) }
-
 func newSignature() *fakeSignature {
 	return &fakeSignature{b: copyBytes(stubSignature)}
-}
-
-func newPublicKey() *fakePublicKey {
-	return &fakePublicKey{b: copyBytes(stubPubkey)}
 }
 
 func copyBytes(b []byte) []byte {

--- a/crypto/bls/fake_test.go
+++ b/crypto/bls/fake_test.go
@@ -37,7 +37,9 @@ func TestFakeRejectsMalformedInput(t *testing.T) {
 	require.NotNil(t, err, "batch with mismatched lengths must not verify")
 }
 
-func TestFakeAggregatedKeys(t *testing.T) {
+// Key material is real, because the spec computes AggregatePKs unconditionally.
+// Ref: https://github.com/ethereum/consensus-specs/pull/5489
+func TestFakeKeysAreReal(t *testing.T) {
 	raw := make([][]byte, 3)
 	keys := make([]PublicKey, 3)
 	for i := range raw {
@@ -52,18 +54,8 @@ func TestFakeAggregatedKeys(t *testing.T) {
 	require.DeepEqual(t, want.Marshal(), got.Marshal())
 	require.DeepEqual(t, want.Marshal(), AggregateMultiplePubkeys(keys).Marshal())
 
-	SetStubPubkeyAggregation(true)
-	defer SetStubPubkeyAggregation(false)
-	stubbed, err := AggregatePublicKeys(raw)
-	require.NoError(t, err)
-	require.DeepEqual(t, stubPubkey, stubbed.Marshal())
-	require.DeepEqual(t, stubPubkey, AggregateMultiplePubkeys(keys).Marshal())
-	require.DeepEqual(t, stubPubkey, stubbed.Aggregate(keys[0]).Marshal())
-	require.Equal(t, true, stubbed.Equals(stubbed.Copy()))
-	require.Equal(t, false, stubbed.IsInfinite())
-
 	_, err = PublicKeyFromBytes(bytes.Repeat([]byte{0x22}, 48))
-	require.NotNil(t, err, "the spec's STUB_PUBKEY is not a valid key")
+	require.NotNil(t, err, "the spec's unused STUB_PUBKEY is not a valid key")
 	_, err = PublicKeyFromBytes(common.InfinitePublicKey[:])
 	require.Equal(t, common.ErrInfinitePubKey, err)
 }

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -114,7 +114,6 @@ func runTest(t *testing.T, config string, fork int, basePath string, fcr bool) {
 					require.NoError(t, utils.UnmarshalYaml(metaFile, meta))
 					if meta.BlsSetting == 2 {
 						builder.service.DisableBlockSignatureVerificationForTesting()
-						utils.StubPubkeyAggregation(t)
 					}
 				}
 

--- a/testing/spectest/utils/BUILD.bazel
+++ b/testing/spectest/utils/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//build/bazel:go_default_library",
         "//config/params:go_default_library",
-        "//crypto/bls:go_default_library",  # keep
         "//io/file:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",

--- a/testing/spectest/utils/crypto_fake.go
+++ b/testing/spectest/utils/crypto_fake.go
@@ -2,16 +2,5 @@
 
 package utils
 
-import (
-	"testing"
-
-	"github.com/OffchainLabs/prysm/v7/crypto/bls"
-)
-
 // FakeCrypto reports whether this binary was built with the fake BLS backend.
 const FakeCrypto = true
-
-func StubPubkeyAggregation(t testing.TB) {
-	bls.SetStubPubkeyAggregation(true)
-	t.Cleanup(func() { bls.SetStubPubkeyAggregation(false) })
-}

--- a/testing/spectest/utils/crypto_real.go
+++ b/testing/spectest/utils/crypto_real.go
@@ -2,9 +2,5 @@
 
 package utils
 
-import "testing"
-
 // FakeCrypto reports whether this binary was built with the fake BLS backend.
 const FakeCrypto = false
-
-func StubPubkeyAggregation(_ testing.TB) {}


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

## Goal

Currently, FCR spectests are red in the `develop` branch. For non-gloas, there are 34 tests are failing, and for gloas, all FCR tests are failing. This PR makes FCR spectest green.

## Commit walkthrough

1. https://github.com/OffchainLabs/prysm/pull/17467/commits/30ecbcd636af93e2c20c4733b0d1d82c7f66ac59

This reverts commit 055ad523543c0961e516e71c2238eb0ea1eae6a5. (in #17122)

The stub aggregate pubkey only matched vectors generated before consensus-specs#5489. From v1.7.0-alpha.13 the pyspec computes real aggregate pubkeys with BLS disabled, so the stub diverges from `next_sync_committee.aggregate_pubkey` on every fast_confirmation case that crosses a sync committee period.

This unlocks two state-mismatch cases for Electra and Fulu:

- `is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot`
- `is_one_confirmed_passes_with_new_validator_activated_in_head_state`

2. https://github.com/OffchainLabs/prysm/pull/17467/commits/6b7667e9c2808df3d034aed4e46f55e046a55478

This enables `SafeBlockHash` return zero hash, which wasn't possible previously because it always falls back to unrealized justifed hash when lookup returns zero hash. This is implausible in mainnet, but with the context of spectest, it is possible as it often starts from genesis (zero hash).

This unlocks six `safe_execution_block_hash mismatch` cases from Bellatrix to Fulu:

- `fcr_no_restart_if_head_gu_is_stale`
- `fcr_no_restart_to_gu_because_gu_too_old`
- `fcr_no_restart_to_gu_mid_epoch`
- `fcr_reverts_to_finalized_when_confirmed_not_canonical_mid_epoch`
- `fcr_reverts_to_finalized_when_confirmed_too_old_lower_participation`
- `reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch`

3. https://github.com/OffchainLabs/prysm/pull/17467/commits/6172a0671e53677b10475f3b5d7ae76cbc99134d

```python
def get_safe_execution_block_hash(fcr_store: FastConfirmationStore) -> Hash32:
    safe_block = fcr_store.store.blocks[fcr_store.confirmed_root]
    # [Modified in Gloas:EIP7732]
    return safe_block.body.signed_execution_payload_bid.message.parent_block_hash
```

In Gloas, the safe execution block hash is the confirmed block's bid `parent_block_hash`. Spectests setup has a Gloas genesis with non-zero `parent_block_hash`, which Prysm currently cannot accommodate as it returns zero byte when it is the tree root node.

Add a new field in FC store (`treeRootParentHash`) that records the payload hash that tree root's bid builds on, and return it when the walk finds no full ancestor.

This makes all 184 FCR tests for Gloas pass.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
