### PR TITLE
Return the confirmed block's payload hash as safe hash even when it is zero

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -163,6 +163,7 @@ go_test(
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/cache/depositsnapshot:go_default_library",
+        "//beacon-chain/confirmation:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/confirmation"
 	testDB "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
@@ -151,6 +152,36 @@ func TestUnrealizedJustifiedBlockHash(t *testing.T) {
 	h := service.UnrealizedJustifiedPayloadBlockHash()
 	require.Equal(t, params.BeaconConfig().ZeroHash, h)
 	require.Equal(t, [32]byte{'j'}, service.cfg.ForkChoiceStore.JustifiedCheckpoint().Root)
+}
+
+func TestSafeBlockHash(t *testing.T) {
+	ctx := t.Context()
+	service := testServiceWithDB(t)
+	ojc := &ethpb.Checkpoint{Root: []byte{'j'}}
+	ofc := &ethpb.Checkpoint{Root: []byte{'f'}}
+	// Genesis carries a zero payload hash, the justified block a real one.
+	st, roblock, err := prepareForkchoiceState(ctx, 0, [32]byte{'g'}, [32]byte{}, params.BeaconConfig().ZeroHash, ojc, ofc)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, st, roblock))
+	st, roblock, err = prepareForkchoiceState(ctx, 1, [32]byte{'j'}, [32]byte{'g'}, [32]byte{'p'}, ojc, ofc)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, st, roblock))
+	service.cfg.ForkChoiceStore.SetBalancesByRooter(func(_ context.Context, _ [32]byte) ([]uint64, error) { return []uint64{}, nil })
+	require.NoError(t, service.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(ctx, &forkchoicetypes.Checkpoint{Epoch: 6, Root: [32]byte{'j'}}))
+	require.Equal(t, [32]byte{'p'}, service.UnrealizedJustifiedPayloadBlockHash())
+
+	t.Run("fcr disabled uses unrealized justified", func(t *testing.T) {
+		service.fcr = nil
+		require.Equal(t, [32]byte{'p'}, service.SafeBlockHash())
+	})
+	t.Run("confirmed genesis returns its zero payload hash", func(t *testing.T) {
+		service.fcr = confirmation.New(service.cfg.ForkChoiceStore, nil, nil, forkchoicetypes.Checkpoint{Root: [32]byte{'g'}})
+		require.Equal(t, params.BeaconConfig().ZeroHash, service.SafeBlockHash())
+	})
+	t.Run("pruned confirmed root falls back to unrealized justified", func(t *testing.T) {
+		service.fcr = confirmation.New(service.cfg.ForkChoiceStore, nil, nil, forkchoicetypes.Checkpoint{Root: [32]byte{'x'}})
+		require.Equal(t, [32]byte{'p'}, service.SafeBlockHash())
+	})
 }
 
 func TestHeadSlot_CanRetrieve(t *testing.T) {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -467,11 +467,9 @@ func (s *Service) SafeBlockHash() [32]byte {
 func (s *Service) safeBlockHash() [32]byte {
 	if s.fcr != nil {
 		root := s.fcr.ConfirmedRoot()
-		if root != ([32]byte{}) {
-			// The lookup can miss, for example on a pruned node, fall back to unrealized justified.
-			if hash := s.cfg.ForkChoiceStore.ConfirmedPayloadBlockHash(root); hash != ([32]byte{}) {
-				return hash
-			}
+		// A pruned confirmed root falls back to unrealized justified; a known root returns its payload hash even when zero (pre-merge).
+		if root != ([32]byte{}) && s.cfg.ForkChoiceStore.HasNode(root) {
+			return s.cfg.ForkChoiceStore.ConfirmedPayloadBlockHash(root)
 		}
 	}
 	return s.cfg.ForkChoiceStore.UnrealizedJustifiedPayloadBlockHash()

--- a/changelog/syjn99_fcr-safe-hash-genesis.md
+++ b/changelog/syjn99_fcr-safe-hash-genesis.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Return the confirmed block's payload hash as the safe execution block hash even when it is zero (pre-merge, genesis in spec tests) instead of falling back to the unrealized justified hash; the fallback now only covers a confirmed root pruned from forkchoice.


### PR DESCRIPTION

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

get_safe_execution_block_hash returns the confirmed block's execution_payload.block_hash with no fallback, so a pre-merge confirmed block (genesis in the fast_confirmation spec tests) yields the zero hash. safeBlockHash treated that zero as a forkchoice miss and answered with the unrealized justified payload hash instead. Gate the fallback on the root being absent from forkchoice and return whatever hash the node has.


**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
