### PR TITLE
Add bulk `All` iterator to multi-value slice and use it for full validator reads

### DIFF
--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -201,13 +201,11 @@ func (b *BeaconState) PublicKeys() ([][fieldparams.BLSPubkeyLength]byte, error) 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	l := b.validatorsLen()
-	res := make([][fieldparams.BLSPubkeyLength]byte, l)
-	for i := range l {
-		val, err := b.validatorsMultiValue.At(b, uint64(i))
-		if err != nil {
-			return nil, err
-		}
+	res := make([][fieldparams.BLSPubkeyLength]byte, b.validatorsLen())
+	if b.validatorsMultiValue == nil {
+		return res, nil
+	}
+	for i, val := range b.validatorsMultiValue.All(b) {
 		res[i] = val.PublicKey
 	}
 	return res, nil
@@ -235,13 +233,7 @@ func (b *BeaconState) ValidatorsReadOnlySeq() iter.Seq2[primitives.ValidatorInde
 		}
 
 		rov := new(readOnlyValidator)
-		for i := range b.validatorsMultiValue.Len(b) {
-			v, err := b.validatorsMultiValue.At(b, uint64(i))
-			if err != nil {
-				log.WithError(err).WithField("index", i).Error("Failed to get validator, should never happen")
-				return
-			}
-
+		for i, v := range b.validatorsMultiValue.All(b) {
 			rov.validator = v
 			if !yield(primitives.ValidatorIndex(i), rov) {
 				return

--- a/beacon-chain/state/state-native/getters_validator_test.go
+++ b/beacon-chain/state/state-native/getters_validator_test.go
@@ -1,6 +1,8 @@
 package state_native_test
 
 import (
+	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
@@ -160,60 +162,127 @@ func TestHasPendingBalanceToWithdraw(t *testing.T) {
 	require.Equal(t, false, ok)
 }
 
+const benchRegistrySize = 2_300_000 // ~ number of validators on mainnet at the time of writing
+
+var (
+	benchRegistryOnce     sync.Once
+	benchRegistryShared   state.BeaconState
+	benchRegistryDiverged state.BeaconState
+	benchRegistryErr      error
+)
+
+// benchRegistryStates returns two cached states holding benchRegistrySize validators each: one
+// whose registry consists purely of shared multi-value slice items, and a copy of it in which
+// every 10th validator has been updated, so that 10% of the registry resolves to individual
+// values. The latter approximates a head state that has diverged from its ancestors.
+func benchRegistryStates(b *testing.B) (sharedOnly, tenPctIndividual state.BeaconState) {
+	benchRegistryOnce.Do(func() {
+		vals := make([]*ethpb.Validator, benchRegistrySize)
+		for i := range vals {
+			pk := make([]byte, 48)
+			wc := make([]byte, 32)
+			pk[0] = byte(i)
+			vals[i] = &ethpb.Validator{
+				PublicKey:             pk,
+				WithdrawalCredentials: wc,
+				EffectiveBalance:      32_000_000_000,
+				ExitEpoch:             100,
+				ActivationEpoch:       1,
+			}
+		}
+		benchRegistryShared, benchRegistryErr = statenative.InitializeFromProtoUnsafeDeneb(&ethpb.BeaconStateDeneb{Validators: vals})
+		if benchRegistryErr != nil {
+			return
+		}
+		diverged := benchRegistryShared.Copy()
+		for i := 0; i < benchRegistrySize; i += 10 {
+			idx := primitives.ValidatorIndex(i)
+			var v *ethpb.Validator
+			v, benchRegistryErr = diverged.ValidatorAtIndex(idx)
+			if benchRegistryErr != nil {
+				return
+			}
+			v.EffectiveBalance = 31_000_000_000
+			if benchRegistryErr = diverged.UpdateValidatorAtIndex(idx, v); benchRegistryErr != nil {
+				return
+			}
+		}
+		benchRegistryDiverged = diverged
+		// Collect the sizeable setup garbage now so that it is not attributed to the first
+		// measured iterations.
+		runtime.GC()
+	})
+	require.NoError(b, benchRegistryErr)
+	return benchRegistryShared, benchRegistryDiverged
+}
+
 // BenchmarkValidatorsReadOnlySeq measures the per-validator cost of iterating the
 // registry through the ReadOnlyValidator wrapper.
+//
+// Results on an Apple M4 Pro, comparing the previous implementation (one lock acquisition
+// and At call per index) against the bulk All iterator
+// (go test -benchtime 20x -count 12, benchstat medians):
+//
+//	shared values only       per-index At 91.0 ms/op, bulk All 75.4 ms/op (-17%)
+//	10% individual values    per-index At 93.7 ms/op, bulk All 78.7 ms/op (-16%)
 func BenchmarkValidatorsReadOnlySeq(b *testing.B) {
-	const n = 2_300_000 // ~ number of validators on mainnet at the time of writing
-
-	vals := make([]*ethpb.Validator, n)
-	for i := range vals {
-		pk := make([]byte, 48)
-		wc := make([]byte, 32)
-		pk[0] = byte(i)
-		vals[i] = &ethpb.Validator{
-			PublicKey:             pk,
-			WithdrawalCredentials: wc,
-			EffectiveBalance:      32_000_000_000,
-			ExitEpoch:             100,
-			ActivationEpoch:       1,
-		}
+	sharedOnly, tenPctIndividual := benchRegistryStates(b)
+	for _, tc := range []struct {
+		name string
+		st   state.BeaconState
+	}{
+		{name: "shared values only", st: sharedOnly},
+		{name: "10% individual values", st: tenPctIndividual},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				for _, v := range tc.st.ValidatorsReadOnlySeq() {
+					_ = v.EffectiveBalance()
+				}
+			}
+		})
 	}
-	st, err := statenative.InitializeFromProtoUnsafeDeneb(&ethpb.BeaconStateDeneb{Validators: vals})
-	require.NoError(b, err)
+}
 
-	b.ReportAllocs()
-	for b.Loop() {
-		for _, v := range st.ValidatorsReadOnlySeq() {
-			_ = v.EffectiveBalance()
-		}
+// BenchmarkPublicKeys measures the cost of building the index-aligned list of every
+// validator public key.
+//
+// Results on an Apple M4 Pro, comparing the previous implementation (one lock acquisition
+// and At call per index) against the bulk All iterator
+// (go test -benchtime 20x -count 12, benchstat medians):
+//
+//	shared values only       per-index At 84.6 ms/op, bulk All 62.5 ms/op (-26%)
+//	10% individual values    per-index At 83.0 ms/op, bulk All 58.9 ms/op (-29%)
+func BenchmarkPublicKeys(b *testing.B) {
+	sharedOnly, tenPctIndividual := benchRegistryStates(b)
+	for _, tc := range []struct {
+		name string
+		st   state.BeaconState
+	}{
+		{name: "shared values only", st: sharedOnly},
+		{name: "10% individual values", st: tenPctIndividual},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				keys, err := tc.st.PublicKeys()
+				require.NoError(b, err)
+				require.Equal(b, benchRegistrySize, len(keys))
+			}
+		})
 	}
 }
 
 // BenchmarkValidatorsReadOnly measures the cost of building the full slice of read-only
 // validator wrappers returned by ValidatorsReadOnly.
 func BenchmarkValidatorsReadOnly(b *testing.B) {
-	const n = 2_300_000 // ~ number of validators on mainnet at the time of writing
-
-	vals := make([]*ethpb.Validator, n)
-	for i := range vals {
-		pk := make([]byte, 48)
-		wc := make([]byte, 32)
-		pk[0] = byte(i)
-		vals[i] = &ethpb.Validator{
-			PublicKey:             pk,
-			WithdrawalCredentials: wc,
-			EffectiveBalance:      32_000_000_000,
-			ExitEpoch:             100,
-			ActivationEpoch:       1,
-		}
-	}
-	st, err := statenative.InitializeFromProtoUnsafeDeneb(&ethpb.BeaconStateDeneb{Validators: vals})
-	require.NoError(b, err)
+	st, _ := benchRegistryStates(b)
 
 	b.ReportAllocs()
 	for b.Loop() {
 		ros := st.ValidatorsReadOnly()
-		require.Equal(b, n, len(ros))
+		require.Equal(b, benchRegistrySize, len(ros))
 	}
 }
 

--- a/changelog/satushh_mvs-bulk-read.md
+++ b/changelog/satushh_mvs-bulk-read.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Add a bulk `All` iterator to the multi-value slice container so a full read acquires the slice lock once instead of once per element.
+- Use `All` in `ValidatorsReadOnlySeq` and `PublicKeys`, speeding up full validator-registry sweeps such as epoch precompute, committee shuffling, and registry updates.

--- a/container/multi-value-slice/multi_value_slice.go
+++ b/container/multi-value-slice/multi_value_slice.go
@@ -91,6 +91,7 @@ package mvslice
 
 import (
 	"fmt"
+	"iter"
 	"slices"
 	"sync"
 
@@ -282,6 +283,53 @@ func (s *Slice[V]) At(obj Identifiable, index uint64) (V, error) {
 		}
 		var def V
 		return def, fmt.Errorf("index %d %w", index, ErrOutOfBounds)
+	}
+}
+
+// All returns an iterator over the input object's (index, value) pairs in index order.
+// It is equivalent to calling At with every index from 0 up to Len(obj)-1, but the lock is
+// acquired once for the whole iteration instead of once per item. The lock is held until
+// iteration stops, so the caller must not invoke any mutating method of the slice from
+// inside the loop.
+func (s *Slice[V]) All(obj Identifiable) iter.Seq2[uint64, V] {
+	return func(yield func(uint64, V) bool) {
+		s.lock.RLock()
+		defer s.lock.RUnlock()
+
+		for i, shared := range s.sharedItems {
+			v := shared
+			if ind, ok := s.individualItems[uint64(i)]; ok {
+				for _, ival := range ind.Values {
+					if _, found := containsId(ival.ids, obj.Id()); found {
+						v = ival.val
+						break
+					}
+				}
+			}
+			if !yield(uint64(i), v) {
+				return
+			}
+		}
+
+		sharedLen := uint64(len(s.sharedItems))
+		for i, item := range s.appendedItems {
+			found := false
+			var v V
+			for _, ival := range item.Values {
+				if _, found = containsId(ival.ids, obj.Id()); found {
+					v = ival.val
+					break
+				}
+			}
+			if !found {
+				// This is an optimization. If we didn't find an appended item at index i,
+				// then all larger indices don't have an appended item for the object either.
+				return
+			}
+			if !yield(sharedLen+uint64(i), v) {
+				return
+			}
+		}
 	}
 }
 

--- a/container/multi-value-slice/multi_value_slice_test.go
+++ b/container/multi-value-slice/multi_value_slice_test.go
@@ -167,6 +167,68 @@ func TestAt(t *testing.T) {
 	assert.ErrorContains(t, "index 8 out of bounds", err)
 }
 
+func TestAll(t *testing.T) {
+	// What we want to check:
+	// - iteration yields the same (index, value) pairs as calling At with every index up to Len
+	// - correct pairs are returned for an object without individual or appended values
+	// - iteration can be stopped early and the lock is released afterwards
+	// - a slice initialized with nil yields nothing
+
+	s := setup()
+	testCases := []struct {
+		name string
+		obj  *testObject
+	}{
+		{name: "first object", obj: &testObject{id: 1}},
+		{name: "second object", obj: &testObject{id: 2}},
+		{name: "object without individual or appended values", obj: &testObject{id: 999}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := s.Value(tc.obj)
+			collected := make([]int, 0, len(expected))
+			next := uint64(0)
+			for i, v := range s.All(tc.obj) {
+				require.Equal(t, next, i)
+				collected = append(collected, v)
+				next++
+			}
+			require.Equal(t, s.Len(tc.obj), len(collected))
+			assert.DeepEqual(t, expected, collected)
+			for i, v := range collected {
+				atValue, err := s.At(tc.obj, uint64(i))
+				require.NoError(t, err)
+				assert.Equal(t, atValue, v)
+			}
+		})
+	}
+
+	t.Run("early break releases the lock", func(t *testing.T) {
+		first := &testObject{id: 1}
+		count := 0
+		for range s.All(first) {
+			count++
+			if count == 2 {
+				break
+			}
+		}
+		assert.Equal(t, 2, count)
+		// UpdateAt takes the write lock, so this would deadlock if All kept holding the lock after the break.
+		require.NoError(t, s.UpdateAt(first, 0, 456))
+		v, err := s.At(first, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 456, v)
+	})
+
+	t.Run("nil-initialized slice", func(t *testing.T) {
+		s := &Slice[int]{}
+		s.Init(nil)
+		for range s.All(&testObject{id: 1}) {
+			t.Fatal("expected no items")
+		}
+	})
+}
+
 func TestUpdateAt(t *testing.T) {
 	// What we want to check:
 	// - shared value is updated only for the updated object, creating a new individual value (shared value remains the same)
@@ -801,6 +863,79 @@ func BenchmarkValue(b *testing.B) {
 		}
 		for b.Loop() {
 			s.Value(objs[rand.Intn(_10m)])
+		}
+	})
+}
+
+var benchSink int
+
+// BenchmarkAll compares a full read of the slice through per-index At calls against the All iterator.
+//
+// Results on an Apple M4 Pro (go test -bench BenchmarkAll -benchtime 20x -count 3, medians):
+//
+//	1,000,000 shared items via At                            6.0 ms/op, 0 allocs/op
+//	1,000,000 shared items via All                           2.3 ms/op, 0 allocs/op
+//	1,000,000 items with 100,000 individual values via At    24.4 ms/op, 0 allocs/op
+//	1,000,000 items with 100,000 individual values via All   20.8 ms/op, 0 allocs/op
+func BenchmarkAll(b *testing.B) {
+	const _1m = 1000000
+
+	b.Run("1,000,000 shared items via At", func(b *testing.B) {
+		s := &Slice[int]{}
+		s.Init(make([]int, _1m))
+		obj := &testObject{}
+		b.ReportAllocs()
+		for b.Loop() {
+			for i := range _1m {
+				v, err := s.At(obj, uint64(i))
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += v
+			}
+		}
+	})
+	b.Run("1,000,000 shared items via All", func(b *testing.B) {
+		s := &Slice[int]{}
+		s.Init(make([]int, _1m))
+		obj := &testObject{}
+		b.ReportAllocs()
+		for b.Loop() {
+			for _, v := range s.All(obj) {
+				benchSink += v
+			}
+		}
+	})
+	b.Run("1,000,000 items with 100,000 individual values via At", func(b *testing.B) {
+		s := &Slice[int]{}
+		s.Init(make([]int, _1m))
+		obj := &testObject{id: 1}
+		for i := 0; i < _1m; i += 10 {
+			s.individualItems[uint64(i)] = &MultiValueItem[int]{Values: []*Value[int]{{val: i, ids: []uint64{1}}}}
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			for i := range _1m {
+				v, err := s.At(obj, uint64(i))
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink += v
+			}
+		}
+	})
+	b.Run("1,000,000 items with 100,000 individual values via All", func(b *testing.B) {
+		s := &Slice[int]{}
+		s.Init(make([]int, _1m))
+		obj := &testObject{id: 1}
+		for i := 0; i < _1m; i += 10 {
+			s.individualItems[uint64(i)] = &MultiValueItem[int]{Values: []*Value[int]{{val: i, ids: []uint64{1}}}}
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			for _, v := range s.All(obj) {
+				benchSink += v
+			}
 		}
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Optimisation

**What does this PR do? Why is it needed?**

- Reading every element of a multi-value slice previously acquired the slice lock once per index through At; this PR adds a bulk All iterator that acquires the lock once for the entire read. 
- PublicKeys and ValidatorsReadOnlySeq now use it, speeding up full validator-registry sweeps such as epoch precompute, committee shuffling, and registry updates. 
- In the included benchmarks at mainnet scale (2.3M validators), these methods measure 16-29% faster than develop, with allocations unchanged.

**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
