### PR TITLE
Make fuzzer happy & Harden hdiff decoding

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,6 +39,7 @@ jobs:
           go-version-file: 'go.mod'
       - uses: shogo82148/actions-go-fuzz/run@v0
         with:
+          base-branch: develop
           packages: ${{ matrix.package }}
           fuzz-regexp: ${{ matrix.func }}
           fuzz-time: "20m"

--- a/changelog/syjn99_fuzz-fix.md
+++ b/changelog/syjn99_fuzz-fix.md
@@ -1,0 +1,9 @@
+### Ignored
+
+- Apply findings from fuzzer in hdiff: OOB error, excessive memory allocation
+- Set `base-branch` of `shogo82148/actions-go-fuzz/run` to `develop` explicitly.
+
+### Changed
+
+- Bound every length-prefixed collection count in hdiff decoding before allocation, so a corrupt diff returns an error instead of panicking.
+- Check malformed snappy compression before decompressing via `DecodedLen`, so decoder doesn't allocate implausibly excessive memory.

--- a/consensus-types/hdiff/BUILD.bazel
+++ b/consensus-types/hdiff/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "log.go",
+        "snappy.go",
         "state_diff.go",
         "state_diff_gloas.go",
     ],
@@ -41,6 +42,7 @@ go_test(
         "fuzz_test.go",
         "property_test.go",
         "security_test.go",
+        "snappy_test.go",
         "state_diff_gloas_test.go",
         "state_diff_test.go",
     ],

--- a/consensus-types/hdiff/fuzz_test.go
+++ b/consensus-types/hdiff/fuzz_test.go
@@ -113,12 +113,6 @@ func FuzzNewHdiff(f *testing.F) {
 // FuzzNewStateDiff tests the newStateDiff function with valid random state diffs
 func FuzzNewStateDiff(f *testing.F) {
 	f.Fuzz(func(t *testing.T, validatorCount uint8, slotDelta uint64, balanceData []byte, validatorData []byte) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("newStateDiff panicked: %v", r)
-			}
-		}()
-
 		// Bound validator count to reasonable range
 		validators := uint64(validatorCount%32 + 8) // 8-39 validators
 		if slotDelta > 100 {
@@ -189,12 +183,6 @@ func FuzzNewStateDiff(f *testing.F) {
 // FuzzNewValidatorDiffs tests validator diff deserialization with valid diffs
 func FuzzNewValidatorDiffs(f *testing.F) {
 	f.Fuzz(func(t *testing.T, validatorCount uint8, changeData []byte) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("newValidatorDiffs panicked: %v", r)
-			}
-		}()
-
 		// Bound validator count to reasonable range
 		validators := uint64(validatorCount%16 + 4) // 4-19 validators
 
@@ -248,12 +236,6 @@ func FuzzNewValidatorDiffs(f *testing.F) {
 // FuzzNewBalancesDiff tests balance diff deserialization with valid diffs
 func FuzzNewBalancesDiff(f *testing.F) {
 	f.Fuzz(func(t *testing.T, balanceCount uint8, balanceData []byte) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("newBalancesDiff panicked: %v", r)
-			}
-		}()
-
 		// Bound balance count to reasonable range
 		numBalances := int(balanceCount%32 + 8) // 8-39 balances
 
@@ -401,12 +383,6 @@ func FuzzReadPendingAttestation(f *testing.F) {
 	f.Add(largeLength)
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("readPendingAttestation panicked: %v", r)
-			}
-		}()
-
 		// Make a copy since the function modifies the slice
 		dataCopy := make([]byte, len(data))
 		copy(dataCopy, data)
@@ -435,12 +411,6 @@ func FuzzKmpIndex(f *testing.F) {
 	f.Add("1,1,1", "2,2,2")
 
 	f.Fuzz(func(t *testing.T, sourceStr string, targetStr string) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("kmpIndex panicked: %v", r)
-			}
-		}()
-
 		// Parse comma-separated strings into int slices
 		var source, target []int
 		if sourceStr != "" {
@@ -499,12 +469,6 @@ func FuzzComputeLPS(f *testing.F) {
 	f.Add("")
 
 	f.Fuzz(func(t *testing.T, patternStr string) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("computeLPS panicked: %v", r)
-			}
-		}()
-
 		// Parse comma-separated string into int slice
 		var pattern []int
 		if patternStr != "" {
@@ -551,12 +515,6 @@ func FuzzComputeLPS(f *testing.F) {
 // FuzzDiffToBalances tests balance diff computation
 func FuzzDiffToBalances(f *testing.F) {
 	f.Fuzz(func(t *testing.T, sourceData, targetData []byte) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("diffToBalances panicked: %v", r)
-			}
-		}()
-
 		// Convert byte data to balance arrays
 		var sourceBalances, targetBalances []uint64
 
@@ -599,12 +557,6 @@ func FuzzDiffToBalances(f *testing.F) {
 // FuzzValidatorsEqual tests validator comparison
 func FuzzValidatorsEqual(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("validatorsEqual panicked: %v", r)
-			}
-		}()
-
 		// Create two validators and fuzz their fields
 		if len(data) < 16 {
 			return

--- a/consensus-types/hdiff/fuzz_test.go
+++ b/consensus-types/hdiff/fuzz_test.go
@@ -326,6 +326,14 @@ func FuzzApplyDiff(f *testing.F) {
 		}
 	}
 
+	// https://github.com/OffchainLabs/prysm/actions/runs/32725115585/job/97425742241
+	// With 15 bytes of input, it allocated 2.37GiB of memory because of snappy.Decode.
+	f.Add(
+		[]byte("\xffŽ\xbd\t\t\t\t\t\xbd\xb6\xaf\xbd\xbd0"),
+		[]byte("\xff"),
+		[]byte("p"),
+	)
+
 	f.Fuzz(func(t *testing.T, stateDiff, validatorDiffs, balancesDiff []byte) {
 		// Only test with reasonable sized inputs
 		if len(stateDiff) > 10000 || len(validatorDiffs) > 10000 || len(balancesDiff) > 10000 {

--- a/consensus-types/hdiff/fuzz_test.go
+++ b/consensus-types/hdiff/fuzz_test.go
@@ -136,7 +136,7 @@ func FuzzNewStateDiff(f *testing.F) {
 		if len(balanceData) >= 8 {
 			balances := target.Balances()
 			numChanges := int(binary.LittleEndian.Uint64(balanceData[:8])) % len(balances)
-			for i := 0; i < numChanges && i*8+8 < len(balanceData); i++ {
+			for i := 0; i < numChanges && (i+2)*8 <= len(balanceData); i++ {
 				idx := i % len(balances)
 				delta := int64(binary.LittleEndian.Uint64(balanceData[i*8+8 : (i+1)*8+8]))
 				// Keep delta reasonable
@@ -266,7 +266,7 @@ func FuzzNewBalancesDiff(f *testing.F) {
 			balances := target.Balances()
 			numChanges := int(binary.LittleEndian.Uint64(balanceData[:8])) % numBalances
 
-			for i := 0; i < numChanges && i*8+8 < len(balanceData); i++ {
+			for i := 0; i < numChanges && (i+2)*8 <= len(balanceData); i++ {
 				idx := i % numBalances
 				delta := int64(binary.LittleEndian.Uint64(balanceData[i*8+8 : (i+1)*8+8]))
 				// Keep delta reasonable

--- a/consensus-types/hdiff/fuzz_test.go
+++ b/consensus-types/hdiff/fuzz_test.go
@@ -11,14 +11,21 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 )
 
-const maxFuzzValidators = 10000
-const maxFuzzStateDiffSize = 1000
-const maxFuzzHistoricalRoots = 10000
-const maxFuzzDecodedSize = maxFuzzStateDiffSize * 10
-const maxFuzzScanRange = 200
-const fuzzRootsLengthOffset = 16
-const maxFuzzInputSize = 10
-const oneEthInGwei = 1000000000
+const (
+	oneEthInGwei = 1000000000
+	// Caps the StateDiff decode buffer at 8 MiB (= 256KiB * 32) via snappyDecode.
+	maxFuzzStateDiffSize = 256 << 10
+)
+
+// snappyBombSeed is a 15-byte StateDiff whose snappy header declares 2.37 GiB of decoded data.
+// https://github.com/OffchainLabs/prysm/actions/runs/32725115585/job/97425742241
+// Kept as hex escapes: bytes 2-3 were once written as the literal character U+017D, which
+// only happens to be \xc5\xbd while the file stays UTF-8.
+var snappyBombSeed = [][]byte{
+	[]byte("\xff\xc5\xbd\xbd\t\t\t\t\t\xbd\xb6\xaf\xbd\xbd0"),
+	[]byte("\xff"),
+	[]byte("p"),
+}
 
 // FuzzNewHdiff tests parsing variations of realistic diffs
 func FuzzNewHdiff(f *testing.F) {
@@ -65,37 +72,12 @@ func FuzzNewHdiff(f *testing.F) {
 			}
 		}
 	}
+	f.Add(snappyBombSeed[0], snappyBombSeed[1], snappyBombSeed[2])
 
 	f.Fuzz(func(t *testing.T, stateDiff, validatorDiffs, balancesDiff []byte) {
 		// Limit input sizes to reasonable bounds
-		if len(stateDiff) > 5000 || len(validatorDiffs) > 5000 || len(balancesDiff) > 5000 {
+		if len(stateDiff) > maxFuzzStateDiffSize || len(validatorDiffs) > 5000 || len(balancesDiff) > 5000 {
 			return
-		}
-
-		// Bound historical roots length in stateDiff (if it contains snappy-compressed data)
-		// The historicalRootsLength is read after snappy decompression, but we can still
-		// limit the compressed input size to prevent extreme decompression ratios
-		if len(stateDiff) > maxFuzzStateDiffSize {
-			// Limit stateDiff to prevent potential memory bombs from snappy decompression
-			stateDiff = stateDiff[:maxFuzzStateDiffSize]
-		}
-
-		// Bound validator count in validatorDiffs
-		if len(validatorDiffs) >= 8 {
-			count := binary.LittleEndian.Uint64(validatorDiffs[0:8])
-			if count >= maxFuzzValidators {
-				boundedCount := count % maxFuzzValidators
-				binary.LittleEndian.PutUint64(validatorDiffs[0:8], boundedCount)
-			}
-		}
-
-		// Bound balance count in balancesDiff
-		if len(balancesDiff) >= 8 {
-			count := binary.LittleEndian.Uint64(balancesDiff[0:8])
-			if count >= maxFuzzValidators {
-				boundedCount := count % maxFuzzValidators
-				binary.LittleEndian.PutUint64(balancesDiff[0:8], boundedCount)
-			}
 		}
 
 		input := HdiffBytes{
@@ -316,51 +298,22 @@ func FuzzApplyDiff(f *testing.F) {
 		}
 
 		for _, scenario := range scenarios {
-			testTarget := source.Copy()
+			target = source.Copy()
 			scenario()
 
-			validDiff, err := Diff(source, testTarget)
+			validDiff, err := Diff(source, target)
 			if err == nil {
 				f.Add(validDiff.StateDiff, validDiff.ValidatorDiffs, validDiff.BalancesDiff)
 			}
 		}
 	}
 
-	// https://github.com/OffchainLabs/prysm/actions/runs/32725115585/job/97425742241
-	// With 15 bytes of input, it allocated 2.37GiB of memory because of snappy.Decode.
-	f.Add(
-		[]byte("\xffŽ\xbd\t\t\t\t\t\xbd\xb6\xaf\xbd\xbd0"),
-		[]byte("\xff"),
-		[]byte("p"),
-	)
+	f.Add(snappyBombSeed[0], snappyBombSeed[1], snappyBombSeed[2])
 
 	f.Fuzz(func(t *testing.T, stateDiff, validatorDiffs, balancesDiff []byte) {
 		// Only test with reasonable sized inputs
-		if len(stateDiff) > 10000 || len(validatorDiffs) > 10000 || len(balancesDiff) > 10000 {
+		if len(stateDiff) > maxFuzzStateDiffSize || len(validatorDiffs) > 10000 || len(balancesDiff) > 10000 {
 			return
-		}
-
-		// Bound historical roots length in stateDiff (same as FuzzNewHdiff)
-		if len(stateDiff) > maxFuzzStateDiffSize {
-			stateDiff = stateDiff[:maxFuzzStateDiffSize]
-		}
-
-		// Bound validator count in validatorDiffs
-		if len(validatorDiffs) >= 8 {
-			count := binary.LittleEndian.Uint64(validatorDiffs[0:8])
-			if count >= maxFuzzValidators {
-				boundedCount := count % maxFuzzValidators
-				binary.LittleEndian.PutUint64(validatorDiffs[0:8], boundedCount)
-			}
-		}
-
-		// Bound balance count in balancesDiff
-		if len(balancesDiff) >= 8 {
-			count := binary.LittleEndian.Uint64(balancesDiff[0:8])
-			if count >= maxFuzzValidators {
-				boundedCount := count % maxFuzzValidators
-				binary.LittleEndian.PutUint64(balancesDiff[0:8], boundedCount)
-			}
 		}
 
 		// Create fresh source state for each test
@@ -391,22 +344,7 @@ func FuzzReadPendingAttestation(f *testing.F) {
 	f.Add(largeLength)
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		// Make a copy since the function modifies the slice
-		dataCopy := make([]byte, len(data))
-		copy(dataCopy, data)
-
-		// Bound the bits length by modifying the first 8 bytes if they exist
-		if len(dataCopy) >= 8 {
-			// Read the bits length and bound it to maxFuzzValidators
-			bitsLength := binary.LittleEndian.Uint64(dataCopy[0:8])
-			if bitsLength >= maxFuzzValidators {
-				boundedLength := bitsLength % maxFuzzValidators
-				binary.LittleEndian.PutUint64(dataCopy[0:8], boundedLength)
-			}
-		}
-
-		_, err := readPendingAttestation(&dataCopy)
-		_ = err
+		_, _ = readPendingAttestation(&data)
 	})
 }
 

--- a/consensus-types/hdiff/security_test.go
+++ b/consensus-types/hdiff/security_test.go
@@ -3,11 +3,14 @@ package hdiff
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"runtime"
 	"sync"
 	"testing"
 	"time"
 
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/golang/snappy"
@@ -395,6 +398,7 @@ func TestOversizedLengthFields(t *testing.T) {
 	// Keep a regressed decoder's allocation bounded while exceeding the 1 MiB budget.
 	binary.LittleEndian.PutUint64(hugeCount, 1<<18)
 	s := &stateDiff{}
+	gloas := func(b []byte) error { return s.readGloasFields(&b) }
 	cases := []struct {
 		name    string
 		decode  func([]byte) error
@@ -405,6 +409,13 @@ func TestOversizedLengthFields(t *testing.T) {
 		{"validator_diffs_count", func(b []byte) error { _, err := newValidatorDiffs(b); return err }, snappy.Encode(nil, hugeCount), errDataSmall},
 		{"previous_epoch_attestations_count", func(b []byte) error { return s.readPreviousEpochAttestations(&b) }, hugeCount, errDataSmall},
 		{"current_epoch_attestations_count", func(b []byte) error { return s.readCurrentEpochAttestations(&b) }, hugeCount, errDataSmall},
+		// Gloas collections live inside one reader, so feed a valid prefix up to each count. The counts
+		// below are positive as int but make count*elementSize negative, which used to slip past
+		// `len < count*size` and reach make(). ptcWindow had no bound at all, so any large count works.
+		{"gloas_builder_diffs_count", gloas, gloasCollectionInput(t, "builderDiffs", math.MaxInt64/(4+builderLength)+1), errDataSmall},
+		{"gloas_builder_pending_withdrawals_count", gloas, gloasCollectionInput(t, "builderPendingWithdrawals", math.MaxInt64/builderPendingWithdrawalLength+1), errDataSmall},
+		{"gloas_payload_expected_withdrawals_count", gloas, gloasCollectionInput(t, "payloadExpectedWithdrawals", math.MaxInt64/withdrawalLength+1), errDataSmall},
+		{"gloas_ptc_window_count", gloas, gloasCollectionInput(t, "ptcWindow", 1<<18), errDataSmall},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -423,12 +434,21 @@ func TestCollectionCountBoundaries(t *testing.T) {
 	s := &stateDiff{}
 	for _, decoder := range []struct {
 		name        string
+		prefix      []byte // bytes the reader consumes before the count
 		elementSize int
 		decode      func([]byte) error
 	}{
-		{"validator_diffs", minValidatorDiffSize, func(b []byte) error { _, err := newValidatorDiffs(snappy.Encode(nil, b)); return err }},
-		{"previous_epoch_attestations", pendingAttestationFixedSize, func(b []byte) error { return s.readPreviousEpochAttestations(&b) }},
-		{"current_epoch_attestations", pendingAttestationFixedSize, func(b []byte) error { return s.readCurrentEpochAttestations(&b) }},
+		{"historical_roots", nil, fieldparams.RootLength, func(b []byte) error { return s.readHistoricalRoots(&b) }},
+		{"eth1_data_votes", []byte{nilMarker}, eth1DataLength, func(b []byte) error { return s.readEth1DataVotes(&b) }},
+		{"previous_epoch_attestations", nil, pendingAttestationFixedSize, func(b []byte) error { return s.readPreviousEpochAttestations(&b) }},
+		{"current_epoch_attestations", nil, pendingAttestationFixedSize, func(b []byte) error { return s.readCurrentEpochAttestations(&b) }},
+		{"inactivity_scores", nil, 8, func(b []byte) error { return s.readInactivityScores(&b) }},
+		{"historical_summaries", nil, 2 * fieldparams.RootLength, func(b []byte) error { return s.readHistoricalSummaries(&b) }},
+		{"pending_deposits", make([]byte, 8), pendingDepositLength, func(b []byte) error { return s.readPendingDeposits(&b) }},
+		{"pending_partial_withdrawals", make([]byte, 8), pendingPartialWithdrawalLength, func(b []byte) error { return s.readPendingPartialWithdrawals(&b) }},
+		{"pending_consolidations", make([]byte, 8), pendingConsolidationLength, func(b []byte) error { return s.readPendingConsolidations(&b) }},
+		{"validator_diffs", nil, minValidatorDiffSize, func(b []byte) error { _, err := newValidatorDiffs(snappy.Encode(nil, b)); return err }},
+		{"balances_diff", nil, 8, func(b []byte) error { _, err := newBalancesDiff(snappy.Encode(nil, b)); return err }},
 	} {
 		t.Run(decoder.name, func(t *testing.T) {
 			for _, tc := range []struct {
@@ -444,13 +464,39 @@ func TestCollectionCountBoundaries(t *testing.T) {
 				{"one_byte_short", 1, decoder.elementSize - 1, errDataSmall},
 				{"count_exceeds_payload", 2, decoder.elementSize, errDataSmall},
 				{"max_uint64", ^uint64(0), 0, errDataSmall},
+				// Positive as int, but count*elementSize overflows to a negative int for every element size.
+				{"count_times_size_overflows", math.MaxInt64/uint64(decoder.elementSize) + 1, 0, errDataSmall},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
-					input := make([]byte, 8+tc.payloadSize)
-					binary.LittleEndian.PutUint64(input, tc.count)
+					input := make([]byte, len(decoder.prefix)+8+tc.payloadSize)
+					copy(input, decoder.prefix)
+					binary.LittleEndian.PutUint64(input[len(decoder.prefix):], tc.count)
 					require.ErrorIs(t, decoder.decode(input), tc.wantErr)
 				})
 			}
 		})
 	}
+}
+
+// gloasCollectionInput serializes the Gloas section up to the named collection and writes count as its length field.
+func gloasCollectionInput(t *testing.T, collection string, count uint64) []byte {
+	bid, err := util.HydrateExecutionPayloadBid(&ethpb.ExecutionPayloadBid{}).MarshalSSZ()
+	require.NoError(t, err)
+	u64 := func(v uint64) []byte { return binary.LittleEndian.AppendUint64(nil, v) }
+	b := append(u64(uint64(len(bid))), bid...)
+	if collection != "builderDiffs" {
+		b = append(b, u64(0)...)                                           // builderDiffs count
+		b = append(b, u64(0)...)                                           // nextWithdrawalBuilderIndex
+		b = append(b, make([]byte, executionPayloadAvailabilityLength)...) // executionPayloadAvailability
+		b = append(b, make([]byte, builderPendingPaymentsTotalLength)...)  // builderPendingPayments
+		b = append(b, u64(0)...)                                           // builderPendingWithdrawalsIndex
+	}
+	if collection != "builderDiffs" && collection != "builderPendingWithdrawals" {
+		b = append(b, u64(0)...)                               // builderPendingWithdrawals count
+		b = append(b, make([]byte, fieldparams.RootLength)...) // latestBlockHash
+	}
+	if collection == "ptcWindow" {
+		b = append(b, u64(0)...) // payloadExpectedWithdrawals count
+	}
+	return append(b, u64(count)...)
 }

--- a/consensus-types/hdiff/security_test.go
+++ b/consensus-types/hdiff/security_test.go
@@ -2,12 +2,14 @@ package hdiff
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/golang/snappy"
 )
 
 // TestIntegerOverflowProtection tests protection against balance overflow attacks
@@ -384,4 +386,26 @@ func TestConcurrencySafety(t *testing.T) {
 			t.Error(err)
 		}
 	})
+}
+
+func TestOversizedLengthFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		decode  func([]byte) error
+		input   []byte
+		wantErr error
+	}{
+		{"snappy_header_4GiB", func(b []byte) error { _, err := newStateDiff(b); return err }, []byte{0xff, 0xff, 0xff, 0xff, 0x0f, 0x00}, snappy.ErrCorrupt},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			err := tc.decode(tc.input)
+			runtime.ReadMemStats(&after)
+			require.ErrorIs(t, err, tc.wantErr)
+			allocated := after.TotalAlloc - before.TotalAlloc
+			require.Equal(t, true, allocated < 1<<20, "allocated %d bytes for a %d-byte input", allocated, len(tc.input))
+		})
+	}
 }

--- a/consensus-types/hdiff/security_test.go
+++ b/consensus-types/hdiff/security_test.go
@@ -1,6 +1,7 @@
 package hdiff
 
 import (
+	"encoding/binary"
 	"fmt"
 	"runtime"
 	"sync"
@@ -389,6 +390,11 @@ func TestConcurrencySafety(t *testing.T) {
 }
 
 func TestOversizedLengthFields(t *testing.T) {
+	hugeCount := make([]byte, 8)
+
+	// Keep a regressed decoder's allocation bounded while exceeding the 1 MiB budget.
+	binary.LittleEndian.PutUint64(hugeCount, 1<<18)
+	s := &stateDiff{}
 	cases := []struct {
 		name    string
 		decode  func([]byte) error
@@ -396,6 +402,9 @@ func TestOversizedLengthFields(t *testing.T) {
 		wantErr error
 	}{
 		{"snappy_header_4GiB", func(b []byte) error { _, err := newStateDiff(b); return err }, []byte{0xff, 0xff, 0xff, 0xff, 0x0f, 0x00}, snappy.ErrCorrupt},
+		{"validator_diffs_count", func(b []byte) error { _, err := newValidatorDiffs(b); return err }, snappy.Encode(nil, hugeCount), errDataSmall},
+		{"previous_epoch_attestations_count", func(b []byte) error { return s.readPreviousEpochAttestations(&b) }, hugeCount, errDataSmall},
+		{"current_epoch_attestations_count", func(b []byte) error { return s.readCurrentEpochAttestations(&b) }, hugeCount, errDataSmall},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -406,6 +415,42 @@ func TestOversizedLengthFields(t *testing.T) {
 			require.ErrorIs(t, err, tc.wantErr)
 			allocated := after.TotalAlloc - before.TotalAlloc
 			require.Equal(t, true, allocated < 1<<20, "allocated %d bytes for a %d-byte input", allocated, len(tc.input))
+		})
+	}
+}
+
+func TestCollectionCountBoundaries(t *testing.T) {
+	s := &stateDiff{}
+	for _, decoder := range []struct {
+		name        string
+		elementSize int
+		decode      func([]byte) error
+	}{
+		{"validator_diffs", minValidatorDiffSize, func(b []byte) error { _, err := newValidatorDiffs(snappy.Encode(nil, b)); return err }},
+		{"previous_epoch_attestations", pendingAttestationFixedSize, func(b []byte) error { return s.readPreviousEpochAttestations(&b) }},
+		{"current_epoch_attestations", pendingAttestationFixedSize, func(b []byte) error { return s.readCurrentEpochAttestations(&b) }},
+	} {
+		t.Run(decoder.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name        string
+				count       uint64
+				payloadSize int
+				wantErr     error
+			}{
+				{"empty", 0, 0, nil},
+				{"one_element", 1, decoder.elementSize, nil},
+				{"two_elements", 2, 2 * decoder.elementSize, nil},
+				{"missing_element", 1, 0, errDataSmall},
+				{"one_byte_short", 1, decoder.elementSize - 1, errDataSmall},
+				{"count_exceeds_payload", 2, decoder.elementSize, errDataSmall},
+				{"max_uint64", ^uint64(0), 0, errDataSmall},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					input := make([]byte, 8+tc.payloadSize)
+					binary.LittleEndian.PutUint64(input, tc.count)
+					require.ErrorIs(t, decoder.decode(input), tc.wantErr)
+				})
+			}
 		})
 	}
 }

--- a/consensus-types/hdiff/snappy.go
+++ b/consensus-types/hdiff/snappy.go
@@ -1,0 +1,25 @@
+package hdiff
+
+import (
+	"fmt"
+
+	"github.com/golang/snappy"
+)
+
+// snappyDecode rejects impossible decoded lengths before allocation.
+func snappyDecode(input []byte) ([]byte, error) {
+	n, err := snappy.DecodedLen(input)
+	if err != nil {
+		return nil, fmt.Errorf("get decoded length: %w", err)
+	}
+
+	// NOTE: 32 is a safety margin to prevent excessive memory allocation.
+	// In theory, a valid snappy block can expand at most 64/3x its compressed size.
+	// See 2.2.2. in:
+	// https://github.com/google/snappy/blob/main/format_description.txt#L88-L111
+	if n > 32*len(input) {
+		return nil, snappy.ErrCorrupt
+	}
+
+	return snappy.Decode(nil, input)
+}

--- a/consensus-types/hdiff/snappy_test.go
+++ b/consensus-types/hdiff/snappy_test.go
@@ -1,0 +1,70 @@
+package hdiff
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/golang/snappy"
+)
+
+func TestSnappyDecode(t *testing.T) {
+	t.Run("valid cases", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			data []byte
+		}{
+			{"empty", nil},
+			{"ordinary", []byte("state diff")},
+			{"high_compression", bytes.Repeat([]byte{0}, 1<<16)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				decoded, err := snappyDecode(snappy.Encode(nil, tc.data))
+				require.NoError(t, err)
+				require.Equal(t, true, bytes.Equal(tc.data, decoded))
+			})
+		}
+	})
+
+	t.Run("invalid cases", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			input []byte
+		}{
+			{"missing_header", nil},
+			{"truncated_header", []byte{0x80}},
+			{"overflowing_header", []byte{0xff, 0xff, 0xff, 0xff, 0x1f}},
+			{"truncated_literal", []byte{1, 0}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				decoded, err := snappyDecode(tc.input)
+				require.ErrorIs(t, err, snappy.ErrCorrupt)
+				require.Equal(t, 0, len(decoded))
+			})
+		}
+	})
+
+	t.Run("reject before allocation", func(t *testing.T) {
+		input := []byte{0x80, 0x80, 0x40} // Declares 1 MiB of decoded data with no body.
+		var err error
+		allocations := testing.AllocsPerRun(1, func() {
+			_, err = snappyDecode(input)
+		})
+		require.ErrorIs(t, err, snappy.ErrCorrupt)
+		require.Equal(t, float64(0), allocations)
+	})
+
+	t.Run("ratio boundary", func(t *testing.T) {
+		// Both inputs are 4 bytes with a corrupt body; only the declared decoded length differs.
+		// 32*4 must reach snappy.Decode (which allocates), 32*4+1 must be rejected before allocation.
+		atLimit := []byte{0x80, 0x01, 0, 0}   // declares 128 decoded bytes
+		overLimit := []byte{0x81, 0x01, 0, 0} // declares 129 decoded bytes
+		var atLimitErr, overLimitErr error
+		atLimitAllocs := testing.AllocsPerRun(1, func() { _, atLimitErr = snappyDecode(atLimit) })
+		overLimitAllocs := testing.AllocsPerRun(1, func() { _, overLimitErr = snappyDecode(overLimit) })
+		require.ErrorIs(t, atLimitErr, snappy.ErrCorrupt)
+		require.NotEqual(t, float64(0), atLimitAllocs, "n == 32*len(input) must not be rejected by the ratio check")
+		require.ErrorIs(t, overLimitErr, snappy.ErrCorrupt)
+		require.Equal(t, float64(0), overLimitAllocs, "n == 32*len(input)+1 must be rejected before allocation")
+	})
+}

--- a/consensus-types/hdiff/state_diff.go
+++ b/consensus-types/hdiff/state_diff.go
@@ -309,7 +309,7 @@ func (ret *stateDiff) readHistoricalRoots(data *[]byte) error {
 	}
 	historicalRootsLength := int(binary.LittleEndian.Uint64((*data)[:8])) // lint:ignore uintcast
 	(*data) = (*data)[8:]
-	if len(*data) < historicalRootsLength*fieldparams.RootLength {
+	if historicalRootsLength < 0 || historicalRootsLength > len(*data)/fieldparams.RootLength {
 		return errors.Wrap(errDataSmall, "historicalRoots")
 	}
 	ret.historicalRoots = make([][fieldparams.RootLength]byte, historicalRootsLength)
@@ -348,7 +348,7 @@ func (ret *stateDiff) readEth1DataVotes(data *[]byte) error {
 	}
 	ret.eth1VotesAppend = ((*data)[0] == nilMarker)
 	eth1DataVotesLength := int(binary.LittleEndian.Uint64((*data)[1 : 1+8])) // lint:ignore uintcast
-	if len(*data) < 1+8+eth1DataVotesLength*eth1DataLength {
+	if eth1DataVotesLength < 0 || eth1DataVotesLength > (len(*data)-9)/eth1DataLength {
 		return errors.Wrap(errDataSmall, "eth1DataVotes")
 	}
 	ret.eth1DataVotes = make([]*ethpb.Eth1Data, eth1DataVotesLength)
@@ -554,7 +554,7 @@ func (ret *stateDiff) readInactivityScores(data *[]byte) error {
 	if inactivityScoresLength < 0 {
 		return errors.Wrap(errDataSmall, "inactivityScores: negative length")
 	}
-	if len(*data)-8 < inactivityScoresLength*8 {
+	if inactivityScoresLength > (len(*data)-8)/8 {
 		return errors.Wrap(errDataSmall, "inactivityScores")
 	}
 	ret.inactivityScores = make([]uint64, inactivityScoresLength)
@@ -672,7 +672,7 @@ func (ret *stateDiff) readHistoricalSummaries(data *[]byte) error {
 	if historicalSummariesLength < 0 {
 		return errors.Wrap(errDataSmall, "historicalSummaries: negative length")
 	}
-	if len(*data) < 8+historicalSummariesLength*fieldparams.RootLength*2 {
+	if historicalSummariesLength > (len(*data)-8)/(2*fieldparams.RootLength) {
 		return errors.Wrap(errDataSmall, "historicalSummaries")
 	}
 	ret.historicalSummaries = make([]*ethpb.HistoricalSummary, historicalSummariesLength)
@@ -711,7 +711,7 @@ func (ret *stateDiff) readPendingDeposits(data *[]byte) error {
 	if pendingDepositDiffLength < 0 {
 		return errors.Wrap(errDataSmall, "pendingDeposits: negative length")
 	}
-	if len(*data) < 16+pendingDepositDiffLength*pendingDepositLength {
+	if pendingDepositDiffLength > (len(*data)-16)/pendingDepositLength {
 		return errors.Wrap(errDataSmall, "pendingDepositDiff")
 	}
 	ret.pendingDepositDiff = make([]*ethpb.PendingDeposit, pendingDepositDiffLength)
@@ -739,7 +739,7 @@ func (ret *stateDiff) readPendingPartialWithdrawals(data *[]byte) error {
 	if pendingPartialWithdrawalsDiffLength < 0 {
 		return errors.Wrap(errDataSmall, "pendingPartialWithdrawals: negative length")
 	}
-	if len(*data) < 16+pendingPartialWithdrawalsDiffLength*pendingPartialWithdrawalLength {
+	if pendingPartialWithdrawalsDiffLength > (len(*data)-16)/pendingPartialWithdrawalLength {
 		return errors.Wrap(errDataSmall, "pendingPartialWithdrawalsDiff")
 	}
 	ret.pendingPartialWithdrawalsDiff = make([]*ethpb.PendingPartialWithdrawal, pendingPartialWithdrawalsDiffLength)
@@ -765,7 +765,7 @@ func (ret *stateDiff) readPendingConsolidations(data *[]byte) error {
 	if pendingConsolidationsDiffsLength < 0 {
 		return errors.Wrap(errDataSmall, "pendingConsolidations: negative length")
 	}
-	if len(*data) < 16+pendingConsolidationsDiffsLength*pendingConsolidationLength {
+	if pendingConsolidationsDiffsLength > (len(*data)-16)/pendingConsolidationLength {
 		return errors.Wrap(errDataSmall, "pendingConsolidationsDiffs")
 	}
 	ret.pendingConsolidationsDiffs = make([]*ethpb.PendingConsolidation, pendingConsolidationsDiffsLength)
@@ -1006,8 +1006,8 @@ func newBalancesDiff(input []byte) ([]int64, error) {
 		return nil, errors.Wrap(errDataSmall, "balancesDiff")
 	}
 	balancesLength := int(binary.LittleEndian.Uint64(data[:8])) // lint:ignore uintcast
-	if balancesLength < 0 {
-		return nil, errors.Wrap(errDataSmall, "balancesDiff: negative length")
+	if balancesLength < 0 || balancesLength > (len(data)-8)/8 {
+		return nil, errors.Wrap(errDataSmall, "balancesDiff")
 	}
 	if len(data) != 8+balancesLength*8 {
 		return nil, errors.Errorf("incorrect length of balancesDiff, expected %d, got %d", 8+balancesLength*8, len(data))

--- a/consensus-types/hdiff/state_diff.go
+++ b/consensus-types/hdiff/state_diff.go
@@ -787,7 +787,7 @@ func (ret *stateDiff) readProposerLookahead(data *[]byte) error {
 
 // newStateDiff deserializes a new stateDiff object from the given data.
 func newStateDiff(input []byte) (*stateDiff, error) {
-	data, err := snappy.Decode(nil, input)
+	data, err := snappyDecode(input)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode snappy")
 	}
@@ -906,7 +906,7 @@ func newStateDiff(input []byte) (*stateDiff, error) {
 
 // newValidatorDiffs deserializes a new validator diffs from the given data.
 func newValidatorDiffs(input []byte) ([]validatorDiff, error) {
-	data, err := snappy.Decode(nil, input)
+	data, err := snappyDecode(input)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode snappy")
 	}
@@ -984,7 +984,7 @@ func newValidatorDiffs(input []byte) ([]validatorDiff, error) {
 
 // newBalancesDiff deserializes a new balances diff from the given data.
 func newBalancesDiff(input []byte) ([]int64, error) {
-	data, err := snappy.Decode(nil, input)
+	data, err := snappyDecode(input)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode snappy")
 	}

--- a/consensus-types/hdiff/state_diff.go
+++ b/consensus-types/hdiff/state_diff.go
@@ -151,6 +151,15 @@ type hdiff struct {
 	balancesDiff   []int64
 }
 
+// minValidatorDiffSize is the serialized size of a validatorDiff with nil PublicKey and WithdrawalCredentials.
+// - index: 4 bytes
+// - PublicKey: 1 byte (nil marker)
+// - WithdrawalCredentials: 1 byte (nil marker)
+// - EffectiveBalance: 8 bytes
+// - Slashed: 1 byte
+// - ActivationEpoch: 4*8 bytes (4 fields of 8 bytes each)
+const minValidatorDiffSize = 4 + 1 + 1 + 8 + 1 + 4*8
+
 // validatorDiff is a type that represents a difference between two validators.
 type validatorDiff struct {
 	Slashed                    bool             // new value (here because of alignement)
@@ -391,6 +400,9 @@ func (ret *stateDiff) readSlashings(data *[]byte) error {
 	return nil
 }
 
+// pendingAttestationFixedSize is 8 (bits length field) + 128 (AttestationData) + 16 (inclusion delay, proposer index).
+const pendingAttestationFixedSize = 152
+
 func readPendingAttestation(data *[]byte) (*ethpb.PendingAttestation, error) {
 	if len(*data) < 8 {
 		return nil, errors.Wrap(errDataSmall, "pendingAttestation")
@@ -399,9 +411,7 @@ func readPendingAttestation(data *[]byte) (*ethpb.PendingAttestation, error) {
 	if bitsLength < 0 {
 		return nil, errors.Wrap(errDataSmall, "pendingAttestation: negative bitsLength")
 	}
-	// Check for integer overflow: 8 + bitsLength + 144
-	const fixedSize = 152 // 8 (length field) + 144 (fixed fields)
-	if bitsLength > len(*data)-fixedSize {
+	if bitsLength > len(*data)-pendingAttestationFixedSize {
 		return nil, errors.Wrap(errDataSmall, "pendingAttestation")
 	}
 	pending := &ethpb.PendingAttestation{}
@@ -422,8 +432,8 @@ func (ret *stateDiff) readPreviousEpochAttestations(data *[]byte) error {
 		return errors.Wrap(errDataSmall, "previousEpochAttestations")
 	}
 	previousEpochAttestationsLength := int(binary.LittleEndian.Uint64((*data)[:8])) // lint:ignore uintcast
-	if previousEpochAttestationsLength < 0 {
-		return errors.Wrap(errDataSmall, "previousEpochAttestations: negative length")
+	if previousEpochAttestationsLength < 0 || previousEpochAttestationsLength > (len(*data)-8)/pendingAttestationFixedSize {
+		return errors.Wrap(errDataSmall, "previousEpochAttestations")
 	}
 	ret.previousEpochAttestations = make([]*ethpb.PendingAttestation, previousEpochAttestationsLength)
 	(*data) = (*data)[8:]
@@ -442,8 +452,8 @@ func (ret *stateDiff) readCurrentEpochAttestations(data *[]byte) error {
 		return errors.Wrap(errDataSmall, "currentEpochAttestations")
 	}
 	currentEpochAttestationsLength := int(binary.LittleEndian.Uint64((*data)[:8])) // lint:ignore uintcast
-	if currentEpochAttestationsLength < 0 {
-		return errors.Wrap(errDataSmall, "currentEpochAttestations: negative length")
+	if currentEpochAttestationsLength < 0 || currentEpochAttestationsLength > (len(*data)-8)/pendingAttestationFixedSize {
+		return errors.Wrap(errDataSmall, "currentEpochAttestations")
 	}
 	ret.currentEpochAttestations = make([]*ethpb.PendingAttestation, currentEpochAttestationsLength)
 	(*data) = (*data)[8:]
@@ -916,6 +926,10 @@ func newValidatorDiffs(input []byte) ([]validatorDiff, error) {
 	}
 	validatorDiffsLength := binary.LittleEndian.Uint64(data[cursor : cursor+8])
 	cursor += 8
+	if validatorDiffsLength > uint64(len(data)-cursor)/minValidatorDiffSize {
+		return nil, errors.Wrap(errDataSmall, "validatorDiffs")
+	}
+
 	validatorDiffs := make([]validatorDiff, validatorDiffsLength)
 	for i := range validatorDiffsLength {
 		if len(data[cursor:]) < 4 {

--- a/consensus-types/hdiff/state_diff_gloas.go
+++ b/consensus-types/hdiff/state_diff_gloas.go
@@ -298,7 +298,7 @@ func (ret *stateDiff) readGloasFields(data *[]byte) error {
 	}
 	*data = (*data)[8:]
 	entrySize := 4 + builderLength // uint32 index + fixed SSZ builder
-	if len(*data) < builderDiffsCount*entrySize {
+	if builderDiffsCount > len(*data)/entrySize {
 		return errors.Wrap(errDataSmall, "builderDiffs data")
 	}
 	ret.builderDiffs = make([]builderDiff, builderDiffsCount)
@@ -350,7 +350,7 @@ func (ret *stateDiff) readGloasFields(data *[]byte) error {
 		return errors.Wrap(errDataSmall, "builderPendingWithdrawals: negative count")
 	}
 	*data = (*data)[16:]
-	if len(*data) < bpwCount*builderPendingWithdrawalLength {
+	if bpwCount > len(*data)/builderPendingWithdrawalLength {
 		return errors.Wrap(errDataSmall, "builderPendingWithdrawals data")
 	}
 	ret.builderPendingWithdrawalsDiff = make([]*ethpb.BuilderPendingWithdrawal, bpwCount)
@@ -378,7 +378,7 @@ func (ret *stateDiff) readGloasFields(data *[]byte) error {
 		return errors.Wrap(errDataSmall, "payloadExpectedWithdrawals: negative count")
 	}
 	*data = (*data)[8:]
-	if len(*data) < pewCount*withdrawalLength {
+	if pewCount > len(*data)/withdrawalLength {
 		return errors.Wrap(errDataSmall, "payloadExpectedWithdrawals data")
 	}
 	ret.payloadExpectedWithdrawals = make([]*enginev1.Withdrawal, pewCount)
@@ -399,13 +399,13 @@ func (ret *stateDiff) readGloasFields(data *[]byte) error {
 		return errors.Wrap(errDataSmall, "ptcWindow: negative count")
 	}
 	*data = (*data)[8:]
+	ptcSize := (&ethpb.PTCs{}).SizeSSZ()
+	if ptcCount > len(*data)/ptcSize {
+		return errors.Wrap(errDataSmall, "ptcWindow data")
+	}
 	ret.ptcWindow = make([]*ethpb.PTCs, ptcCount)
 	for i := range ptcCount {
 		ret.ptcWindow[i] = &ethpb.PTCs{}
-		ptcSize := ret.ptcWindow[i].SizeSSZ()
-		if len(*data) < ptcSize {
-			return errors.Wrap(errDataSmall, "ptcWindow data")
-		}
 		if err := ret.ptcWindow[i].UnmarshalSSZ((*data)[:ptcSize]); err != nil {
 			return errors.Wrap(err, "failed to unmarshal ptc window slot")
 		}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix & CI

**What does this PR do? Why is it needed?**

Our CI for fuzzing has been mostly red these days: https://github.com/OffchainLabs/prysm/actions/workflows/fuzz.yml. Most of them are complaining the out-of-bound issue that we currently have in fuzzing harness. https://github.com/OffchainLabs/prysm/pull/17470/commits/ccfc94a273206cf9ef9071683cc06204a7da2037 exactly fixes this.

Otherwise, it oftentime fails with this unknown status ([example run](https://github.com/OffchainLabs/prysm/actions/runs/32725115585/job/97425742241)):

```
  --- FAIL: FuzzApplyDiff (419.54s)
      fuzzing process hung or terminated unexpectedly: exit status 2
      Failing input written to testdata/fuzz/FuzzApplyDiff/52bafb783381e056
      To re-run:
      go test -run=FuzzApplyDiff/52bafb783381e056
```

and I (and Astra) strongly believe this was due to OOM as `snappy.Decode` will anyway allocate some crazy bytes from the fuzzed input. https://github.com/OffchainLabs/prysm/pull/17470/commits/f79bb748c6456713bfc01d34046c62b448b90ea7 uses `DecodedLen` so it **never** allocates an implausibly excessive memory, which will save our fuzzer run.

This PR also includes some hardening hdiff decoding (or reading) across few commits (https://github.com/OffchainLabs/prysm/pull/17470/commits/8bf5291cbdfcdaa81b7ce500a4460531942ea895, https://github.com/OffchainLabs/prysm/pull/17470/commits/115e550b8a0b17c93726e0becaa81cfd22318a92), including multiplication overflow.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
