### PR TITLE
Read Gloas fork-choice spectest `head.payload_status` from the head object

### DIFF
--- a/changelog/syjn99_head-payload-status-check.md
+++ b/changelog/syjn99_head-payload-status-check.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Read the Gloas fork-choice spectest `head.payload_status` check from the head object. The check silently never ran because it looked for a top-level `head_payload_status` key that the vectors no longer carry.

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -232,6 +232,15 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 		wantedRoot := common.FromHex(c.Head.Root)
 		require.Equal(t, true, bytes.Equal(wantedRoot, r), fmt.Sprintf("Roots differ. wanted %#x, got %#x", wantedRoot, r))
 		require.Equal(t, primitives.Slot(c.Head.Slot), bb.service.HeadSlot())
+		if c.Head.PayloadStatus != nil {
+			_, _, full, err := bb.fc.FullHead(ctx)
+			require.NoError(t, err)
+			got := 0
+			if full {
+				got = 1
+			}
+			require.Equal(t, *c.Head.PayloadStatus, got, "head payload status mismatch")
+		}
 	}
 	if c.JustifiedCheckPoint != nil {
 		cp := &ethpb.Checkpoint{
@@ -258,16 +267,6 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 		want := fmt.Sprintf("%#x", common.FromHex(*c.GetProposerHead))
 		got := fmt.Sprintf("%#x", bb.service.GetProposerHead())
 		require.Equal(t, want, got)
-	}
-	if c.HeadPayloadStatus != nil {
-		_, _, full, err := bb.fc.FullHead(ctx)
-		require.NoError(t, err)
-		want := *c.HeadPayloadStatus
-		got := 0
-		if full {
-			got = 1
-		}
-		require.Equal(t, want, got, "head payload status mismatch")
 	}
 	/* TODO: We need to mock the entire proposer system to be able to test this.
 	if c.ShouldOverrideFCU != nil {

--- a/testing/spectest/shared/common/forkchoice/type.go
+++ b/testing/spectest/shared/common/forkchoice/type.go
@@ -26,7 +26,6 @@ type Check struct {
 	FinalizedCheckPoint         *EpochRoot      `json:"finalized_checkpoint"`
 	GetProposerHead             *string         `json:"get_proposer_head"`
 	ShouldOverrideFCU           *ShouldOverride `json:"should_override_forkchoice_update"`
-	HeadPayloadStatus           *int            `json:"head_payload_status"`
 	PayloadTimelinessVote       *PTCVotes       `json:"payload_timeliness_vote"`
 	PayloadDataAvailabilityVote *PTCVotes       `json:"payload_data_availability_vote"`
 
@@ -50,8 +49,9 @@ type PTCVotes struct {
 }
 
 type SlotRoot struct {
-	Slot int    `json:"slot"`
-	Root string `json:"root"`
+	Slot          int    `json:"slot"`
+	Root          string `json:"root"`
+	PayloadStatus *int   `json:"payload_status"` // Gloas: 0 empty, 1 full.
 }
 
 type EpochRoot struct {


### PR DESCRIPTION
**What type of PR is this?**

> Other: Spectest

**What does this PR do? Why is it needed?**

- https://github.com/ethereum/consensus-specs/pull/5250

Since consensus-specs#5250, there's no more `head_payload_status` check in fork choice spectest. Instead, `PayloadStatus` was embeded in the head, which means we were not checking payload status (EMPTY / FULL) in the spectest.

This PR corrects this issue by embedding payload status check under `c.Head != nil` branch.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
