### PR TITLE
Derive SaveOrigin checkpoint epoch from the origin state slot

### DIFF
--- a/beacon-chain/db/kv/wss.go
+++ b/beacon-chain/db/kv/wss.go
@@ -99,9 +99,12 @@ func (s *Store) SaveOrigin(ctx context.Context, serState, serBlock []byte) error
 		return errors.Wrap(err, "save origin checkpoint block root")
 	}
 
-	// rebuild the checkpoint from the block
-	// use it to mark the block as justified and finalized
-	slotEpoch, err := wblk.Block().Slot().SafeDivSlot(params.BeaconConfig().SlotsPerEpoch)
+	// Rebuild the checkpoint the node is syncing from and use it to mark the block as
+	// justified and finalized. The epoch must come from the state slot, not the block slot:
+	// the origin state sits at the checkpoint epoch's start slot (advanced through any empty
+	// slots), while the origin block sits in an earlier epoch whenever the first slot of the
+	// checkpoint epoch is empty.
+	slotEpoch, err := state.Slot().SafeDivSlot(params.BeaconConfig().SlotsPerEpoch)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/db/kv/wss_test.go
+++ b/beacon-chain/db/kv/wss_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/genesis"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
 func TestSaveOrigin(t *testing.T) {
@@ -48,6 +50,48 @@ func TestSaveOrigin(t *testing.T) {
 	broot, err := scb.Block().HashTreeRoot()
 	require.NoError(t, err)
 	require.Equal(t, true, db.IsFinalizedBlock(ctx, broot))
+}
+
+func TestSaveOrigin_BoundaryBlockCheckpointEpoch(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	params.OverrideBeaconConfig(params.MainnetConfig())
+
+	ctx := t.Context()
+	db := setupDB(t)
+
+	// The origin state sits at the first slot of the checkpoint epoch, while the origin
+	// block sits in the previous epoch because the checkpoint epoch's first slot is empty.
+	checkpointEpoch := primitives.Epoch(2)
+	boundarySlot, err := slots.EpochStart(checkpointEpoch)
+	require.NoError(t, err)
+
+	cst, err := util.NewBeaconState()
+	require.NoError(t, err)
+	require.NoError(t, cst.SetSlot(boundarySlot))
+	csb, err := cst.MarshalSSZ()
+	require.NoError(t, err)
+
+	cb := util.NewBeaconBlock()
+	cb.Block.Slot = boundarySlot - 1
+	scb, err := blocks.NewSignedBeaconBlock(cb)
+	require.NoError(t, err)
+	cbb, err := scb.MarshalSSZ()
+	require.NoError(t, err)
+
+	require.NoError(t, db.SaveOrigin(ctx, csb, cbb))
+
+	broot, err := scb.Block().HashTreeRoot()
+	require.NoError(t, err)
+
+	fcp, err := db.FinalizedCheckpoint(ctx)
+	require.NoError(t, err)
+	require.Equal(t, checkpointEpoch, fcp.Epoch)
+	require.DeepEqual(t, broot[:], fcp.Root)
+
+	jcp, err := db.JustifiedCheckpoint(ctx)
+	require.NoError(t, err)
+	require.Equal(t, checkpointEpoch, jcp.Epoch)
+	require.DeepEqual(t, broot[:], jcp.Root)
 }
 
 func TestSaveOrigin_StateDiffNonEpochBoundarySlot(t *testing.T) {

--- a/changelog/satushh_saveorigin-epoch-from-state.md
+++ b/changelog/satushh_saveorigin-epoch-from-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Derive the justified and finalized checkpoint epoch persisted by `SaveOrigin` from the origin state slot instead of the origin block slot, so checkpoint sync records the correct epoch when the checkpoint epoch's first slot is empty.


### PR DESCRIPTION
**What type of PR is this?**

Fix

**What does this PR do? Why is it needed?**

- SaveOrigin rebuilt the justified/finalized checkpoint epoch from the origin block's slot, which is one epoch short whenever the checkpoint epoch's first slot is empty. 
- Derive it from the origin state slot instead, which always sits at the checkpoint epoch's start.


**Which issue(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
