### PR TITLE
Drop Gloas payload-present votes for unknown payloads in fork choice

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -88,13 +88,22 @@ func (f *ForkChoice) ProcessAttestation(ctx context.Context, validatorIndices []
 	_, span := trace.StartSpan(ctx, "doublyLinkedForkchoice.ProcessAttestation")
 	defer span.End()
 
-	// Same-slot attestations cannot vote payload present (validate_on_attestation).
 	if payloadStatus && slots.ToEpoch(slot) >= params.BeaconConfig().GloasForkEpoch {
+		// Same-slot attestations cannot vote payload present (validate_on_attestation).
 		if en, ok := f.store.emptyNodeByRoot[blockRoot]; ok && en.node != nil && en.node.slot == slot {
 			log.WithFields(logrus.Fields{
 				"slot":            slot,
 				"beaconBlockRoot": fmt.Sprintf("%#x", bytesutil.Trunc(blockRoot[:])),
 			}).Debug("Skipping same-slot payload-present attestation")
+			return
+		}
+
+		// Payload-present votes require a known payload (validate_on_attestation).
+		if _, ok := f.store.fullNodeByRoot[blockRoot]; !ok {
+			log.WithFields(logrus.Fields{
+				"slot":            slot,
+				"beaconBlockRoot": fmt.Sprintf("%#x", bytesutil.Trunc(blockRoot[:])),
+			}).Debug("Skipping payload-present attestation for unknown payload")
 			return
 		}
 	}

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -2413,11 +2413,71 @@ func TestProcessAttestation_SameSlotPayloadVote(t *testing.T) {
 	require.Equal(t, rootA, f.votes[0].nextRoot)
 	require.Equal(t, false, f.votes[0].nextPayloadStatus)
 
-	// Later-slot payload-present vote is recorded.
+	// Later-slot payload-present vote is recorded once the payload is known.
+	pe, err := prepareGloasForkchoicePayload(rootA)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
 	f.ProcessAttestation(ctx, []uint64{1}, rootA, slotA+1, true)
 	require.Equal(t, 2, len(f.votes))
 	require.Equal(t, rootA, f.votes[1].nextRoot)
 	require.Equal(t, true, f.votes[1].nextPayloadStatus)
+}
+
+func TestProcessAttestation_UnknownPayloadVote(t *testing.T) {
+	ctx := t.Context()
+	zeroHash := params.BeaconConfig().ZeroHash
+	validatorBalance := uint64(32000000000)
+	slotA := primitives.Slot(32)
+	rootA := indexToHash(1)
+
+	// setupA returns a forkchoice with block A inserted as an empty node only.
+	setupA := func(t *testing.T) *ForkChoice {
+		f := setupGloas(t, 1, 1)
+		driftGenesisTime(f, slotA, 0)
+		st, blk, err := prepareGloasForkchoiceState(ctx, slotA, rootA, zeroHash, indexToHash(100), zeroHash, 1, 1)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertNode(ctx, st, blk))
+		f.justifiedBalances = []uint64{validatorBalance, validatorBalance}
+		return f
+	}
+
+	t.Run("no full node drops the vote", func(t *testing.T) {
+		f := setupA(t)
+		// Validator 0 first votes payload-absent for A.
+		f.ProcessAttestation(ctx, []uint64{0}, rootA, slotA+1, false)
+		require.Equal(t, 1, len(f.votes))
+		before := f.votes[0]
+
+		// A later-epoch payload-present vote for A, whose payload is unknown, is not recorded.
+		f.ProcessAttestation(ctx, []uint64{0, 1}, rootA, slotA+params.BeaconConfig().SlotsPerEpoch, true)
+		require.Equal(t, 1, len(f.votes))
+		assert.DeepEqual(t, before, f.votes[0])
+		require.NoError(t, f.updateBalances())
+
+		// The envelope arriving later must not credit the dropped vote to the full node.
+		pe, err := prepareGloasForkchoicePayload(rootA)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertPayload(pe))
+		fn := f.store.fullNodeByRoot[rootA]
+		require.NotNil(t, fn)
+		assert.Equal(t, uint64(0), fn.balance)
+		assert.Equal(t, uint64(0), fn.weight)
+		assert.Equal(t, validatorBalance, f.store.emptyNodeByRoot[rootA].balance)
+	})
+
+	t.Run("full node present counts the vote", func(t *testing.T) {
+		f := setupA(t)
+		pe, err := prepareGloasForkchoicePayload(rootA)
+		require.NoError(t, err)
+		require.NoError(t, f.InsertPayload(pe))
+
+		f.ProcessAttestation(ctx, []uint64{0}, rootA, slotA+1, true)
+		require.Equal(t, 1, len(f.votes))
+		assert.Equal(t, rootA, f.votes[0].nextRoot)
+		assert.Equal(t, true, f.votes[0].nextPayloadStatus)
+		require.NoError(t, f.updateBalances())
+		assert.Equal(t, validatorBalance, f.store.fullNodeByRoot[rootA].balance)
+	})
 }
 
 // BenchmarkConsensusChildrenLen compares the older length-only use of

--- a/changelog/syjn99_fc-drop-unverified-payload-votes.md
+++ b/changelog/syjn99_fc-drop-unverified-payload-votes.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fork choice no longer counts Gloas payload-present attestations whose execution payload is unknown, matching the `is_payload_verified` check in `validate_on_attestation` (https://github.com/ethereum/consensus-specs/pull/4918).


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

This mirrors the spec change:
- https://github.com/ethereum/consensus-specs/pull/4918

which we presumably missed adding this at 

- https://github.com/OffchainLabs/prysm/pull/16357.

Even though it IGNOREs this kind of attestation through gossip path (`validateGloasCommitteeIndex`), it is required to add this filter in forkchoice attestation processing for other paths like pending attestation. This also unlocks most of the Gloas forkchoice compliance tests

**Which issue(s) does this PR fix?**

N/A

**Other notes for review**

If you want to run the test, harness is ready here:

- https://github.com/OffchainLabs/prysm/pull/17478

But there are some important notes regarding the test harness:

- I think we need to use `synctest` for deterministic test run in forkchoice runner, so #17478 will probably not merged.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
