### PR TITLE
Ignore proposer preferences for pre-Gloas proposal slots

### DIFF
--- a/beacon-chain/sync/validate_signed_proposer_preferences.go
+++ b/beacon-chain/sync/validate_signed_proposer_preferences.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -46,6 +47,11 @@ func (s *Service) validateSignedProposerPreferencesGossip(ctx context.Context, p
 	}
 	if len(signedPreferences.Message.DependentRoot) != fieldparams.RootLength {
 		return pubsub.ValidationReject, errors.New("dependent_root must be 32 bytes")
+	}
+
+	// [IGNORE] compute_epoch_at_slot(proposal_slot) >= GLOAS_FORK_EPOCH.
+	if slots.ToEpoch(signedPreferences.Message.ProposalSlot) < params.BeaconConfig().GloasForkEpoch {
+		return pubsub.ValidationIgnore, nil
 	}
 
 	v := s.newSignedProposerPreferencesVerifier(signedPreferences, verification.SignedProposerPreferencesGossipRequirements)

--- a/beacon-chain/sync/validate_signed_proposer_preferences_test.go
+++ b/beacon-chain/sync/validate_signed_proposer_preferences_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stategen"
 	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -186,6 +187,19 @@ func TestValidateSignedProposerPreferencesGossip_EpochPlus2DependentRootMismatch
 	require.Equal(t, primitives.Epoch(1), gotEpoch)
 }
 
+func TestValidateSignedProposerPreferencesGossip_PreGloasProposalEpoch(t *testing.T) {
+	ctx := context.Background()
+	s, msg, _ := setupSignedProposerPreferencesService(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 2
+	params.OverrideBeaconConfig(cfg)
+
+	// The proposal slot is in epoch 1, before the fork.
+	result, err := s.validateSignedProposerPreferencesGossip(ctx, "", msg)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+}
+
 func TestValidateSignedProposerPreferencesGossip_HappyPath(t *testing.T) {
 	ctx := context.Background()
 	s, msg, signedPreferences := setupSignedProposerPreferencesService(t)
@@ -253,6 +267,12 @@ func testNewSignedProposerPreferencesVerifier(m mockSignedProposerPreferencesVer
 // the checkpoint state.
 func setupSignedProposerPreferencesService(t *testing.T) (*Service, *pubsub.Message, *ethpb.SignedProposerPreferences) {
 	t.Helper()
+
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+	params.BeaconConfig().InitializeForkSchedule()
 
 	ctx := context.Background()
 	db := dbtest.SetupDB(t)

--- a/changelog/terence_gloas-preferences-pre-fork-ignore.md
+++ b/changelog/terence_gloas-preferences-pre-fork-ignore.md
@@ -1,0 +1,3 @@
+### Added
+
+- Gloas: ignore proposer preferences whose proposal slot is before the fork.


### PR DESCRIPTION
- Adds the `[IGNORE]` condition from [consensus-specs#5559](https://github.com/ethereum/consensus-specs/pull/5559) to `proposer_preferences` gossip validation.
- Matters while nodes subscribe to the topic an epoch ahead of the fork, where a proposal slot can still fall before `GLOAS_FORK_EPOCH`.
- The test setup now pins `GloasForkEpoch` to 0, which the existing cases need once the check exists.