### PR TITLE
Ignore bids from builders exited by the parent's payload

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_builder_test.go
@@ -25,7 +25,7 @@ import (
 // configurable errors and captures the parent-linkage closures for assertion.
 type fakeBidVerifier struct {
 	slotErr, activeErr, versionErr, coverErr, blobErr, randaoErr, sigErr error
-	rootSeenErr, parentHashErr, feeErr, gasErr                           error
+	rootSeenErr, parentHashErr, feeErr, gasErr, exitingErr               error
 	rootSeenFn                                                           func([32]byte) bool
 	hasPayloadFn                                                         func([32]byte, [32]byte) bool
 }
@@ -57,6 +57,9 @@ func (v *fakeBidVerifier) VerifyParentBlockHash(fn func([32]byte, [32]byte) bool
 	return v.parentHashErr
 }
 func (v *fakeBidVerifier) VerifyGasLimitTargetCompatible(uint64, uint64) error { return v.gasErr }
+func (v *fakeBidVerifier) VerifyBuilderNotExiting(state.ReadOnlyBeaconState, func([32]byte) ([]*enginev1.BuilderExitRequest, error)) error {
+	return v.exitingErr
+}
 func (v *fakeBidVerifier) VerifyBuilderCanCoverBid(state.ReadOnlyBeaconState) error {
 	return v.coverErr
 }

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -143,6 +143,7 @@ go_library(
         "//math:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
+        "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/prysm/v1alpha1/attestation:go_default_library",
         "//proto/prysm/v1alpha1/metadata:go_default_library",

--- a/beacon-chain/sync/validate_execution_payload_bid.go
+++ b/beacon-chain/sync/validate_execution_payload_bid.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -129,6 +130,19 @@ func (s *Service) validateExecutionPayloadBidGossip(ctx context.Context, pid pee
 	}
 	// [IGNORE] bid.value is less or equal than the builder's excess balance.
 	if err := v.VerifyBuilderCanCoverBid(st); err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+	// [IGNORE] the parent's payload does not try to exit the builder.
+	if err := v.VerifyBuilderNotExiting(st, func(root [32]byte) ([]*enginev1.BuilderExitRequest, error) {
+		envelope, err := s.cfg.beaconDB.ExecutionPayloadEnvelope(ctx, root)
+		if err != nil {
+			return nil, err
+		}
+		if envelope == nil || envelope.Message == nil {
+			return nil, nil
+		}
+		return envelope.Message.ExecutionRequests.GetBuilderExits(), nil
+	}); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 	// [IGNORE] bid.parent_block_hash is the block hash of a known execution payload in fork choice

--- a/beacon-chain/sync/validate_execution_payload_bid_test.go
+++ b/beacon-chain/sync/validate_execution_payload_bid_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
@@ -210,6 +211,12 @@ func TestValidateExecutionPayloadBidGossip_ErrorPathsWithMock(t *testing.T) {
 		{
 			name:      "builder cannot cover",
 			verifier:  mockExecutionPayloadBidVerifier{errBuilderCanCoverBid: errors.New("cannot cover")},
+			result:    pubsub.ValidationIgnore,
+			wantError: true,
+		},
+		{
+			name:      "builder exited by parent payload",
+			verifier:  mockExecutionPayloadBidVerifier{errBuilderNotExiting: errors.New("builder may exit")},
 			result:    pubsub.ValidationIgnore,
 			wantError: true,
 		},
@@ -484,6 +491,7 @@ type mockExecutionPayloadBidVerifier struct {
 	errSlotHigherThanParent  error
 	errParentBlockHash       error
 	errBuilderCanCoverBid    error
+	errBuilderNotExiting     error
 	errSignature             error
 }
 
@@ -543,6 +551,10 @@ func (m *mockExecutionPayloadBidVerifier) VerifyParentBlockHash(func([32]byte, [
 
 func (m *mockExecutionPayloadBidVerifier) VerifyBuilderCanCoverBid(state.ReadOnlyBeaconState) error {
 	return m.errBuilderCanCoverBid
+}
+
+func (m *mockExecutionPayloadBidVerifier) VerifyBuilderNotExiting(state.ReadOnlyBeaconState, func([32]byte) ([]*enginev1.BuilderExitRequest, error)) error {
+	return m.errBuilderNotExiting
 }
 
 func (m *mockExecutionPayloadBidVerifier) VerifySignature(state.ReadOnlyBeaconState) error {

--- a/beacon-chain/verification/BUILD.bazel
+++ b/beacon-chain/verification/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//consensus-types/primitives:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//runtime/logging:go_default_library",
         "//runtime/version:go_default_library",

--- a/beacon-chain/verification/execution_payload_bid.go
+++ b/beacon-chain/verification/execution_payload_bid.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
@@ -28,6 +29,7 @@ var ExecutionPayloadBidGossipRequirements = []Requirement{
 	RequireBidParentBlockHashValid,
 	RequireBidGasLimitCompatible,
 	RequireBidBuilderCanCover,
+	RequireBidBuilderNotExiting,
 	RequireBidSignatureValid,
 }
 
@@ -66,6 +68,7 @@ var (
 	ErrBidSlotNotHigherThanParent   = errors.New("bid slot is not higher than parent block slot")
 	ErrBidParentBlockHashMismatch   = errors.New("parent block hash does not match forkchoice")
 	ErrBidBuilderCannotCover        = errors.New("builder cannot cover bid")
+	ErrBidBuilderExitedByParent     = errors.New("parent payload exits the bid builder")
 )
 
 // payloadBuilderVersion is PAYLOAD_BUILDER_VERSION: the builder version byte
@@ -330,6 +333,38 @@ func (v *BidVerifier) VerifyBuilderCanCoverBid(st state.ReadOnlyBeaconState) (er
 	}
 	if !ok {
 		return fmt.Errorf("%w: builder=%d amount=%d", ErrBidBuilderCannotCover, bid.BuilderIndex(), bid.Value())
+	}
+	return nil
+}
+
+// VerifyBuilderNotExiting verifies the parent's payload does not exit the bid's builder.
+// The exits lookup is only consulted when the bid builds on the parent's revealed payload.
+func (v *BidVerifier) VerifyBuilderNotExiting(st state.ReadOnlyBeaconState, exits func([32]byte) ([]*enginev1.BuilderExitRequest, error)) (err error) {
+	defer v.record(RequireBidBuilderNotExiting, &err)
+
+	bid, err := v.b.Bid()
+	if err != nil {
+		return errors.Wrap(err, "failed to get bid")
+	}
+	latest, err := st.LatestExecutionPayloadBid()
+	if err != nil {
+		return errors.Wrap(err, "failed to get latest execution payload bid")
+	}
+	if bid.ParentBlockHash() != latest.BlockHash() {
+		return nil
+	}
+	builder, err := st.Builder(bid.BuilderIndex())
+	if err != nil {
+		return errors.Wrap(err, "failed to get builder")
+	}
+	requests, err := exits(bid.ParentBlockRoot())
+	if err != nil {
+		return errors.Wrap(err, "failed to get parent builder exits")
+	}
+	for _, r := range requests {
+		if bytes.Equal(r.Pubkey, builder.Pubkey) && bytes.Equal(r.SourceAddress, builder.ExecutionAddress) {
+			return fmt.Errorf("%w: builder=%d", ErrBidBuilderExitedByParent, bid.BuilderIndex())
+		}
 	}
 	return nil
 }

--- a/beacon-chain/verification/execution_payload_bid_test.go
+++ b/beacon-chain/verification/execution_payload_bid_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
@@ -230,6 +231,45 @@ func TestBidVerifier_VerifyBuilderCanCoverBid(t *testing.T) {
 	})
 	verifier = &BidVerifier{results: newResults(RequireBidBuilderCanCover), b: wrapped}
 	require.ErrorIs(t, verifier.VerifyBuilderCanCoverBid(insufficientState), ErrBidBuilderCannotCover)
+}
+
+func TestBidVerifier_VerifyBuilderNotExiting(t *testing.T) {
+	signed := testSignedExecutionPayloadBid(t, 1)
+	wrapped, err := blocks.WrappedROSignedExecutionPayloadBid(signed)
+	require.NoError(t, err)
+
+	builderPubkey := bytes.Repeat([]byte{0x07}, 48)
+	builderAddress := bytes.Repeat([]byte{0x08}, 20)
+	newState := func(latestBlockHash []byte) state.BeaconState {
+		return newBidState(t, 1, func(s *ethpb.BeaconStateGloas) {
+			s.Builders = []*ethpb.Builder{{
+				Pubkey:            builderPubkey,
+				ExecutionAddress:  builderAddress,
+				WithdrawableEpoch: params.BeaconConfig().FarFutureEpoch,
+			}}
+			s.LatestExecutionPayloadBid.BlockHash = latestBlockHash
+		})
+	}
+	matchingExit := func([32]byte) ([]*enginev1.BuilderExitRequest, error) {
+		return []*enginev1.BuilderExitRequest{{Pubkey: builderPubkey, SourceAddress: builderAddress}}, nil
+	}
+
+	// The bid builds on the parent's revealed payload and the parent exits the builder.
+	verifier := &BidVerifier{results: newResults(RequireBidBuilderNotExiting), b: wrapped}
+	require.ErrorIs(t, verifier.VerifyBuilderNotExiting(newState(signed.Message.ParentBlockHash), matchingExit), ErrBidBuilderExitedByParent)
+
+	// The exit is for a different source address.
+	verifier = &BidVerifier{results: newResults(RequireBidBuilderNotExiting), b: wrapped}
+	require.NoError(t, verifier.VerifyBuilderNotExiting(newState(signed.Message.ParentBlockHash), func([32]byte) ([]*enginev1.BuilderExitRequest, error) {
+		return []*enginev1.BuilderExitRequest{{Pubkey: builderPubkey, SourceAddress: bytes.Repeat([]byte{0x09}, 20)}}, nil
+	}))
+
+	// The bid builds on the parent's empty payload, so the exits are never consulted.
+	verifier = &BidVerifier{results: newResults(RequireBidBuilderNotExiting), b: wrapped}
+	require.NoError(t, verifier.VerifyBuilderNotExiting(newState(bytes.Repeat([]byte{0x0a}, 32)), func([32]byte) ([]*enginev1.BuilderExitRequest, error) {
+		t.Fatal("exits should not be fetched for an empty parent payload")
+		return nil, nil
+	}))
 }
 
 func TestBidVerifier_VerifySignature(t *testing.T) {

--- a/beacon-chain/verification/interface.go
+++ b/beacon-chain/verification/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	payloadattestation "github.com/OffchainLabs/prysm/v7/consensus-types/payload-attestation"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 )
 
@@ -114,6 +115,7 @@ type ExecutionPayloadBidVerifier interface {
 	VerifyParentBlockHash(func([32]byte, [32]byte) bool) error
 	VerifyGasLimitTargetCompatible(parentGasLimit, targetGasLimit uint64) error
 	VerifyBuilderCanCoverBid(state.ReadOnlyBeaconState) error
+	VerifyBuilderNotExiting(state.ReadOnlyBeaconState, func([32]byte) ([]*enginev1.BuilderExitRequest, error)) error
 	VerifySignature(state.ReadOnlyBeaconState) error
 	SatisfyRequirement(Requirement)
 }

--- a/beacon-chain/verification/requirements.go
+++ b/beacon-chain/verification/requirements.go
@@ -52,6 +52,7 @@ const (
 	RequireBidSlotHigherThanParent
 	RequireBidParentBlockHashValid
 	RequireBidBuilderCanCover
+	RequireBidBuilderNotExiting
 	RequireBidSignatureValid
 	RequireBidSlotMatches
 	RequireBidCompatibleWithHead

--- a/beacon-chain/verification/result.go
+++ b/beacon-chain/verification/result.go
@@ -93,6 +93,8 @@ func (r Requirement) String() string {
 		return "RequireBidParentBlockHashValid"
 	case RequireBidBuilderCanCover:
 		return "RequireBidBuilderCanCover"
+	case RequireBidBuilderNotExiting:
+		return "RequireBidBuilderNotExiting"
 	case RequireBidSignatureValid:
 		return "RequireBidSignatureValid"
 	case RequireBidSlotMatches:

--- a/changelog/terence_gloas-bid-builder-exit-gossip.md
+++ b/changelog/terence_gloas-bid-builder-exit-gossip.md
@@ -1,0 +1,3 @@
+### Added
+
+- Gloas: ignore an execution payload bid whose builder the parent's payload exits.


### PR DESCRIPTION
- Adds the `[IGNORE]` condition from [consensus-specs#5580](https://github.com/ethereum/consensus-specs/pull/5580) to execution payload bid gossip validation.
- The parent's builder exits are applied by the child block, so the parent's post-state still shows the builder as active. A bid accepted here sinks the proposal that includes it.
- The parent envelope is only read when the bid builds on the parent's revealed payload, and the check runs after signature verification.
- That read is cheap. The DB stores the envelope blinded, so the transactions are already gone and only the execution requests are decoded: ~3us for a typical payload (4 KB stored) and ~64us for an unusually request-heavy one.