### PR TITLE
Skip slashed validators when weighting a new Gloas full node

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -528,6 +528,11 @@ func (f *ForkChoice) InsertPayload(pe interfaces.ROExecutionPayloadEnvelope) err
 
 func (f *ForkChoice) updateNewFullNodeWeight(fn *PayloadNode) {
 	for index, vote := range f.votes {
+		// Equivocating validators carry no weight.
+		if f.store.slashedIndices[primitives.ValidatorIndex(index)] {
+			continue
+		}
+
 		if vote.currentRoot == fn.node.root && vote.nextPayloadStatus && index < len(f.balances) {
 			fn.balance += f.balances[index]
 		}

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -2396,3 +2396,51 @@ func BenchmarkConsensusChildrenLen(b *testing.B) {
 		}
 	})
 }
+
+func TestUpdateNewFullNodeWeight_SkipsSlashed(t *testing.T) {
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	// Setup:
+	// - block at slot 1
+	// - validator 0 and 1 vote payload-present for it at slot 2 (before payload is known)
+	setupParkedVotes := func(t *testing.T) (*ForkChoice, [32]byte) {
+		f := setupGloas(t, 0, 0)
+		ctx := t.Context()
+		root := indexToHash(1)
+		st, blk, err := prepareGloasForkchoiceState(ctx, 1, root, zeroHash, indexToHash(100), zeroHash, 0, 0)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertNode(ctx, st, blk))
+		f.ProcessAttestation(ctx, []uint64{0, 1}, root, 2, true)
+		f.justifiedBalances = []uint64{100, 200}
+		require.NoError(t, f.updateBalances())
+		require.Equal(t, true, f.votes[0].currentPayloadStatus)
+		return f, root
+	}
+
+	t.Run("slashed before payload arrives", func(t *testing.T) {
+		f, root := setupParkedVotes(t)
+
+		f.InsertSlashedIndex(t.Context(), 0)
+		pe, err := prepareGloasForkchoicePayload(root)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertPayload(pe))
+
+		fn := f.store.fullNodeByRoot[root]
+		require.NotNil(t, fn)
+		assert.Equal(t, uint64(200), fn.balance)
+		assert.Equal(t, uint64(200), fn.weight)
+	})
+
+	t.Run("slashed after payload arrives", func(t *testing.T) {
+		f, root := setupParkedVotes(t)
+		pe, err := prepareGloasForkchoicePayload(root)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertPayload(pe))
+		fn := f.store.fullNodeByRoot[root]
+		require.NotNil(t, fn)
+		require.Equal(t, uint64(300), fn.balance)
+
+		f.InsertSlashedIndex(t.Context(), 0)
+		assert.Equal(t, uint64(200), fn.balance)
+	})
+}

--- a/changelog/syjn99_fc-fullnode-weight-skip-slashed.md
+++ b/changelog/syjn99_fc-fullnode-weight-skip-slashed.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fork choice: skip equivocating (slashed) validators when crediting parked payload-present votes to a newly inserted Gloas full payload node.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Found while running forkchoice compliance test (case: `attester_slashing_test_2_910865503_3`).

This can happen when 

- A validator already casts a vote
- The validator got slashed
- And then payload has arrived a bit late (`InsertPayload`)

An unit test (`"slashed before payload arrives"`) depicts this scenario.

This PR simply checks equivocated indices **before** updating the FULL node weight when payload is arrived.

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

If you want to run the test, harness is ready here:

- https://github.com/OffchainLabs/prysm/pull/17478

But there are some important notes regarding the test harness:

- I think we need to use `synctest` for deterministic test run in forkchoice runner, so #17478 will probably not merged.
- Only with this change, `attester_slashing_test_2_910865503_3` won't be passed. It needs to drop payload-present votes whose payload is not yet verified.
  - https://github.com/OffchainLabs/prysm/pull/17481

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
